### PR TITLE
Import sys/libjade/build.rs from franziskus/hacl-sys branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ hacl = { version = "=0.0.2", features = ["hazmat"] }
 rand = { version = "0.8" }
 log = "0.4"
 
-[target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
 libjade-sys = { version = "0.0.1", path = "sys/libjade" }
 
 [dev-dependencies]

--- a/src/jasmin/sha3.rs
+++ b/src/jasmin/sha3.rs
@@ -40,7 +40,7 @@ macro_rules! sha3_simd256 {
 sha3_simd256!(
     sha3_224,
     Sha3_224,
-    libjade_sys::simd256::jade_hash_sha3_224_amd64_avx2,
+    libjade_sys::jade_hash_sha3_224_amd64_avx2,
     libjade_sys::jade_hash_sha3_224_amd64_ref
 );
 
@@ -48,7 +48,7 @@ sha3_simd256!(
 sha3_simd256!(
     sha3_256,
     Sha3_256,
-    libjade_sys::simd256::jade_hash_sha3_256_amd64_avx2,
+    libjade_sys::jade_hash_sha3_256_amd64_avx2,
     libjade_sys::jade_hash_sha3_256_amd64_ref
 );
 
@@ -56,7 +56,7 @@ sha3_simd256!(
 sha3_simd256!(
     sha3_384,
     Sha3_384,
-    libjade_sys::simd256::jade_hash_sha3_384_amd64_avx2,
+    libjade_sys::jade_hash_sha3_384_amd64_avx2,
     libjade_sys::jade_hash_sha3_384_amd64_ref
 );
 
@@ -64,7 +64,7 @@ sha3_simd256!(
 sha3_simd256!(
     sha3_512,
     Sha3_512,
-    libjade_sys::simd256::jade_hash_sha3_512_amd64_avx2,
+    libjade_sys::jade_hash_sha3_512_amd64_avx2,
     libjade_sys::jade_hash_sha3_512_amd64_ref
 );
 

--- a/src/jasmin/sha3.rs
+++ b/src/jasmin/sha3.rs
@@ -40,7 +40,7 @@ macro_rules! sha3_simd256 {
 sha3_simd256!(
     sha3_224,
     Sha3_224,
-    libjade_sys::jade_hash_sha3_224_amd64_avx2,
+    libjade_sys::simd256::jade_hash_sha3_224_amd64_avx2,
     libjade_sys::jade_hash_sha3_224_amd64_ref
 );
 
@@ -48,7 +48,7 @@ sha3_simd256!(
 sha3_simd256!(
     sha3_256,
     Sha3_256,
-    libjade_sys::jade_hash_sha3_256_amd64_avx2,
+    libjade_sys::simd256::jade_hash_sha3_256_amd64_avx2,
     libjade_sys::jade_hash_sha3_256_amd64_ref
 );
 
@@ -56,7 +56,7 @@ sha3_simd256!(
 sha3_simd256!(
     sha3_384,
     Sha3_384,
-    libjade_sys::jade_hash_sha3_384_amd64_avx2,
+    libjade_sys::simd256::jade_hash_sha3_384_amd64_avx2,
     libjade_sys::jade_hash_sha3_384_amd64_ref
 );
 
@@ -64,7 +64,7 @@ sha3_simd256!(
 sha3_simd256!(
     sha3_512,
     Sha3_512,
-    libjade_sys::jade_hash_sha3_512_amd64_avx2,
+    libjade_sys::simd256::jade_hash_sha3_512_amd64_avx2,
     libjade_sys::jade_hash_sha3_512_amd64_ref
 );
 

--- a/sys/libjade/Cargo.toml
+++ b/sys/libjade/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4"
 libc = { version = "0.2", default-features = false }
 fs_extra = "1.2"
 cc = { version = "1.0", features = ["parallel"] }
+libcrux_platform = { path = "../platform" }
 
 [target.'cfg(not(windows))'.build-dependencies]
 bindgen = "0.66"

--- a/sys/libjade/Cargo.toml
+++ b/sys/libjade/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4"
 [build-dependencies]
 libc = { version = "0.2", default-features = false }
 fs_extra = "1.2"
+cc = { version = "1.0", features = ["parallel"] }
 
 [target.'cfg(not(windows))'.build-dependencies]
 bindgen = "0.66"

--- a/sys/libjade/Cargo.toml
+++ b/sys/libjade/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 libc = { version = "0.2", default-features = false }
 fs_extra = "1.2"
 cc = { version = "1.0", features = ["parallel"] }
-libcrux_platform = { path = "../platform" }
+libcrux_platform = { version = "=0.0.1", path = "../platform" }
 
 [target.'cfg(not(windows))'.build-dependencies]
 bindgen = "0.66"

--- a/sys/libjade/build.rs
+++ b/sys/libjade/build.rs
@@ -193,9 +193,11 @@ pub fn main() -> Result<(), u8> {
     let mode = "static";
     println!("cargo:rustc-link-lib={}={}", mode, library_name);
     if platform.simd128 {
+        println!("cargo:rustc-cfg=simd128");
         println!("cargo:rustc-link-lib={}={}", mode, "jade_128");
     }
     if platform.simd256 {
+        println!("cargo:rustc-cfg=simd256");
         println!("cargo:rustc-link-lib={}={}", mode, "jade_256");
     }
     println!("cargo:rustc-link-search=native={}", out_path.display());

--- a/sys/libjade/build.rs
+++ b/sys/libjade/build.rs
@@ -168,8 +168,8 @@ pub fn main() -> Result<(), u8> {
         }
     } else {
         Platform {
-            simd128: std::arch::is_x86_feature_detected!("avx"),
-            simd256: std::arch::is_x86_feature_detected!("avx2"),
+            simd128: libcrux_platform::simd128_support(),
+            simd256: libcrux_platform::simd256_support(),
         }
     };
 

--- a/sys/libjade/build.rs
+++ b/sys/libjade/build.rs
@@ -1,211 +1,184 @@
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-mod x64_build {
-    use std::{path::Path, process::Command};
+use std::{env, path::Path};
 
-    macro_rules! svec {
+macro_rules! svec {
         ($($x:expr),*$(,)?) => (vec![$($x.to_string()),*]);
     }
 
-    pub fn copy_files(home_path: &Path, out_path: &Path) {
-        let mut options = fs_extra::dir::CopyOptions::new();
-        options.overwrite = true;
-        fs_extra::dir::copy(home_path.join("jazz"), out_path, &options).unwrap();
-    }
+fn copy_files(home_path: &Path, out_path: &Path) {
+    let mut options = fs_extra::dir::CopyOptions::new();
+    options.overwrite = true;
+    fs_extra::dir::copy(home_path.join("jazz"), out_path, &options).unwrap();
+}
 
-    pub fn append_simd128_flags(flags: &mut Vec<String>) {
-        // Platform detection
-        if simd128_support() {
-            flags.push("-DSIMD128".to_string());
-            flags.push("-mavx".to_string());
-        }
-    }
+fn append_simd128_flags(flags: &mut Vec<String>) {
+    flags.push("-DSIMD128".to_string());
+    flags.push("-mavx".to_string());
+}
 
-    pub fn append_simd256_flags(flags: &mut Vec<String>) {
-        // Platform detection
-        if simd256_support() {
-            flags.push("-DSIMD256".to_string());
-            flags.push("-mavx2".to_string());
-        }
-    }
+fn append_simd256_flags(flags: &mut Vec<String>) {
+    flags.push("-DSIMD256".to_string());
+    flags.push("-mavx2".to_string());
+}
 
-    #[cfg(not(windows))]
-    pub fn create_bindings(home_dir: &Path) {
-        let jazz_dir = home_dir.join("jazz");
-        let mut clang_args = vec![format!("-I{}", jazz_dir.join("include").display())];
+#[cfg(not(windows))]
+fn create_bindings(platform: Platform, home_dir: &Path) {
+    let jazz_dir = home_dir.join("jazz");
+    let mut clang_args = vec![format!("-I{}", jazz_dir.join("include").display())];
+    if platform.simd128 {
         append_simd128_flags(&mut clang_args);
+    }
+    if platform.simd256 {
         append_simd256_flags(&mut clang_args);
-
-        let bindings = bindgen::Builder::default()
-            // Header to wrap headers
-            .header("jazz/include/libjade.h")
-            // Set include paths for headers
-            .clang_args(clang_args)
-            // Allow function we want to have in
-            .allowlist_function("jade_hash_.*")
-            .allowlist_var("JADE_HASH_.*")
-            .allowlist_function("jade_scalarmult_curve25519_.*")
-            .allowlist_var("JADE_SCALARMULT_CURVE25519_.*")
-            .allowlist_function("jade_hash_sha3_.*")
-            .allowlist_var("JADE_HASH_SHA3_.*")
-            .allowlist_function("jade_onetimeauth_poly1305_.*")
-            .allowlist_var("JADE_ONETIMEAUTH_POLY1305_.*")
-            .allowlist_function("jade_stream_chacha_chacha20.*")
-            .allowlist_var("JADE_STREAM_CHACHA_CHACHA20_.*")
-            .allowlist_function("jade_kem_kyber_kyber768_.*")
-            .allowlist_var("JADE_KEM_KYBER_KYBER768_.*")
-            // Block everything we don't need or define ourselves.
-            .blocklist_type("__.*")
-            // Disable tests to avoid warnings and keep it portable
-            .layout_tests(false)
-            // Generate bindings
-            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let home_bindings = home_dir.join("src/bindings.rs");
-        bindings
-            .write_to_file(home_bindings)
-            .expect("Couldn't write bindings!");
     }
 
-    #[cfg(windows)]
-    pub fn create_bindings(_: &Path) {}
+    let bindings = bindgen::Builder::default()
+        // Header to wrap headers
+        .header("jazz/include/libjade.h")
+        // Set include paths for headers
+        .clang_args(clang_args)
+        // Allow function we want to have in
+        .allowlist_function("jade_hash_.*")
+        .allowlist_var("JADE_HASH_.*")
+        .allowlist_function("jade_scalarmult_curve25519_.*")
+        .allowlist_var("JADE_SCALARMULT_CURVE25519_.*")
+        .allowlist_function("jade_hash_sha3_.*")
+        .allowlist_var("JADE_HASH_SHA3_.*")
+        .allowlist_function("jade_onetimeauth_poly1305_.*")
+        .allowlist_var("JADE_ONETIMEAUTH_POLY1305_.*")
+        .allowlist_function("jade_stream_chacha_chacha20.*")
+        .allowlist_var("JADE_STREAM_CHACHA_CHACHA20_.*")
+        .allowlist_function("jade_kem_kyber_kyber768_.*")
+        .allowlist_var("JADE_KEM_KYBER_KYBER768_.*")
+        // Block everything we don't need or define ourselves.
+        .blocklist_type("__.*")
+        // Disable tests to avoid warnings and keep it portable
+        .layout_tests(false)
+        // Generate bindings
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .use_core()
+        .generate()
+        .expect("Unable to generate bindings");
 
-    pub fn compile_files(files: &[String], out_path: &Path, args: &[String]) {
-        let jazz_dir = out_path.join("jazz");
-        let mut clang_args = vec![format!("-I{}", jazz_dir.join("include").display())];
-        clang_args.push("-O3".to_string());
-        clang_args.push("-c".to_string());
-        clang_args.extend_from_slice(args);
+    let home_bindings = home_dir.join("src/bindings.rs");
+    bindings
+        .write_to_file(home_bindings)
+        .expect("Couldn't write bindings!");
+}
 
-        let mut build_cmd = Command::new("clang");
-        let mut build_args = clang_args;
-        build_args.extend_from_slice(files);
-        println!(" >>> {}", out_path.join("jazz").display());
-        println!(" >>> {}", build_args.join(" "));
+#[cfg(windows)]
+fn create_bindings(platform: Platform, _: &Path) {}
 
-        build_cmd
-            .current_dir(out_path.join("jazz"))
-            .args(&build_args);
-        println!(" >>> build_cmd: {:?}", build_cmd);
-        println!("     current dir: {:?}", build_cmd.get_current_dir());
+fn compile_files(library_name: &str, files: &[String], out_path: &Path, args: &[String]) {
+    let jazz_dir = out_path.join("jazz");
 
-        let build_status = build_cmd.status().expect("Failed to run build.");
-        println!(" >>> build status: {:?}", build_status);
-        println!(" >>> out {:?}", out_path);
-        assert!(build_status.success());
+    let mut build = cc::Build::new();
+    build
+        .files(files.iter().map(|fname| jazz_dir.join(fname)))
+        .warnings_into_errors(true)
+        .no_default_flags(true);
+
+    build.include(jazz_dir.join("include"));
+    build.flag("-O3").flag("-c");
+    for arg in args {
+        build.flag(arg);
     }
 
-    pub fn build(out_path: &Path, cross_target: Option<String>) {
-        let args = cross_target
-            .map(|s| match s.as_str() {
-                // We only support cross compilation here for now.
-                // We assume that we're using clang and can just add the target
-                "x86_64-apple-darwin" => svec!["-target", "x86_64-apple-darwin"],
-                _ => panic!("Unsupported cross compilation target {s}"),
-            })
-            .unwrap_or_default();
+    build.compile(library_name);
+}
 
-        let files = svec![
-            "sha256.s",
-            "x25519_ref.s",
-            "x25519_mulx.s",
-            "sha3_224_ref.s",
-            "sha3_256_ref.s",
-            "sha3_384_ref.s",
-            "sha3_512_ref.s",
-            "chacha20_ref.s",
-            "poly1305_ref.s",
-            "kyber_kyber768_ref.s",
+fn build(platform: Platform, out_path: &Path, cross_target: Option<String>) {
+    let args = cross_target
+        .map(|s| match s.as_str() {
+            // We only support cross compilation here for now.
+            "x86_64-apple-darwin" => svec!["-target", "x86_64-apple-darwin"],
+            _ => panic!("Unsupported cross compilation target {s}"),
+        })
+        .unwrap_or_default();
+
+    let files = svec![
+        "sha256.s",
+        "x25519_ref.s",
+        "x25519_mulx.s",
+        "sha3_224_ref.s",
+        "sha3_256_ref.s",
+        "sha3_384_ref.s",
+        "sha3_512_ref.s",
+        "chacha20_ref.s",
+        "poly1305_ref.s",
+        "kyber_kyber768_ref.s",
+    ];
+    compile_files("libjade.a", &files, out_path, &args);
+
+    if platform.simd256 {
+        let files256 = svec![
+            "sha3_224_avx2.s",
+            "sha3_256_avx2.s",
+            "sha3_384_avx2.s",
+            "sha3_512_avx2.s",
+            "chacha20_avx2.s",
+            "poly1305_avx2.s",
         ];
-        let mut all_files = files.clone();
 
-        // Platform detection
-        if simd256_support() {
-            let files256 = svec![
-                "sha3_224_avx2.s",
-                "sha3_256_avx2.s",
-                "sha3_384_avx2.s",
-                "sha3_512_avx2.s",
-                "chacha20_avx2.s",
-                "poly1305_avx2.s",
-            ];
-            all_files.extend_from_slice(&files256);
-
-            let mut simd256_flags = args.clone();
-            append_simd256_flags(&mut simd256_flags);
-            compile_files(&files256, out_path, &simd256_flags);
-        }
-        if simd128_support() {
-            let files128 = svec!["chacha20_avx.s", "poly1305_avx.s",];
-            all_files.extend_from_slice(&files128);
-
-            let mut simd128_flags = args.clone();
-            append_simd128_flags(&mut simd128_flags);
-            compile_files(&files128, out_path, &simd128_flags);
-        }
-
-        let mut object_files = vec![];
-        compile_files(&files, out_path, &args);
-        for file in all_files {
-            object_files.push(Path::new(&file).with_extension("o"));
-        }
-
-        // Link
-        let mut build_cmd = Command::new("ar");
-        build_cmd
-            .current_dir(out_path.join("jazz"))
-            .args(&["-r", &out_path.join("libjade.a").display().to_string()])
-            .args(&object_files);
-        println!(" >>> build_cmd: {:?}", build_cmd);
-        println!("     current dir: {:?}", build_cmd.get_current_dir());
-
-        let build_status = build_cmd.status().expect("Failed to link.");
-        println!("{:?}", build_status);
-        assert!(build_status.success());
+        let mut simd256_flags = args.clone();
+        append_simd256_flags(&mut simd256_flags);
+        compile_files("libjade_256.a", &files256, out_path, &simd256_flags);
     }
 
-    // === hardware detection
-    pub fn simd128_support() -> bool {
-        std::arch::is_x86_feature_detected!("avx")
-    }
+    if platform.simd128 {
+        let files128 = svec!["chacha20_avx.s", "poly1305_avx.s",];
 
-    pub fn simd256_support() -> bool {
-        std::arch::is_x86_feature_detected!("avx2")
+        let mut simd128_flags = args.clone();
+        append_simd128_flags(&mut simd128_flags);
+        compile_files("libjade_128.a", &files128, out_path, &simd128_flags);
     }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub fn main() {
-    use std::{env, path::Path};
-    use x64_build::*;
+#[derive(Debug, Clone, Copy)]
+struct Platform {
+    simd128: bool,
+    simd256: bool,
+}
 
+pub fn main() -> Result<(), u8> {
     // Get ENV variables
     let home_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let home_path = Path::new(&home_dir);
     let out_dir = env::var("OUT_DIR").unwrap();
     let out_path = Path::new(&out_dir);
     let target = env::var("TARGET").unwrap();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let host = env::var("HOST").unwrap();
 
-    let cross_target = if target != host { Some(target) } else { None };
-    if cross_target.is_none() && host == "aarch64-apple-darwin" {
-        panic!("libjade does not support aarch64-apple-darwin");
+    if target_arch != "x86_64" && target_arch != "x86" {
+        eprintln!(" ! Only x86 and x64 CPUs are supported !");
+        return Err(1);
     }
 
-    if simd128_support() {
-        println!("cargo:rustc-cfg=simd128");
-    }
-    if simd256_support() {
-        println!("cargo:rustc-cfg=simd256");
-    }
+    let cross_target = if target != host {
+        Some(target.clone())
+    } else {
+        None
+    };
+
+    // If cross compiling, we assume to have it all.
+    let platform = if cross_target.is_some() {
+        Platform {
+            simd128: true,
+            simd256: true,
+        }
+    } else {
+        Platform {
+            simd128: std::arch::is_x86_feature_detected!("avx"),
+            simd256: std::arch::is_x86_feature_detected!("avx2"),
+        }
+    };
 
     // Moving C/ASM code to output to make build easier.
     copy_files(home_path, out_path);
     eprintln!(" >>> out {:?}", out_path);
 
     // Build the C/ASM files
-    build(out_path, cross_target);
+    build(platform, out_path, cross_target);
 
     // Set library name to look up
     let library_name = "jade";
@@ -214,16 +187,19 @@ pub fn main() {
     println!("cargo:rerun-if-changed=cs");
 
     // Generate new bindings. This is a no-op on Windows.
-    create_bindings(home_path);
+    create_bindings(platform, home_path);
 
     // Link hacl library.
     let mode = "static";
     println!("cargo:rustc-link-lib={}={}", mode, library_name);
+    if platform.simd128 {
+        println!("cargo:rustc-link-lib={}={}", mode, "jade_128");
+    }
+    if platform.simd256 {
+        println!("cargo:rustc-link-lib={}={}", mode, "jade_256");
+    }
     println!("cargo:rustc-link-search=native={}", out_path.display());
     println!("cargo:lib={}", out_path.display());
-}
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-fn main() {
-    eprintln!("Only x86 and x64 CPUs are supported.");
+    Ok(())
 }

--- a/sys/platform/Cargo.toml
+++ b/sys/platform/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "libcrux_platform"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+libc = "0.2.147"

--- a/sys/platform/src/lib.rs
+++ b/sys/platform/src/lib.rs
@@ -1,3 +1,7 @@
+/* High-level functions to optian specific CPU features 
+   at runtime that are avaiable on supported processor 
+   architectures and operation systems */
+
 #![no_std]
 
 // Use std for tests

--- a/sys/platform/src/lib.rs
+++ b/sys/platform/src/lib.rs
@@ -1,0 +1,199 @@
+#![no_std]
+
+// Use std for tests
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod x86;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use x86::{self as cpu_id, Feature};
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+mod macos_arm;
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+mod linux_arm;
+
+#[cfg(test)]
+mod test;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub fn simd128_support() -> bool {
+    cpu_id::supported(Feature::sse2)
+        && cpu_id::supported(Feature::sse3)
+        && cpu_id::supported(Feature::sse4_1)
+        && cpu_id::supported(Feature::avx)
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+pub fn simd128_support() -> bool {
+    use linux_arm::*;
+    adv_simd()
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+pub fn simd128_support() -> bool {
+    use macos_arm::*;
+    adv_simd()
+}
+
+#[cfg(all(target_arch = "aarch64", not(any(target_os = "linux", target_os = "macos"))))]
+pub fn simd128_support() -> bool {
+    false
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+pub fn simd128_support() -> bool {
+    // XXX: Check for z14 or z15
+    false
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub fn simd256_support() -> bool {
+    cpu_id::supported(Feature::avx2)
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+pub fn simd256_support() -> bool {
+    // XXX: Check for z14 or z15
+    false
+}
+
+pub fn x25519_support() -> bool {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    return cpu_id::supported(Feature::bmi2) && cpu_id::supported(Feature::adx);
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    false
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub fn bmi2_adx_support() -> bool {
+    cpu_id::supported(Feature::bmi2) && cpu_id::supported(Feature::adx)
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+pub fn bmi2_adx_support() -> bool {
+    false
+}
+
+/// Check whether p(cl)mull is supported
+pub fn pmull_support() -> bool {
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    {
+        use crate::macos_arm::*;
+        pmull()
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        cpu_id::supported(Feature::pclmulqdq)
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        use crate::linux_arm::*;
+        pmull()
+    }
+}
+
+/// Check whether advanced SIMD features are supported
+pub fn adv_simd_support() -> bool {
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    {
+        use macos_arm::*;
+        adv_simd()
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        use linux_arm::*;
+        adv_simd()
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        false
+    }
+}
+
+/// Check whether AES is supported
+pub fn aes_ni_support() -> bool {
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    {
+        use crate::macos_arm::*;
+        aes()
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        use crate::linux_arm::*;
+        aes()
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        cpu_id::supported(Feature::avx)
+            && cpu_id::supported(Feature::sse)
+            && cpu_id::supported(Feature::aes)
+            && cpu_id::supported(Feature::pclmulqdq)
+            && cpu_id::supported(Feature::movbe)
+    }
+}
+
+/// Check whether SHA256 is supported
+pub fn sha256_support() -> bool {
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    {
+        use crate::macos_arm::*;
+        sha256()
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        use crate::linux_arm::*;
+        sha256()
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        cpu_id::supported(Feature::sha)
+    }
+}
+
+#[cfg(not(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(
+        target_arch = "aarch64",
+        not(any(target_os = "macos", target_os = "linux"))
+    )
+)))]
+mod other {
+    /// Check whether p(cl)mull is supported
+    pub fn pmull_support() -> bool {
+        false
+    }
+
+    /// Check whether advanced SIMD features are supported
+    pub fn adv_simd_support() -> bool {
+        false
+    }
+
+    /// Check whether AES is supported
+    pub fn aes_ni_support() -> bool {
+        false
+    }
+}
+#[cfg(not(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(
+        target_arch = "aarch64",
+        not(any(target_os = "macos", target_os = "linux"))
+    )
+)))]
+pub use other::*;

--- a/sys/platform/src/lib.rs
+++ b/sys/platform/src/lib.rs
@@ -18,45 +18,41 @@ mod linux_arm;
 #[cfg(test)]
 mod test;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+// TODO: Check for z14 or z15
 pub fn simd128_support() -> bool {
-    cpu_id::supported(Feature::sse2)
-        && cpu_id::supported(Feature::sse3)
-        && cpu_id::supported(Feature::sse4_1)
-        && cpu_id::supported(Feature::avx)
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    {
+        use macos_arm::*;
+        adv_simd()
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        cpu_id::supported(Feature::sse2)
+            && cpu_id::supported(Feature::sse3)
+            && cpu_id::supported(Feature::sse4_1)
+            && cpu_id::supported(Feature::avx)
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        use linux_arm::*;
+        adv_simd()
+    }
+
+    #[cfg(not(any(all(target_arch = "aarch64", 
+        any(target_os = "linux", target_os = "macos")),
+        target_arch = "x86", target_arch = "x86_64")))]
+    {
+        false
+    }
 }
 
-#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-pub fn simd128_support() -> bool {
-    use linux_arm::*;
-    adv_simd()
-}
-
-#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-pub fn simd128_support() -> bool {
-    use macos_arm::*;
-    adv_simd()
-}
-
-#[cfg(all(target_arch = "aarch64", not(any(target_os = "linux", target_os = "macos"))))]
-pub fn simd128_support() -> bool {
-    false
-}
-
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
-pub fn simd128_support() -> bool {
-    // XXX: Check for z14 or z15
-    false
-}
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn simd256_support() -> bool {
-    cpu_id::supported(Feature::avx2)
-}
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    return cpu_id::supported(Feature::avx2);
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-pub fn simd256_support() -> bool {
-    // XXX: Check for z14 or z15
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     false
 }
 
@@ -68,13 +64,11 @@ pub fn x25519_support() -> bool {
     false
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn bmi2_adx_support() -> bool {
-    cpu_id::supported(Feature::bmi2) && cpu_id::supported(Feature::adx)
-}
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    return cpu_id::supported(Feature::bmi2) && cpu_id::supported(Feature::adx);
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-pub fn bmi2_adx_support() -> bool {
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     false
 }
 
@@ -96,6 +90,13 @@ pub fn pmull_support() -> bool {
         use crate::linux_arm::*;
         pmull()
     }
+
+    #[cfg(not(any(all(target_arch = "aarch64", 
+        any(target_os = "linux", target_os = "macos")),
+        target_arch = "x86", target_arch = "x86_64")))]
+    {
+        false
+    }
 }
 
 /// Check whether advanced SIMD features are supported
@@ -112,7 +113,8 @@ pub fn adv_simd_support() -> bool {
         adv_simd()
     }
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(not(all(target_arch = "aarch64", 
+        any(target_os = "linux", target_os = "macos"))))]
     {
         false
     }
@@ -140,6 +142,13 @@ pub fn aes_ni_support() -> bool {
             && cpu_id::supported(Feature::pclmulqdq)
             && cpu_id::supported(Feature::movbe)
     }
+
+    #[cfg(not(any(all(target_arch = "aarch64", 
+        any(target_os = "linux", target_os = "macos")),
+        target_arch = "x86", target_arch = "x86_64")))]
+    {
+        false
+    }
 }
 
 /// Check whether SHA256 is supported
