### PR TITLE
Yet more kyber optimizations

### DIFF
--- a/src/kem/kyber768.rs
+++ b/src/kem/kyber768.rs
@@ -117,8 +117,7 @@ pub fn decapsulate(
         implicit_rejection_value.as_array()
     };
 
-    let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] =
-        to_hash.as_ref().to_padded_array();
+    let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = to_hash.as_ref().to_padded_array();
     to_hash[SHARED_SECRET_SIZE..].copy_from_slice(&H(&ciphertext));
 
     KDF(&to_hash)

--- a/src/kem/kyber768.rs
+++ b/src/kem/kyber768.rs
@@ -99,6 +99,17 @@ pub fn decapsulate(
         &pseudorandomness.as_array(),
     );
 
+    // Since we decrypt the ciphertext and hash this decrypted value in
+    // to obtain the pseudorandomness, it is in theory possible that a modified
+    // ciphertext could result in a set of pseudorandom bytes that are insufficient
+    // to rejection-sample the ring elements we need.
+    //
+    // In that case, the 'else' branch of this if-else block will be taken; notice
+    // that it performs less operations than the 'if' branch. The resulting timing
+    // difference would let an observer know that implicit rejection has taken
+    // place. We do not think this poses a security issue since such information
+    // would be conveyed anyway at a higher level (e.g. a key-exchange protocol
+    // would no longer proceed).
     let to_hash = if let Ok(expected_ciphertext) = expected_ciphertext_result {
         let selector = compare_ciphertexts_in_constant_time(&ciphertext, &expected_ciphertext);
         select_shared_secret_in_constant_time(k_not, implicit_rejection_value, selector)

--- a/src/kem/kyber768.rs
+++ b/src/kem/kyber768.rs
@@ -59,7 +59,7 @@ pub fn encapsulate(
 ) -> Result<(Kyber768Ciphertext, Kyber768SharedSecret), BadRejectionSamplingRandomnessError> {
     let randomness_hashed = H(&randomness);
 
-    let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = randomness_hashed.as_ref().into_padded_array();
+    let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = randomness_hashed.as_ref().to_padded_array();
     to_hash[H_DIGEST_SIZE..].copy_from_slice(&H(&public_key));
 
     let hashed = G(&to_hash);
@@ -68,7 +68,7 @@ pub fn encapsulate(
     let ciphertext =
         ind_cpa::encrypt(&public_key, randomness_hashed, &pseudorandomness.as_array())?;
 
-    let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = k_not.as_ref().into_padded_array();
+    let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = k_not.as_ref().to_padded_array();
     to_hash[H_DIGEST_SIZE..].copy_from_slice(&H(&ciphertext));
 
     let shared_secret: Kyber768SharedSecret = KDF(&to_hash);
@@ -87,7 +87,7 @@ pub fn decapsulate(
     let decrypted = ind_cpa::decrypt(&ind_cpa_secret_key.as_array(), &ciphertext);
 
     let mut to_hash: [u8; CPA_PKE_MESSAGE_SIZE + H_DIGEST_SIZE] =
-        decrypted.as_ref().into_padded_array();
+        decrypted.as_ref().to_padded_array();
     to_hash[CPA_PKE_MESSAGE_SIZE..].copy_from_slice(ind_cpa_public_key_hash);
 
     let hashed = G(&to_hash);
@@ -107,7 +107,7 @@ pub fn decapsulate(
     };
 
     let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] =
-        to_hash.as_ref().into_padded_array();
+        to_hash.as_ref().to_padded_array();
     to_hash[SHARED_SECRET_SIZE..].copy_from_slice(&H(&ciphertext));
 
     KDF(&to_hash)

--- a/src/kem/kyber768/arithmetic.rs
+++ b/src/kem/kyber768/arithmetic.rs
@@ -2,15 +2,14 @@ use std::ops::{self, Index, IndexMut};
 
 use crate::kem::kyber768::parameters::{COEFFICIENTS_IN_RING_ELEMENT, FIELD_MODULUS};
 
-pub(crate) type KyberFieldElement = i16;
+pub(crate) type KyberFieldElement = i32;
 
 const BARRETT_SHIFT: i32 = 26;
 const BARRETT_R: i32 = 1i32 << BARRETT_SHIFT;
 const BARRETT_MULTIPLIER: i32 = 20159; // floor((BARRETT_R / FIELD_MODULUS) + 0.5)
 
-pub(crate) fn barrett_reduce(value: i16) -> KyberFieldElement {
-    let quotient = (i32::from(value) * BARRETT_MULTIPLIER) + (BARRETT_R >> 1);
-    let quotient = (quotient >> BARRETT_SHIFT) as i16;
+pub(crate) fn barrett_reduce(value: KyberFieldElement) -> KyberFieldElement {
+    let quotient = ((value * BARRETT_MULTIPLIER) + (BARRETT_R >> 1)) >> BARRETT_SHIFT;
 
     value - (quotient * FIELD_MODULUS)
 }
@@ -19,19 +18,17 @@ const MONTGOMERY_SHIFT: i64 = 16;
 const MONTGOMERY_R: i64 = 1i64 << MONTGOMERY_SHIFT;
 const INVERSE_OF_MODULUS_MOD_R: i64 = -3327; // FIELD_MODULUS^{-1} mod MONTGOMERY_R
 
-pub(crate) fn montgomery_reduce(value: i32) -> KyberFieldElement {
+pub(crate) fn montgomery_reduce(value: KyberFieldElement) -> KyberFieldElement {
     let t: i64 = i64::from(value) * INVERSE_OF_MODULUS_MOD_R;
     let t: i32 = (t & (MONTGOMERY_R - 1)) as i32;
 
-    let t = value - (t * i32::from(FIELD_MODULUS));
-
-    (t >> MONTGOMERY_SHIFT) as i16
+    (value - (t * FIELD_MODULUS)) >> MONTGOMERY_SHIFT
 }
 
 // Given a |value|, return |value|*R mod q. Notice that montgomery_reduce
 // returns a value aR^{-1} mod q, and so montgomery_reduce(|value| * R^2)
 // returns |value| * R^2 & R^{-1} mod q  = |value| * R mod q.
-pub(crate) fn to_montgomery_domain(value: i32) -> KyberFieldElement {
+pub(crate) fn to_montgomery_domain(value: KyberFieldElement) -> KyberFieldElement {
     // R^2 mod q = (2^16)^2 mod 3329 = 1353
     montgomery_reduce(1353 * value)
 }
@@ -43,7 +40,7 @@ pub struct KyberPolynomialRingElement {
 
 impl KyberPolynomialRingElement {
     pub const ZERO: Self = Self {
-        coefficients: [0i16; COEFFICIENTS_IN_RING_ELEMENT],
+        coefficients: [0i32; COEFFICIENTS_IN_RING_ELEMENT],
     };
 }
 

--- a/src/kem/kyber768/compress.rs
+++ b/src/kem/kyber768/compress.rs
@@ -36,7 +36,7 @@ fn compress_q(fe: KyberFieldElement, to_bit_size: usize) -> KyberFieldElement {
     compressed += parameters::FIELD_MODULUS as u32;
     compressed /= (parameters::FIELD_MODULUS << 1) as u32;
 
-    (compressed & (two_pow_bit_size - 1)) as i16
+    (compressed & (two_pow_bit_size - 1)) as KyberFieldElement
 }
 
 fn decompress_q(fe: KyberFieldElement, to_bit_size: usize) -> KyberFieldElement {
@@ -46,5 +46,5 @@ fn decompress_q(fe: KyberFieldElement, to_bit_size: usize) -> KyberFieldElement 
     decompressed = (decompressed << 1) + (1 << to_bit_size);
     decompressed >>= to_bit_size + 1;
 
-    decompressed as i16
+    decompressed as KyberFieldElement
 }

--- a/src/kem/kyber768/constant_time_ops.rs
+++ b/src/kem/kyber768/constant_time_ops.rs
@@ -5,7 +5,7 @@ use crate::kem::kyber768::{CIPHERTEXT_SIZE, SHARED_SECRET_SIZE};
 
 #[inline]
 fn is_non_zero(value: u8) -> u8 {
-    let value_negated = -1 * (value as i8);
+    let value_negated = -(value as i8);
     ((value | (value_negated as u8)) >> 7) & 1
 }
 

--- a/src/kem/kyber768/conversions.rs
+++ b/src/kem/kyber768/conversions.rs
@@ -1,6 +1,6 @@
 pub trait ArrayConversion<const LEN: usize> {
     fn as_array(&self) -> [u8; LEN];
-    fn into_padded_array(&self) -> [u8; LEN];
+    fn to_padded_array(&self) -> [u8; LEN];
 }
 
 impl<const LEN: usize> ArrayConversion<LEN> for &[u8] {
@@ -8,7 +8,7 @@ impl<const LEN: usize> ArrayConversion<LEN> for &[u8] {
         self.to_vec().try_into().unwrap()
     }
 
-    fn into_padded_array(&self) -> [u8; LEN] {
+    fn to_padded_array(&self) -> [u8; LEN] {
         assert!(self.len() <= LEN);
         let mut out = [0u8; LEN];
         out[0..self.len()].copy_from_slice(self);
@@ -17,11 +17,11 @@ impl<const LEN: usize> ArrayConversion<LEN> for &[u8] {
 }
 
 pub trait ArrayPadding<const LEN: usize> {
-    fn into_padded_array<const OLEN: usize>(&self) -> [u8; OLEN];
+    fn to_padded_array<const OLEN: usize>(&self) -> [u8; OLEN];
 }
 
 impl<const LEN: usize> ArrayPadding<LEN> for &[u8; LEN] {
-    fn into_padded_array<const OLEN: usize>(&self) -> [u8; OLEN] {
+    fn to_padded_array<const OLEN: usize>(&self) -> [u8; OLEN] {
         assert!(self.len() <= OLEN);
         let mut out = [0u8; OLEN];
         out[0..self.len()].copy_from_slice(*self);

--- a/src/kem/kyber768/ind_cpa.rs
+++ b/src/kem/kyber768/ind_cpa.rs
@@ -126,7 +126,7 @@ pub(crate) fn generate_keypair(
     let hashed = G(key_generation_seed);
     let (seed_for_A, seed_for_secret_and_error) = hashed.split_at(32);
 
-    let A_transpose = parse_a(seed_for_A.into_padded_array(), true)?;
+    let A_transpose = parse_a(seed_for_A.to_padded_array(), true)?;
 
     // for i from 0 to k−1 do
     //     s[i] := CBD_{η1}(PRF(σ, N))
@@ -217,14 +217,14 @@ pub(crate) fn encrypt(
     //     end for
     // end for
     let seed = &public_key[T_AS_NTT_ENCODED_SIZE..];
-    let A_transpose = parse_a(seed.into_padded_array(), false)?;
+    let A_transpose = parse_a(seed.to_padded_array(), false)?;
 
     // for i from 0 to k−1 do
     //     r[i] := CBD{η1}(PRF(r, N))
     //     N := N + 1
     // end for
     // rˆ := NTT(r)
-    let mut prf_input: [u8; 33] = randomness.into_padded_array();
+    let mut prf_input: [u8; 33] = randomness.to_padded_array();
     let (r_as_ntt, mut domain_separator) = cbd(prf_input);
 
     // for i from 0 to k−1 do
@@ -265,7 +265,7 @@ pub(crate) fn encrypt(
     // c_2 := Encode_{dv}(Compress_q(v,d_v))
     let c2 = serialize_little_endian_4(compress(v, VECTOR_V_COMPRESSION_FACTOR));
 
-    let mut ciphertext: CiphertextCpa = (&c1).into_padded_array();
+    let mut ciphertext: CiphertextCpa = (&c1).to_padded_array();
     ciphertext[VECTOR_U_ENCODED_SIZE..].copy_from_slice(c2.as_slice());
 
     Ok(ciphertext)

--- a/src/kem/kyber768/ntt.rs
+++ b/src/kem/kyber768/ntt.rs
@@ -13,7 +13,7 @@ pub(crate) mod kyber_polynomial_ring_element_mod {
         parameters::COEFFICIENTS_IN_RING_ELEMENT,
     };
 
-    const ZETAS_MONTGOMERY_DOMAIN: [i32; 128] = [
+    const ZETAS_MONTGOMERY_DOMAIN: [KyberFieldElement; 128] = [
         -1044, -758, -359, -1517, 1493, 1422, 287, 202, -171, 622, 1577, 182, 962, -1202, -1474,
         1468, 573, -1325, 264, 383, -829, 1458, -1602, -130, -681, 1017, 732, 608, -1542, 411,
         -205, -1571, 1223, 652, -552, 1015, -1293, 1491, -282, -1544, 516, -8, -320, -666, -1618,
@@ -35,7 +35,7 @@ pub(crate) mod kyber_polynomial_ring_element_mod {
 
                 for j in offset..offset + layer {
                     let t = montgomery_reduce(
-                        i32::from(re[j + layer]) * ZETAS_MONTGOMERY_DOMAIN[zeta_i],
+                        re[j + layer] * ZETAS_MONTGOMERY_DOMAIN[zeta_i],
                     );
                     re[j + layer] = re[j] - t;
                     re[j] += t;
@@ -55,11 +55,11 @@ pub(crate) mod kyber_polynomial_ring_element_mod {
                 zeta_i -= 1;
 
                 for j in offset..offset + layer {
-                    let a_minus_b = (re[j + layer] - re[j]) as i32;
+                    let a_minus_b = re[j + layer] - re[j];
 
                     // Instead of dividing by 2 here, we just divide by
                     // 2^7 in one go in the end.
-                    re[j] = barrett_reduce(re[j] + re[j + layer]);
+                    re[j] = re[j] + re[j + layer];
                     re[j + layer] = montgomery_reduce(a_minus_b * ZETAS_MONTGOMERY_DOMAIN[zeta_i]);
                 }
             }
@@ -67,7 +67,7 @@ pub(crate) mod kyber_polynomial_ring_element_mod {
 
         re.coefficients = re
             .coefficients
-            .map(|coefficient| montgomery_reduce((coefficient as i32) * 1441))
+            .map(|coefficient| montgomery_reduce(coefficient * 1441))
             .map(barrett_reduce);
 
         re
@@ -78,15 +78,9 @@ pub(crate) mod kyber_polynomial_ring_element_mod {
         (b0, b1): (KyberFieldElement, KyberFieldElement),
         zeta: i32,
     ) -> (KyberFieldElement, KyberFieldElement) {
-        let a0 = a0 as i32;
-        let a1 = a1 as i32;
-
-        let b0 = b0 as i32;
-        let b1 = b1 as i32;
-
         (
             montgomery_reduce(a0 * b0)
-                + montgomery_reduce((montgomery_reduce(a1 * b1) as i32) * zeta),
+                + montgomery_reduce(montgomery_reduce(a1 * b1) * zeta),
             montgomery_reduce(a0 * b1) + montgomery_reduce(a1 * b0),
         )
     }
@@ -154,9 +148,9 @@ pub(crate) fn multiply_matrix_by_column_montgomery(
 
 // NOTE: This function performs matrix multiplication, then conversion from the
 // montgomery domain, and last barrett reduction. It is only used in
-// ind_cpa::generate_keypair(). (TODO: Verify this) Doing barrett reduction after
-// conversion from montgomery form lets us skip an extra barrett_reduction step
-// in generate_keypair.
+// ind_cpa::generate_keypair(). (TODO: Verify this) Doing barrett reduction in
+// this function after conversion from montgomery form lets us skip an extra
+// barrett reduction step in generate_keypair itself.
 pub(crate) fn multiply_matrix_by_column(
     matrix: &[[KyberPolynomialRingElement; RANK]; RANK],
     vector: &[KyberPolynomialRingElement; RANK],
@@ -173,7 +167,7 @@ pub(crate) fn multiply_matrix_by_column(
         // calling to_montgomery_domain() on them should return a mod q.
         result[i].coefficients = result[i]
             .coefficients
-            .map(|coefficient| to_montgomery_domain(coefficient as i32))
+            .map(|coefficient| to_montgomery_domain(coefficient))
             .map(barrett_reduce);
     }
 

--- a/src/kem/kyber768/ntt.rs
+++ b/src/kem/kyber768/ntt.rs
@@ -34,9 +34,7 @@ pub(crate) mod kyber_polynomial_ring_element_mod {
                 zeta_i += 1;
 
                 for j in offset..offset + layer {
-                    let t = montgomery_reduce(
-                        re[j + layer] * ZETAS_MONTGOMERY_DOMAIN[zeta_i],
-                    );
+                    let t = montgomery_reduce(re[j + layer] * ZETAS_MONTGOMERY_DOMAIN[zeta_i]);
                     re[j + layer] = re[j] - t;
                     re[j] += t;
                 }
@@ -79,8 +77,7 @@ pub(crate) mod kyber_polynomial_ring_element_mod {
         zeta: i32,
     ) -> (KyberFieldElement, KyberFieldElement) {
         (
-            montgomery_reduce(a0 * b0)
-                + montgomery_reduce(montgomery_reduce(a1 * b1) * zeta),
+            montgomery_reduce(a0 * b0) + montgomery_reduce(montgomery_reduce(a1 * b1) * zeta),
             montgomery_reduce(a0 * b1) + montgomery_reduce(a1 * b0),
         )
     }
@@ -165,12 +162,10 @@ pub(crate) fn multiply_matrix_by_column(
 
         // The coefficients of the form aR^{-1} mod q, which means
         // calling to_montgomery_domain() on them should return a mod q.
-        result[i].coefficients = result[i]
-            .coefficients
-            .map(|coefficient| {
-                let coefficient_montgomery = to_montgomery_domain(coefficient);
-                barrett_reduce(coefficient_montgomery)
-            });
+        result[i].coefficients = result[i].coefficients.map(|coefficient| {
+            let coefficient_montgomery = to_montgomery_domain(coefficient);
+            barrett_reduce(coefficient_montgomery)
+        });
     }
 
     result

--- a/src/kem/kyber768/ntt.rs
+++ b/src/kem/kyber768/ntt.rs
@@ -58,7 +58,7 @@ pub(crate) mod kyber_polynomial_ring_element_mod {
                     let a_minus_b = (re[j + layer] - re[j]) as i32;
 
                     // Instead of dividing by 2 here, we just divide by
-                    // 2^7 at once in the end.
+                    // 2^7 in one go in the end.
                     re[j] = barrett_reduce(re[j] + re[j + layer]);
                     re[j + layer] = montgomery_reduce(a_minus_b * ZETAS_MONTGOMERY_DOMAIN[zeta_i]);
                 }

--- a/src/kem/kyber768/ntt.rs
+++ b/src/kem/kyber768/ntt.rs
@@ -167,8 +167,10 @@ pub(crate) fn multiply_matrix_by_column(
         // calling to_montgomery_domain() on them should return a mod q.
         result[i].coefficients = result[i]
             .coefficients
-            .map(|coefficient| to_montgomery_domain(coefficient))
-            .map(barrett_reduce);
+            .map(|coefficient| {
+                let coefficient_montgomery = to_montgomery_domain(coefficient);
+                barrett_reduce(coefficient_montgomery)
+            });
     }
 
     result

--- a/src/kem/kyber768/parameters.rs
+++ b/src/kem/kyber768/parameters.rs
@@ -1,5 +1,5 @@
 /// Field modulus: 3329
-pub(crate) const FIELD_MODULUS: i16 = 3329;
+pub(crate) const FIELD_MODULUS: i32 = 3329;
 
 /// Each field element needs floor(log_2(FIELD_MODULUS)) + 1 = 12 bits to represent
 pub(crate) const BITS_PER_COEFFICIENT: usize = 12;

--- a/src/kem/kyber768/sampling.rs
+++ b/src/kem/kyber768/sampling.rs
@@ -1,5 +1,5 @@
 use crate::kem::kyber768::{
-    arithmetic::KyberPolynomialRingElement,
+    arithmetic::{KyberFieldElement, KyberPolynomialRingElement},
     parameters::{COEFFICIENTS_IN_RING_ELEMENT, FIELD_MODULUS, REJECTION_SAMPLING_SEED_SIZE},
     BadRejectionSamplingRandomnessError,
 };
@@ -11,9 +11,9 @@ pub fn sample_from_uniform_distribution(
     let mut out: KyberPolynomialRingElement = KyberPolynomialRingElement::ZERO;
 
     for bytes in randomness.chunks(3) {
-        let b1 = bytes[0] as i16;
-        let b2 = bytes[1] as i16;
-        let b3 = bytes[2] as i16;
+        let b1 = bytes[0] as i32;
+        let b2 = bytes[1] as i32;
+        let b3 = bytes[2] as i32;
 
         let d1 = ((b2 & 0xF) << 8) | b1;
         let d2 = (b3 << 4) | (b2 >> 4);
@@ -83,8 +83,8 @@ pub fn sample_from_binomial_distribution_2(randomness: [u8; 128]) -> KyberPolyno
         let coin_toss_outcomes = even_bits + odd_bits;
 
         for outcome_set in (0..u32::BITS).step_by(4) {
-            let outcome_1 = ((coin_toss_outcomes >> outcome_set) & 0x3) as i16;
-            let outcome_2 = ((coin_toss_outcomes >> (outcome_set + 2)) & 0x3) as i16;
+            let outcome_1 = ((coin_toss_outcomes >> outcome_set) & 0x3) as KyberFieldElement;
+            let outcome_2 = ((coin_toss_outcomes >> (outcome_set + 2)) & 0x3) as KyberFieldElement;
 
             let offset = (outcome_set >> 2) as usize;
             sampled[8 * chunk_number + offset] = outcome_1 - outcome_2;

--- a/src/kem/kyber768/serialize.rs
+++ b/src/kem/kyber768/serialize.rs
@@ -1,5 +1,5 @@
 use crate::kem::kyber768::{
-    arithmetic::KyberPolynomialRingElement,
+    arithmetic::{KyberFieldElement, KyberPolynomialRingElement},
     parameters::{BYTES_PER_RING_ELEMENT, COEFFICIENTS_IN_RING_ELEMENT, FIELD_MODULUS},
 };
 
@@ -59,7 +59,7 @@ pub fn deserialize_little_endian_1(serialized: &[u8]) -> KyberPolynomialRingElem
 
     for (i, byte) in serialized.iter().enumerate() {
         for j in 0..8 {
-            re.coefficients[8 * i + j] = ((byte >> j) & 0x1) as i16;
+            re.coefficients[8 * i + j] = ((byte >> j) & 0x1) as KyberFieldElement;
         }
     }
 
@@ -86,8 +86,8 @@ pub fn deserialize_little_endian_4(serialized: &[u8]) -> KyberPolynomialRingElem
     let mut re = KyberPolynomialRingElement::ZERO;
 
     for (i, byte) in serialized.iter().enumerate() {
-        re.coefficients[2 * i] = (byte & 0x0F) as i16;
-        re.coefficients[2 * i + 1] = ((byte >> 4) & 0x0F) as i16;
+        re.coefficients[2 * i] = (byte & 0x0F) as KyberFieldElement;
+        re.coefficients[2 * i + 1] = ((byte >> 4) & 0x0F) as KyberFieldElement;
     }
 
     re
@@ -122,11 +122,11 @@ pub fn deserialize_little_endian_10(serialized: &[u8]) -> KyberPolynomialRingEle
     let mut re = KyberPolynomialRingElement::ZERO;
 
     for (i, bytes) in serialized.chunks(5).enumerate() {
-        let byte1 = bytes[0] as i16;
-        let byte2 = bytes[1] as i16;
-        let byte3 = bytes[2] as i16;
-        let byte4 = bytes[3] as i16;
-        let byte5 = bytes[4] as i16;
+        let byte1 = bytes[0] as KyberFieldElement;
+        let byte2 = bytes[1] as KyberFieldElement;
+        let byte3 = bytes[2] as KyberFieldElement;
+        let byte4 = bytes[3] as KyberFieldElement;
+        let byte5 = bytes[4] as KyberFieldElement;
 
         re.coefficients[4 * i] = (byte2 & 0x03) << 8 | (byte1 & 0xFF);
         re.coefficients[4 * i + 1] = (byte3 & 0x0F) << 6 | (byte2 >> 2);
@@ -160,9 +160,9 @@ pub fn deserialize_little_endian_12(serialized: &[u8]) -> KyberPolynomialRingEle
     let mut re = KyberPolynomialRingElement::ZERO;
 
     for (i, bytes) in serialized.chunks_exact(3).enumerate() {
-        let byte1 = bytes[0] as i16;
-        let byte2 = bytes[1] as i16;
-        let byte3 = bytes[2] as i16;
+        let byte1 = bytes[0] as KyberFieldElement;
+        let byte2 = bytes[1] as KyberFieldElement;
+        let byte3 = bytes[2] as KyberFieldElement;
 
         re.coefficients[2 * i] = (byte2 & 0x0F) << 8 | (byte1 & 0xFF);
         re.coefficients[2 * i + 1] = (byte3 << 4) | ((byte2 >> 4) & 0x0F);


### PR DESCRIPTION
- Where possible, after matrix/vector multiplication, leave the result in montgomery form and convert it back to normal form after the inverse NTT
- Use i32s instead of i16s for field elements
- Applied some changes suggested by `cargo clippy`