### PR TITLE
Only Enable aes-ni configuration on x86_64/x86

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,7 @@ fn main() {
         println!("cargo:rustc-cfg=bmi2");
         println!("cargo:rustc-cfg=adx");
     }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if aes_ni_support() {
         println!("cargo:rustc-cfg=aes_ni");
     }


### PR DESCRIPTION
Some functions in `aead.rs` don't support `aarch64` yet, this patch only enables `aes-ni` configuration on `x86_64/x86` architectures.