@@ -160,45 +169,11 @@ pub fn sha256_support() -> bool {
     {
         cpu_id::supported(Feature::sha)
     }
-}
 
-#[cfg(not(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "aarch64",
-    all(
-        target_arch = "aarch64",
-        not(any(target_os = "macos", target_os = "linux"))
-    )
-)))]
-mod other {
-    /// Check whether p(cl)mull is supported
-    pub fn pmull_support() -> bool {
-        false
-    }
-
-    /// Check whether advanced SIMD features are supported
-    pub fn adv_simd_support() -> bool {
-        false
-    }
-
-    /// Check whether AES is supported
-    pub fn aes_ni_support() -> bool {
-        false
-    }
-
-    /// Check whether SHA256 is supported
-    pub fn sha256_support() -> bool {
+    #[cfg(not(any(all(target_arch = "aarch64", 
+        any(target_os = "linux", target_os = "macos")),
+        target_arch = "x86", target_arch = "x86_64")))]
+    {
         false
     }
 }
-#[cfg(not(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "aarch64",
-    all(
-        target_arch = "aarch64",
-        not(any(target_os = "macos", target_os = "linux"))
-    )
-)))]
-pub use other::*;

--- a/sys/platform/src/lib.rs
+++ b/sys/platform/src/lib.rs
@@ -1,6 +1,6 @@
-/* High-level functions to optian specific CPU features 
-   at runtime that are avaiable on supported processor 
-   architectures and operation systems */
+/* High-level functions to optian specific CPU features
+at runtime that are avaiable on supported processor
+architectures and operation systems */
 
 #![no_std]
 
@@ -14,10 +14,10 @@ mod x86;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use x86::{self as cpu_id, Feature};
 
-#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-mod macos_arm;
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 mod linux_arm;
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+mod macos_arm;
 
 #[cfg(test)]
 mod test;
@@ -44,9 +44,11 @@ pub fn simd128_support() -> bool {
         adv_simd()
     }
 
-    #[cfg(not(any(all(target_arch = "aarch64", 
-        any(target_os = "linux", target_os = "macos")),
-        target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(not(any(
+        all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
+        target_arch = "x86",
+        target_arch = "x86_64"
+    )))]
     {
         false
     }
@@ -95,9 +97,11 @@ pub fn pmull_support() -> bool {
         pmull()
     }
 
-    #[cfg(not(any(all(target_arch = "aarch64", 
-        any(target_os = "linux", target_os = "macos")),
-        target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(not(any(
+        all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
+        target_arch = "x86",
+        target_arch = "x86_64"
+    )))]
     {
         false
     }
@@ -117,8 +121,7 @@ pub fn adv_simd_support() -> bool {
         adv_simd()
     }
 
-    #[cfg(not(all(target_arch = "aarch64", 
-        any(target_os = "linux", target_os = "macos"))))]
+    #[cfg(not(all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos"))))]
     {
         false
     }
@@ -147,9 +150,11 @@ pub fn aes_ni_support() -> bool {
             && cpu_id::supported(Feature::movbe)
     }
 
-    #[cfg(not(any(all(target_arch = "aarch64", 
-        any(target_os = "linux", target_os = "macos")),
-        target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(not(any(
+        all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
+        target_arch = "x86",
+        target_arch = "x86_64"
+    )))]
     {
         false
     }
@@ -174,9 +179,11 @@ pub fn sha256_support() -> bool {
         cpu_id::supported(Feature::sha)
     }
 
-    #[cfg(not(any(all(target_arch = "aarch64", 
-        any(target_os = "linux", target_os = "macos")),
-        target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(not(any(
+        all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
+        target_arch = "x86",
+        target_arch = "x86_64"
+    )))]
     {
         false
     }

--- a/sys/platform/src/lib.rs
+++ b/sys/platform/src/lib.rs
@@ -186,6 +186,11 @@ mod other {
     pub fn aes_ni_support() -> bool {
         false
     }
+
+    /// Check whether SHA256 is supported
+    pub fn sha256_support() -> bool {
+        false
+    }
 }
 #[cfg(not(any(
     target_arch = "x86",

--- a/sys/platform/src/lib.rs
+++ b/sys/platform/src/lib.rs
@@ -1,6 +1,6 @@
-/* High-level functions to optian specific CPU features
-at runtime that are avaiable on supported processor
-architectures and operation systems */
+//! High-level functions to detect available CPU features
+//! at runtime on supported processor architectures and
+//! operation systems
 
 #![no_std]
 

--- a/sys/platform/src/linux_arm.rs
+++ b/sys/platform/src/linux_arm.rs
@@ -1,14 +1,18 @@
-/* Obtain particular CPU features for AArch64 on Linux */
+//! Obtain particular CPU features for AArch64 on Linux
 
-use libc::{getauxval, AT_HWCAP, HWCAP_AES, HWCAP_ASIMD, HWCAP_PMULL, HWCAP_SHA2};
+use libc::{getauxval, AT_HWCAP, HWCAP_ASIMD, HWCAP_AES, HWCAP_PMULL, HWCAP_SHA2};
 
 #[inline(always)]
 fn auxval() {
     let val = unsafe { getauxval(AT_HWCAP) };
-    unsafe { ADV_SIMD = val & HWCAP_ASIMD != 0 };
-    unsafe { AES = val & HWCAP_AES != 0 };
-    unsafe { PMULL = val & HWCAP_PMULL != 0 };
-    unsafe { SHA256 = val & HWCAP_SHA2 != 0 };
+    let val_asimd = val & HWCAP_ASIMD != 0;
+    unsafe { ADV_SIMD = val_asimd };
+    let val_aes = val & HWCAP_AES != 0;
+    unsafe { AES = val_aes };
+    let val_pmull = val & HWCAP_PMULL != 0;
+    unsafe { PMULL = val_pmull };
+    let val_sha256 = val & HWCAP_SHA2 != 0;
+    unsafe { SHA256 = val_sha256 };
 }
 
 static mut ADV_SIMD: bool = false;

--- a/sys/platform/src/linux_arm.rs
+++ b/sys/platform/src/linux_arm.rs
@@ -1,0 +1,53 @@
+use libc::{getauxval, AT_HWCAP, HWCAP_ASIMD, HWCAP_AES, HWCAP_PMULL, HWCAP_SHA2};
+
+#[inline(always)]
+fn auxval() {
+    let val = unsafe { getauxval(AT_HWCAP) };
+    unsafe { ADV_SIMD = val & HWCAP_ASIMD != 0 };
+    unsafe { AES = val & HWCAP_AES != 0 };
+    unsafe { PMULL = val & HWCAP_PMULL != 0 };
+    unsafe { SHA256 = val & HWCAP_SHA2 != 0 };
+}
+
+static mut ADV_SIMD: bool = false;
+static mut AES: bool = false;
+static mut PMULL: bool = false;
+static mut SHA256: bool = false;
+
+#[inline(always)]
+pub(super) fn aes() -> bool {
+    init();
+    unsafe { AES }
+}
+
+#[inline(always)]
+pub(super) fn adv_simd() -> bool {
+    init();
+    unsafe { ADV_SIMD }
+}
+
+#[inline(always)]
+pub(super) fn pmull() -> bool {
+    init();
+    unsafe { PMULL }
+}
+
+#[inline(always)]
+pub(super) fn sha256() -> bool {
+    init();
+    unsafe { SHA256 }
+}
+
+static mut INITIALIZED: bool = false;
+
+/// Initialize CPU detection.
+#[inline(always)]
+pub(super) fn init() {
+    if unsafe { INITIALIZED } {
+        return;
+    }
+    auxval();
+    unsafe {
+        INITIALIZED = true;
+    }
+}

--- a/sys/platform/src/linux_arm.rs
+++ b/sys/platform/src/linux_arm.rs
@@ -1,3 +1,5 @@
+/* Obtain particular CPU features for AArch64 on Linux */
+
 use libc::{
     getauxval,
     AT_HWCAP,

--- a/sys/platform/src/linux_arm.rs
+++ b/sys/platform/src/linux_arm.rs
@@ -1,4 +1,11 @@
-use libc::{getauxval, AT_HWCAP, HWCAP_ASIMD, HWCAP_AES, HWCAP_PMULL, HWCAP_SHA2};
+use libc::{
+    getauxval,
+    AT_HWCAP,
+    HWCAP_ASIMD,
+    HWCAP_AES,
+    HWCAP_PMULL,
+    HWCAP_SHA2
+};
 
 #[inline(always)]
 fn auxval() {

--- a/sys/platform/src/linux_arm.rs
+++ b/sys/platform/src/linux_arm.rs
@@ -1,13 +1,6 @@
 /* Obtain particular CPU features for AArch64 on Linux */
 
-use libc::{
-    getauxval,
-    AT_HWCAP,
-    HWCAP_ASIMD,
-    HWCAP_AES,
-    HWCAP_PMULL,
-    HWCAP_SHA2
-};
+use libc::{getauxval, AT_HWCAP, HWCAP_AES, HWCAP_ASIMD, HWCAP_PMULL, HWCAP_SHA2};
 
 #[inline(always)]
 fn auxval() {

--- a/sys/platform/src/macos_arm.rs
+++ b/sys/platform/src/macos_arm.rs
@@ -1,0 +1,104 @@
+use libc::{c_void, sysctlbyname};
+
+#[inline(always)]
+fn check(feature: &[i8]) -> bool {
+    let mut ret = 0i64;
+    let mut size = core::mem::size_of::<i64>();
+    let error = unsafe {
+        sysctlbyname(
+            feature.as_ptr(),
+            &mut ret as *mut _ as *mut c_void,
+            &mut size,
+            core::ptr::null_mut(),
+            0,
+        )
+    };
+    error == 0 && ret > 0
+}
+
+#[inline(always)]
+fn sysctl() {
+    // hw.optional.AdvSIMD
+    const ADV_SIMD_STR: [i8; 20] = [
+        0x68, 0x77, 0x2e, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x2e, 0x41, 0x64, 0x76,
+        0x53, 0x49, 0x4d, 0x44, 0x00,
+    ];
+    if check(&ADV_SIMD_STR) {
+        unsafe { ADV_SIMD = true };
+    }
+
+    // hw.optional.arm.FEAT_AES
+    const FEAT_AES_STR: [i8; 25] = [
+        0x68, 0x77, 0x2e, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x2e, 0x61, 0x72, 0x6d,
+        0x2e, 0x46, 0x45, 0x41, 0x54, 0x5f, 0x41, 0x45, 0x53, 0x00,
+    ];
+    if check(&FEAT_AES_STR) {
+        unsafe { AES = true };
+    }
+
+    // hw.optional.arm.FEAT_PMULL
+    const FEAT_PMULL_STR: [i8; 27] = [
+        0x68, 0x77, 0x2e, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x2e, 0x61, 0x72, 0x6d,
+        0x2e, 0x46, 0x45, 0x41, 0x54, 0x5f, 0x50, 0x4d, 0x55, 0x4c, 0x4c, 0x00,
+    ];
+    if check(&FEAT_PMULL_STR) {
+        unsafe { PMULL = true };
+    }
+
+    // hw.optional.arm.FEAT_SHA256
+    const FEAT_SHA256_STR: [i8; 28] = [
+        0x68, 0x77, 0x2e, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x2e, 0x61, 0x72, 0x6d,
+        0x2e, 0x46, 0x45, 0x41, 0x54, 0x5f, 0x53, 0x48, 0x41, 0x32, 0x35, 0x36, 0x00,
+    ];
+    if check(&FEAT_SHA256_STR) {
+        unsafe { SHA256 = true };
+    }
+}
+
+static mut ADV_SIMD: bool = false;
+static mut AES: bool = false;
+static mut PMULL: bool = false;
+static mut SHA256: bool = false;
+
+#[inline(always)]
+pub(super) fn aes() -> bool {
+    init();
+    unsafe { AES }
+}
+
+#[inline(always)]
+pub(super) fn adv_simd() -> bool {
+    init();
+    unsafe { ADV_SIMD }
+}
+
+#[inline(always)]
+pub(super) fn pmull() -> bool {
+    init();
+    unsafe { PMULL }
+}
+
+#[inline(always)]
+pub(super) fn sha256() -> bool {
+    init();
+    unsafe { SHA256 }
+}
+
+static mut INITIALIZED: bool = false;
+
+/// Initialize CPU detection.
+#[inline(always)]
+pub(super) fn init() {
+    if unsafe { INITIALIZED } {
+        return;
+    }
+    // XXX[no_std]: no good way to do this in no_std
+    // let _ = std::panic::catch_unwind(|| {
+    // If there's no CPU ID because we're in SGX or whatever other reason,
+    // we'll consider the hw detection as initialized but always return false.
+    sysctl();
+    // });
+    unsafe {
+        INITIALIZED = true;
+    }
+}

--- a/sys/platform/src/macos_arm.rs
+++ b/sys/platform/src/macos_arm.rs
@@ -1,4 +1,4 @@
-/* Obtain particular CPU features for AArch64 on macOS */
+//! Obtain particular CPU features for AArch64 on macOS
 
 use libc::{c_void, sysctlbyname};
 

--- a/sys/platform/src/macos_arm.rs
+++ b/sys/platform/src/macos_arm.rs
@@ -1,3 +1,5 @@
+/* Obtain particular CPU features for AArch64 on macOS */
+
 use libc::{c_void, sysctlbyname};
 
 #[inline(always)]

--- a/sys/platform/src/test.rs
+++ b/sys/platform/src/test.rs
@@ -14,11 +14,6 @@ fn dump_features() {
     eprintln!("sha256\t\t{:?}", sha256_support());
 }
 
-// XXX[windows]: Something is running into a STATUS_ACCESS_VIOLATION here.
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    not(target_os = "windows")
-))]
 #[test]
 fn dump_raw() {
     use super::x86::{supported, Feature};
@@ -55,10 +50,6 @@ fn dump_raw() {
     eprintln!("avx512vl\t{:?}", supported(Feature::avx512vl));
 }
 
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    not(target_os = "windows")
-))]
 #[test]
 fn cpuid() {
     use super::x86::supported;

--- a/sys/platform/src/test.rs
+++ b/sys/platform/src/test.rs
@@ -1,3 +1,5 @@
+/* Test functions for CPU feature detection */
+
 use super::*;
 
 #[test]

--- a/sys/platform/src/test.rs
+++ b/sys/platform/src/test.rs
@@ -1,0 +1,84 @@
+use super::*;
+
+#[test]
+fn dump_features() {
+    eprintln!("simd128\t\t{:?}", simd128_support());
+    eprintln!("simd256\t\t{:?}", simd256_support());
+    eprintln!("x25519\t\t{:?}", x25519_support());
+    eprintln!("bmi2 & adx\t{:?}", bmi2_adx_support());
+    eprintln!("aes\t\t{:?}", aes_ni_support());
+    eprintln!("advSimd\t\t{:?}", adv_simd_support());
+    eprintln!("pmull\t\t{:?}", pmull_support());
+    eprintln!("sha256\t\t{:?}", sha256_support());
+}
+
+// XXX[windows]: Something is running into a STATUS_ACCESS_VIOLATION here.
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    not(target_os = "windows")
+))]
+#[test]
+fn dump_raw() {
+    use super::x86::{supported, Feature};
+    eprintln!("mmx\t\t{:?}", supported(Feature::mmx));
+    eprintln!("sse\t\t{:?}", supported(Feature::sse));
+    eprintln!("sse2\t\t{:?}", supported(Feature::sse2));
+    eprintln!("sse3\t\t{:?}", supported(Feature::sse3));
+    eprintln!("pclmulqdq\t{:?}", supported(Feature::pclmulqdq));
+    eprintln!("ssse3\t\t{:?}", supported(Feature::ssse3));
+    eprintln!("fma\t\t{:?}", supported(Feature::fma));
+    eprintln!("movbe\t\t{:?}", supported(Feature::movbe));
+    eprintln!("sse4_1\t\t{:?}", supported(Feature::sse4_1));
+    eprintln!("sse4_2\t\t{:?}", supported(Feature::sse4_2));
+    eprintln!("popcnt\t\t{:?}", supported(Feature::popcnt));
+    eprintln!("aes\t\t{:?}", supported(Feature::aes));
+    eprintln!("xsave\t\t{:?}", supported(Feature::xsave));
+    eprintln!("osxsave\t\t{:?}", supported(Feature::osxsave));
+    eprintln!("avx\t\t{:?}", supported(Feature::avx));
+    eprintln!("rdrand\t\t{:?}", supported(Feature::rdrand));
+    eprintln!("sgx\t\t{:?}", supported(Feature::sgx));
+    eprintln!("bmi1\t\t{:?}", supported(Feature::bmi1));
+    eprintln!("avx2\t\t{:?}", supported(Feature::avx2));
+    eprintln!("bmi2\t\t{:?}", supported(Feature::bmi2));
+    eprintln!("avx512f\t\t{:?}", supported(Feature::avx512f));
+    eprintln!("avx512dq\t{:?}", supported(Feature::avx512dq));
+    eprintln!("rdseed\t\t{:?}", supported(Feature::rdseed));
+    eprintln!("adx\t\t{:?}", supported(Feature::adx));
+    eprintln!("avx512ifma\t{:?}", supported(Feature::avx512ifma));
+    eprintln!("avx512pf\t{:?}", supported(Feature::avx512pf));
+    eprintln!("avx512er\t{:?}", supported(Feature::avx512er));
+    eprintln!("avx512cd\t{:?}", supported(Feature::avx512cd));
+    eprintln!("sha\t\t{:?}", supported(Feature::sha));
+    eprintln!("avx512bw\t{:?}", supported(Feature::avx512bw));
+    eprintln!("avx512vl\t{:?}", supported(Feature::avx512vl));
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    not(target_os = "windows")
+))]
+#[test]
+fn cpuid() {
+    use super::x86::supported;
+    use std::time::Instant;
+
+    let now = Instant::now();
+    let _avx2 = supported(Feature::avx2);
+    let elapsed = now.elapsed();
+    eprintln!("libcrux init: {elapsed:.2?}");
+
+    let now = Instant::now();
+    let _avx2 = supported(Feature::avx2);
+    let elapsed = now.elapsed();
+    eprintln!("libcrux after: {elapsed:.2?}");
+
+    let now = Instant::now();
+    let _avx2 = std::arch::is_x86_feature_detected!("avx2");
+    let elapsed = now.elapsed();
+    eprintln!("std init: {elapsed:.2?}");
+
+    let now = Instant::now();
+    let _avx2 = std::arch::is_x86_feature_detected!("avx2");
+    let elapsed = now.elapsed();
+    eprintln!("std after: {elapsed:.2?}");
+}

--- a/sys/platform/src/test.rs
+++ b/sys/platform/src/test.rs
@@ -1,4 +1,4 @@
-/* Test functions for CPU feature detection */
+//! Test functions for CPU feature detection
 
 use super::*;
 
@@ -14,6 +14,7 @@ fn dump_features() {
     eprintln!("sha256\t\t{:?}", sha256_support());
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[test]
 fn dump_raw() {
     use super::x86::{supported, Feature};
@@ -50,6 +51,7 @@ fn dump_raw() {
     eprintln!("avx512vl\t{:?}", supported(Feature::avx512vl));
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[test]
 fn cpuid() {
     use super::x86::supported;

--- a/sys/platform/src/x86.rs
+++ b/sys/platform/src/x86.rs
@@ -1,0 +1,140 @@
+#![allow(non_upper_case_globals)]
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{CpuidResult, __cpuid, __cpuid_count};
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::{CpuidResult, __cpuid, __cpuid_count};
+
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+pub(super) enum Feature {
+    mmx,
+    sse,
+    sse2,
+    sse3,
+    pclmulqdq,
+    ssse3,
+    fma,
+    movbe,
+    sse4_1,
+    sse4_2,
+    popcnt,
+    aes,
+    xsave,
+    osxsave,
+    avx,
+    rdrand,
+    sgx,
+    bmi1,
+    avx2,
+    bmi2,
+    avx512f,
+    avx512dq,
+    rdseed,
+    adx,
+    avx512ifma,
+    avx512pf,
+    avx512er,
+    avx512cd,
+    sha,
+    avx512bw,
+    avx512vl,
+}
+
+/// Check hardware [`Feature`] support.
+pub(super) fn supported(feature: Feature) -> bool {
+    init();
+    let cpu_id_0 = unsafe { CPU_ID[0] };
+    let cpu_id_1 = unsafe { CPU_ID[1] };
+    match feature {
+        Feature::mmx => cpu_id_0.edx & (1 << 23) != 0,
+        Feature::sse => cpu_id_0.edx & (1 << 25) != 0,
+        Feature::sse2 => cpu_id_0.edx & (1 << 26) != 0,
+        Feature::sse3 => cpu_id_0.ecx & (1 << 0) != 0,
+        Feature::pclmulqdq => cpu_id_0.ecx & (1 << 1) != 0,
+        Feature::ssse3 => cpu_id_0.ecx & (1 << 9) != 0,
+        Feature::fma => cpu_id_0.ecx & (1 << 12) != 0,
+        Feature::movbe => cpu_id_0.ecx & (1 << 22) != 0,
+        Feature::sse4_1 => cpu_id_0.ecx & (1 << 19) != 0,
+        Feature::sse4_2 => cpu_id_0.ecx & (1 << 20) != 0,
+        Feature::popcnt => cpu_id_0.ecx & (1 << 23) != 0,
+        Feature::aes => cpu_id_0.ecx & (1 << 25) != 0,
+        Feature::xsave => cpu_id_0.ecx & (1 << 26) != 0,
+        Feature::osxsave => cpu_id_0.ecx & (1 << 27) != 0,
+        Feature::avx => {
+            cpu_id_0.ecx & (1 << 28) != 0
+                && supported(Feature::xsave)
+                && supported(Feature::osxsave)
+        }
+        Feature::rdrand => cpu_id_0.ecx & (1 << 30) != 0,
+        Feature::sgx => cpu_id_1.ebx & (1 << 2) != 0,
+        Feature::bmi1 => cpu_id_1.ebx & (1 << 3) != 0,
+        Feature::avx2 => {
+            cpu_id_1.ebx & (1 << 5) != 0
+                && supported(Feature::bmi1)
+                && supported(Feature::bmi2)
+                && supported(Feature::fma)
+                && supported(Feature::movbe)
+        }
+        Feature::bmi2 => cpu_id_1.ebx & (1 << 8) != 0,
+        Feature::avx512f => cpu_id_1.ebx & (1 << 16) != 0,
+        Feature::avx512dq => cpu_id_1.ebx & (1 << 17) != 0,
+        Feature::rdseed => cpu_id_1.ebx & (1 << 18) != 0,
+        Feature::adx => cpu_id_1.ebx & (1 << 19) != 0,
+        Feature::avx512ifma => cpu_id_1.ebx & (1 << 21) != 0,
+        Feature::avx512pf => cpu_id_1.ebx & (1 << 26) != 0,
+        Feature::avx512er => cpu_id_1.ebx & (1 << 27) != 0,
+        Feature::avx512cd => cpu_id_1.ebx & (1 << 28) != 0,
+        Feature::sha => cpu_id_1.ebx & (1 << 29) != 0,
+        Feature::avx512bw => cpu_id_1.ebx & (1 << 30) != 0,
+        Feature::avx512vl => cpu_id_1.ebx & (1 << 31) != 0,
+    }
+}
+
+static mut CPU_ID: [CpuidResult; 2] = [
+    CpuidResult {
+        eax: 0,
+        ebx: 0,
+        ecx: 0,
+        edx: 0,
+    },
+    CpuidResult {
+        eax: 0,
+        ebx: 0,
+        ecx: 0,
+        edx: 0,
+    },
+];
+static mut INITIALIZED: bool = false;
+
+/// Initialize CPU detection.
+#[inline(always)]
+pub(super) fn init() {
+    if unsafe { INITIALIZED } {
+        return;
+    }
+
+    // XXX: https://github.com/rust-lang/rust/issues/101346
+    #[inline(never)]
+    unsafe fn cpuid(leaf: u32) -> CpuidResult {
+        __cpuid(leaf)
+    }
+
+    #[inline(never)]
+    unsafe fn cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
+        __cpuid_count(leaf, sub_leaf)
+    }
+
+    // XXX[no_std]: no good way to do this in no_std
+    // std::panic::catch_unwind(|| {
+    // If there's no CPU ID because we're in SGX or whatever other reason,
+    // we'll consider the hw detection as initialized but always return false.
+    unsafe {
+        CPU_ID = [cpuid(1), cpuid_count(7, 0)];
+    }
+    // });
+    unsafe {
+        INITIALIZED = true;
+    }
+}

--- a/sys/platform/src/x86.rs
+++ b/sys/platform/src/x86.rs
@@ -1,4 +1,4 @@
-/* Obtain particular CPU features for x86/x86_64 */
+//! Obtain particular CPU features for x86/x86_64
 
 #![allow(non_upper_case_globals)]
 

--- a/sys/platform/src/x86.rs
+++ b/sys/platform/src/x86.rs
@@ -1,3 +1,5 @@
+/* Obtain particular CPU features for x86/x86_64 */
+
 #![allow(non_upper_case_globals)]
 
 #[cfg(target_arch = "x86")]


### PR DESCRIPTION
The patch uses `cc` library to compile libjade instead of clang commands and create `libcrux_platform` package to detect cpu features.