### PR TITLE
Compile Vale AESGCM in hacl

### DIFF
--- a/sys/hacl/build.rs
+++ b/sys/hacl/build.rs
@@ -30,13 +30,25 @@ fn includes(home_dir: &Path, include_str: &str) -> Vec<String> {
     ]
 }
 
+fn append_vale_include_dir(home_dir: &Path, include_str: &str, include_dirs: &mut Vec<String>) {
+    let c_path = home_dir.join("c");
+    include_dirs.push(format!(
+        "{}{}",
+        include_str,
+        c_path.join("vale").join("include").display()
+    ));
+}
+
+fn append_aesgcm_flags(flags: &mut Vec<String>) {
+    if cfg!(not(target_env = "msvc")) {
+        flags.push("-maes".to_string());
+        flags.push("-mpclmul".to_string());
+    }
+}
+
 fn append_simd128_flags(flags: &mut Vec<String>, is_bindgen: bool) {
-    if is_bindgen
-        || cfg!(all(
-            any(target_arch = "x86", target_arch = "x86_64"),
-            not(target_env = "msvc")
-        ))
-    {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_bindgen || cfg!(not(target_env = "msvc")) {
         flags.push("-msse4.1".to_string());
         flags.push("-msse4.2".to_string());
         flags.push("-mavx".to_string());
@@ -53,6 +65,22 @@ fn create_bindings(platform: Platform, home_dir: &Path) {
     let mut clang_args = includes(home_dir, "-I");
 
     let mut bindings = bindgen::Builder::default();
+
+    #[cfg(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        any(
+            target_os = "linux",
+            target_os = "macos",
+            all(target_os = "windows", any(target_env = "msvc", target_env = "gnu"))
+        )
+    ))]
+    if platform.simd128 && platform.aes_ni && platform.pmull {
+        append_vale_include_dir(home_dir, "-I", &mut clang_args);
+        bindings = bindings
+            // Header to wrap Vale header
+            .header("c/config/vale-aes.h");
+    }
+
     bindings = bindings
         // Header to wrap HACL headers
         .header("c/config/hacl.h");
@@ -90,6 +118,11 @@ fn create_bindings(platform: Platform, home_dir: &Path) {
         .allowlist_function("Hacl_HMAC_.*")
         .allowlist_function("Hacl_P256_.*")
         .allowlist_function("EverCrypt_AEAD_.*")
+        .allowlist_function("aes128_.*")
+        .allowlist_function("aes256_.*")
+        .allowlist_function("gcm128_.*")
+        .allowlist_function("gcm256_.*")
+        .allowlist_function("compute_iv_stdcall")
         .allowlist_type("Spec_.*")
         .allowlist_type("Hacl_Streaming_SHA2.*")
         .allowlist_type("Hacl_HMAC_DRBG.*")
@@ -121,11 +154,17 @@ fn compile_files(
     home_path: &Path,
     args: &[String],
     defines: &[(&str, &str)],
+    is_vale: bool,
 ) {
-    let mut src_prefix = home_path.join("c").join("src");
-    if cfg!(target_env = "msvc") {
-        src_prefix = src_prefix.join("msvc");
-    }
+    let src_prefix = if is_vale {
+        home_path.join("c").join("vale").join("src")
+    } else {
+        if cfg!(target_env = "msvc") {
+            home_path.join("c").join("src").join("msvc")
+        } else {
+            home_path.join("c").join("src")
+        }
+    };
 
     let mut build = cc::Build::new();
     build
@@ -133,7 +172,11 @@ fn compile_files(
         // XXX: There are too many warnings for now
         .warnings(false);
 
-    for include in includes(home_path, "") {
+    let mut include_dirs = includes(home_path, "");
+    if is_vale {
+        append_vale_include_dir(home_path, "", &mut include_dirs);
+    }
+    for include in include_dirs {
         build.include(include);
     }
     build.opt_level(3);
@@ -190,6 +233,38 @@ fn build(platform: Platform, home_path: &Path) {
     let mut defines = vec![];
 
     // Platform detection
+    #[cfg(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        any(
+            target_os = "linux",
+            target_os = "macos",
+            all(target_os = "windows", any(target_env = "msvc", target_env = "gnu"))
+        )
+    ))]
+    if platform.simd128 && platform.aes_ni && platform.pmull {
+        let mut files_aesgcm = vec![];
+        if cfg!(target_os = "linux") {
+            files_aesgcm.push("aesgcm-x86_64-linux.S".to_string())
+        } else if cfg!(all(target_os = "windows", target_env = "msvc")) {
+            files_aesgcm.push("aesgcm-x86_64-msvc.asm".to_string())
+        } else if cfg!(all(target_os = "windows", target_env = "gnu")) {
+            files_aesgcm.push("aesgcm-x86_64-mingw.S".to_string())
+        } else if cfg!(target_os = "macos") {
+            files_aesgcm.push("aesgcm-x86_64-darwin.S".to_string())
+        }
+
+        let mut aesgcm_flags = vec![];
+        append_simd128_flags(&mut aesgcm_flags, false);
+        append_aesgcm_flags(&mut aesgcm_flags);
+        compile_files(
+            "libhacl_aesgcm.a",
+            &files_aesgcm,
+            home_path,
+            &aesgcm_flags,
+            &defines,
+            true,
+        );
+    }
     if platform.simd128 {
         let files128 = svec![
             "Hacl_Hash_Blake2s_128.c",
@@ -215,6 +290,7 @@ fn build(platform: Platform, home_path: &Path) {
             home_path,
             &simd128_flags,
             &defines,
+            false,
         );
     }
     if platform.simd256 {
@@ -239,10 +315,11 @@ fn build(platform: Platform, home_path: &Path) {
             home_path,
             &simd256_flags,
             &defines,
+            false,
         );
     }
 
-    compile_files("libhacl.a", &files, home_path, &[], &defines);
+    compile_files("libhacl.a", &files, home_path, &[], &defines, false);
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -297,6 +374,17 @@ fn main() {
     }
     if platform.simd256 {
         println!("cargo:rustc-link-lib={}={}", MODE, "hacl_256");
+    }
+    #[cfg(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        any(
+            target_os = "linux",
+            target_os = "macos",
+            all(target_os = "windows", any(target_env = "msvc", target_env = "gnu"))
+        )
+    ))]
+    if platform.simd128 && platform.aes_ni && platform.pmull {
+        println!("cargo:rustc-link-lib={}={}", MODE, "hacl_aesgcm");
     }
     println!("cargo:rustc-link-search=native={}", out_path.display());
     println!("cargo:lib={}", out_path.display());

--- a/sys/hacl/build.rs
+++ b/sys/hacl/build.rs
@@ -35,6 +35,14 @@ fn includes(home_dir: &Path, include_str: &str) -> Vec<String> {
     ]
 }
 
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    any(
+        target_os = "linux",
+        target_os = "macos",
+        all(target_os = "windows", any(target_env = "msvc", target_env = "gnu"))
+    )
+))]
 fn append_aesgcm_flags(flags: &mut Vec<String>) {
     if cfg!(not(target_env = "msvc")) {
         flags.push("-maes".to_string());
@@ -43,8 +51,9 @@ fn append_aesgcm_flags(flags: &mut Vec<String>) {
 }
 
 fn append_simd128_flags(flags: &mut Vec<String>, is_bindgen: bool) {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    if is_bindgen || cfg!(not(target_env = "msvc")) {
+    if cfg!(any(target_arch = "x86", target_arch = "x86_64"))
+        && (is_bindgen || cfg!(not(target_env = "msvc")))
+    {
         flags.push("-msse4.1".to_string());
         flags.push("-msse4.2".to_string());
         flags.push("-mavx".to_string());

--- a/sys/hacl/c/config/vale-aes.h
+++ b/sys/hacl/c/config/vale-aes.h
@@ -5,4 +5,4 @@
 
 #include "config.h"
 
-#include "EverCrypt_AEAD.h"
+#include "Vale.h"

--- a/sys/hacl/c/vale/include/Vale.h
+++ b/sys/hacl/c/vale/include/Vale.h
@@ -1,0 +1,145 @@
+/* MIT License
+ *
+ * Copyright (c) 2016-2022 INRIA, CMU and Microsoft Corporation
+ * Copyright (c) 2022-2023 HACL* Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifndef __internal_Vale_H
+#define __internal_Vale_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <string.h>
+#include "krml/internal/types.h"
+#include "krml/lowstar_endianness.h"
+#include "krml/internal/target.h"
+
+extern uint64_t
+gcm128_decrypt_opt(
+  uint8_t *x0,
+  uint64_t x1,
+  uint64_t x2,
+  uint8_t *x3,
+  uint8_t *x4,
+  uint8_t *x5,
+  uint8_t *x6,
+  uint8_t *x7,
+  uint8_t *x8,
+  uint64_t x9,
+  uint8_t *x10,
+  uint8_t *x11,
+  uint64_t x12,
+  uint8_t *x13,
+  uint64_t x14,
+  uint8_t *x15,
+  uint8_t *x16
+);
+
+extern uint64_t
+gcm256_decrypt_opt(
+  uint8_t *x0,
+  uint64_t x1,
+  uint64_t x2,
+  uint8_t *x3,
+  uint8_t *x4,
+  uint8_t *x5,
+  uint8_t *x6,
+  uint8_t *x7,
+  uint8_t *x8,
+  uint64_t x9,
+  uint8_t *x10,
+  uint8_t *x11,
+  uint64_t x12,
+  uint8_t *x13,
+  uint64_t x14,
+  uint8_t *x15,
+  uint8_t *x16
+);
+
+extern uint64_t aes128_key_expansion(uint8_t *x0, uint8_t *x1);
+
+extern uint64_t aes256_key_expansion(uint8_t *x0, uint8_t *x1);
+
+extern uint64_t
+compute_iv_stdcall(
+  uint8_t *x0,
+  uint64_t x1,
+  uint64_t x2,
+  uint8_t *x3,
+  uint8_t *x4,
+  uint8_t *x5
+);
+
+extern uint64_t
+gcm128_encrypt_opt(
+  uint8_t *x0,
+  uint64_t x1,
+  uint64_t x2,
+  uint8_t *x3,
+  uint8_t *x4,
+  uint8_t *x5,
+  uint8_t *x6,
+  uint8_t *x7,
+  uint8_t *x8,
+  uint64_t x9,
+  uint8_t *x10,
+  uint8_t *x11,
+  uint64_t x12,
+  uint8_t *x13,
+  uint64_t x14,
+  uint8_t *x15,
+  uint8_t *x16
+);
+
+extern uint64_t
+gcm256_encrypt_opt(
+  uint8_t *x0,
+  uint64_t x1,
+  uint64_t x2,
+  uint8_t *x3,
+  uint8_t *x4,
+  uint8_t *x5,
+  uint8_t *x6,
+  uint8_t *x7,
+  uint8_t *x8,
+  uint64_t x9,
+  uint8_t *x10,
+  uint8_t *x11,
+  uint64_t x12,
+  uint8_t *x13,
+  uint64_t x14,
+  uint8_t *x15,
+  uint8_t *x16
+);
+
+extern uint64_t aes128_keyhash_init(uint8_t *x0, uint8_t *x1);
+
+extern uint64_t aes256_keyhash_init(uint8_t *x0, uint8_t *x1);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#define __internal_Vale_H_DEFINED
+#endif

--- a/sys/hacl/c/vale/src/aesgcm-x86_64-darwin.S
+++ b/sys/hacl/c/vale/src/aesgcm-x86_64-darwin.S
@@ -1,0 +1,8101 @@
+.text
+.global _aes128_key_expansion
+_aes128_key_expansion:
+  movdqu 0(%rdi), %xmm1
+  mov %rsi, %rdx
+  movdqu %xmm1, 0(%rdx)
+  aeskeygenassist $1, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 16(%rdx)
+  aeskeygenassist $2, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 32(%rdx)
+  aeskeygenassist $4, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 48(%rdx)
+  aeskeygenassist $8, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 64(%rdx)
+  aeskeygenassist $16, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 80(%rdx)
+  aeskeygenassist $32, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 96(%rdx)
+  aeskeygenassist $64, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 112(%rdx)
+  aeskeygenassist $128, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 128(%rdx)
+  aeskeygenassist $27, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 144(%rdx)
+  aeskeygenassist $54, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 160(%rdx)
+  pxor %xmm1, %xmm1
+  pxor %xmm2, %xmm2
+  pxor %xmm3, %xmm3
+  ret
+
+.global _aes128_keyhash_init
+_aes128_keyhash_init:
+  mov $579005069656919567, %r8
+  pinsrq $0, %r8, %xmm4
+  mov $283686952306183, %r8
+  pinsrq $1, %r8, %xmm4
+  pxor %xmm0, %xmm0
+  movdqu %xmm0, 80(%rsi)
+  mov %rdi, %r8
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm4, %xmm0
+  mov %rsi, %rcx
+  movdqu %xmm0, 32(%rcx)
+  movdqu %xmm6, %xmm0
+  mov %r12, %rax
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 0(%rcx)
+  movdqu %xmm6, %xmm1
+  movdqu %xmm6, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 16(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 48(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 64(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 96(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 112(%rcx)
+  movdqu %xmm0, %xmm6
+  mov %rax, %r12
+  ret
+
+.global _aes256_key_expansion
+_aes256_key_expansion:
+  movdqu 0(%rdi), %xmm1
+  movdqu 16(%rdi), %xmm3
+  mov %rsi, %rdx
+  movdqu %xmm1, 0(%rdx)
+  movdqu %xmm3, 16(%rdx)
+  aeskeygenassist $1, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 32(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 48(%rdx)
+  aeskeygenassist $2, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 64(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 80(%rdx)
+  aeskeygenassist $4, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 96(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 112(%rdx)
+  aeskeygenassist $8, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 128(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 144(%rdx)
+  aeskeygenassist $16, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 160(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 176(%rdx)
+  aeskeygenassist $32, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 192(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 208(%rdx)
+  aeskeygenassist $64, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 224(%rdx)
+  pxor %xmm1, %xmm1
+  pxor %xmm2, %xmm2
+  pxor %xmm3, %xmm3
+  pxor %xmm4, %xmm4
+  ret
+
+.global _aes256_keyhash_init
+_aes256_keyhash_init:
+  mov $579005069656919567, %r8
+  pinsrq $0, %r8, %xmm4
+  mov $283686952306183, %r8
+  pinsrq $1, %r8, %xmm4
+  pxor %xmm0, %xmm0
+  movdqu %xmm0, 80(%rsi)
+  mov %rdi, %r8
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm4, %xmm0
+  mov %rsi, %rcx
+  movdqu %xmm0, 32(%rcx)
+  movdqu %xmm6, %xmm0
+  mov %r12, %rax
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 0(%rcx)
+  movdqu %xmm6, %xmm1
+  movdqu %xmm6, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 16(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 48(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 64(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 96(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 112(%rcx)
+  movdqu %xmm0, %xmm6
+  mov %rax, %r12
+  ret
+
+.global _gctr128_bytes
+_gctr128_bytes:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  movdqu 0(%r9), %xmm7
+  mov %rdi, %rax
+  mov %rdx, %rbx
+  mov %rcx, %r13
+  mov 72(%rsp), %rcx
+  mov %rcx, %rbp
+  imul $16, %rbp
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm8
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm8
+  mov %rcx, %rdx
+  shr $2, %rdx
+  and $3, %rcx
+  cmp $0, %rdx
+  jbe L0
+  mov %rax, %r9
+  mov %rbx, %r10
+  pshufb %xmm8, %xmm7
+  movdqu %xmm7, %xmm9
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pshufb %xmm0, %xmm9
+  movdqu %xmm9, %xmm10
+  pxor %xmm3, %xmm3
+  mov $1, %rax
+  pinsrd $2, %eax, %xmm3
+  paddd %xmm3, %xmm9
+  mov $3, %rax
+  pinsrd $2, %eax, %xmm3
+  mov $2, %rax
+  pinsrd $0, %eax, %xmm3
+  paddd %xmm3, %xmm10
+  pshufb %xmm8, %xmm9
+  pshufb %xmm8, %xmm10
+  pextrq $0, %xmm7, %rdi
+  mov $283686952306183, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pxor %xmm15, %xmm15
+  mov $4, %rax
+  pinsrd $0, %eax, %xmm15
+  mov $4, %rax
+  pinsrd $2, %eax, %xmm15
+  jmp L3
+.balign 16
+L2:
+  pinsrq $0, %rdi, %xmm2
+  pinsrq $0, %rdi, %xmm12
+  pinsrq $0, %rdi, %xmm13
+  pinsrq $0, %rdi, %xmm14
+  shufpd $2, %xmm9, %xmm2
+  shufpd $0, %xmm9, %xmm12
+  shufpd $2, %xmm10, %xmm13
+  shufpd $0, %xmm10, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  movdqu 0(%r8), %xmm3
+  movdqu 16(%r8), %xmm4
+  movdqu 32(%r8), %xmm5
+  movdqu 48(%r8), %xmm6
+  paddd %xmm15, %xmm9
+  paddd %xmm15, %xmm10
+  pxor %xmm3, %xmm2
+  pxor %xmm3, %xmm12
+  pxor %xmm3, %xmm13
+  pxor %xmm3, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 64(%r8), %xmm3
+  movdqu 80(%r8), %xmm4
+  movdqu 96(%r8), %xmm5
+  movdqu 112(%r8), %xmm6
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 128(%r8), %xmm3
+  movdqu 144(%r8), %xmm4
+  movdqu 160(%r8), %xmm5
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenclast %xmm5, %xmm2
+  aesenclast %xmm5, %xmm12
+  aesenclast %xmm5, %xmm13
+  aesenclast %xmm5, %xmm14
+  movdqu 0(%r9), %xmm7
+  pxor %xmm7, %xmm2
+  movdqu 16(%r9), %xmm7
+  pxor %xmm7, %xmm12
+  movdqu 32(%r9), %xmm7
+  pxor %xmm7, %xmm13
+  movdqu 48(%r9), %xmm7
+  pxor %xmm7, %xmm14
+  movdqu %xmm2, 0(%r10)
+  movdqu %xmm12, 16(%r10)
+  movdqu %xmm13, 32(%r10)
+  movdqu %xmm14, 48(%r10)
+  sub $1, %rdx
+  add $64, %r9
+  add $64, %r10
+.balign 16
+L3:
+  cmp $0, %rdx
+  ja L2
+  movdqu %xmm9, %xmm7
+  pinsrq $0, %rdi, %xmm7
+  pshufb %xmm8, %xmm7
+  mov %r9, %rax
+  mov %r10, %rbx
+  jmp L1
+L0:
+L1:
+  mov $0, %rdx
+  mov %rax, %r9
+  mov %rbx, %r10
+  pxor %xmm4, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  jmp L5
+.balign 16
+L4:
+  movdqu %xmm7, %xmm0
+  pshufb %xmm8, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r9), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rdx
+  add $16, %r9
+  add $16, %r10
+  paddd %xmm4, %xmm7
+.balign 16
+L5:
+  cmp %rcx, %rdx
+  jne L4
+  cmp %rbp, %rsi
+  jbe L6
+  movdqu 0(%r13), %xmm1
+  movdqu %xmm7, %xmm0
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm2
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm2
+  pshufb %xmm2, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm1
+  movdqu %xmm1, 0(%r13)
+  jmp L7
+L6:
+L7:
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global _gctr256_bytes
+_gctr256_bytes:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  movdqu 0(%r9), %xmm7
+  mov %rdi, %rax
+  mov %rdx, %rbx
+  mov %rcx, %r13
+  mov 72(%rsp), %rcx
+  mov %rcx, %rbp
+  imul $16, %rbp
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm8
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm8
+  mov %rcx, %rdx
+  shr $2, %rdx
+  and $3, %rcx
+  cmp $0, %rdx
+  jbe L8
+  mov %rax, %r9
+  mov %rbx, %r10
+  pshufb %xmm8, %xmm7
+  movdqu %xmm7, %xmm9
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pshufb %xmm0, %xmm9
+  movdqu %xmm9, %xmm10
+  pxor %xmm3, %xmm3
+  mov $1, %rax
+  pinsrd $2, %eax, %xmm3
+  paddd %xmm3, %xmm9
+  mov $3, %rax
+  pinsrd $2, %eax, %xmm3
+  mov $2, %rax
+  pinsrd $0, %eax, %xmm3
+  paddd %xmm3, %xmm10
+  pshufb %xmm8, %xmm9
+  pshufb %xmm8, %xmm10
+  pextrq $0, %xmm7, %rdi
+  mov $283686952306183, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pxor %xmm15, %xmm15
+  mov $4, %rax
+  pinsrd $0, %eax, %xmm15
+  mov $4, %rax
+  pinsrd $2, %eax, %xmm15
+  jmp L11
+.balign 16
+L10:
+  pinsrq $0, %rdi, %xmm2
+  pinsrq $0, %rdi, %xmm12
+  pinsrq $0, %rdi, %xmm13
+  pinsrq $0, %rdi, %xmm14
+  shufpd $2, %xmm9, %xmm2
+  shufpd $0, %xmm9, %xmm12
+  shufpd $2, %xmm10, %xmm13
+  shufpd $0, %xmm10, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  movdqu 0(%r8), %xmm3
+  movdqu 16(%r8), %xmm4
+  movdqu 32(%r8), %xmm5
+  movdqu 48(%r8), %xmm6
+  paddd %xmm15, %xmm9
+  paddd %xmm15, %xmm10
+  pxor %xmm3, %xmm2
+  pxor %xmm3, %xmm12
+  pxor %xmm3, %xmm13
+  pxor %xmm3, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 64(%r8), %xmm3
+  movdqu 80(%r8), %xmm4
+  movdqu 96(%r8), %xmm5
+  movdqu 112(%r8), %xmm6
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 128(%r8), %xmm3
+  movdqu 144(%r8), %xmm4
+  movdqu 160(%r8), %xmm5
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  movdqu %xmm5, %xmm3
+  movdqu 176(%r8), %xmm4
+  movdqu 192(%r8), %xmm5
+  movdqu 208(%r8), %xmm6
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 224(%r8), %xmm5
+  aesenclast %xmm5, %xmm2
+  aesenclast %xmm5, %xmm12
+  aesenclast %xmm5, %xmm13
+  aesenclast %xmm5, %xmm14
+  movdqu 0(%r9), %xmm7
+  pxor %xmm7, %xmm2
+  movdqu 16(%r9), %xmm7
+  pxor %xmm7, %xmm12
+  movdqu 32(%r9), %xmm7
+  pxor %xmm7, %xmm13
+  movdqu 48(%r9), %xmm7
+  pxor %xmm7, %xmm14
+  movdqu %xmm2, 0(%r10)
+  movdqu %xmm12, 16(%r10)
+  movdqu %xmm13, 32(%r10)
+  movdqu %xmm14, 48(%r10)
+  sub $1, %rdx
+  add $64, %r9
+  add $64, %r10
+.balign 16
+L11:
+  cmp $0, %rdx
+  ja L10
+  movdqu %xmm9, %xmm7
+  pinsrq $0, %rdi, %xmm7
+  pshufb %xmm8, %xmm7
+  mov %r9, %rax
+  mov %r10, %rbx
+  jmp L9
+L8:
+L9:
+  mov $0, %rdx
+  mov %rax, %r9
+  mov %rbx, %r10
+  pxor %xmm4, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  jmp L13
+.balign 16
+L12:
+  movdqu %xmm7, %xmm0
+  pshufb %xmm8, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r9), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rdx
+  add $16, %r9
+  add $16, %r10
+  paddd %xmm4, %xmm7
+.balign 16
+L13:
+  cmp %rcx, %rdx
+  jne L12
+  cmp %rbp, %rsi
+  jbe L14
+  movdqu 0(%r13), %xmm1
+  movdqu %xmm7, %xmm0
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm2
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm2
+  pshufb %xmm2, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm1
+  movdqu %xmm1, 0(%r13)
+  jmp L15
+L14:
+L15:
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global _compute_iv_stdcall
+_compute_iv_stdcall:
+  cmp $12, %rsi
+  jne L16
+  cmp $12, %rsi
+  jne L18
+  movdqu 0(%r8), %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm1
+  mov $283686952306183, %rax
+  pinsrq $1, %rax, %xmm1
+  pshufb %xmm1, %xmm0
+  mov $1, %rax
+  pinsrd $0, %eax, %xmm0
+  movdqu %xmm0, 0(%rcx)
+  jmp L19
+L18:
+  mov %rcx, %rax
+  add $32, %r9
+  mov %r8, %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L21
+.balign 16
+L20:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L21:
+  cmp $6, %rdx
+  jae L20
+  cmp $0, %rdx
+  jbe L22
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L24
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L25
+L24:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L26
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L28
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L30
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L31
+L30:
+L31:
+  jmp L29
+L28:
+L29:
+  jmp L27
+L26:
+L27:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L25:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L23
+L22:
+L23:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L32
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L34
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L35
+L34:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L35:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L33
+L32:
+L33:
+  mov %rax, %rcx
+  mov $0, %r11
+  mov %rsi, %r13
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm8, 0(%rcx)
+L19:
+  jmp L17
+L16:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  cmp $12, %rsi
+  jne L36
+  movdqu 0(%r8), %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm1
+  mov $283686952306183, %rax
+  pinsrq $1, %rax, %xmm1
+  pshufb %xmm1, %xmm0
+  mov $1, %rax
+  pinsrd $0, %eax, %xmm0
+  movdqu %xmm0, 0(%rcx)
+  jmp L37
+L36:
+  mov %rcx, %rax
+  add $32, %r9
+  mov %r8, %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L39
+.balign 16
+L38:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L39:
+  cmp $6, %rdx
+  jae L38
+  cmp $0, %rdx
+  jbe L40
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L42
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L43
+L42:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L44
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L46
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L48
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L49
+L48:
+L49:
+  jmp L47
+L46:
+L47:
+  jmp L45
+L44:
+L45:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L43:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L41
+L40:
+L41:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L50
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L52
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L53
+L52:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L53:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L51
+L50:
+L51:
+  mov %rax, %rcx
+  mov $0, %r11
+  mov %rsi, %r13
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm8, 0(%rcx)
+L37:
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+L17:
+  ret
+
+.global _gcm128_encrypt_opt
+_gcm128_encrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  mov 144(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 72(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L55
+.balign 16
+L54:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L55:
+  cmp $6, %rdx
+  jae L54
+  cmp $0, %rdx
+  jbe L56
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L58
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L59
+L58:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L60
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L62
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L64
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L65
+L64:
+L65:
+  jmp L63
+L62:
+L63:
+  jmp L61
+L60:
+L61:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L59:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L57
+L56:
+L57:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L66
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L68
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L69
+L68:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L69:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L67
+L66:
+L67:
+  mov 80(%rsp), %rdi
+  mov 88(%rsp), %rsi
+  mov 96(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L70
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L71
+L70:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rsi), %r14
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L72
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L73
+L72:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L73:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  movdqu 32(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  vpshufb %xmm0, %xmm9, %xmm8
+  vpshufb %xmm0, %xmm10, %xmm2
+  movdqu %xmm8, 112(%rbp)
+  vpshufb %xmm0, %xmm11, %xmm4
+  movdqu %xmm2, 96(%rbp)
+  vpshufb %xmm0, %xmm12, %xmm5
+  movdqu %xmm4, 80(%rbp)
+  vpshufb %xmm0, %xmm13, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm14, %xmm7
+  movdqu %xmm6, 48(%rbp)
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L74
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L75
+L74:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L75:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  movdqu 32(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  sub $12, %rdx
+  movdqu 32(%rbp), %xmm8
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  jmp L77
+.balign 16
+L76:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L78
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L79
+L78:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L79:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  add $96, %r14
+  cmp $0, %rdx
+  jbe L80
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L81
+L80:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L81:
+.balign 16
+L77:
+  cmp $0, %rdx
+  ja L76
+  movdqu 32(%rbp), %xmm7
+  movdqu %xmm1, 32(%rbp)
+  pxor %xmm4, %xmm4
+  movdqu %xmm4, 16(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm0
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm0
+  movdqu %xmm9, -96(%rsi)
+  vpshufb %xmm0, %xmm9, %xmm9
+  vpxor %xmm7, %xmm1, %xmm1
+  movdqu %xmm10, -80(%rsi)
+  vpshufb %xmm0, %xmm10, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  vpshufb %xmm0, %xmm11, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  vpshufb %xmm0, %xmm12, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  vpshufb %xmm0, %xmm13, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  vpshufb %xmm0, %xmm14, %xmm14
+  pxor %xmm4, %xmm4
+  movdqu %xmm14, %xmm7
+  movdqu %xmm4, 16(%rbp)
+  movdqu %xmm13, 48(%rbp)
+  movdqu %xmm12, 64(%rbp)
+  movdqu %xmm11, 80(%rbp)
+  movdqu %xmm10, 96(%rbp)
+  movdqu %xmm9, 112(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  sub $128, %rcx
+L71:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 104(%rsp), %rax
+  mov 112(%rsp), %rdi
+  mov 120(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L83
+.balign 16
+L82:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L83:
+  cmp %rdx, %rbx
+  jne L82
+  mov %rdi, %r11
+  jmp L85
+.balign 16
+L84:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L85:
+  cmp $6, %rdx
+  jae L84
+  cmp $0, %rdx
+  jbe L86
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L88
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L89
+L88:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L90
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L92
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L94
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L95
+L94:
+L95:
+  jmp L93
+L92:
+L93:
+  jmp L91
+L90:
+L91:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L89:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L87
+L86:
+L87:
+  add 96(%rsp), %r14
+  imul $16, %r14
+  mov 136(%rsp), %r13
+  cmp %r14, %r13
+  jbe L96
+  mov 128(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%rax), %xmm4
+  pxor %xmm4, %xmm0
+  movdqu %xmm0, 0(%rax)
+  cmp $8, %r10
+  jae L98
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L99
+L98:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L99:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L97
+L96:
+L97:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 152(%rsp), %r15
+  movdqu %xmm8, 0(%r15)
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global _gcm256_encrypt_opt
+_gcm256_encrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  mov 144(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 72(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L101
+.balign 16
+L100:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L101:
+  cmp $6, %rdx
+  jae L100
+  cmp $0, %rdx
+  jbe L102
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L104
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L105
+L104:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L106
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L108
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L110
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L111
+L110:
+L111:
+  jmp L109
+L108:
+L109:
+  jmp L107
+L106:
+L107:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L105:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L103
+L102:
+L103:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L112
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L114
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L115
+L114:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L115:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L113
+L112:
+L113:
+  mov 80(%rsp), %rdi
+  mov 88(%rsp), %rsi
+  mov 96(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L116
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L117
+L116:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rsi), %r14
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L118
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L119
+L118:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L119:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 80(%rcx), %xmm15
+  movdqu 96(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  vpshufb %xmm0, %xmm9, %xmm8
+  vpshufb %xmm0, %xmm10, %xmm2
+  movdqu %xmm8, 112(%rbp)
+  vpshufb %xmm0, %xmm11, %xmm4
+  movdqu %xmm2, 96(%rbp)
+  vpshufb %xmm0, %xmm12, %xmm5
+  movdqu %xmm4, 80(%rbp)
+  vpshufb %xmm0, %xmm13, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm14, %xmm7
+  movdqu %xmm6, 48(%rbp)
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L120
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L121
+L120:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L121:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 80(%rcx), %xmm15
+  movdqu 96(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  sub $12, %rdx
+  movdqu 32(%rbp), %xmm8
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  jmp L123
+.balign 16
+L122:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L124
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L125
+L124:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L125:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 80(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 96(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  add $96, %r14
+  cmp $0, %rdx
+  jbe L126
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L127
+L126:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L127:
+.balign 16
+L123:
+  cmp $0, %rdx
+  ja L122
+  movdqu 32(%rbp), %xmm7
+  movdqu %xmm1, 32(%rbp)
+  pxor %xmm4, %xmm4
+  movdqu %xmm4, 16(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm0
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm0
+  movdqu %xmm9, -96(%rsi)
+  vpshufb %xmm0, %xmm9, %xmm9
+  vpxor %xmm7, %xmm1, %xmm1
+  movdqu %xmm10, -80(%rsi)
+  vpshufb %xmm0, %xmm10, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  vpshufb %xmm0, %xmm11, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  vpshufb %xmm0, %xmm12, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  vpshufb %xmm0, %xmm13, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  vpshufb %xmm0, %xmm14, %xmm14
+  pxor %xmm4, %xmm4
+  movdqu %xmm14, %xmm7
+  movdqu %xmm4, 16(%rbp)
+  movdqu %xmm13, 48(%rbp)
+  movdqu %xmm12, 64(%rbp)
+  movdqu %xmm11, 80(%rbp)
+  movdqu %xmm10, 96(%rbp)
+  movdqu %xmm9, 112(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  sub $128, %rcx
+L117:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 104(%rsp), %rax
+  mov 112(%rsp), %rdi
+  mov 120(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L129
+.balign 16
+L128:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L129:
+  cmp %rdx, %rbx
+  jne L128
+  mov %rdi, %r11
+  jmp L131
+.balign 16
+L130:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L131:
+  cmp $6, %rdx
+  jae L130
+  cmp $0, %rdx
+  jbe L132
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L134
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L135
+L134:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L136
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L138
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L140
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L141
+L140:
+L141:
+  jmp L139
+L138:
+L139:
+  jmp L137
+L136:
+L137:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L135:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L133
+L132:
+L133:
+  add 96(%rsp), %r14
+  imul $16, %r14
+  mov 136(%rsp), %r13
+  cmp %r14, %r13
+  jbe L142
+  mov 128(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%rax), %xmm4
+  pxor %xmm4, %xmm0
+  movdqu %xmm0, 0(%rax)
+  cmp $8, %r10
+  jae L144
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L145
+L144:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L145:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L143
+L142:
+L143:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 152(%rsp), %r15
+  movdqu %xmm8, 0(%r15)
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global _gcm128_decrypt_opt
+_gcm128_decrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  mov 144(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 72(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L147
+.balign 16
+L146:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L147:
+  cmp $6, %rdx
+  jae L146
+  cmp $0, %rdx
+  jbe L148
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L150
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L151
+L150:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L152
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L154
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L156
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L157
+L156:
+L157:
+  jmp L155
+L154:
+L155:
+  jmp L153
+L152:
+L153:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L151:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L149
+L148:
+L149:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L158
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L160
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L161
+L160:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L161:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L159
+L158:
+L159:
+  mov 80(%rsp), %rdi
+  mov 88(%rsp), %rsi
+  mov 96(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L162
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L163
+L162:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rdi), %r14
+  movdqu 32(%rbp), %xmm8
+  movdqu 80(%rdi), %xmm7
+  movdqu 64(%rdi), %xmm4
+  movdqu 48(%rdi), %xmm5
+  movdqu 32(%rdi), %xmm6
+  vpshufb %xmm0, %xmm7, %xmm7
+  movdqu 16(%rdi), %xmm2
+  vpshufb %xmm0, %xmm4, %xmm4
+  movdqu 0(%rdi), %xmm3
+  vpshufb %xmm0, %xmm5, %xmm5
+  movdqu %xmm4, 48(%rbp)
+  vpshufb %xmm0, %xmm6, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm2, %xmm2
+  movdqu %xmm6, 80(%rbp)
+  vpshufb %xmm0, %xmm3, %xmm3
+  movdqu %xmm2, 96(%rbp)
+  movdqu %xmm3, 112(%rbp)
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  cmp $6, %rdx
+  jne L164
+  sub $96, %r14
+  jmp L165
+L164:
+L165:
+  jmp L167
+.balign 16
+L166:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L168
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L169
+L168:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L169:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  cmp $6, %rdx
+  jbe L170
+  add $96, %r14
+  jmp L171
+L170:
+L171:
+  cmp $0, %rdx
+  jbe L172
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L173
+L172:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L173:
+.balign 16
+L167:
+  cmp $0, %rdx
+  ja L166
+  movdqu %xmm1, 32(%rbp)
+  movdqu %xmm9, -96(%rsi)
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm14, -16(%rsi)
+  sub $128, %rcx
+L163:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 104(%rsp), %rax
+  mov 112(%rsp), %rdi
+  mov 120(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  mov %rdi, %rbx
+  mov %rdx, %r12
+  mov %rax, %rdi
+  mov %rdi, %r11
+  jmp L175
+.balign 16
+L174:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L175:
+  cmp $6, %rdx
+  jae L174
+  cmp $0, %rdx
+  jbe L176
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L178
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L179
+L178:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L180
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L182
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L184
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L185
+L184:
+L185:
+  jmp L183
+L182:
+L183:
+  jmp L181
+L180:
+L181:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L179:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L177
+L176:
+L177:
+  mov %rbx, %rdi
+  mov %r12, %rdx
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L187
+.balign 16
+L186:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L187:
+  cmp %rdx, %rbx
+  jne L186
+  add 96(%rsp), %r14
+  imul $16, %r14
+  mov 136(%rsp), %r13
+  cmp %r14, %r13
+  jbe L188
+  mov 128(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu 0(%rax), %xmm0
+  movdqu %xmm0, %xmm10
+  cmp $8, %r10
+  jae L190
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L191
+L190:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L191:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm10
+  movdqu %xmm10, 0(%rax)
+  jmp L189
+L188:
+L189:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 152(%rsp), %r15
+  movdqu 0(%r15), %xmm0
+  pcmpeqd %xmm8, %xmm0
+  pextrq $0, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rax
+  adc $0, %rax
+  pextrq $1, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rdx
+  adc $0, %rdx
+  add %rdx, %rax
+  mov %rax, %rcx
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  mov %rcx, %rax
+  ret
+
+.global _gcm256_decrypt_opt
+_gcm256_decrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  mov 144(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 72(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L193
+.balign 16
+L192:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L193:
+  cmp $6, %rdx
+  jae L192
+  cmp $0, %rdx
+  jbe L194
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L196
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L197
+L196:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L198
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L200
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L202
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L203
+L202:
+L203:
+  jmp L201
+L200:
+L201:
+  jmp L199
+L198:
+L199:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L197:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L195
+L194:
+L195:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L204
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L206
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L207
+L206:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L207:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L205
+L204:
+L205:
+  mov 80(%rsp), %rdi
+  mov 88(%rsp), %rsi
+  mov 96(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L208
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L209
+L208:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rdi), %r14
+  movdqu 32(%rbp), %xmm8
+  movdqu 80(%rdi), %xmm7
+  movdqu 64(%rdi), %xmm4
+  movdqu 48(%rdi), %xmm5
+  movdqu 32(%rdi), %xmm6
+  vpshufb %xmm0, %xmm7, %xmm7
+  movdqu 16(%rdi), %xmm2
+  vpshufb %xmm0, %xmm4, %xmm4
+  movdqu 0(%rdi), %xmm3
+  vpshufb %xmm0, %xmm5, %xmm5
+  movdqu %xmm4, 48(%rbp)
+  vpshufb %xmm0, %xmm6, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm2, %xmm2
+  movdqu %xmm6, 80(%rbp)
+  vpshufb %xmm0, %xmm3, %xmm3
+  movdqu %xmm2, 96(%rbp)
+  movdqu %xmm3, 112(%rbp)
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  cmp $6, %rdx
+  jne L210
+  sub $96, %r14
+  jmp L211
+L210:
+L211:
+  jmp L213
+.balign 16
+L212:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L214
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L215
+L214:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L215:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 80(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 96(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  cmp $6, %rdx
+  jbe L216
+  add $96, %r14
+  jmp L217
+L216:
+L217:
+  cmp $0, %rdx
+  jbe L218
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L219
+L218:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L219:
+.balign 16
+L213:
+  cmp $0, %rdx
+  ja L212
+  movdqu %xmm1, 32(%rbp)
+  movdqu %xmm9, -96(%rsi)
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm14, -16(%rsi)
+  sub $128, %rcx
+L209:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 104(%rsp), %rax
+  mov 112(%rsp), %rdi
+  mov 120(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  mov %rdi, %rbx
+  mov %rdx, %r12
+  mov %rax, %rdi
+  mov %rdi, %r11
+  jmp L221
+.balign 16
+L220:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L221:
+  cmp $6, %rdx
+  jae L220
+  cmp $0, %rdx
+  jbe L222
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L224
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L225
+L224:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L226
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L228
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L230
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L231
+L230:
+L231:
+  jmp L229
+L228:
+L229:
+  jmp L227
+L226:
+L227:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L225:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L223
+L222:
+L223:
+  mov %rbx, %rdi
+  mov %r12, %rdx
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L233
+.balign 16
+L232:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L233:
+  cmp %rdx, %rbx
+  jne L232
+  add 96(%rsp), %r14
+  imul $16, %r14
+  mov 136(%rsp), %r13
+  cmp %r14, %r13
+  jbe L234
+  mov 128(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu 0(%rax), %xmm0
+  movdqu %xmm0, %xmm10
+  cmp $8, %r10
+  jae L236
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L237
+L236:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L237:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm10
+  movdqu %xmm10, 0(%rax)
+  jmp L235
+L234:
+L235:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 152(%rsp), %r15
+  movdqu 0(%r15), %xmm0
+  pcmpeqd %xmm8, %xmm0
+  pextrq $0, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rax
+  adc $0, %rax
+  pextrq $1, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rdx
+  adc $0, %rdx
+  add %rdx, %rax
+  mov %rax, %rcx
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  mov %rcx, %rax
+  ret
+
+

--- a/sys/hacl/c/vale/src/aesgcm-x86_64-linux.S
+++ b/sys/hacl/c/vale/src/aesgcm-x86_64-linux.S
@@ -1,0 +1,8101 @@
+.text
+.global aes128_key_expansion
+aes128_key_expansion:
+  movdqu 0(%rdi), %xmm1
+  mov %rsi, %rdx
+  movdqu %xmm1, 0(%rdx)
+  aeskeygenassist $1, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 16(%rdx)
+  aeskeygenassist $2, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 32(%rdx)
+  aeskeygenassist $4, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 48(%rdx)
+  aeskeygenassist $8, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 64(%rdx)
+  aeskeygenassist $16, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 80(%rdx)
+  aeskeygenassist $32, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 96(%rdx)
+  aeskeygenassist $64, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 112(%rdx)
+  aeskeygenassist $128, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 128(%rdx)
+  aeskeygenassist $27, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 144(%rdx)
+  aeskeygenassist $54, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 160(%rdx)
+  pxor %xmm1, %xmm1
+  pxor %xmm2, %xmm2
+  pxor %xmm3, %xmm3
+  ret
+
+.global aes128_keyhash_init
+aes128_keyhash_init:
+  mov $579005069656919567, %r8
+  pinsrq $0, %r8, %xmm4
+  mov $283686952306183, %r8
+  pinsrq $1, %r8, %xmm4
+  pxor %xmm0, %xmm0
+  movdqu %xmm0, 80(%rsi)
+  mov %rdi, %r8
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm4, %xmm0
+  mov %rsi, %rcx
+  movdqu %xmm0, 32(%rcx)
+  movdqu %xmm6, %xmm0
+  mov %r12, %rax
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 0(%rcx)
+  movdqu %xmm6, %xmm1
+  movdqu %xmm6, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 16(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 48(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 64(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 96(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 112(%rcx)
+  movdqu %xmm0, %xmm6
+  mov %rax, %r12
+  ret
+
+.global aes256_key_expansion
+aes256_key_expansion:
+  movdqu 0(%rdi), %xmm1
+  movdqu 16(%rdi), %xmm3
+  mov %rsi, %rdx
+  movdqu %xmm1, 0(%rdx)
+  movdqu %xmm3, 16(%rdx)
+  aeskeygenassist $1, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 32(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 48(%rdx)
+  aeskeygenassist $2, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 64(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 80(%rdx)
+  aeskeygenassist $4, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 96(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 112(%rdx)
+  aeskeygenassist $8, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 128(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 144(%rdx)
+  aeskeygenassist $16, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 160(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 176(%rdx)
+  aeskeygenassist $32, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 192(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 208(%rdx)
+  aeskeygenassist $64, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 224(%rdx)
+  pxor %xmm1, %xmm1
+  pxor %xmm2, %xmm2
+  pxor %xmm3, %xmm3
+  pxor %xmm4, %xmm4
+  ret
+
+.global aes256_keyhash_init
+aes256_keyhash_init:
+  mov $579005069656919567, %r8
+  pinsrq $0, %r8, %xmm4
+  mov $283686952306183, %r8
+  pinsrq $1, %r8, %xmm4
+  pxor %xmm0, %xmm0
+  movdqu %xmm0, 80(%rsi)
+  mov %rdi, %r8
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm4, %xmm0
+  mov %rsi, %rcx
+  movdqu %xmm0, 32(%rcx)
+  movdqu %xmm6, %xmm0
+  mov %r12, %rax
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 0(%rcx)
+  movdqu %xmm6, %xmm1
+  movdqu %xmm6, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 16(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 48(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 64(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 96(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 112(%rcx)
+  movdqu %xmm0, %xmm6
+  mov %rax, %r12
+  ret
+
+.global gctr128_bytes
+gctr128_bytes:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  movdqu 0(%r9), %xmm7
+  mov %rdi, %rax
+  mov %rdx, %rbx
+  mov %rcx, %r13
+  mov 72(%rsp), %rcx
+  mov %rcx, %rbp
+  imul $16, %rbp
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm8
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm8
+  mov %rcx, %rdx
+  shr $2, %rdx
+  and $3, %rcx
+  cmp $0, %rdx
+  jbe L0
+  mov %rax, %r9
+  mov %rbx, %r10
+  pshufb %xmm8, %xmm7
+  movdqu %xmm7, %xmm9
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pshufb %xmm0, %xmm9
+  movdqu %xmm9, %xmm10
+  pxor %xmm3, %xmm3
+  mov $1, %rax
+  pinsrd $2, %eax, %xmm3
+  paddd %xmm3, %xmm9
+  mov $3, %rax
+  pinsrd $2, %eax, %xmm3
+  mov $2, %rax
+  pinsrd $0, %eax, %xmm3
+  paddd %xmm3, %xmm10
+  pshufb %xmm8, %xmm9
+  pshufb %xmm8, %xmm10
+  pextrq $0, %xmm7, %rdi
+  mov $283686952306183, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pxor %xmm15, %xmm15
+  mov $4, %rax
+  pinsrd $0, %eax, %xmm15
+  mov $4, %rax
+  pinsrd $2, %eax, %xmm15
+  jmp L3
+.balign 16
+L2:
+  pinsrq $0, %rdi, %xmm2
+  pinsrq $0, %rdi, %xmm12
+  pinsrq $0, %rdi, %xmm13
+  pinsrq $0, %rdi, %xmm14
+  shufpd $2, %xmm9, %xmm2
+  shufpd $0, %xmm9, %xmm12
+  shufpd $2, %xmm10, %xmm13
+  shufpd $0, %xmm10, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  movdqu 0(%r8), %xmm3
+  movdqu 16(%r8), %xmm4
+  movdqu 32(%r8), %xmm5
+  movdqu 48(%r8), %xmm6
+  paddd %xmm15, %xmm9
+  paddd %xmm15, %xmm10
+  pxor %xmm3, %xmm2
+  pxor %xmm3, %xmm12
+  pxor %xmm3, %xmm13
+  pxor %xmm3, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 64(%r8), %xmm3
+  movdqu 80(%r8), %xmm4
+  movdqu 96(%r8), %xmm5
+  movdqu 112(%r8), %xmm6
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 128(%r8), %xmm3
+  movdqu 144(%r8), %xmm4
+  movdqu 160(%r8), %xmm5
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenclast %xmm5, %xmm2
+  aesenclast %xmm5, %xmm12
+  aesenclast %xmm5, %xmm13
+  aesenclast %xmm5, %xmm14
+  movdqu 0(%r9), %xmm7
+  pxor %xmm7, %xmm2
+  movdqu 16(%r9), %xmm7
+  pxor %xmm7, %xmm12
+  movdqu 32(%r9), %xmm7
+  pxor %xmm7, %xmm13
+  movdqu 48(%r9), %xmm7
+  pxor %xmm7, %xmm14
+  movdqu %xmm2, 0(%r10)
+  movdqu %xmm12, 16(%r10)
+  movdqu %xmm13, 32(%r10)
+  movdqu %xmm14, 48(%r10)
+  sub $1, %rdx
+  add $64, %r9
+  add $64, %r10
+.balign 16
+L3:
+  cmp $0, %rdx
+  ja L2
+  movdqu %xmm9, %xmm7
+  pinsrq $0, %rdi, %xmm7
+  pshufb %xmm8, %xmm7
+  mov %r9, %rax
+  mov %r10, %rbx
+  jmp L1
+L0:
+L1:
+  mov $0, %rdx
+  mov %rax, %r9
+  mov %rbx, %r10
+  pxor %xmm4, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  jmp L5
+.balign 16
+L4:
+  movdqu %xmm7, %xmm0
+  pshufb %xmm8, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r9), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rdx
+  add $16, %r9
+  add $16, %r10
+  paddd %xmm4, %xmm7
+.balign 16
+L5:
+  cmp %rcx, %rdx
+  jne L4
+  cmp %rbp, %rsi
+  jbe L6
+  movdqu 0(%r13), %xmm1
+  movdqu %xmm7, %xmm0
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm2
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm2
+  pshufb %xmm2, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm1
+  movdqu %xmm1, 0(%r13)
+  jmp L7
+L6:
+L7:
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global gctr256_bytes
+gctr256_bytes:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  movdqu 0(%r9), %xmm7
+  mov %rdi, %rax
+  mov %rdx, %rbx
+  mov %rcx, %r13
+  mov 72(%rsp), %rcx
+  mov %rcx, %rbp
+  imul $16, %rbp
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm8
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm8
+  mov %rcx, %rdx
+  shr $2, %rdx
+  and $3, %rcx
+  cmp $0, %rdx
+  jbe L8
+  mov %rax, %r9
+  mov %rbx, %r10
+  pshufb %xmm8, %xmm7
+  movdqu %xmm7, %xmm9
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pshufb %xmm0, %xmm9
+  movdqu %xmm9, %xmm10
+  pxor %xmm3, %xmm3
+  mov $1, %rax
+  pinsrd $2, %eax, %xmm3
+  paddd %xmm3, %xmm9
+  mov $3, %rax
+  pinsrd $2, %eax, %xmm3
+  mov $2, %rax
+  pinsrd $0, %eax, %xmm3
+  paddd %xmm3, %xmm10
+  pshufb %xmm8, %xmm9
+  pshufb %xmm8, %xmm10
+  pextrq $0, %xmm7, %rdi
+  mov $283686952306183, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pxor %xmm15, %xmm15
+  mov $4, %rax
+  pinsrd $0, %eax, %xmm15
+  mov $4, %rax
+  pinsrd $2, %eax, %xmm15
+  jmp L11
+.balign 16
+L10:
+  pinsrq $0, %rdi, %xmm2
+  pinsrq $0, %rdi, %xmm12
+  pinsrq $0, %rdi, %xmm13
+  pinsrq $0, %rdi, %xmm14
+  shufpd $2, %xmm9, %xmm2
+  shufpd $0, %xmm9, %xmm12
+  shufpd $2, %xmm10, %xmm13
+  shufpd $0, %xmm10, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  movdqu 0(%r8), %xmm3
+  movdqu 16(%r8), %xmm4
+  movdqu 32(%r8), %xmm5
+  movdqu 48(%r8), %xmm6
+  paddd %xmm15, %xmm9
+  paddd %xmm15, %xmm10
+  pxor %xmm3, %xmm2
+  pxor %xmm3, %xmm12
+  pxor %xmm3, %xmm13
+  pxor %xmm3, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 64(%r8), %xmm3
+  movdqu 80(%r8), %xmm4
+  movdqu 96(%r8), %xmm5
+  movdqu 112(%r8), %xmm6
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 128(%r8), %xmm3
+  movdqu 144(%r8), %xmm4
+  movdqu 160(%r8), %xmm5
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  movdqu %xmm5, %xmm3
+  movdqu 176(%r8), %xmm4
+  movdqu 192(%r8), %xmm5
+  movdqu 208(%r8), %xmm6
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 224(%r8), %xmm5
+  aesenclast %xmm5, %xmm2
+  aesenclast %xmm5, %xmm12
+  aesenclast %xmm5, %xmm13
+  aesenclast %xmm5, %xmm14
+  movdqu 0(%r9), %xmm7
+  pxor %xmm7, %xmm2
+  movdqu 16(%r9), %xmm7
+  pxor %xmm7, %xmm12
+  movdqu 32(%r9), %xmm7
+  pxor %xmm7, %xmm13
+  movdqu 48(%r9), %xmm7
+  pxor %xmm7, %xmm14
+  movdqu %xmm2, 0(%r10)
+  movdqu %xmm12, 16(%r10)
+  movdqu %xmm13, 32(%r10)
+  movdqu %xmm14, 48(%r10)
+  sub $1, %rdx
+  add $64, %r9
+  add $64, %r10
+.balign 16
+L11:
+  cmp $0, %rdx
+  ja L10
+  movdqu %xmm9, %xmm7
+  pinsrq $0, %rdi, %xmm7
+  pshufb %xmm8, %xmm7
+  mov %r9, %rax
+  mov %r10, %rbx
+  jmp L9
+L8:
+L9:
+  mov $0, %rdx
+  mov %rax, %r9
+  mov %rbx, %r10
+  pxor %xmm4, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  jmp L13
+.balign 16
+L12:
+  movdqu %xmm7, %xmm0
+  pshufb %xmm8, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r9), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rdx
+  add $16, %r9
+  add $16, %r10
+  paddd %xmm4, %xmm7
+.balign 16
+L13:
+  cmp %rcx, %rdx
+  jne L12
+  cmp %rbp, %rsi
+  jbe L14
+  movdqu 0(%r13), %xmm1
+  movdqu %xmm7, %xmm0
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm2
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm2
+  pshufb %xmm2, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm1
+  movdqu %xmm1, 0(%r13)
+  jmp L15
+L14:
+L15:
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global compute_iv_stdcall
+compute_iv_stdcall:
+  cmp $12, %rsi
+  jne L16
+  cmp $12, %rsi
+  jne L18
+  movdqu 0(%r8), %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm1
+  mov $283686952306183, %rax
+  pinsrq $1, %rax, %xmm1
+  pshufb %xmm1, %xmm0
+  mov $1, %rax
+  pinsrd $0, %eax, %xmm0
+  movdqu %xmm0, 0(%rcx)
+  jmp L19
+L18:
+  mov %rcx, %rax
+  add $32, %r9
+  mov %r8, %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L21
+.balign 16
+L20:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L21:
+  cmp $6, %rdx
+  jae L20
+  cmp $0, %rdx
+  jbe L22
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L24
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L25
+L24:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L26
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L28
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L30
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L31
+L30:
+L31:
+  jmp L29
+L28:
+L29:
+  jmp L27
+L26:
+L27:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L25:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L23
+L22:
+L23:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L32
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L34
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L35
+L34:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L35:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L33
+L32:
+L33:
+  mov %rax, %rcx
+  mov $0, %r11
+  mov %rsi, %r13
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm8, 0(%rcx)
+L19:
+  jmp L17
+L16:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  cmp $12, %rsi
+  jne L36
+  movdqu 0(%r8), %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm1
+  mov $283686952306183, %rax
+  pinsrq $1, %rax, %xmm1
+  pshufb %xmm1, %xmm0
+  mov $1, %rax
+  pinsrd $0, %eax, %xmm0
+  movdqu %xmm0, 0(%rcx)
+  jmp L37
+L36:
+  mov %rcx, %rax
+  add $32, %r9
+  mov %r8, %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L39
+.balign 16
+L38:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L39:
+  cmp $6, %rdx
+  jae L38
+  cmp $0, %rdx
+  jbe L40
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L42
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L43
+L42:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L44
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L46
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L48
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L49
+L48:
+L49:
+  jmp L47
+L46:
+L47:
+  jmp L45
+L44:
+L45:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L43:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L41
+L40:
+L41:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L50
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L52
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L53
+L52:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L53:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L51
+L50:
+L51:
+  mov %rax, %rcx
+  mov $0, %r11
+  mov %rsi, %r13
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm8, 0(%rcx)
+L37:
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+L17:
+  ret
+
+.global gcm128_encrypt_opt
+gcm128_encrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  mov 144(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 72(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L55
+.balign 16
+L54:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L55:
+  cmp $6, %rdx
+  jae L54
+  cmp $0, %rdx
+  jbe L56
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L58
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L59
+L58:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L60
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L62
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L64
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L65
+L64:
+L65:
+  jmp L63
+L62:
+L63:
+  jmp L61
+L60:
+L61:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L59:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L57
+L56:
+L57:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L66
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L68
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L69
+L68:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L69:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L67
+L66:
+L67:
+  mov 80(%rsp), %rdi
+  mov 88(%rsp), %rsi
+  mov 96(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L70
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L71
+L70:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rsi), %r14
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L72
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L73
+L72:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L73:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  movdqu 32(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  vpshufb %xmm0, %xmm9, %xmm8
+  vpshufb %xmm0, %xmm10, %xmm2
+  movdqu %xmm8, 112(%rbp)
+  vpshufb %xmm0, %xmm11, %xmm4
+  movdqu %xmm2, 96(%rbp)
+  vpshufb %xmm0, %xmm12, %xmm5
+  movdqu %xmm4, 80(%rbp)
+  vpshufb %xmm0, %xmm13, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm14, %xmm7
+  movdqu %xmm6, 48(%rbp)
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L74
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L75
+L74:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L75:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  movdqu 32(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  sub $12, %rdx
+  movdqu 32(%rbp), %xmm8
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  jmp L77
+.balign 16
+L76:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L78
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L79
+L78:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L79:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  add $96, %r14
+  cmp $0, %rdx
+  jbe L80
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L81
+L80:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L81:
+.balign 16
+L77:
+  cmp $0, %rdx
+  ja L76
+  movdqu 32(%rbp), %xmm7
+  movdqu %xmm1, 32(%rbp)
+  pxor %xmm4, %xmm4
+  movdqu %xmm4, 16(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm0
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm0
+  movdqu %xmm9, -96(%rsi)
+  vpshufb %xmm0, %xmm9, %xmm9
+  vpxor %xmm7, %xmm1, %xmm1
+  movdqu %xmm10, -80(%rsi)
+  vpshufb %xmm0, %xmm10, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  vpshufb %xmm0, %xmm11, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  vpshufb %xmm0, %xmm12, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  vpshufb %xmm0, %xmm13, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  vpshufb %xmm0, %xmm14, %xmm14
+  pxor %xmm4, %xmm4
+  movdqu %xmm14, %xmm7
+  movdqu %xmm4, 16(%rbp)
+  movdqu %xmm13, 48(%rbp)
+  movdqu %xmm12, 64(%rbp)
+  movdqu %xmm11, 80(%rbp)
+  movdqu %xmm10, 96(%rbp)
+  movdqu %xmm9, 112(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  sub $128, %rcx
+L71:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 104(%rsp), %rax
+  mov 112(%rsp), %rdi
+  mov 120(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L83
+.balign 16
+L82:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L83:
+  cmp %rdx, %rbx
+  jne L82
+  mov %rdi, %r11
+  jmp L85
+.balign 16
+L84:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L85:
+  cmp $6, %rdx
+  jae L84
+  cmp $0, %rdx
+  jbe L86
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L88
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L89
+L88:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L90
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L92
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L94
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L95
+L94:
+L95:
+  jmp L93
+L92:
+L93:
+  jmp L91
+L90:
+L91:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L89:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L87
+L86:
+L87:
+  add 96(%rsp), %r14
+  imul $16, %r14
+  mov 136(%rsp), %r13
+  cmp %r14, %r13
+  jbe L96
+  mov 128(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%rax), %xmm4
+  pxor %xmm4, %xmm0
+  movdqu %xmm0, 0(%rax)
+  cmp $8, %r10
+  jae L98
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L99
+L98:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L99:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L97
+L96:
+L97:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 152(%rsp), %r15
+  movdqu %xmm8, 0(%r15)
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global gcm256_encrypt_opt
+gcm256_encrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  mov 144(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 72(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L101
+.balign 16
+L100:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L101:
+  cmp $6, %rdx
+  jae L100
+  cmp $0, %rdx
+  jbe L102
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L104
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L105
+L104:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L106
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L108
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L110
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L111
+L110:
+L111:
+  jmp L109
+L108:
+L109:
+  jmp L107
+L106:
+L107:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L105:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L103
+L102:
+L103:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L112
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L114
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L115
+L114:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L115:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L113
+L112:
+L113:
+  mov 80(%rsp), %rdi
+  mov 88(%rsp), %rsi
+  mov 96(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L116
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L117
+L116:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rsi), %r14
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L118
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L119
+L118:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L119:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 80(%rcx), %xmm15
+  movdqu 96(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  vpshufb %xmm0, %xmm9, %xmm8
+  vpshufb %xmm0, %xmm10, %xmm2
+  movdqu %xmm8, 112(%rbp)
+  vpshufb %xmm0, %xmm11, %xmm4
+  movdqu %xmm2, 96(%rbp)
+  vpshufb %xmm0, %xmm12, %xmm5
+  movdqu %xmm4, 80(%rbp)
+  vpshufb %xmm0, %xmm13, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm14, %xmm7
+  movdqu %xmm6, 48(%rbp)
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L120
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L121
+L120:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L121:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 80(%rcx), %xmm15
+  movdqu 96(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  sub $12, %rdx
+  movdqu 32(%rbp), %xmm8
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  jmp L123
+.balign 16
+L122:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L124
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L125
+L124:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L125:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 80(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 96(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  add $96, %r14
+  cmp $0, %rdx
+  jbe L126
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L127
+L126:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L127:
+.balign 16
+L123:
+  cmp $0, %rdx
+  ja L122
+  movdqu 32(%rbp), %xmm7
+  movdqu %xmm1, 32(%rbp)
+  pxor %xmm4, %xmm4
+  movdqu %xmm4, 16(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm0
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm0
+  movdqu %xmm9, -96(%rsi)
+  vpshufb %xmm0, %xmm9, %xmm9
+  vpxor %xmm7, %xmm1, %xmm1
+  movdqu %xmm10, -80(%rsi)
+  vpshufb %xmm0, %xmm10, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  vpshufb %xmm0, %xmm11, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  vpshufb %xmm0, %xmm12, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  vpshufb %xmm0, %xmm13, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  vpshufb %xmm0, %xmm14, %xmm14
+  pxor %xmm4, %xmm4
+  movdqu %xmm14, %xmm7
+  movdqu %xmm4, 16(%rbp)
+  movdqu %xmm13, 48(%rbp)
+  movdqu %xmm12, 64(%rbp)
+  movdqu %xmm11, 80(%rbp)
+  movdqu %xmm10, 96(%rbp)
+  movdqu %xmm9, 112(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  sub $128, %rcx
+L117:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 104(%rsp), %rax
+  mov 112(%rsp), %rdi
+  mov 120(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L129
+.balign 16
+L128:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L129:
+  cmp %rdx, %rbx
+  jne L128
+  mov %rdi, %r11
+  jmp L131
+.balign 16
+L130:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L131:
+  cmp $6, %rdx
+  jae L130
+  cmp $0, %rdx
+  jbe L132
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L134
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L135
+L134:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L136
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L138
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L140
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L141
+L140:
+L141:
+  jmp L139
+L138:
+L139:
+  jmp L137
+L136:
+L137:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L135:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L133
+L132:
+L133:
+  add 96(%rsp), %r14
+  imul $16, %r14
+  mov 136(%rsp), %r13
+  cmp %r14, %r13
+  jbe L142
+  mov 128(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%rax), %xmm4
+  pxor %xmm4, %xmm0
+  movdqu %xmm0, 0(%rax)
+  cmp $8, %r10
+  jae L144
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L145
+L144:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L145:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L143
+L142:
+L143:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 152(%rsp), %r15
+  movdqu %xmm8, 0(%r15)
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global gcm128_decrypt_opt
+gcm128_decrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  mov 144(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 72(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L147
+.balign 16
+L146:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L147:
+  cmp $6, %rdx
+  jae L146
+  cmp $0, %rdx
+  jbe L148
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L150
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L151
+L150:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L152
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L154
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L156
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L157
+L156:
+L157:
+  jmp L155
+L154:
+L155:
+  jmp L153
+L152:
+L153:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L151:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L149
+L148:
+L149:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L158
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L160
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L161
+L160:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L161:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L159
+L158:
+L159:
+  mov 80(%rsp), %rdi
+  mov 88(%rsp), %rsi
+  mov 96(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L162
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L163
+L162:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rdi), %r14
+  movdqu 32(%rbp), %xmm8
+  movdqu 80(%rdi), %xmm7
+  movdqu 64(%rdi), %xmm4
+  movdqu 48(%rdi), %xmm5
+  movdqu 32(%rdi), %xmm6
+  vpshufb %xmm0, %xmm7, %xmm7
+  movdqu 16(%rdi), %xmm2
+  vpshufb %xmm0, %xmm4, %xmm4
+  movdqu 0(%rdi), %xmm3
+  vpshufb %xmm0, %xmm5, %xmm5
+  movdqu %xmm4, 48(%rbp)
+  vpshufb %xmm0, %xmm6, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm2, %xmm2
+  movdqu %xmm6, 80(%rbp)
+  vpshufb %xmm0, %xmm3, %xmm3
+  movdqu %xmm2, 96(%rbp)
+  movdqu %xmm3, 112(%rbp)
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  cmp $6, %rdx
+  jne L164
+  sub $96, %r14
+  jmp L165
+L164:
+L165:
+  jmp L167
+.balign 16
+L166:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L168
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L169
+L168:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L169:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  cmp $6, %rdx
+  jbe L170
+  add $96, %r14
+  jmp L171
+L170:
+L171:
+  cmp $0, %rdx
+  jbe L172
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L173
+L172:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L173:
+.balign 16
+L167:
+  cmp $0, %rdx
+  ja L166
+  movdqu %xmm1, 32(%rbp)
+  movdqu %xmm9, -96(%rsi)
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm14, -16(%rsi)
+  sub $128, %rcx
+L163:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 104(%rsp), %rax
+  mov 112(%rsp), %rdi
+  mov 120(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  mov %rdi, %rbx
+  mov %rdx, %r12
+  mov %rax, %rdi
+  mov %rdi, %r11
+  jmp L175
+.balign 16
+L174:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L175:
+  cmp $6, %rdx
+  jae L174
+  cmp $0, %rdx
+  jbe L176
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L178
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L179
+L178:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L180
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L182
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L184
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L185
+L184:
+L185:
+  jmp L183
+L182:
+L183:
+  jmp L181
+L180:
+L181:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L179:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L177
+L176:
+L177:
+  mov %rbx, %rdi
+  mov %r12, %rdx
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L187
+.balign 16
+L186:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L187:
+  cmp %rdx, %rbx
+  jne L186
+  add 96(%rsp), %r14
+  imul $16, %r14
+  mov 136(%rsp), %r13
+  cmp %r14, %r13
+  jbe L188
+  mov 128(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu 0(%rax), %xmm0
+  movdqu %xmm0, %xmm10
+  cmp $8, %r10
+  jae L190
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L191
+L190:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L191:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm10
+  movdqu %xmm10, 0(%rax)
+  jmp L189
+L188:
+L189:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 152(%rsp), %r15
+  movdqu 0(%r15), %xmm0
+  pcmpeqd %xmm8, %xmm0
+  pextrq $0, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rax
+  adc $0, %rax
+  pextrq $1, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rdx
+  adc $0, %rdx
+  add %rdx, %rax
+  mov %rax, %rcx
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  mov %rcx, %rax
+  ret
+
+.global gcm256_decrypt_opt
+gcm256_decrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  mov 144(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 72(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L193
+.balign 16
+L192:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L193:
+  cmp $6, %rdx
+  jae L192
+  cmp $0, %rdx
+  jbe L194
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L196
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L197
+L196:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L198
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L200
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L202
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L203
+L202:
+L203:
+  jmp L201
+L200:
+L201:
+  jmp L199
+L198:
+L199:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L197:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L195
+L194:
+L195:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L204
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L206
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L207
+L206:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L207:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L205
+L204:
+L205:
+  mov 80(%rsp), %rdi
+  mov 88(%rsp), %rsi
+  mov 96(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L208
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L209
+L208:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rdi), %r14
+  movdqu 32(%rbp), %xmm8
+  movdqu 80(%rdi), %xmm7
+  movdqu 64(%rdi), %xmm4
+  movdqu 48(%rdi), %xmm5
+  movdqu 32(%rdi), %xmm6
+  vpshufb %xmm0, %xmm7, %xmm7
+  movdqu 16(%rdi), %xmm2
+  vpshufb %xmm0, %xmm4, %xmm4
+  movdqu 0(%rdi), %xmm3
+  vpshufb %xmm0, %xmm5, %xmm5
+  movdqu %xmm4, 48(%rbp)
+  vpshufb %xmm0, %xmm6, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm2, %xmm2
+  movdqu %xmm6, 80(%rbp)
+  vpshufb %xmm0, %xmm3, %xmm3
+  movdqu %xmm2, 96(%rbp)
+  movdqu %xmm3, 112(%rbp)
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  cmp $6, %rdx
+  jne L210
+  sub $96, %r14
+  jmp L211
+L210:
+L211:
+  jmp L213
+.balign 16
+L212:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L214
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L215
+L214:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L215:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 80(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 96(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  cmp $6, %rdx
+  jbe L216
+  add $96, %r14
+  jmp L217
+L216:
+L217:
+  cmp $0, %rdx
+  jbe L218
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L219
+L218:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L219:
+.balign 16
+L213:
+  cmp $0, %rdx
+  ja L212
+  movdqu %xmm1, 32(%rbp)
+  movdqu %xmm9, -96(%rsi)
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm14, -16(%rsi)
+  sub $128, %rcx
+L209:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 104(%rsp), %rax
+  mov 112(%rsp), %rdi
+  mov 120(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  mov %rdi, %rbx
+  mov %rdx, %r12
+  mov %rax, %rdi
+  mov %rdi, %r11
+  jmp L221
+.balign 16
+L220:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L221:
+  cmp $6, %rdx
+  jae L220
+  cmp $0, %rdx
+  jbe L222
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L224
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L225
+L224:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L226
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L228
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L230
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L231
+L230:
+L231:
+  jmp L229
+L228:
+L229:
+  jmp L227
+L226:
+L227:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L225:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L223
+L222:
+L223:
+  mov %rbx, %rdi
+  mov %r12, %rdx
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L233
+.balign 16
+L232:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L233:
+  cmp %rdx, %rbx
+  jne L232
+  add 96(%rsp), %r14
+  imul $16, %r14
+  mov 136(%rsp), %r13
+  cmp %r14, %r13
+  jbe L234
+  mov 128(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu 0(%rax), %xmm0
+  movdqu %xmm0, %xmm10
+  cmp $8, %r10
+  jae L236
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L237
+L236:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L237:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm10
+  movdqu %xmm10, 0(%rax)
+  jmp L235
+L234:
+L235:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 152(%rsp), %r15
+  movdqu 0(%r15), %xmm0
+  pcmpeqd %xmm8, %xmm0
+  pextrq $0, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rax
+  adc $0, %rax
+  pextrq $1, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rdx
+  adc $0, %rdx
+  add %rdx, %rax
+  mov %rax, %rcx
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  mov %rcx, %rax
+  ret
+
+.section .note.GNU-stack,"",%progbits

--- a/sys/hacl/c/vale/src/aesgcm-x86_64-mingw.S
+++ b/sys/hacl/c/vale/src/aesgcm-x86_64-mingw.S
@@ -1,0 +1,8705 @@
+.text
+.global aes128_key_expansion
+aes128_key_expansion:
+  movdqu 0(%rcx), %xmm1
+  movdqu %xmm1, 0(%rdx)
+  aeskeygenassist $1, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 16(%rdx)
+  aeskeygenassist $2, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 32(%rdx)
+  aeskeygenassist $4, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 48(%rdx)
+  aeskeygenassist $8, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 64(%rdx)
+  aeskeygenassist $16, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 80(%rdx)
+  aeskeygenassist $32, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 96(%rdx)
+  aeskeygenassist $64, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 112(%rdx)
+  aeskeygenassist $128, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 128(%rdx)
+  aeskeygenassist $27, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 144(%rdx)
+  aeskeygenassist $54, %xmm1, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  vpslldq $4, %xmm1, %xmm3
+  pxor %xmm3, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 160(%rdx)
+  pxor %xmm1, %xmm1
+  pxor %xmm2, %xmm2
+  pxor %xmm3, %xmm3
+  ret
+
+.global aes128_keyhash_init
+aes128_keyhash_init:
+  mov $579005069656919567, %r8
+  pinsrq $0, %r8, %xmm4
+  mov $283686952306183, %r8
+  pinsrq $1, %r8, %xmm4
+  pxor %xmm0, %xmm0
+  movdqu %xmm0, 80(%rdx)
+  mov %rcx, %r8
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm4, %xmm0
+  mov %rdx, %rcx
+  movdqu %xmm0, 32(%rcx)
+  movdqu %xmm6, %xmm0
+  mov %r12, %rax
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 0(%rcx)
+  movdqu %xmm6, %xmm1
+  movdqu %xmm6, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 16(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 48(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 64(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 96(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 112(%rcx)
+  movdqu %xmm0, %xmm6
+  mov %rax, %r12
+  ret
+
+.global aes256_key_expansion
+aes256_key_expansion:
+  movdqu 0(%rcx), %xmm1
+  movdqu 16(%rcx), %xmm3
+  movdqu %xmm1, 0(%rdx)
+  movdqu %xmm3, 16(%rdx)
+  aeskeygenassist $1, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 32(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 48(%rdx)
+  aeskeygenassist $2, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 64(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 80(%rdx)
+  aeskeygenassist $4, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 96(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 112(%rdx)
+  aeskeygenassist $8, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 128(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 144(%rdx)
+  aeskeygenassist $16, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 160(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 176(%rdx)
+  aeskeygenassist $32, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 192(%rdx)
+  aeskeygenassist $0, %xmm1, %xmm2
+  pshufd $170, %xmm2, %xmm2
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  vpslldq $4, %xmm3, %xmm4
+  pxor %xmm4, %xmm3
+  pxor %xmm2, %xmm3
+  movdqu %xmm3, 208(%rdx)
+  aeskeygenassist $64, %xmm3, %xmm2
+  pshufd $255, %xmm2, %xmm2
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  vpslldq $4, %xmm1, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm2, %xmm1
+  movdqu %xmm1, 224(%rdx)
+  pxor %xmm1, %xmm1
+  pxor %xmm2, %xmm2
+  pxor %xmm3, %xmm3
+  pxor %xmm4, %xmm4
+  ret
+
+.global aes256_keyhash_init
+aes256_keyhash_init:
+  mov $579005069656919567, %r8
+  pinsrq $0, %r8, %xmm4
+  mov $283686952306183, %r8
+  pinsrq $1, %r8, %xmm4
+  pxor %xmm0, %xmm0
+  movdqu %xmm0, 80(%rdx)
+  mov %rcx, %r8
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm4, %xmm0
+  mov %rdx, %rcx
+  movdqu %xmm0, 32(%rcx)
+  movdqu %xmm6, %xmm0
+  mov %r12, %rax
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 0(%rcx)
+  movdqu %xmm6, %xmm1
+  movdqu %xmm6, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 16(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 48(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 64(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 96(%rcx)
+  movdqu %xmm6, %xmm2
+  movdqu 32(%rcx), %xmm1
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm6
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  movdqu %xmm1, %xmm5
+  pclmulqdq $16, %xmm2, %xmm1
+  movdqu %xmm1, %xmm3
+  movdqu %xmm5, %xmm1
+  pclmulqdq $1, %xmm2, %xmm1
+  movdqu %xmm1, %xmm4
+  movdqu %xmm5, %xmm1
+  pclmulqdq $0, %xmm2, %xmm1
+  pclmulqdq $17, %xmm2, %xmm5
+  movdqu %xmm5, %xmm2
+  movdqu %xmm1, %xmm5
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm4, %xmm1
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm1
+  pshufd $14, %xmm1, %xmm1
+  pxor %xmm1, %xmm2
+  movdqu %xmm3, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm1
+  pshufd $79, %xmm1, %xmm1
+  mov $0, %r12
+  pinsrd $3, %r12d, %xmm4
+  pshufd $79, %xmm4, %xmm4
+  pxor %xmm4, %xmm1
+  pxor %xmm5, %xmm1
+  movdqu %xmm1, %xmm3
+  psrld $31, %xmm3
+  movdqu %xmm2, %xmm4
+  psrld $31, %xmm4
+  pslld $1, %xmm1
+  pslld $1, %xmm2
+  vpslldq $4, %xmm3, %xmm5
+  vpslldq $4, %xmm4, %xmm4
+  mov $0, %r12
+  pinsrd $0, %r12d, %xmm3
+  pshufd $3, %xmm3, %xmm3
+  pxor %xmm4, %xmm3
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm2
+  movdqu %xmm2, %xmm5
+  pxor %xmm2, %xmm2
+  mov $3774873600, %r12
+  pinsrd $3, %r12d, %xmm2
+  pclmulqdq $17, %xmm2, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm1
+  movdqu %xmm1, %xmm6
+  movdqu %xmm1, %xmm3
+  pxor %xmm4, %xmm4
+  pxor %xmm5, %xmm5
+  mov $3254779904, %r12
+  pinsrd $3, %r12d, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  mov $2147483648, %r12
+  pinsrd $3, %r12d, %xmm5
+  movdqu %xmm3, %xmm1
+  movdqu %xmm1, %xmm2
+  psrld $31, %xmm2
+  pslld $1, %xmm1
+  vpslldq $4, %xmm2, %xmm2
+  pxor %xmm2, %xmm1
+  pand %xmm5, %xmm3
+  pcmpeqd %xmm5, %xmm3
+  pshufd $255, %xmm3, %xmm3
+  pand %xmm4, %xmm3
+  vpxor %xmm3, %xmm1, %xmm1
+  movdqu %xmm1, 112(%rcx)
+  movdqu %xmm0, %xmm6
+  mov %rax, %r12
+  ret
+
+.global gctr128_bytes
+gctr128_bytes:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  pextrq $0, %xmm15, %rax
+  push %rax
+  pextrq $1, %xmm15, %rax
+  push %rax
+  pextrq $0, %xmm14, %rax
+  push %rax
+  pextrq $1, %xmm14, %rax
+  push %rax
+  pextrq $0, %xmm13, %rax
+  push %rax
+  pextrq $1, %xmm13, %rax
+  push %rax
+  pextrq $0, %xmm12, %rax
+  push %rax
+  pextrq $1, %xmm12, %rax
+  push %rax
+  pextrq $0, %xmm11, %rax
+  push %rax
+  pextrq $1, %xmm11, %rax
+  push %rax
+  pextrq $0, %xmm10, %rax
+  push %rax
+  pextrq $1, %xmm10, %rax
+  push %rax
+  pextrq $0, %xmm9, %rax
+  push %rax
+  pextrq $1, %xmm9, %rax
+  push %rax
+  pextrq $0, %xmm8, %rax
+  push %rax
+  pextrq $1, %xmm8, %rax
+  push %rax
+  pextrq $0, %xmm7, %rax
+  push %rax
+  pextrq $1, %xmm7, %rax
+  push %rax
+  pextrq $0, %xmm6, %rax
+  push %rax
+  pextrq $1, %xmm6, %rax
+  push %rax
+  mov 272(%rsp), %rax
+  movdqu 0(%rax), %xmm7
+  mov %rcx, %rax
+  mov %r8, %rbx
+  mov %rdx, %rsi
+  mov %r9, %r13
+  mov 264(%rsp), %r8
+  mov 280(%rsp), %rcx
+  mov %rcx, %rbp
+  imul $16, %rbp
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm8
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm8
+  mov %rcx, %rdx
+  shr $2, %rdx
+  and $3, %rcx
+  cmp $0, %rdx
+  jbe L0
+  mov %rax, %r9
+  mov %rbx, %r10
+  pshufb %xmm8, %xmm7
+  movdqu %xmm7, %xmm9
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pshufb %xmm0, %xmm9
+  movdqu %xmm9, %xmm10
+  pxor %xmm3, %xmm3
+  mov $1, %rax
+  pinsrd $2, %eax, %xmm3
+  paddd %xmm3, %xmm9
+  mov $3, %rax
+  pinsrd $2, %eax, %xmm3
+  mov $2, %rax
+  pinsrd $0, %eax, %xmm3
+  paddd %xmm3, %xmm10
+  pshufb %xmm8, %xmm9
+  pshufb %xmm8, %xmm10
+  pextrq $0, %xmm7, %rdi
+  mov $283686952306183, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pxor %xmm15, %xmm15
+  mov $4, %rax
+  pinsrd $0, %eax, %xmm15
+  mov $4, %rax
+  pinsrd $2, %eax, %xmm15
+  jmp L3
+.balign 16
+L2:
+  pinsrq $0, %rdi, %xmm2
+  pinsrq $0, %rdi, %xmm12
+  pinsrq $0, %rdi, %xmm13
+  pinsrq $0, %rdi, %xmm14
+  shufpd $2, %xmm9, %xmm2
+  shufpd $0, %xmm9, %xmm12
+  shufpd $2, %xmm10, %xmm13
+  shufpd $0, %xmm10, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  movdqu 0(%r8), %xmm3
+  movdqu 16(%r8), %xmm4
+  movdqu 32(%r8), %xmm5
+  movdqu 48(%r8), %xmm6
+  paddd %xmm15, %xmm9
+  paddd %xmm15, %xmm10
+  pxor %xmm3, %xmm2
+  pxor %xmm3, %xmm12
+  pxor %xmm3, %xmm13
+  pxor %xmm3, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 64(%r8), %xmm3
+  movdqu 80(%r8), %xmm4
+  movdqu 96(%r8), %xmm5
+  movdqu 112(%r8), %xmm6
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 128(%r8), %xmm3
+  movdqu 144(%r8), %xmm4
+  movdqu 160(%r8), %xmm5
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenclast %xmm5, %xmm2
+  aesenclast %xmm5, %xmm12
+  aesenclast %xmm5, %xmm13
+  aesenclast %xmm5, %xmm14
+  movdqu 0(%r9), %xmm7
+  pxor %xmm7, %xmm2
+  movdqu 16(%r9), %xmm7
+  pxor %xmm7, %xmm12
+  movdqu 32(%r9), %xmm7
+  pxor %xmm7, %xmm13
+  movdqu 48(%r9), %xmm7
+  pxor %xmm7, %xmm14
+  movdqu %xmm2, 0(%r10)
+  movdqu %xmm12, 16(%r10)
+  movdqu %xmm13, 32(%r10)
+  movdqu %xmm14, 48(%r10)
+  sub $1, %rdx
+  add $64, %r9
+  add $64, %r10
+.balign 16
+L3:
+  cmp $0, %rdx
+  ja L2
+  movdqu %xmm9, %xmm7
+  pinsrq $0, %rdi, %xmm7
+  pshufb %xmm8, %xmm7
+  mov %r9, %rax
+  mov %r10, %rbx
+  jmp L1
+L0:
+L1:
+  mov $0, %rdx
+  mov %rax, %r9
+  mov %rbx, %r10
+  pxor %xmm4, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  jmp L5
+.balign 16
+L4:
+  movdqu %xmm7, %xmm0
+  pshufb %xmm8, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r9), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rdx
+  add $16, %r9
+  add $16, %r10
+  paddd %xmm4, %xmm7
+.balign 16
+L5:
+  cmp %rcx, %rdx
+  jne L4
+  cmp %rbp, %rsi
+  jbe L6
+  movdqu 0(%r13), %xmm1
+  movdqu %xmm7, %xmm0
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm2
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm2
+  pshufb %xmm2, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm1
+  movdqu %xmm1, 0(%r13)
+  jmp L7
+L6:
+L7:
+  pop %rax
+  pinsrq $1, %rax, %xmm6
+  pop %rax
+  pinsrq $0, %rax, %xmm6
+  pop %rax
+  pinsrq $1, %rax, %xmm7
+  pop %rax
+  pinsrq $0, %rax, %xmm7
+  pop %rax
+  pinsrq $1, %rax, %xmm8
+  pop %rax
+  pinsrq $0, %rax, %xmm8
+  pop %rax
+  pinsrq $1, %rax, %xmm9
+  pop %rax
+  pinsrq $0, %rax, %xmm9
+  pop %rax
+  pinsrq $1, %rax, %xmm10
+  pop %rax
+  pinsrq $0, %rax, %xmm10
+  pop %rax
+  pinsrq $1, %rax, %xmm11
+  pop %rax
+  pinsrq $0, %rax, %xmm11
+  pop %rax
+  pinsrq $1, %rax, %xmm12
+  pop %rax
+  pinsrq $0, %rax, %xmm12
+  pop %rax
+  pinsrq $1, %rax, %xmm13
+  pop %rax
+  pinsrq $0, %rax, %xmm13
+  pop %rax
+  pinsrq $1, %rax, %xmm14
+  pop %rax
+  pinsrq $0, %rax, %xmm14
+  pop %rax
+  pinsrq $1, %rax, %xmm15
+  pop %rax
+  pinsrq $0, %rax, %xmm15
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global gctr256_bytes
+gctr256_bytes:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  pextrq $0, %xmm15, %rax
+  push %rax
+  pextrq $1, %xmm15, %rax
+  push %rax
+  pextrq $0, %xmm14, %rax
+  push %rax
+  pextrq $1, %xmm14, %rax
+  push %rax
+  pextrq $0, %xmm13, %rax
+  push %rax
+  pextrq $1, %xmm13, %rax
+  push %rax
+  pextrq $0, %xmm12, %rax
+  push %rax
+  pextrq $1, %xmm12, %rax
+  push %rax
+  pextrq $0, %xmm11, %rax
+  push %rax
+  pextrq $1, %xmm11, %rax
+  push %rax
+  pextrq $0, %xmm10, %rax
+  push %rax
+  pextrq $1, %xmm10, %rax
+  push %rax
+  pextrq $0, %xmm9, %rax
+  push %rax
+  pextrq $1, %xmm9, %rax
+  push %rax
+  pextrq $0, %xmm8, %rax
+  push %rax
+  pextrq $1, %xmm8, %rax
+  push %rax
+  pextrq $0, %xmm7, %rax
+  push %rax
+  pextrq $1, %xmm7, %rax
+  push %rax
+  pextrq $0, %xmm6, %rax
+  push %rax
+  pextrq $1, %xmm6, %rax
+  push %rax
+  mov 272(%rsp), %rax
+  movdqu 0(%rax), %xmm7
+  mov %rcx, %rax
+  mov %r8, %rbx
+  mov %rdx, %rsi
+  mov %r9, %r13
+  mov 264(%rsp), %r8
+  mov 280(%rsp), %rcx
+  mov %rcx, %rbp
+  imul $16, %rbp
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm8
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm8
+  mov %rcx, %rdx
+  shr $2, %rdx
+  and $3, %rcx
+  cmp $0, %rdx
+  jbe L8
+  mov %rax, %r9
+  mov %rbx, %r10
+  pshufb %xmm8, %xmm7
+  movdqu %xmm7, %xmm9
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pshufb %xmm0, %xmm9
+  movdqu %xmm9, %xmm10
+  pxor %xmm3, %xmm3
+  mov $1, %rax
+  pinsrd $2, %eax, %xmm3
+  paddd %xmm3, %xmm9
+  mov $3, %rax
+  pinsrd $2, %eax, %xmm3
+  mov $2, %rax
+  pinsrd $0, %eax, %xmm3
+  paddd %xmm3, %xmm10
+  pshufb %xmm8, %xmm9
+  pshufb %xmm8, %xmm10
+  pextrq $0, %xmm7, %rdi
+  mov $283686952306183, %rax
+  pinsrq $0, %rax, %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $1, %rax, %xmm0
+  pxor %xmm15, %xmm15
+  mov $4, %rax
+  pinsrd $0, %eax, %xmm15
+  mov $4, %rax
+  pinsrd $2, %eax, %xmm15
+  jmp L11
+.balign 16
+L10:
+  pinsrq $0, %rdi, %xmm2
+  pinsrq $0, %rdi, %xmm12
+  pinsrq $0, %rdi, %xmm13
+  pinsrq $0, %rdi, %xmm14
+  shufpd $2, %xmm9, %xmm2
+  shufpd $0, %xmm9, %xmm12
+  shufpd $2, %xmm10, %xmm13
+  shufpd $0, %xmm10, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  movdqu 0(%r8), %xmm3
+  movdqu 16(%r8), %xmm4
+  movdqu 32(%r8), %xmm5
+  movdqu 48(%r8), %xmm6
+  paddd %xmm15, %xmm9
+  paddd %xmm15, %xmm10
+  pxor %xmm3, %xmm2
+  pxor %xmm3, %xmm12
+  pxor %xmm3, %xmm13
+  pxor %xmm3, %xmm14
+  pshufb %xmm0, %xmm9
+  pshufb %xmm0, %xmm10
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 64(%r8), %xmm3
+  movdqu 80(%r8), %xmm4
+  movdqu 96(%r8), %xmm5
+  movdqu 112(%r8), %xmm6
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 128(%r8), %xmm3
+  movdqu 144(%r8), %xmm4
+  movdqu 160(%r8), %xmm5
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  movdqu %xmm5, %xmm3
+  movdqu 176(%r8), %xmm4
+  movdqu 192(%r8), %xmm5
+  movdqu 208(%r8), %xmm6
+  aesenc %xmm3, %xmm2
+  aesenc %xmm3, %xmm12
+  aesenc %xmm3, %xmm13
+  aesenc %xmm3, %xmm14
+  aesenc %xmm4, %xmm2
+  aesenc %xmm4, %xmm12
+  aesenc %xmm4, %xmm13
+  aesenc %xmm4, %xmm14
+  aesenc %xmm5, %xmm2
+  aesenc %xmm5, %xmm12
+  aesenc %xmm5, %xmm13
+  aesenc %xmm5, %xmm14
+  aesenc %xmm6, %xmm2
+  aesenc %xmm6, %xmm12
+  aesenc %xmm6, %xmm13
+  aesenc %xmm6, %xmm14
+  movdqu 224(%r8), %xmm5
+  aesenclast %xmm5, %xmm2
+  aesenclast %xmm5, %xmm12
+  aesenclast %xmm5, %xmm13
+  aesenclast %xmm5, %xmm14
+  movdqu 0(%r9), %xmm7
+  pxor %xmm7, %xmm2
+  movdqu 16(%r9), %xmm7
+  pxor %xmm7, %xmm12
+  movdqu 32(%r9), %xmm7
+  pxor %xmm7, %xmm13
+  movdqu 48(%r9), %xmm7
+  pxor %xmm7, %xmm14
+  movdqu %xmm2, 0(%r10)
+  movdqu %xmm12, 16(%r10)
+  movdqu %xmm13, 32(%r10)
+  movdqu %xmm14, 48(%r10)
+  sub $1, %rdx
+  add $64, %r9
+  add $64, %r10
+.balign 16
+L11:
+  cmp $0, %rdx
+  ja L10
+  movdqu %xmm9, %xmm7
+  pinsrq $0, %rdi, %xmm7
+  pshufb %xmm8, %xmm7
+  mov %r9, %rax
+  mov %r10, %rbx
+  jmp L9
+L8:
+L9:
+  mov $0, %rdx
+  mov %rax, %r9
+  mov %rbx, %r10
+  pxor %xmm4, %xmm4
+  mov $1, %r12
+  pinsrd $0, %r12d, %xmm4
+  jmp L13
+.balign 16
+L12:
+  movdqu %xmm7, %xmm0
+  pshufb %xmm8, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r9), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rdx
+  add $16, %r9
+  add $16, %r10
+  paddd %xmm4, %xmm7
+.balign 16
+L13:
+  cmp %rcx, %rdx
+  jne L12
+  cmp %rbp, %rsi
+  jbe L14
+  movdqu 0(%r13), %xmm1
+  movdqu %xmm7, %xmm0
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm2
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm2
+  pshufb %xmm2, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm1
+  movdqu %xmm1, 0(%r13)
+  jmp L15
+L14:
+L15:
+  pop %rax
+  pinsrq $1, %rax, %xmm6
+  pop %rax
+  pinsrq $0, %rax, %xmm6
+  pop %rax
+  pinsrq $1, %rax, %xmm7
+  pop %rax
+  pinsrq $0, %rax, %xmm7
+  pop %rax
+  pinsrq $1, %rax, %xmm8
+  pop %rax
+  pinsrq $0, %rax, %xmm8
+  pop %rax
+  pinsrq $1, %rax, %xmm9
+  pop %rax
+  pinsrq $0, %rax, %xmm9
+  pop %rax
+  pinsrq $1, %rax, %xmm10
+  pop %rax
+  pinsrq $0, %rax, %xmm10
+  pop %rax
+  pinsrq $1, %rax, %xmm11
+  pop %rax
+  pinsrq $0, %rax, %xmm11
+  pop %rax
+  pinsrq $1, %rax, %xmm12
+  pop %rax
+  pinsrq $0, %rax, %xmm12
+  pop %rax
+  pinsrq $1, %rax, %xmm13
+  pop %rax
+  pinsrq $0, %rax, %xmm13
+  pop %rax
+  pinsrq $1, %rax, %xmm14
+  pop %rax
+  pinsrq $0, %rax, %xmm14
+  pop %rax
+  pinsrq $1, %rax, %xmm15
+  pop %rax
+  pinsrq $0, %rax, %xmm15
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global compute_iv_stdcall
+compute_iv_stdcall:
+  cmp $12, %rdx
+  jne L16
+  push %rdi
+  push %rsi
+  mov %rcx, %rdi
+  mov %rdx, %rsi
+  mov %r8, %rdx
+  mov %r9, %rcx
+  mov 56(%rsp), %r8
+  mov 64(%rsp), %r9
+  cmp $12, %rsi
+  jne L18
+  movdqu 0(%r8), %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm1
+  mov $283686952306183, %rax
+  pinsrq $1, %rax, %xmm1
+  pshufb %xmm1, %xmm0
+  mov $1, %rax
+  pinsrd $0, %eax, %xmm0
+  movdqu %xmm0, 0(%rcx)
+  jmp L19
+L18:
+  mov %rcx, %rax
+  add $32, %r9
+  mov %r8, %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L21
+.balign 16
+L20:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L21:
+  cmp $6, %rdx
+  jae L20
+  cmp $0, %rdx
+  jbe L22
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L24
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L25
+L24:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L26
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L28
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L30
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L31
+L30:
+L31:
+  jmp L29
+L28:
+L29:
+  jmp L27
+L26:
+L27:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L25:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L23
+L22:
+L23:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L32
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L34
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L35
+L34:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L35:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L33
+L32:
+L33:
+  mov %rax, %rcx
+  mov $0, %r11
+  mov %rsi, %r13
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm8, 0(%rcx)
+L19:
+  pop %rsi
+  pop %rdi
+  jmp L17
+L16:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  pextrq $0, %xmm15, %rax
+  push %rax
+  pextrq $1, %xmm15, %rax
+  push %rax
+  pextrq $0, %xmm14, %rax
+  push %rax
+  pextrq $1, %xmm14, %rax
+  push %rax
+  pextrq $0, %xmm13, %rax
+  push %rax
+  pextrq $1, %xmm13, %rax
+  push %rax
+  pextrq $0, %xmm12, %rax
+  push %rax
+  pextrq $1, %xmm12, %rax
+  push %rax
+  pextrq $0, %xmm11, %rax
+  push %rax
+  pextrq $1, %xmm11, %rax
+  push %rax
+  pextrq $0, %xmm10, %rax
+  push %rax
+  pextrq $1, %xmm10, %rax
+  push %rax
+  pextrq $0, %xmm9, %rax
+  push %rax
+  pextrq $1, %xmm9, %rax
+  push %rax
+  pextrq $0, %xmm8, %rax
+  push %rax
+  pextrq $1, %xmm8, %rax
+  push %rax
+  pextrq $0, %xmm7, %rax
+  push %rax
+  pextrq $1, %xmm7, %rax
+  push %rax
+  pextrq $0, %xmm6, %rax
+  push %rax
+  pextrq $1, %xmm6, %rax
+  push %rax
+  mov %rcx, %rdi
+  mov %rdx, %rsi
+  mov %r8, %rdx
+  mov %r9, %rcx
+  mov 264(%rsp), %r8
+  mov 272(%rsp), %r9
+  cmp $12, %rsi
+  jne L36
+  movdqu 0(%r8), %xmm0
+  mov $579005069656919567, %rax
+  pinsrq $0, %rax, %xmm1
+  mov $283686952306183, %rax
+  pinsrq $1, %rax, %xmm1
+  pshufb %xmm1, %xmm0
+  mov $1, %rax
+  pinsrd $0, %eax, %xmm0
+  movdqu %xmm0, 0(%rcx)
+  jmp L37
+L36:
+  mov %rcx, %rax
+  add $32, %r9
+  mov %r8, %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L39
+.balign 16
+L38:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L39:
+  cmp $6, %rdx
+  jae L38
+  cmp $0, %rdx
+  jbe L40
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L42
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L43
+L42:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L44
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L46
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L48
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L49
+L48:
+L49:
+  jmp L47
+L46:
+L47:
+  jmp L45
+L44:
+L45:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L43:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L41
+L40:
+L41:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L50
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L52
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L53
+L52:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L53:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L51
+L50:
+L51:
+  mov %rax, %rcx
+  mov $0, %r11
+  mov %rsi, %r13
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm8, 0(%rcx)
+L37:
+  pop %rax
+  pinsrq $1, %rax, %xmm6
+  pop %rax
+  pinsrq $0, %rax, %xmm6
+  pop %rax
+  pinsrq $1, %rax, %xmm7
+  pop %rax
+  pinsrq $0, %rax, %xmm7
+  pop %rax
+  pinsrq $1, %rax, %xmm8
+  pop %rax
+  pinsrq $0, %rax, %xmm8
+  pop %rax
+  pinsrq $1, %rax, %xmm9
+  pop %rax
+  pinsrq $0, %rax, %xmm9
+  pop %rax
+  pinsrq $1, %rax, %xmm10
+  pop %rax
+  pinsrq $0, %rax, %xmm10
+  pop %rax
+  pinsrq $1, %rax, %xmm11
+  pop %rax
+  pinsrq $0, %rax, %xmm11
+  pop %rax
+  pinsrq $1, %rax, %xmm12
+  pop %rax
+  pinsrq $0, %rax, %xmm12
+  pop %rax
+  pinsrq $1, %rax, %xmm13
+  pop %rax
+  pinsrq $0, %rax, %xmm13
+  pop %rax
+  pinsrq $1, %rax, %xmm14
+  pop %rax
+  pinsrq $0, %rax, %xmm14
+  pop %rax
+  pinsrq $1, %rax, %xmm15
+  pop %rax
+  pinsrq $0, %rax, %xmm15
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+L17:
+  ret
+
+.global gcm128_encrypt_opt
+gcm128_encrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  pextrq $0, %xmm15, %rax
+  push %rax
+  pextrq $1, %xmm15, %rax
+  push %rax
+  pextrq $0, %xmm14, %rax
+  push %rax
+  pextrq $1, %xmm14, %rax
+  push %rax
+  pextrq $0, %xmm13, %rax
+  push %rax
+  pextrq $1, %xmm13, %rax
+  push %rax
+  pextrq $0, %xmm12, %rax
+  push %rax
+  pextrq $1, %xmm12, %rax
+  push %rax
+  pextrq $0, %xmm11, %rax
+  push %rax
+  pextrq $1, %xmm11, %rax
+  push %rax
+  pextrq $0, %xmm10, %rax
+  push %rax
+  pextrq $1, %xmm10, %rax
+  push %rax
+  pextrq $0, %xmm9, %rax
+  push %rax
+  pextrq $1, %xmm9, %rax
+  push %rax
+  pextrq $0, %xmm8, %rax
+  push %rax
+  pextrq $1, %xmm8, %rax
+  push %rax
+  pextrq $0, %xmm7, %rax
+  push %rax
+  pextrq $1, %xmm7, %rax
+  push %rax
+  pextrq $0, %xmm6, %rax
+  push %rax
+  pextrq $1, %xmm6, %rax
+  push %rax
+  mov %rcx, %rdi
+  mov %rdx, %rsi
+  mov %r8, %rdx
+  mov %r9, %rcx
+  mov 264(%rsp), %r8
+  mov 272(%rsp), %r9
+  mov 352(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 280(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L55
+.balign 16
+L54:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L55:
+  cmp $6, %rdx
+  jae L54
+  cmp $0, %rdx
+  jbe L56
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L58
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L59
+L58:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L60
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L62
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L64
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L65
+L64:
+L65:
+  jmp L63
+L62:
+L63:
+  jmp L61
+L60:
+L61:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L59:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L57
+L56:
+L57:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L66
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L68
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L69
+L68:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L69:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L67
+L66:
+L67:
+  mov 288(%rsp), %rdi
+  mov 296(%rsp), %rsi
+  mov 304(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L70
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L71
+L70:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rsi), %r14
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L72
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L73
+L72:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L73:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  movdqu 32(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  vpshufb %xmm0, %xmm9, %xmm8
+  vpshufb %xmm0, %xmm10, %xmm2
+  movdqu %xmm8, 112(%rbp)
+  vpshufb %xmm0, %xmm11, %xmm4
+  movdqu %xmm2, 96(%rbp)
+  vpshufb %xmm0, %xmm12, %xmm5
+  movdqu %xmm4, 80(%rbp)
+  vpshufb %xmm0, %xmm13, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm14, %xmm7
+  movdqu %xmm6, 48(%rbp)
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L74
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L75
+L74:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L75:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  movdqu 32(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  sub $12, %rdx
+  movdqu 32(%rbp), %xmm8
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  jmp L77
+.balign 16
+L76:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L78
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L79
+L78:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L79:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  add $96, %r14
+  cmp $0, %rdx
+  jbe L80
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L81
+L80:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L81:
+.balign 16
+L77:
+  cmp $0, %rdx
+  ja L76
+  movdqu 32(%rbp), %xmm7
+  movdqu %xmm1, 32(%rbp)
+  pxor %xmm4, %xmm4
+  movdqu %xmm4, 16(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm0
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm0
+  movdqu %xmm9, -96(%rsi)
+  vpshufb %xmm0, %xmm9, %xmm9
+  vpxor %xmm7, %xmm1, %xmm1
+  movdqu %xmm10, -80(%rsi)
+  vpshufb %xmm0, %xmm10, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  vpshufb %xmm0, %xmm11, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  vpshufb %xmm0, %xmm12, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  vpshufb %xmm0, %xmm13, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  vpshufb %xmm0, %xmm14, %xmm14
+  pxor %xmm4, %xmm4
+  movdqu %xmm14, %xmm7
+  movdqu %xmm4, 16(%rbp)
+  movdqu %xmm13, 48(%rbp)
+  movdqu %xmm12, 64(%rbp)
+  movdqu %xmm11, 80(%rbp)
+  movdqu %xmm10, 96(%rbp)
+  movdqu %xmm9, 112(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  sub $128, %rcx
+L71:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 312(%rsp), %rax
+  mov 320(%rsp), %rdi
+  mov 328(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L83
+.balign 16
+L82:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L83:
+  cmp %rdx, %rbx
+  jne L82
+  mov %rdi, %r11
+  jmp L85
+.balign 16
+L84:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L85:
+  cmp $6, %rdx
+  jae L84
+  cmp $0, %rdx
+  jbe L86
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L88
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L89
+L88:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L90
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L92
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L94
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L95
+L94:
+L95:
+  jmp L93
+L92:
+L93:
+  jmp L91
+L90:
+L91:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L89:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L87
+L86:
+L87:
+  add 304(%rsp), %r14
+  imul $16, %r14
+  mov 344(%rsp), %r13
+  cmp %r14, %r13
+  jbe L96
+  mov 336(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%rax), %xmm4
+  pxor %xmm4, %xmm0
+  movdqu %xmm0, 0(%rax)
+  cmp $8, %r10
+  jae L98
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L99
+L98:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L99:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L97
+L96:
+L97:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 360(%rsp), %r15
+  movdqu %xmm8, 0(%r15)
+  pop %rax
+  pinsrq $1, %rax, %xmm6
+  pop %rax
+  pinsrq $0, %rax, %xmm6
+  pop %rax
+  pinsrq $1, %rax, %xmm7
+  pop %rax
+  pinsrq $0, %rax, %xmm7
+  pop %rax
+  pinsrq $1, %rax, %xmm8
+  pop %rax
+  pinsrq $0, %rax, %xmm8
+  pop %rax
+  pinsrq $1, %rax, %xmm9
+  pop %rax
+  pinsrq $0, %rax, %xmm9
+  pop %rax
+  pinsrq $1, %rax, %xmm10
+  pop %rax
+  pinsrq $0, %rax, %xmm10
+  pop %rax
+  pinsrq $1, %rax, %xmm11
+  pop %rax
+  pinsrq $0, %rax, %xmm11
+  pop %rax
+  pinsrq $1, %rax, %xmm12
+  pop %rax
+  pinsrq $0, %rax, %xmm12
+  pop %rax
+  pinsrq $1, %rax, %xmm13
+  pop %rax
+  pinsrq $0, %rax, %xmm13
+  pop %rax
+  pinsrq $1, %rax, %xmm14
+  pop %rax
+  pinsrq $0, %rax, %xmm14
+  pop %rax
+  pinsrq $1, %rax, %xmm15
+  pop %rax
+  pinsrq $0, %rax, %xmm15
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global gcm256_encrypt_opt
+gcm256_encrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  pextrq $0, %xmm15, %rax
+  push %rax
+  pextrq $1, %xmm15, %rax
+  push %rax
+  pextrq $0, %xmm14, %rax
+  push %rax
+  pextrq $1, %xmm14, %rax
+  push %rax
+  pextrq $0, %xmm13, %rax
+  push %rax
+  pextrq $1, %xmm13, %rax
+  push %rax
+  pextrq $0, %xmm12, %rax
+  push %rax
+  pextrq $1, %xmm12, %rax
+  push %rax
+  pextrq $0, %xmm11, %rax
+  push %rax
+  pextrq $1, %xmm11, %rax
+  push %rax
+  pextrq $0, %xmm10, %rax
+  push %rax
+  pextrq $1, %xmm10, %rax
+  push %rax
+  pextrq $0, %xmm9, %rax
+  push %rax
+  pextrq $1, %xmm9, %rax
+  push %rax
+  pextrq $0, %xmm8, %rax
+  push %rax
+  pextrq $1, %xmm8, %rax
+  push %rax
+  pextrq $0, %xmm7, %rax
+  push %rax
+  pextrq $1, %xmm7, %rax
+  push %rax
+  pextrq $0, %xmm6, %rax
+  push %rax
+  pextrq $1, %xmm6, %rax
+  push %rax
+  mov %rcx, %rdi
+  mov %rdx, %rsi
+  mov %r8, %rdx
+  mov %r9, %rcx
+  mov 264(%rsp), %r8
+  mov 272(%rsp), %r9
+  mov 352(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 280(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L101
+.balign 16
+L100:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L101:
+  cmp $6, %rdx
+  jae L100
+  cmp $0, %rdx
+  jbe L102
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L104
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L105
+L104:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L106
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L108
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L110
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L111
+L110:
+L111:
+  jmp L109
+L108:
+L109:
+  jmp L107
+L106:
+L107:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L105:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L103
+L102:
+L103:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L112
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L114
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L115
+L114:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L115:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L113
+L112:
+L113:
+  mov 288(%rsp), %rdi
+  mov 296(%rsp), %rsi
+  mov 304(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L116
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L117
+L116:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rsi), %r14
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L118
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L119
+L118:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L119:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 80(%rcx), %xmm15
+  movdqu 96(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  vpshufb %xmm0, %xmm9, %xmm8
+  vpshufb %xmm0, %xmm10, %xmm2
+  movdqu %xmm8, 112(%rbp)
+  vpshufb %xmm0, %xmm11, %xmm4
+  movdqu %xmm2, 96(%rbp)
+  vpshufb %xmm0, %xmm12, %xmm5
+  movdqu %xmm4, 80(%rbp)
+  vpshufb %xmm0, %xmm13, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm14, %xmm7
+  movdqu %xmm6, 48(%rbp)
+  movdqu -128(%rcx), %xmm4
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  movdqu -112(%rcx), %xmm15
+  mov %rcx, %r12
+  sub $96, %r12
+  vpxor %xmm4, %xmm1, %xmm9
+  add $6, %rbx
+  cmp $256, %rbx
+  jae L120
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm14, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+  jmp L121
+L120:
+  sub $256, %rbx
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm4, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm4, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpxor %xmm4, %xmm12, %xmm12
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpxor %xmm4, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm1, %xmm1
+  vpxor %xmm4, %xmm14, %xmm14
+L121:
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm15
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 80(%rcx), %xmm15
+  movdqu 96(%rcx), %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 0(%rdi), %xmm3, %xmm4
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor 16(%rdi), %xmm3, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 32(%rdi), %xmm3, %xmm6
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 48(%rdi), %xmm3, %xmm8
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 64(%rdi), %xmm3, %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 80(%rdi), %xmm3, %xmm3
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm4, %xmm9, %xmm9
+  vaesenclast %xmm5, %xmm10, %xmm10
+  vaesenclast %xmm6, %xmm11, %xmm11
+  vaesenclast %xmm8, %xmm12, %xmm12
+  vaesenclast %xmm2, %xmm13, %xmm13
+  vaesenclast %xmm3, %xmm14, %xmm14
+  movdqu %xmm9, 0(%rsi)
+  movdqu %xmm10, 16(%rsi)
+  movdqu %xmm11, 32(%rsi)
+  movdqu %xmm12, 48(%rsi)
+  movdqu %xmm13, 64(%rsi)
+  movdqu %xmm14, 80(%rsi)
+  lea 96(%rsi), %rsi
+  sub $12, %rdx
+  movdqu 32(%rbp), %xmm8
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  jmp L123
+.balign 16
+L122:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L124
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L125
+L124:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L125:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 80(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 96(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  add $96, %r14
+  cmp $0, %rdx
+  jbe L126
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L127
+L126:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L127:
+.balign 16
+L123:
+  cmp $0, %rdx
+  ja L122
+  movdqu 32(%rbp), %xmm7
+  movdqu %xmm1, 32(%rbp)
+  pxor %xmm4, %xmm4
+  movdqu %xmm4, 16(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm0
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm0
+  movdqu %xmm9, -96(%rsi)
+  vpshufb %xmm0, %xmm9, %xmm9
+  vpxor %xmm7, %xmm1, %xmm1
+  movdqu %xmm10, -80(%rsi)
+  vpshufb %xmm0, %xmm10, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  vpshufb %xmm0, %xmm11, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  vpshufb %xmm0, %xmm12, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  vpshufb %xmm0, %xmm13, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  vpshufb %xmm0, %xmm14, %xmm14
+  pxor %xmm4, %xmm4
+  movdqu %xmm14, %xmm7
+  movdqu %xmm4, 16(%rbp)
+  movdqu %xmm13, 48(%rbp)
+  movdqu %xmm12, 64(%rbp)
+  movdqu %xmm11, 80(%rbp)
+  movdqu %xmm10, 96(%rbp)
+  movdqu %xmm9, 112(%rbp)
+  movdqu -32(%r9), %xmm3
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  movdqu 48(%rbp), %xmm0
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  movdqu -16(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  movdqu 16(%r9), %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vpxor %xmm5, %xmm6, %xmm6
+  vpxor %xmm1, %xmm6, %xmm6
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $3254779904, %rax
+  pinsrd $3, %eax, %xmm3
+  vpxor %xmm8, %xmm7, %xmm7
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  sub $128, %rcx
+L117:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 312(%rsp), %rax
+  mov 320(%rsp), %rdi
+  mov 328(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L129
+.balign 16
+L128:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L129:
+  cmp %rdx, %rbx
+  jne L128
+  mov %rdi, %r11
+  jmp L131
+.balign 16
+L130:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L131:
+  cmp $6, %rdx
+  jae L130
+  cmp $0, %rdx
+  jbe L132
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L134
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L135
+L134:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L136
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L138
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L140
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L141
+L140:
+L141:
+  jmp L139
+L138:
+L139:
+  jmp L137
+L136:
+L137:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L135:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L133
+L132:
+L133:
+  add 304(%rsp), %r14
+  imul $16, %r14
+  mov 344(%rsp), %r13
+  cmp %r14, %r13
+  jbe L142
+  mov 336(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%rax), %xmm4
+  pxor %xmm4, %xmm0
+  movdqu %xmm0, 0(%rax)
+  cmp $8, %r10
+  jae L144
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L145
+L144:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L145:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L143
+L142:
+L143:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 360(%rsp), %r15
+  movdqu %xmm8, 0(%r15)
+  pop %rax
+  pinsrq $1, %rax, %xmm6
+  pop %rax
+  pinsrq $0, %rax, %xmm6
+  pop %rax
+  pinsrq $1, %rax, %xmm7
+  pop %rax
+  pinsrq $0, %rax, %xmm7
+  pop %rax
+  pinsrq $1, %rax, %xmm8
+  pop %rax
+  pinsrq $0, %rax, %xmm8
+  pop %rax
+  pinsrq $1, %rax, %xmm9
+  pop %rax
+  pinsrq $0, %rax, %xmm9
+  pop %rax
+  pinsrq $1, %rax, %xmm10
+  pop %rax
+  pinsrq $0, %rax, %xmm10
+  pop %rax
+  pinsrq $1, %rax, %xmm11
+  pop %rax
+  pinsrq $0, %rax, %xmm11
+  pop %rax
+  pinsrq $1, %rax, %xmm12
+  pop %rax
+  pinsrq $0, %rax, %xmm12
+  pop %rax
+  pinsrq $1, %rax, %xmm13
+  pop %rax
+  pinsrq $0, %rax, %xmm13
+  pop %rax
+  pinsrq $1, %rax, %xmm14
+  pop %rax
+  pinsrq $0, %rax, %xmm14
+  pop %rax
+  pinsrq $1, %rax, %xmm15
+  pop %rax
+  pinsrq $0, %rax, %xmm15
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  ret
+
+.global gcm128_decrypt_opt
+gcm128_decrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  pextrq $0, %xmm15, %rax
+  push %rax
+  pextrq $1, %xmm15, %rax
+  push %rax
+  pextrq $0, %xmm14, %rax
+  push %rax
+  pextrq $1, %xmm14, %rax
+  push %rax
+  pextrq $0, %xmm13, %rax
+  push %rax
+  pextrq $1, %xmm13, %rax
+  push %rax
+  pextrq $0, %xmm12, %rax
+  push %rax
+  pextrq $1, %xmm12, %rax
+  push %rax
+  pextrq $0, %xmm11, %rax
+  push %rax
+  pextrq $1, %xmm11, %rax
+  push %rax
+  pextrq $0, %xmm10, %rax
+  push %rax
+  pextrq $1, %xmm10, %rax
+  push %rax
+  pextrq $0, %xmm9, %rax
+  push %rax
+  pextrq $1, %xmm9, %rax
+  push %rax
+  pextrq $0, %xmm8, %rax
+  push %rax
+  pextrq $1, %xmm8, %rax
+  push %rax
+  pextrq $0, %xmm7, %rax
+  push %rax
+  pextrq $1, %xmm7, %rax
+  push %rax
+  pextrq $0, %xmm6, %rax
+  push %rax
+  pextrq $1, %xmm6, %rax
+  push %rax
+  mov %rcx, %rdi
+  mov %rdx, %rsi
+  mov %r8, %rdx
+  mov %r9, %rcx
+  mov 264(%rsp), %r8
+  mov 272(%rsp), %r9
+  mov 352(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 280(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L147
+.balign 16
+L146:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L147:
+  cmp $6, %rdx
+  jae L146
+  cmp $0, %rdx
+  jbe L148
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L150
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L151
+L150:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L152
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L154
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L156
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L157
+L156:
+L157:
+  jmp L155
+L154:
+L155:
+  jmp L153
+L152:
+L153:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L151:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L149
+L148:
+L149:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L158
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L160
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L161
+L160:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L161:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L159
+L158:
+L159:
+  mov 288(%rsp), %rdi
+  mov 296(%rsp), %rsi
+  mov 304(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L162
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L163
+L162:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rdi), %r14
+  movdqu 32(%rbp), %xmm8
+  movdqu 80(%rdi), %xmm7
+  movdqu 64(%rdi), %xmm4
+  movdqu 48(%rdi), %xmm5
+  movdqu 32(%rdi), %xmm6
+  vpshufb %xmm0, %xmm7, %xmm7
+  movdqu 16(%rdi), %xmm2
+  vpshufb %xmm0, %xmm4, %xmm4
+  movdqu 0(%rdi), %xmm3
+  vpshufb %xmm0, %xmm5, %xmm5
+  movdqu %xmm4, 48(%rbp)
+  vpshufb %xmm0, %xmm6, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm2, %xmm2
+  movdqu %xmm6, 80(%rbp)
+  vpshufb %xmm0, %xmm3, %xmm3
+  movdqu %xmm2, 96(%rbp)
+  movdqu %xmm3, 112(%rbp)
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  cmp $6, %rdx
+  jne L164
+  sub $96, %r14
+  jmp L165
+L164:
+L165:
+  jmp L167
+.balign 16
+L166:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L168
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L169
+L168:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L169:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  cmp $6, %rdx
+  jbe L170
+  add $96, %r14
+  jmp L171
+L170:
+L171:
+  cmp $0, %rdx
+  jbe L172
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L173
+L172:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L173:
+.balign 16
+L167:
+  cmp $0, %rdx
+  ja L166
+  movdqu %xmm1, 32(%rbp)
+  movdqu %xmm9, -96(%rsi)
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm14, -16(%rsi)
+  sub $128, %rcx
+L163:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 312(%rsp), %rax
+  mov 320(%rsp), %rdi
+  mov 328(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  mov %rdi, %rbx
+  mov %rdx, %r12
+  mov %rax, %rdi
+  mov %rdi, %r11
+  jmp L175
+.balign 16
+L174:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L175:
+  cmp $6, %rdx
+  jae L174
+  cmp $0, %rdx
+  jbe L176
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L178
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L179
+L178:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L180
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L182
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L184
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L185
+L184:
+L185:
+  jmp L183
+L182:
+L183:
+  jmp L181
+L180:
+L181:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L179:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L177
+L176:
+L177:
+  mov %rbx, %rdi
+  mov %r12, %rdx
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L187
+.balign 16
+L186:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L187:
+  cmp %rdx, %rbx
+  jne L186
+  add 304(%rsp), %r14
+  imul $16, %r14
+  mov 344(%rsp), %r13
+  cmp %r14, %r13
+  jbe L188
+  mov 336(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu 0(%rax), %xmm0
+  movdqu %xmm0, %xmm10
+  cmp $8, %r10
+  jae L190
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L191
+L190:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L191:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm10
+  movdqu %xmm10, 0(%rax)
+  jmp L189
+L188:
+L189:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 360(%rsp), %r15
+  movdqu 0(%r15), %xmm0
+  pcmpeqd %xmm8, %xmm0
+  pextrq $0, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rax
+  adc $0, %rax
+  pextrq $1, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rdx
+  adc $0, %rdx
+  add %rdx, %rax
+  mov %rax, %rcx
+  pop %rax
+  pinsrq $1, %rax, %xmm6
+  pop %rax
+  pinsrq $0, %rax, %xmm6
+  pop %rax
+  pinsrq $1, %rax, %xmm7
+  pop %rax
+  pinsrq $0, %rax, %xmm7
+  pop %rax
+  pinsrq $1, %rax, %xmm8
+  pop %rax
+  pinsrq $0, %rax, %xmm8
+  pop %rax
+  pinsrq $1, %rax, %xmm9
+  pop %rax
+  pinsrq $0, %rax, %xmm9
+  pop %rax
+  pinsrq $1, %rax, %xmm10
+  pop %rax
+  pinsrq $0, %rax, %xmm10
+  pop %rax
+  pinsrq $1, %rax, %xmm11
+  pop %rax
+  pinsrq $0, %rax, %xmm11
+  pop %rax
+  pinsrq $1, %rax, %xmm12
+  pop %rax
+  pinsrq $0, %rax, %xmm12
+  pop %rax
+  pinsrq $1, %rax, %xmm13
+  pop %rax
+  pinsrq $0, %rax, %xmm13
+  pop %rax
+  pinsrq $1, %rax, %xmm14
+  pop %rax
+  pinsrq $0, %rax, %xmm14
+  pop %rax
+  pinsrq $1, %rax, %xmm15
+  pop %rax
+  pinsrq $0, %rax, %xmm15
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  mov %rcx, %rax
+  ret
+
+.global gcm256_decrypt_opt
+gcm256_decrypt_opt:
+  push %r15
+  push %r14
+  push %r13
+  push %r12
+  push %rsi
+  push %rdi
+  push %rbp
+  push %rbx
+  pextrq $0, %xmm15, %rax
+  push %rax
+  pextrq $1, %xmm15, %rax
+  push %rax
+  pextrq $0, %xmm14, %rax
+  push %rax
+  pextrq $1, %xmm14, %rax
+  push %rax
+  pextrq $0, %xmm13, %rax
+  push %rax
+  pextrq $1, %xmm13, %rax
+  push %rax
+  pextrq $0, %xmm12, %rax
+  push %rax
+  pextrq $1, %xmm12, %rax
+  push %rax
+  pextrq $0, %xmm11, %rax
+  push %rax
+  pextrq $1, %xmm11, %rax
+  push %rax
+  pextrq $0, %xmm10, %rax
+  push %rax
+  pextrq $1, %xmm10, %rax
+  push %rax
+  pextrq $0, %xmm9, %rax
+  push %rax
+  pextrq $1, %xmm9, %rax
+  push %rax
+  pextrq $0, %xmm8, %rax
+  push %rax
+  pextrq $1, %xmm8, %rax
+  push %rax
+  pextrq $0, %xmm7, %rax
+  push %rax
+  pextrq $1, %xmm7, %rax
+  push %rax
+  pextrq $0, %xmm6, %rax
+  push %rax
+  pextrq $1, %xmm6, %rax
+  push %rax
+  mov %rcx, %rdi
+  mov %rdx, %rsi
+  mov %r8, %rdx
+  mov %r9, %rcx
+  mov 264(%rsp), %r8
+  mov 272(%rsp), %r9
+  mov 352(%rsp), %rbp
+  mov %rcx, %r13
+  lea 32(%r9), %r9
+  mov 280(%rsp), %rbx
+  mov %rdx, %rcx
+  imul $16, %rcx
+  mov $579005069656919567, %r10
+  pinsrq $0, %r10, %xmm9
+  mov $283686952306183, %r10
+  pinsrq $1, %r10, %xmm9
+  pxor %xmm8, %xmm8
+  mov %rdi, %r11
+  jmp L193
+.balign 16
+L192:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L193:
+  cmp $6, %rdx
+  jae L192
+  cmp $0, %rdx
+  jbe L194
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L196
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L197
+L196:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L198
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L200
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L202
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L203
+L202:
+L203:
+  jmp L201
+L200:
+L201:
+  jmp L199
+L198:
+L199:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L197:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L195
+L194:
+L195:
+  mov %rsi, %r15
+  cmp %rcx, %rsi
+  jbe L204
+  movdqu 0(%rbx), %xmm0
+  mov %rsi, %r10
+  and $15, %r10
+  cmp $8, %r10
+  jae L206
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L207
+L206:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L207:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L205
+L204:
+L205:
+  mov 288(%rsp), %rdi
+  mov 296(%rsp), %rsi
+  mov 304(%rsp), %rdx
+  mov %r13, %rcx
+  movdqu %xmm9, %xmm0
+  movdqu 0(%r8), %xmm1
+  movdqu %xmm1, 0(%rbp)
+  pxor %xmm10, %xmm10
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm10
+  vpaddd %xmm10, %xmm1, %xmm1
+  cmp $0, %rdx
+  jne L208
+  vpshufb %xmm0, %xmm1, %xmm1
+  movdqu %xmm1, 32(%rbp)
+  jmp L209
+L208:
+  movdqu %xmm8, 32(%rbp)
+  add $128, %rcx
+  pextrq $0, %xmm1, %rbx
+  and $255, %rbx
+  vpshufb %xmm0, %xmm1, %xmm1
+  lea 96(%rdi), %r14
+  movdqu 32(%rbp), %xmm8
+  movdqu 80(%rdi), %xmm7
+  movdqu 64(%rdi), %xmm4
+  movdqu 48(%rdi), %xmm5
+  movdqu 32(%rdi), %xmm6
+  vpshufb %xmm0, %xmm7, %xmm7
+  movdqu 16(%rdi), %xmm2
+  vpshufb %xmm0, %xmm4, %xmm4
+  movdqu 0(%rdi), %xmm3
+  vpshufb %xmm0, %xmm5, %xmm5
+  movdqu %xmm4, 48(%rbp)
+  vpshufb %xmm0, %xmm6, %xmm6
+  movdqu %xmm5, 64(%rbp)
+  vpshufb %xmm0, %xmm2, %xmm2
+  movdqu %xmm6, 80(%rbp)
+  vpshufb %xmm0, %xmm3, %xmm3
+  movdqu %xmm2, 96(%rbp)
+  movdqu %xmm3, 112(%rbp)
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vpxor %xmm4, %xmm4, %xmm4
+  movdqu -128(%rcx), %xmm15
+  vpaddd %xmm2, %xmm1, %xmm10
+  vpaddd %xmm2, %xmm10, %xmm11
+  vpaddd %xmm2, %xmm11, %xmm12
+  vpaddd %xmm2, %xmm12, %xmm13
+  vpaddd %xmm2, %xmm13, %xmm14
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm4, 16(%rbp)
+  cmp $6, %rdx
+  jne L210
+  sub $96, %r14
+  jmp L211
+L210:
+L211:
+  jmp L213
+.balign 16
+L212:
+  add $6, %rbx
+  cmp $256, %rbx
+  jb L214
+  mov $579005069656919567, %r11
+  pinsrq $0, %r11, %xmm0
+  mov $283686952306183, %r11
+  pinsrq $1, %r11, %xmm0
+  vpshufb %xmm0, %xmm1, %xmm6
+  pxor %xmm5, %xmm5
+  mov $1, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm10
+  pxor %xmm5, %xmm5
+  mov $2, %r11
+  pinsrq $0, %r11, %xmm5
+  vpaddd %xmm5, %xmm6, %xmm11
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm5, %xmm10, %xmm12
+  vpshufb %xmm0, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm11, %xmm13
+  vpshufb %xmm0, %xmm11, %xmm11
+  vpxor %xmm15, %xmm10, %xmm10
+  vpaddd %xmm5, %xmm12, %xmm14
+  vpshufb %xmm0, %xmm12, %xmm12
+  vpxor %xmm15, %xmm11, %xmm11
+  vpaddd %xmm5, %xmm13, %xmm1
+  vpshufb %xmm0, %xmm13, %xmm13
+  vpshufb %xmm0, %xmm14, %xmm14
+  vpshufb %xmm0, %xmm1, %xmm1
+  sub $256, %rbx
+  jmp L215
+L214:
+  movdqu -32(%r9), %xmm3
+  vpaddd %xmm14, %xmm2, %xmm1
+  vpxor %xmm15, %xmm10, %xmm10
+  vpxor %xmm15, %xmm11, %xmm11
+L215:
+  movdqu %xmm1, 128(%rbp)
+  vpclmulqdq $16, %xmm3, %xmm7, %xmm5
+  vpxor %xmm15, %xmm12, %xmm12
+  movdqu -112(%rcx), %xmm2
+  vpclmulqdq $1, %xmm3, %xmm7, %xmm6
+  vaesenc %xmm2, %xmm9, %xmm9
+  movdqu 48(%rbp), %xmm0
+  vpxor %xmm15, %xmm13, %xmm13
+  vpclmulqdq $0, %xmm3, %xmm7, %xmm1
+  vaesenc %xmm2, %xmm10, %xmm10
+  vpxor %xmm15, %xmm14, %xmm14
+  vpclmulqdq $17, %xmm3, %xmm7, %xmm7
+  vaesenc %xmm2, %xmm11, %xmm11
+  movdqu -16(%r9), %xmm3
+  vaesenc %xmm2, %xmm12, %xmm12
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm3, %xmm0, %xmm5
+  vpxor %xmm4, %xmm8, %xmm8
+  vaesenc %xmm2, %xmm13, %xmm13
+  vpxor %xmm5, %xmm1, %xmm4
+  vpclmulqdq $16, %xmm3, %xmm0, %xmm1
+  vaesenc %xmm2, %xmm14, %xmm14
+  movdqu -96(%rcx), %xmm15
+  vpclmulqdq $1, %xmm3, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpclmulqdq $17, %xmm3, %xmm0, %xmm3
+  movdqu 64(%rbp), %xmm0
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 88(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 80(%r14), %r12
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 32(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 40(%rbp)
+  movdqu 16(%r9), %xmm5
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -80(%rcx), %xmm15
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm3, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 80(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -64(%rcx), %xmm15
+  vpxor %xmm2, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm1, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm1, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 72(%r14), %r13
+  vpxor %xmm5, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm1, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 64(%r14), %r12
+  vpclmulqdq $17, %xmm1, %xmm0, %xmm1
+  movdqu 96(%rbp), %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 48(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 56(%rbp)
+  vpxor %xmm2, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm2
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -48(%rcx), %xmm15
+  vpxor %xmm3, %xmm6, %xmm6
+  vpclmulqdq $0, %xmm2, %xmm0, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm2, %xmm0, %xmm5
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 56(%r14), %r13
+  vpxor %xmm1, %xmm7, %xmm7
+  vpclmulqdq $1, %xmm2, %xmm0, %xmm1
+  vpxor 112(%rbp), %xmm8, %xmm8
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 48(%r14), %r12
+  vpclmulqdq $17, %xmm2, %xmm0, %xmm2
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 64(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 72(%rbp)
+  vpxor %xmm3, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm3
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu -32(%rcx), %xmm15
+  vpxor %xmm5, %xmm6, %xmm6
+  vpclmulqdq $16, %xmm3, %xmm8, %xmm5
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm1, %xmm6, %xmm6
+  vpclmulqdq $1, %xmm3, %xmm8, %xmm1
+  vaesenc %xmm15, %xmm10, %xmm10
+  movbeq 40(%r14), %r13
+  vpxor %xmm2, %xmm7, %xmm7
+  vpclmulqdq $0, %xmm3, %xmm8, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 32(%r14), %r12
+  vpclmulqdq $17, %xmm3, %xmm8, %xmm8
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r13, 80(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  movq %r12, 88(%rbp)
+  vpxor %xmm5, %xmm6, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor %xmm1, %xmm6, %xmm6
+  movdqu -16(%rcx), %xmm15
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm2, %xmm4, %xmm4
+  pxor %xmm3, %xmm3
+  mov $13979173243358019584, %r11
+  pinsrq $1, %r11, %xmm3
+  vaesenc %xmm15, %xmm9, %xmm9
+  vpxor %xmm8, %xmm7, %xmm7
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpxor %xmm5, %xmm4, %xmm4
+  movbeq 24(%r14), %r13
+  vaesenc %xmm15, %xmm11, %xmm11
+  movbeq 16(%r14), %r12
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  movq %r13, 96(%rbp)
+  vaesenc %xmm15, %xmm12, %xmm12
+  movq %r12, 104(%rbp)
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  movdqu 0(%rcx), %xmm1
+  vaesenc %xmm1, %xmm9, %xmm9
+  movdqu 16(%rcx), %xmm15
+  vaesenc %xmm1, %xmm10, %xmm10
+  vpsrldq $8, %xmm6, %xmm6
+  vaesenc %xmm1, %xmm11, %xmm11
+  vpxor %xmm6, %xmm7, %xmm7
+  vaesenc %xmm1, %xmm12, %xmm12
+  vpxor %xmm0, %xmm4, %xmm4
+  movbeq 8(%r14), %r13
+  vaesenc %xmm1, %xmm13, %xmm13
+  movbeq 0(%r14), %r12
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 32(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 48(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 64(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  vaesenc %xmm15, %xmm10, %xmm10
+  vaesenc %xmm15, %xmm11, %xmm11
+  vaesenc %xmm15, %xmm12, %xmm12
+  vaesenc %xmm15, %xmm13, %xmm13
+  vaesenc %xmm15, %xmm14, %xmm14
+  vaesenc %xmm1, %xmm9, %xmm9
+  vaesenc %xmm1, %xmm10, %xmm10
+  vaesenc %xmm1, %xmm11, %xmm11
+  vaesenc %xmm1, %xmm12, %xmm12
+  vaesenc %xmm1, %xmm13, %xmm13
+  movdqu 80(%rcx), %xmm15
+  vaesenc %xmm1, %xmm14, %xmm14
+  movdqu 96(%rcx), %xmm1
+  vaesenc %xmm15, %xmm9, %xmm9
+  movdqu %xmm7, 16(%rbp)
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vaesenc %xmm15, %xmm10, %xmm10
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor 0(%rdi), %xmm1, %xmm2
+  vaesenc %xmm15, %xmm11, %xmm11
+  vpxor 16(%rdi), %xmm1, %xmm0
+  vaesenc %xmm15, %xmm12, %xmm12
+  vpxor 32(%rdi), %xmm1, %xmm5
+  vaesenc %xmm15, %xmm13, %xmm13
+  vpxor 48(%rdi), %xmm1, %xmm6
+  vaesenc %xmm15, %xmm14, %xmm14
+  vpxor 64(%rdi), %xmm1, %xmm7
+  vpxor 80(%rdi), %xmm1, %xmm3
+  movdqu 128(%rbp), %xmm1
+  vaesenclast %xmm2, %xmm9, %xmm9
+  pxor %xmm2, %xmm2
+  mov $72057594037927936, %r11
+  pinsrq $1, %r11, %xmm2
+  vaesenclast %xmm0, %xmm10, %xmm10
+  vpaddd %xmm2, %xmm1, %xmm0
+  movq %r13, 112(%rbp)
+  lea 96(%rdi), %rdi
+  vaesenclast %xmm5, %xmm11, %xmm11
+  vpaddd %xmm2, %xmm0, %xmm5
+  movq %r12, 120(%rbp)
+  lea 96(%rsi), %rsi
+  movdqu -128(%rcx), %xmm15
+  vaesenclast %xmm6, %xmm12, %xmm12
+  vpaddd %xmm2, %xmm5, %xmm6
+  vaesenclast %xmm7, %xmm13, %xmm13
+  vpaddd %xmm2, %xmm6, %xmm7
+  vaesenclast %xmm3, %xmm14, %xmm14
+  vpaddd %xmm2, %xmm7, %xmm3
+  sub $6, %rdx
+  cmp $6, %rdx
+  jbe L216
+  add $96, %r14
+  jmp L217
+L216:
+L217:
+  cmp $0, %rdx
+  jbe L218
+  movdqu %xmm9, -96(%rsi)
+  vpxor %xmm15, %xmm1, %xmm9
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm0, %xmm10
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm5, %xmm11
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm6, %xmm12
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm7, %xmm13
+  movdqu %xmm14, -16(%rsi)
+  movdqu %xmm3, %xmm14
+  movdqu 32(%rbp), %xmm7
+  jmp L219
+L218:
+  vpxor 16(%rbp), %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+L219:
+.balign 16
+L213:
+  cmp $0, %rdx
+  ja L212
+  movdqu %xmm1, 32(%rbp)
+  movdqu %xmm9, -96(%rsi)
+  movdqu %xmm10, -80(%rsi)
+  movdqu %xmm11, -64(%rsi)
+  movdqu %xmm12, -48(%rsi)
+  movdqu %xmm13, -32(%rsi)
+  movdqu %xmm14, -16(%rsi)
+  sub $128, %rcx
+L209:
+  movdqu 32(%rbp), %xmm11
+  mov %rcx, %r8
+  mov 312(%rsp), %rax
+  mov 320(%rsp), %rdi
+  mov 328(%rsp), %rdx
+  mov %rdx, %r14
+  mov $579005069656919567, %r12
+  pinsrq $0, %r12, %xmm9
+  mov $283686952306183, %r12
+  pinsrq $1, %r12, %xmm9
+  pshufb %xmm9, %xmm11
+  mov %rdi, %rbx
+  mov %rdx, %r12
+  mov %rax, %rdi
+  mov %rdi, %r11
+  jmp L221
+.balign 16
+L220:
+  add $80, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 80(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  add $96, %r11
+  sub $6, %rdx
+.balign 16
+L221:
+  cmp $6, %rdx
+  jae L220
+  cmp $0, %rdx
+  jbe L222
+  mov %rdx, %r10
+  sub $1, %r10
+  imul $16, %r10
+  add %r10, %r11
+  movdqu -32(%r9), %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  cmp $1, %rdx
+  jne L224
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  jmp L225
+L224:
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu %xmm1, %xmm4
+  movdqu -16(%r9), %xmm1
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $2, %rdx
+  je L226
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 16(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $3, %rdx
+  je L228
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 32(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  cmp $4, %rdx
+  je L230
+  sub $16, %r11
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu 0(%r11), %xmm0
+  pshufb %xmm9, %xmm0
+  vpxor %xmm1, %xmm4, %xmm4
+  movdqu 64(%r9), %xmm1
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+  movdqu %xmm1, %xmm5
+  jmp L231
+L230:
+L231:
+  jmp L229
+L228:
+L229:
+  jmp L227
+L226:
+L227:
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  vpxor %xmm1, %xmm4, %xmm4
+  vpxor %xmm2, %xmm6, %xmm6
+  vpxor %xmm3, %xmm6, %xmm6
+  vpxor %xmm5, %xmm7, %xmm7
+L225:
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r10
+  pinsrd $3, %r10d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  jmp L223
+L222:
+L223:
+  mov %rbx, %rdi
+  mov %r12, %rdx
+  pxor %xmm10, %xmm10
+  mov $1, %rbx
+  pinsrd $0, %ebx, %xmm10
+  mov %rax, %r11
+  mov %rdi, %r10
+  mov $0, %rbx
+  jmp L233
+.balign 16
+L232:
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  movdqu 0(%r11), %xmm2
+  pxor %xmm0, %xmm2
+  movdqu %xmm2, 0(%r10)
+  add $1, %rbx
+  add $16, %r11
+  add $16, %r10
+  paddd %xmm10, %xmm11
+.balign 16
+L233:
+  cmp %rdx, %rbx
+  jne L232
+  add 304(%rsp), %r14
+  imul $16, %r14
+  mov 344(%rsp), %r13
+  cmp %r14, %r13
+  jbe L234
+  mov 336(%rsp), %rax
+  mov %r13, %r10
+  and $15, %r10
+  movdqu 0(%rax), %xmm0
+  movdqu %xmm0, %xmm10
+  cmp $8, %r10
+  jae L236
+  mov $0, %rcx
+  pinsrq $1, %rcx, %xmm0
+  mov %r10, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $0, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $0, %rcx, %xmm0
+  jmp L237
+L236:
+  mov %r10, %rcx
+  sub $8, %rcx
+  shl $3, %rcx
+  mov $1, %r11
+  shl %cl, %r11
+  sub $1, %r11
+  pextrq $1, %xmm0, %rcx
+  and %r11, %rcx
+  pinsrq $1, %rcx, %xmm0
+L237:
+  pshufb %xmm9, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu %xmm11, %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pxor %xmm0, %xmm10
+  movdqu %xmm10, 0(%rax)
+  jmp L235
+L234:
+L235:
+  mov %r15, %r11
+  pxor %xmm0, %xmm0
+  mov %r11, %rax
+  imul $8, %rax
+  pinsrq $1, %rax, %xmm0
+  mov %r13, %rax
+  imul $8, %rax
+  pinsrq $0, %rax, %xmm0
+  movdqu -32(%r9), %xmm5
+  vpxor %xmm0, %xmm8, %xmm0
+  vpclmulqdq $0, %xmm5, %xmm0, %xmm1
+  vpclmulqdq $16, %xmm5, %xmm0, %xmm2
+  vpclmulqdq $1, %xmm5, %xmm0, %xmm3
+  vpclmulqdq $17, %xmm5, %xmm0, %xmm5
+  movdqu %xmm1, %xmm4
+  vpxor %xmm3, %xmm2, %xmm6
+  movdqu %xmm5, %xmm7
+  pxor %xmm3, %xmm3
+  mov $3254779904, %r11
+  pinsrd $3, %r11d, %xmm3
+  vpslldq $8, %xmm6, %xmm5
+  vpxor %xmm5, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm0
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpsrldq $8, %xmm6, %xmm6
+  vpxor %xmm6, %xmm7, %xmm7
+  vpxor %xmm0, %xmm4, %xmm4
+  vpalignr $8, %xmm4, %xmm4, %xmm8
+  vpclmulqdq $16, %xmm3, %xmm4, %xmm4
+  vpxor %xmm7, %xmm8, %xmm8
+  vpxor %xmm4, %xmm8, %xmm8
+  movdqu 0(%rbp), %xmm0
+  pshufb %xmm9, %xmm0
+  movdqu 0(%r8), %xmm2
+  pxor %xmm2, %xmm0
+  movdqu 16(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 32(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 48(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 64(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 80(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 96(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 112(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 128(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 144(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 160(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 176(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 192(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 208(%r8), %xmm2
+  aesenc %xmm2, %xmm0
+  movdqu 224(%r8), %xmm2
+  aesenclast %xmm2, %xmm0
+  pxor %xmm2, %xmm2
+  pshufb %xmm9, %xmm8
+  pxor %xmm0, %xmm8
+  mov 360(%rsp), %r15
+  movdqu 0(%r15), %xmm0
+  pcmpeqd %xmm8, %xmm0
+  pextrq $0, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rax
+  adc $0, %rax
+  pextrq $1, %xmm0, %rdx
+  sub $18446744073709551615, %rdx
+  mov $0, %rdx
+  adc $0, %rdx
+  add %rdx, %rax
+  mov %rax, %rcx
+  pop %rax
+  pinsrq $1, %rax, %xmm6
+  pop %rax
+  pinsrq $0, %rax, %xmm6
+  pop %rax
+  pinsrq $1, %rax, %xmm7
+  pop %rax
+  pinsrq $0, %rax, %xmm7
+  pop %rax
+  pinsrq $1, %rax, %xmm8
+  pop %rax
+  pinsrq $0, %rax, %xmm8
+  pop %rax
+  pinsrq $1, %rax, %xmm9
+  pop %rax
+  pinsrq $0, %rax, %xmm9
+  pop %rax
+  pinsrq $1, %rax, %xmm10
+  pop %rax
+  pinsrq $0, %rax, %xmm10
+  pop %rax
+  pinsrq $1, %rax, %xmm11
+  pop %rax
+  pinsrq $0, %rax, %xmm11
+  pop %rax
+  pinsrq $1, %rax, %xmm12
+  pop %rax
+  pinsrq $0, %rax, %xmm12
+  pop %rax
+  pinsrq $1, %rax, %xmm13
+  pop %rax
+  pinsrq $0, %rax, %xmm13
+  pop %rax
+  pinsrq $1, %rax, %xmm14
+  pop %rax
+  pinsrq $0, %rax, %xmm14
+  pop %rax
+  pinsrq $1, %rax, %xmm15
+  pop %rax
+  pinsrq $0, %rax, %xmm15
+  pop %rbx
+  pop %rbp
+  pop %rdi
+  pop %rsi
+  pop %r12
+  pop %r13
+  pop %r14
+  pop %r15
+  mov %rcx, %rax
+  ret
+
+

--- a/sys/hacl/c/vale/src/aesgcm-x86_64-msvc.asm
+++ b/sys/hacl/c/vale/src/aesgcm-x86_64-msvc.asm
@@ -1,0 +1,8705 @@
+.code
+ALIGN 16
+aes128_key_expansion proc
+  movdqu xmm1, xmmword ptr [rcx + 0]
+  movdqu xmmword ptr [rdx + 0], xmm1
+  aeskeygenassist xmm2, xmm1, 1
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 16], xmm1
+  aeskeygenassist xmm2, xmm1, 2
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 32], xmm1
+  aeskeygenassist xmm2, xmm1, 4
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 48], xmm1
+  aeskeygenassist xmm2, xmm1, 8
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 64], xmm1
+  aeskeygenassist xmm2, xmm1, 16
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 80], xmm1
+  aeskeygenassist xmm2, xmm1, 32
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 96], xmm1
+  aeskeygenassist xmm2, xmm1, 64
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 112], xmm1
+  aeskeygenassist xmm2, xmm1, 128
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 128], xmm1
+  aeskeygenassist xmm2, xmm1, 27
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 144], xmm1
+  aeskeygenassist xmm2, xmm1, 54
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  vpslldq xmm3, xmm1, 4
+  pxor xmm1, xmm3
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 160], xmm1
+  pxor xmm1, xmm1
+  pxor xmm2, xmm2
+  pxor xmm3, xmm3
+  ret
+aes128_key_expansion endp
+ALIGN 16
+aes128_keyhash_init proc
+  mov r8, 579005069656919567
+  pinsrq xmm4, r8, 0
+  mov r8, 283686952306183
+  pinsrq xmm4, r8, 1
+  pxor xmm0, xmm0
+  movdqu xmmword ptr [rdx + 80], xmm0
+  mov r8, rcx
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  pshufb xmm0, xmm4
+  mov rcx, rdx
+  movdqu xmmword ptr [rcx + 32], xmm0
+  movdqu xmm0, xmm6
+  mov rax, r12
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 0], xmm1
+  movdqu xmm1, xmm6
+  movdqu xmm2, xmm6
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm6, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm5, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  pclmulqdq xmm1, xmm2, 17
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pxor xmm1, xmm5
+  pxor xmm1, xmm6
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 16], xmm1
+  movdqu xmm2, xmm6
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm6, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm5, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  pclmulqdq xmm1, xmm2, 17
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pxor xmm1, xmm5
+  pxor xmm1, xmm6
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 48], xmm1
+  movdqu xmm2, xmm6
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm6, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm5, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  pclmulqdq xmm1, xmm2, 17
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pxor xmm1, xmm5
+  pxor xmm1, xmm6
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 64], xmm1
+  movdqu xmm2, xmm6
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm6, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm5, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  pclmulqdq xmm1, xmm2, 17
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pxor xmm1, xmm5
+  pxor xmm1, xmm6
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 96], xmm1
+  movdqu xmm2, xmm6
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm6, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm5, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  pclmulqdq xmm1, xmm2, 17
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pxor xmm1, xmm5
+  pxor xmm1, xmm6
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 112], xmm1
+  movdqu xmm6, xmm0
+  mov r12, rax
+  ret
+aes128_keyhash_init endp
+ALIGN 16
+aes256_key_expansion proc
+  movdqu xmm1, xmmword ptr [rcx + 0]
+  movdqu xmm3, xmmword ptr [rcx + 16]
+  movdqu xmmword ptr [rdx + 0], xmm1
+  movdqu xmmword ptr [rdx + 16], xmm3
+  aeskeygenassist xmm2, xmm3, 1
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 32], xmm1
+  aeskeygenassist xmm2, xmm1, 0
+  pshufd xmm2, xmm2, 170
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  pxor xmm3, xmm2
+  movdqu xmmword ptr [rdx + 48], xmm3
+  aeskeygenassist xmm2, xmm3, 2
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 64], xmm1
+  aeskeygenassist xmm2, xmm1, 0
+  pshufd xmm2, xmm2, 170
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  pxor xmm3, xmm2
+  movdqu xmmword ptr [rdx + 80], xmm3
+  aeskeygenassist xmm2, xmm3, 4
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 96], xmm1
+  aeskeygenassist xmm2, xmm1, 0
+  pshufd xmm2, xmm2, 170
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  pxor xmm3, xmm2
+  movdqu xmmword ptr [rdx + 112], xmm3
+  aeskeygenassist xmm2, xmm3, 8
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 128], xmm1
+  aeskeygenassist xmm2, xmm1, 0
+  pshufd xmm2, xmm2, 170
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  pxor xmm3, xmm2
+  movdqu xmmword ptr [rdx + 144], xmm3
+  aeskeygenassist xmm2, xmm3, 16
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 160], xmm1
+  aeskeygenassist xmm2, xmm1, 0
+  pshufd xmm2, xmm2, 170
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  pxor xmm3, xmm2
+  movdqu xmmword ptr [rdx + 176], xmm3
+  aeskeygenassist xmm2, xmm3, 32
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 192], xmm1
+  aeskeygenassist xmm2, xmm1, 0
+  pshufd xmm2, xmm2, 170
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  vpslldq xmm4, xmm3, 4
+  pxor xmm3, xmm4
+  pxor xmm3, xmm2
+  movdqu xmmword ptr [rdx + 208], xmm3
+  aeskeygenassist xmm2, xmm3, 64
+  pshufd xmm2, xmm2, 255
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  vpslldq xmm4, xmm1, 4
+  pxor xmm1, xmm4
+  pxor xmm1, xmm2
+  movdqu xmmword ptr [rdx + 224], xmm1
+  pxor xmm1, xmm1
+  pxor xmm2, xmm2
+  pxor xmm3, xmm3
+  pxor xmm4, xmm4
+  ret
+aes256_key_expansion endp
+ALIGN 16
+aes256_keyhash_init proc
+  mov r8, 579005069656919567
+  pinsrq xmm4, r8, 0
+  mov r8, 283686952306183
+  pinsrq xmm4, r8, 1
+  pxor xmm0, xmm0
+  movdqu xmmword ptr [rdx + 80], xmm0
+  mov r8, rcx
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 176]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 192]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 208]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 224]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  pshufb xmm0, xmm4
+  mov rcx, rdx
+  movdqu xmmword ptr [rcx + 32], xmm0
+  movdqu xmm0, xmm6
+  mov rax, r12
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 0], xmm1
+  movdqu xmm1, xmm6
+  movdqu xmm2, xmm6
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm6, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm5, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  pclmulqdq xmm1, xmm2, 17
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pxor xmm1, xmm5
+  pxor xmm1, xmm6
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 16], xmm1
+  movdqu xmm2, xmm6
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm6, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm5, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  pclmulqdq xmm1, xmm2, 17
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pxor xmm1, xmm5
+  pxor xmm1, xmm6
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 48], xmm1
+  movdqu xmm2, xmm6
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm6, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm5, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  pclmulqdq xmm1, xmm2, 17
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pxor xmm1, xmm5
+  pxor xmm1, xmm6
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 64], xmm1
+  movdqu xmm2, xmm6
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm6, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm5, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  pclmulqdq xmm1, xmm2, 17
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pxor xmm1, xmm5
+  pxor xmm1, xmm6
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 96], xmm1
+  movdqu xmm2, xmm6
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm6, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  movdqu xmm5, xmm1
+  pclmulqdq xmm1, xmm2, 16
+  movdqu xmm3, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 1
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmm5
+  pclmulqdq xmm1, xmm2, 0
+  pclmulqdq xmm5, xmm2, 17
+  movdqu xmm2, xmm5
+  movdqu xmm5, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm4
+  mov r12, 0
+  pinsrd xmm1, r12d, 0
+  pshufd xmm1, xmm1, 14
+  pxor xmm2, xmm1
+  movdqu xmm1, xmm3
+  mov r12, 0
+  pinsrd xmm1, r12d, 3
+  pshufd xmm1, xmm1, 79
+  mov r12, 0
+  pinsrd xmm4, r12d, 3
+  pshufd xmm4, xmm4, 79
+  pxor xmm1, xmm4
+  pxor xmm1, xmm5
+  movdqu xmm3, xmm1
+  psrld xmm3, 31
+  movdqu xmm4, xmm2
+  psrld xmm4, 31
+  pslld xmm1, 1
+  pslld xmm2, 1
+  vpslldq xmm5, xmm3, 4
+  vpslldq xmm4, xmm4, 4
+  mov r12, 0
+  pinsrd xmm3, r12d, 0
+  pshufd xmm3, xmm3, 3
+  pxor xmm3, xmm4
+  pxor xmm1, xmm5
+  pxor xmm2, xmm3
+  movdqu xmm5, xmm2
+  pxor xmm2, xmm2
+  mov r12, 3774873600
+  pinsrd xmm2, r12d, 3
+  pclmulqdq xmm1, xmm2, 17
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pxor xmm1, xmm5
+  pxor xmm1, xmm6
+  movdqu xmm6, xmm1
+  movdqu xmm3, xmm1
+  pxor xmm4, xmm4
+  pxor xmm5, xmm5
+  mov r12, 3254779904
+  pinsrd xmm4, r12d, 3
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  mov r12, 2147483648
+  pinsrd xmm5, r12d, 3
+  movdqu xmm1, xmm3
+  movdqu xmm2, xmm1
+  psrld xmm2, 31
+  pslld xmm1, 1
+  vpslldq xmm2, xmm2, 4
+  pxor xmm1, xmm2
+  pand xmm3, xmm5
+  pcmpeqd xmm3, xmm5
+  pshufd xmm3, xmm3, 255
+  pand xmm3, xmm4
+  vpxor xmm1, xmm1, xmm3
+  movdqu xmmword ptr [rcx + 112], xmm1
+  movdqu xmm6, xmm0
+  mov r12, rax
+  ret
+aes256_keyhash_init endp
+ALIGN 16
+gctr128_bytes proc
+  push r15
+  push r14
+  push r13
+  push r12
+  push rsi
+  push rdi
+  push rbp
+  push rbx
+  pextrq rax, xmm15, 0
+  push rax
+  pextrq rax, xmm15, 1
+  push rax
+  pextrq rax, xmm14, 0
+  push rax
+  pextrq rax, xmm14, 1
+  push rax
+  pextrq rax, xmm13, 0
+  push rax
+  pextrq rax, xmm13, 1
+  push rax
+  pextrq rax, xmm12, 0
+  push rax
+  pextrq rax, xmm12, 1
+  push rax
+  pextrq rax, xmm11, 0
+  push rax
+  pextrq rax, xmm11, 1
+  push rax
+  pextrq rax, xmm10, 0
+  push rax
+  pextrq rax, xmm10, 1
+  push rax
+  pextrq rax, xmm9, 0
+  push rax
+  pextrq rax, xmm9, 1
+  push rax
+  pextrq rax, xmm8, 0
+  push rax
+  pextrq rax, xmm8, 1
+  push rax
+  pextrq rax, xmm7, 0
+  push rax
+  pextrq rax, xmm7, 1
+  push rax
+  pextrq rax, xmm6, 0
+  push rax
+  pextrq rax, xmm6, 1
+  push rax
+  mov rax, qword ptr [rsp + 272]
+  movdqu xmm7, xmmword ptr [rax + 0]
+  mov rax, rcx
+  mov rbx, r8
+  mov rsi, rdx
+  mov r13, r9
+  mov r8, qword ptr [rsp + 264]
+  mov rcx, qword ptr [rsp + 280]
+  mov rbp, rcx
+  imul rbp, 16
+  mov r12, 579005069656919567
+  pinsrq xmm8, r12, 0
+  mov r12, 283686952306183
+  pinsrq xmm8, r12, 1
+  mov rdx, rcx
+  shr rdx, 2
+  and rcx, 3
+  cmp rdx, 0
+  jbe L0
+  mov r9, rax
+  mov r10, rbx
+  pshufb xmm7, xmm8
+  movdqu xmm9, xmm7
+  mov rax, 579005069656919567
+  pinsrq xmm0, rax, 0
+  mov rax, 579005069656919567
+  pinsrq xmm0, rax, 1
+  pshufb xmm9, xmm0
+  movdqu xmm10, xmm9
+  pxor xmm3, xmm3
+  mov rax, 1
+  pinsrd xmm3, eax, 2
+  paddd xmm9, xmm3
+  mov rax, 3
+  pinsrd xmm3, eax, 2
+  mov rax, 2
+  pinsrd xmm3, eax, 0
+  paddd xmm10, xmm3
+  pshufb xmm9, xmm8
+  pshufb xmm10, xmm8
+  pextrq rdi, xmm7, 0
+  mov rax, 283686952306183
+  pinsrq xmm0, rax, 0
+  mov rax, 579005069656919567
+  pinsrq xmm0, rax, 1
+  pxor xmm15, xmm15
+  mov rax, 4
+  pinsrd xmm15, eax, 0
+  mov rax, 4
+  pinsrd xmm15, eax, 2
+  jmp L3
+ALIGN 16
+L2:
+  pinsrq xmm2, rdi, 0
+  pinsrq xmm12, rdi, 0
+  pinsrq xmm13, rdi, 0
+  pinsrq xmm14, rdi, 0
+  shufpd xmm2, xmm9, 2
+  shufpd xmm12, xmm9, 0
+  shufpd xmm13, xmm10, 2
+  shufpd xmm14, xmm10, 0
+  pshufb xmm9, xmm0
+  pshufb xmm10, xmm0
+  movdqu xmm3, xmmword ptr [r8 + 0]
+  movdqu xmm4, xmmword ptr [r8 + 16]
+  movdqu xmm5, xmmword ptr [r8 + 32]
+  movdqu xmm6, xmmword ptr [r8 + 48]
+  paddd xmm9, xmm15
+  paddd xmm10, xmm15
+  pxor xmm2, xmm3
+  pxor xmm12, xmm3
+  pxor xmm13, xmm3
+  pxor xmm14, xmm3
+  pshufb xmm9, xmm0
+  pshufb xmm10, xmm0
+  aesenc xmm2, xmm4
+  aesenc xmm12, xmm4
+  aesenc xmm13, xmm4
+  aesenc xmm14, xmm4
+  aesenc xmm2, xmm5
+  aesenc xmm12, xmm5
+  aesenc xmm13, xmm5
+  aesenc xmm14, xmm5
+  aesenc xmm2, xmm6
+  aesenc xmm12, xmm6
+  aesenc xmm13, xmm6
+  aesenc xmm14, xmm6
+  movdqu xmm3, xmmword ptr [r8 + 64]
+  movdqu xmm4, xmmword ptr [r8 + 80]
+  movdqu xmm5, xmmword ptr [r8 + 96]
+  movdqu xmm6, xmmword ptr [r8 + 112]
+  aesenc xmm2, xmm3
+  aesenc xmm12, xmm3
+  aesenc xmm13, xmm3
+  aesenc xmm14, xmm3
+  aesenc xmm2, xmm4
+  aesenc xmm12, xmm4
+  aesenc xmm13, xmm4
+  aesenc xmm14, xmm4
+  aesenc xmm2, xmm5
+  aesenc xmm12, xmm5
+  aesenc xmm13, xmm5
+  aesenc xmm14, xmm5
+  aesenc xmm2, xmm6
+  aesenc xmm12, xmm6
+  aesenc xmm13, xmm6
+  aesenc xmm14, xmm6
+  movdqu xmm3, xmmword ptr [r8 + 128]
+  movdqu xmm4, xmmword ptr [r8 + 144]
+  movdqu xmm5, xmmword ptr [r8 + 160]
+  aesenc xmm2, xmm3
+  aesenc xmm12, xmm3
+  aesenc xmm13, xmm3
+  aesenc xmm14, xmm3
+  aesenc xmm2, xmm4
+  aesenc xmm12, xmm4
+  aesenc xmm13, xmm4
+  aesenc xmm14, xmm4
+  aesenclast xmm2, xmm5
+  aesenclast xmm12, xmm5
+  aesenclast xmm13, xmm5
+  aesenclast xmm14, xmm5
+  movdqu xmm7, xmmword ptr [r9 + 0]
+  pxor xmm2, xmm7
+  movdqu xmm7, xmmword ptr [r9 + 16]
+  pxor xmm12, xmm7
+  movdqu xmm7, xmmword ptr [r9 + 32]
+  pxor xmm13, xmm7
+  movdqu xmm7, xmmword ptr [r9 + 48]
+  pxor xmm14, xmm7
+  movdqu xmmword ptr [r10 + 0], xmm2
+  movdqu xmmword ptr [r10 + 16], xmm12
+  movdqu xmmword ptr [r10 + 32], xmm13
+  movdqu xmmword ptr [r10 + 48], xmm14
+  sub rdx, 1
+  add r9, 64
+  add r10, 64
+ALIGN 16
+L3:
+  cmp rdx, 0
+  ja L2
+  movdqu xmm7, xmm9
+  pinsrq xmm7, rdi, 0
+  pshufb xmm7, xmm8
+  mov rax, r9
+  mov rbx, r10
+  jmp L1
+L0:
+L1:
+  mov rdx, 0
+  mov r9, rax
+  mov r10, rbx
+  pxor xmm4, xmm4
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  jmp L5
+ALIGN 16
+L4:
+  movdqu xmm0, xmm7
+  pshufb xmm0, xmm8
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  movdqu xmm2, xmmword ptr [r9 + 0]
+  pxor xmm2, xmm0
+  movdqu xmmword ptr [r10 + 0], xmm2
+  add rdx, 1
+  add r9, 16
+  add r10, 16
+  paddd xmm7, xmm4
+ALIGN 16
+L5:
+  cmp rdx, rcx
+  jne L4
+  cmp rsi, rbp
+  jbe L6
+  movdqu xmm1, xmmword ptr [r13 + 0]
+  movdqu xmm0, xmm7
+  mov r12, 579005069656919567
+  pinsrq xmm2, r12, 0
+  mov r12, 283686952306183
+  pinsrq xmm2, r12, 1
+  pshufb xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  pxor xmm1, xmm0
+  movdqu xmmword ptr [r13 + 0], xmm1
+  jmp L7
+L6:
+L7:
+  pop rax
+  pinsrq xmm6, rax, 1
+  pop rax
+  pinsrq xmm6, rax, 0
+  pop rax
+  pinsrq xmm7, rax, 1
+  pop rax
+  pinsrq xmm7, rax, 0
+  pop rax
+  pinsrq xmm8, rax, 1
+  pop rax
+  pinsrq xmm8, rax, 0
+  pop rax
+  pinsrq xmm9, rax, 1
+  pop rax
+  pinsrq xmm9, rax, 0
+  pop rax
+  pinsrq xmm10, rax, 1
+  pop rax
+  pinsrq xmm10, rax, 0
+  pop rax
+  pinsrq xmm11, rax, 1
+  pop rax
+  pinsrq xmm11, rax, 0
+  pop rax
+  pinsrq xmm12, rax, 1
+  pop rax
+  pinsrq xmm12, rax, 0
+  pop rax
+  pinsrq xmm13, rax, 1
+  pop rax
+  pinsrq xmm13, rax, 0
+  pop rax
+  pinsrq xmm14, rax, 1
+  pop rax
+  pinsrq xmm14, rax, 0
+  pop rax
+  pinsrq xmm15, rax, 1
+  pop rax
+  pinsrq xmm15, rax, 0
+  pop rbx
+  pop rbp
+  pop rdi
+  pop rsi
+  pop r12
+  pop r13
+  pop r14
+  pop r15
+  ret
+gctr128_bytes endp
+ALIGN 16
+gctr256_bytes proc
+  push r15
+  push r14
+  push r13
+  push r12
+  push rsi
+  push rdi
+  push rbp
+  push rbx
+  pextrq rax, xmm15, 0
+  push rax
+  pextrq rax, xmm15, 1
+  push rax
+  pextrq rax, xmm14, 0
+  push rax
+  pextrq rax, xmm14, 1
+  push rax
+  pextrq rax, xmm13, 0
+  push rax
+  pextrq rax, xmm13, 1
+  push rax
+  pextrq rax, xmm12, 0
+  push rax
+  pextrq rax, xmm12, 1
+  push rax
+  pextrq rax, xmm11, 0
+  push rax
+  pextrq rax, xmm11, 1
+  push rax
+  pextrq rax, xmm10, 0
+  push rax
+  pextrq rax, xmm10, 1
+  push rax
+  pextrq rax, xmm9, 0
+  push rax
+  pextrq rax, xmm9, 1
+  push rax
+  pextrq rax, xmm8, 0
+  push rax
+  pextrq rax, xmm8, 1
+  push rax
+  pextrq rax, xmm7, 0
+  push rax
+  pextrq rax, xmm7, 1
+  push rax
+  pextrq rax, xmm6, 0
+  push rax
+  pextrq rax, xmm6, 1
+  push rax
+  mov rax, qword ptr [rsp + 272]
+  movdqu xmm7, xmmword ptr [rax + 0]
+  mov rax, rcx
+  mov rbx, r8
+  mov rsi, rdx
+  mov r13, r9
+  mov r8, qword ptr [rsp + 264]
+  mov rcx, qword ptr [rsp + 280]
+  mov rbp, rcx
+  imul rbp, 16
+  mov r12, 579005069656919567
+  pinsrq xmm8, r12, 0
+  mov r12, 283686952306183
+  pinsrq xmm8, r12, 1
+  mov rdx, rcx
+  shr rdx, 2
+  and rcx, 3
+  cmp rdx, 0
+  jbe L8
+  mov r9, rax
+  mov r10, rbx
+  pshufb xmm7, xmm8
+  movdqu xmm9, xmm7
+  mov rax, 579005069656919567
+  pinsrq xmm0, rax, 0
+  mov rax, 579005069656919567
+  pinsrq xmm0, rax, 1
+  pshufb xmm9, xmm0
+  movdqu xmm10, xmm9
+  pxor xmm3, xmm3
+  mov rax, 1
+  pinsrd xmm3, eax, 2
+  paddd xmm9, xmm3
+  mov rax, 3
+  pinsrd xmm3, eax, 2
+  mov rax, 2
+  pinsrd xmm3, eax, 0
+  paddd xmm10, xmm3
+  pshufb xmm9, xmm8
+  pshufb xmm10, xmm8
+  pextrq rdi, xmm7, 0
+  mov rax, 283686952306183
+  pinsrq xmm0, rax, 0
+  mov rax, 579005069656919567
+  pinsrq xmm0, rax, 1
+  pxor xmm15, xmm15
+  mov rax, 4
+  pinsrd xmm15, eax, 0
+  mov rax, 4
+  pinsrd xmm15, eax, 2
+  jmp L11
+ALIGN 16
+L10:
+  pinsrq xmm2, rdi, 0
+  pinsrq xmm12, rdi, 0
+  pinsrq xmm13, rdi, 0
+  pinsrq xmm14, rdi, 0
+  shufpd xmm2, xmm9, 2
+  shufpd xmm12, xmm9, 0
+  shufpd xmm13, xmm10, 2
+  shufpd xmm14, xmm10, 0
+  pshufb xmm9, xmm0
+  pshufb xmm10, xmm0
+  movdqu xmm3, xmmword ptr [r8 + 0]
+  movdqu xmm4, xmmword ptr [r8 + 16]
+  movdqu xmm5, xmmword ptr [r8 + 32]
+  movdqu xmm6, xmmword ptr [r8 + 48]
+  paddd xmm9, xmm15
+  paddd xmm10, xmm15
+  pxor xmm2, xmm3
+  pxor xmm12, xmm3
+  pxor xmm13, xmm3
+  pxor xmm14, xmm3
+  pshufb xmm9, xmm0
+  pshufb xmm10, xmm0
+  aesenc xmm2, xmm4
+  aesenc xmm12, xmm4
+  aesenc xmm13, xmm4
+  aesenc xmm14, xmm4
+  aesenc xmm2, xmm5
+  aesenc xmm12, xmm5
+  aesenc xmm13, xmm5
+  aesenc xmm14, xmm5
+  aesenc xmm2, xmm6
+  aesenc xmm12, xmm6
+  aesenc xmm13, xmm6
+  aesenc xmm14, xmm6
+  movdqu xmm3, xmmword ptr [r8 + 64]
+  movdqu xmm4, xmmword ptr [r8 + 80]
+  movdqu xmm5, xmmword ptr [r8 + 96]
+  movdqu xmm6, xmmword ptr [r8 + 112]
+  aesenc xmm2, xmm3
+  aesenc xmm12, xmm3
+  aesenc xmm13, xmm3
+  aesenc xmm14, xmm3
+  aesenc xmm2, xmm4
+  aesenc xmm12, xmm4
+  aesenc xmm13, xmm4
+  aesenc xmm14, xmm4
+  aesenc xmm2, xmm5
+  aesenc xmm12, xmm5
+  aesenc xmm13, xmm5
+  aesenc xmm14, xmm5
+  aesenc xmm2, xmm6
+  aesenc xmm12, xmm6
+  aesenc xmm13, xmm6
+  aesenc xmm14, xmm6
+  movdqu xmm3, xmmword ptr [r8 + 128]
+  movdqu xmm4, xmmword ptr [r8 + 144]
+  movdqu xmm5, xmmword ptr [r8 + 160]
+  aesenc xmm2, xmm3
+  aesenc xmm12, xmm3
+  aesenc xmm13, xmm3
+  aesenc xmm14, xmm3
+  aesenc xmm2, xmm4
+  aesenc xmm12, xmm4
+  aesenc xmm13, xmm4
+  aesenc xmm14, xmm4
+  movdqu xmm3, xmm5
+  movdqu xmm4, xmmword ptr [r8 + 176]
+  movdqu xmm5, xmmword ptr [r8 + 192]
+  movdqu xmm6, xmmword ptr [r8 + 208]
+  aesenc xmm2, xmm3
+  aesenc xmm12, xmm3
+  aesenc xmm13, xmm3
+  aesenc xmm14, xmm3
+  aesenc xmm2, xmm4
+  aesenc xmm12, xmm4
+  aesenc xmm13, xmm4
+  aesenc xmm14, xmm4
+  aesenc xmm2, xmm5
+  aesenc xmm12, xmm5
+  aesenc xmm13, xmm5
+  aesenc xmm14, xmm5
+  aesenc xmm2, xmm6
+  aesenc xmm12, xmm6
+  aesenc xmm13, xmm6
+  aesenc xmm14, xmm6
+  movdqu xmm5, xmmword ptr [r8 + 224]
+  aesenclast xmm2, xmm5
+  aesenclast xmm12, xmm5
+  aesenclast xmm13, xmm5
+  aesenclast xmm14, xmm5
+  movdqu xmm7, xmmword ptr [r9 + 0]
+  pxor xmm2, xmm7
+  movdqu xmm7, xmmword ptr [r9 + 16]
+  pxor xmm12, xmm7
+  movdqu xmm7, xmmword ptr [r9 + 32]
+  pxor xmm13, xmm7
+  movdqu xmm7, xmmword ptr [r9 + 48]
+  pxor xmm14, xmm7
+  movdqu xmmword ptr [r10 + 0], xmm2
+  movdqu xmmword ptr [r10 + 16], xmm12
+  movdqu xmmword ptr [r10 + 32], xmm13
+  movdqu xmmword ptr [r10 + 48], xmm14
+  sub rdx, 1
+  add r9, 64
+  add r10, 64
+ALIGN 16
+L11:
+  cmp rdx, 0
+  ja L10
+  movdqu xmm7, xmm9
+  pinsrq xmm7, rdi, 0
+  pshufb xmm7, xmm8
+  mov rax, r9
+  mov rbx, r10
+  jmp L9
+L8:
+L9:
+  mov rdx, 0
+  mov r9, rax
+  mov r10, rbx
+  pxor xmm4, xmm4
+  mov r12, 1
+  pinsrd xmm4, r12d, 0
+  jmp L13
+ALIGN 16
+L12:
+  movdqu xmm0, xmm7
+  pshufb xmm0, xmm8
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 176]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 192]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 208]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 224]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  movdqu xmm2, xmmword ptr [r9 + 0]
+  pxor xmm2, xmm0
+  movdqu xmmword ptr [r10 + 0], xmm2
+  add rdx, 1
+  add r9, 16
+  add r10, 16
+  paddd xmm7, xmm4
+ALIGN 16
+L13:
+  cmp rdx, rcx
+  jne L12
+  cmp rsi, rbp
+  jbe L14
+  movdqu xmm1, xmmword ptr [r13 + 0]
+  movdqu xmm0, xmm7
+  mov r12, 579005069656919567
+  pinsrq xmm2, r12, 0
+  mov r12, 283686952306183
+  pinsrq xmm2, r12, 1
+  pshufb xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 176]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 192]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 208]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 224]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  pxor xmm1, xmm0
+  movdqu xmmword ptr [r13 + 0], xmm1
+  jmp L15
+L14:
+L15:
+  pop rax
+  pinsrq xmm6, rax, 1
+  pop rax
+  pinsrq xmm6, rax, 0
+  pop rax
+  pinsrq xmm7, rax, 1
+  pop rax
+  pinsrq xmm7, rax, 0
+  pop rax
+  pinsrq xmm8, rax, 1
+  pop rax
+  pinsrq xmm8, rax, 0
+  pop rax
+  pinsrq xmm9, rax, 1
+  pop rax
+  pinsrq xmm9, rax, 0
+  pop rax
+  pinsrq xmm10, rax, 1
+  pop rax
+  pinsrq xmm10, rax, 0
+  pop rax
+  pinsrq xmm11, rax, 1
+  pop rax
+  pinsrq xmm11, rax, 0
+  pop rax
+  pinsrq xmm12, rax, 1
+  pop rax
+  pinsrq xmm12, rax, 0
+  pop rax
+  pinsrq xmm13, rax, 1
+  pop rax
+  pinsrq xmm13, rax, 0
+  pop rax
+  pinsrq xmm14, rax, 1
+  pop rax
+  pinsrq xmm14, rax, 0
+  pop rax
+  pinsrq xmm15, rax, 1
+  pop rax
+  pinsrq xmm15, rax, 0
+  pop rbx
+  pop rbp
+  pop rdi
+  pop rsi
+  pop r12
+  pop r13
+  pop r14
+  pop r15
+  ret
+gctr256_bytes endp
+ALIGN 16
+compute_iv_stdcall proc
+  cmp rdx, 12
+  jne L16
+  push rdi
+  push rsi
+  mov rdi, rcx
+  mov rsi, rdx
+  mov rdx, r8
+  mov rcx, r9
+  mov r8, qword ptr [rsp + 56]
+  mov r9, qword ptr [rsp + 64]
+  cmp rsi, 12
+  jne L18
+  movdqu xmm0, xmmword ptr [r8 + 0]
+  mov rax, 579005069656919567
+  pinsrq xmm1, rax, 0
+  mov rax, 283686952306183
+  pinsrq xmm1, rax, 1
+  pshufb xmm0, xmm1
+  mov rax, 1
+  pinsrd xmm0, eax, 0
+  movdqu xmmword ptr [rcx + 0], xmm0
+  jmp L19
+L18:
+  mov rax, rcx
+  add r9, 32
+  mov rbx, r8
+  mov rcx, rdx
+  imul rcx, 16
+  mov r10, 579005069656919567
+  pinsrq xmm9, r10, 0
+  mov r10, 283686952306183
+  pinsrq xmm9, r10, 1
+  pxor xmm8, xmm8
+  mov r11, rdi
+  jmp L21
+ALIGN 16
+L20:
+  add r11, 80
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  add r11, 96
+  sub rdx, 6
+ALIGN 16
+L21:
+  cmp rdx, 6
+  jae L20
+  cmp rdx, 0
+  jbe L22
+  mov r10, rdx
+  sub r10, 1
+  imul r10, 16
+  add r11, r10
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  cmp rdx, 1
+  jne L24
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  jmp L25
+L24:
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 2
+  je L26
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 3
+  je L28
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 4
+  je L30
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  jmp L31
+L30:
+L31:
+  jmp L29
+L28:
+L29:
+  jmp L27
+L26:
+L27:
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+L25:
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L23
+L22:
+L23:
+  mov r15, rsi
+  cmp rsi, rcx
+  jbe L32
+  movdqu xmm0, xmmword ptr [rbx + 0]
+  mov r10, rsi
+  and r10, 15
+  cmp r10, 8
+  jae L34
+  mov rcx, 0
+  pinsrq xmm0, rcx, 1
+  mov rcx, r10
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 0
+  and rcx, r11
+  pinsrq xmm0, rcx, 0
+  jmp L35
+L34:
+  mov rcx, r10
+  sub rcx, 8
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 1
+  and rcx, r11
+  pinsrq xmm0, rcx, 1
+L35:
+  pshufb xmm0, xmm9
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L33
+L32:
+L33:
+  mov rcx, rax
+  mov r11, 0
+  mov r13, rsi
+  pxor xmm0, xmm0
+  mov rax, r11
+  imul rax, 8
+  pinsrq xmm0, rax, 1
+  mov rax, r13
+  imul rax, 8
+  pinsrq xmm0, rax, 0
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  movdqu xmmword ptr [rcx + 0], xmm8
+L19:
+  pop rsi
+  pop rdi
+  jmp L17
+L16:
+  push r15
+  push r14
+  push r13
+  push r12
+  push rsi
+  push rdi
+  push rbp
+  push rbx
+  pextrq rax, xmm15, 0
+  push rax
+  pextrq rax, xmm15, 1
+  push rax
+  pextrq rax, xmm14, 0
+  push rax
+  pextrq rax, xmm14, 1
+  push rax
+  pextrq rax, xmm13, 0
+  push rax
+  pextrq rax, xmm13, 1
+  push rax
+  pextrq rax, xmm12, 0
+  push rax
+  pextrq rax, xmm12, 1
+  push rax
+  pextrq rax, xmm11, 0
+  push rax
+  pextrq rax, xmm11, 1
+  push rax
+  pextrq rax, xmm10, 0
+  push rax
+  pextrq rax, xmm10, 1
+  push rax
+  pextrq rax, xmm9, 0
+  push rax
+  pextrq rax, xmm9, 1
+  push rax
+  pextrq rax, xmm8, 0
+  push rax
+  pextrq rax, xmm8, 1
+  push rax
+  pextrq rax, xmm7, 0
+  push rax
+  pextrq rax, xmm7, 1
+  push rax
+  pextrq rax, xmm6, 0
+  push rax
+  pextrq rax, xmm6, 1
+  push rax
+  mov rdi, rcx
+  mov rsi, rdx
+  mov rdx, r8
+  mov rcx, r9
+  mov r8, qword ptr [rsp + 264]
+  mov r9, qword ptr [rsp + 272]
+  cmp rsi, 12
+  jne L36
+  movdqu xmm0, xmmword ptr [r8 + 0]
+  mov rax, 579005069656919567
+  pinsrq xmm1, rax, 0
+  mov rax, 283686952306183
+  pinsrq xmm1, rax, 1
+  pshufb xmm0, xmm1
+  mov rax, 1
+  pinsrd xmm0, eax, 0
+  movdqu xmmword ptr [rcx + 0], xmm0
+  jmp L37
+L36:
+  mov rax, rcx
+  add r9, 32
+  mov rbx, r8
+  mov rcx, rdx
+  imul rcx, 16
+  mov r10, 579005069656919567
+  pinsrq xmm9, r10, 0
+  mov r10, 283686952306183
+  pinsrq xmm9, r10, 1
+  pxor xmm8, xmm8
+  mov r11, rdi
+  jmp L39
+ALIGN 16
+L38:
+  add r11, 80
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  add r11, 96
+  sub rdx, 6
+ALIGN 16
+L39:
+  cmp rdx, 6
+  jae L38
+  cmp rdx, 0
+  jbe L40
+  mov r10, rdx
+  sub r10, 1
+  imul r10, 16
+  add r11, r10
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  cmp rdx, 1
+  jne L42
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  jmp L43
+L42:
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 2
+  je L44
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 3
+  je L46
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 4
+  je L48
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  jmp L49
+L48:
+L49:
+  jmp L47
+L46:
+L47:
+  jmp L45
+L44:
+L45:
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+L43:
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L41
+L40:
+L41:
+  mov r15, rsi
+  cmp rsi, rcx
+  jbe L50
+  movdqu xmm0, xmmword ptr [rbx + 0]
+  mov r10, rsi
+  and r10, 15
+  cmp r10, 8
+  jae L52
+  mov rcx, 0
+  pinsrq xmm0, rcx, 1
+  mov rcx, r10
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 0
+  and rcx, r11
+  pinsrq xmm0, rcx, 0
+  jmp L53
+L52:
+  mov rcx, r10
+  sub rcx, 8
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 1
+  and rcx, r11
+  pinsrq xmm0, rcx, 1
+L53:
+  pshufb xmm0, xmm9
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L51
+L50:
+L51:
+  mov rcx, rax
+  mov r11, 0
+  mov r13, rsi
+  pxor xmm0, xmm0
+  mov rax, r11
+  imul rax, 8
+  pinsrq xmm0, rax, 1
+  mov rax, r13
+  imul rax, 8
+  pinsrq xmm0, rax, 0
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  movdqu xmmword ptr [rcx + 0], xmm8
+L37:
+  pop rax
+  pinsrq xmm6, rax, 1
+  pop rax
+  pinsrq xmm6, rax, 0
+  pop rax
+  pinsrq xmm7, rax, 1
+  pop rax
+  pinsrq xmm7, rax, 0
+  pop rax
+  pinsrq xmm8, rax, 1
+  pop rax
+  pinsrq xmm8, rax, 0
+  pop rax
+  pinsrq xmm9, rax, 1
+  pop rax
+  pinsrq xmm9, rax, 0
+  pop rax
+  pinsrq xmm10, rax, 1
+  pop rax
+  pinsrq xmm10, rax, 0
+  pop rax
+  pinsrq xmm11, rax, 1
+  pop rax
+  pinsrq xmm11, rax, 0
+  pop rax
+  pinsrq xmm12, rax, 1
+  pop rax
+  pinsrq xmm12, rax, 0
+  pop rax
+  pinsrq xmm13, rax, 1
+  pop rax
+  pinsrq xmm13, rax, 0
+  pop rax
+  pinsrq xmm14, rax, 1
+  pop rax
+  pinsrq xmm14, rax, 0
+  pop rax
+  pinsrq xmm15, rax, 1
+  pop rax
+  pinsrq xmm15, rax, 0
+  pop rbx
+  pop rbp
+  pop rdi
+  pop rsi
+  pop r12
+  pop r13
+  pop r14
+  pop r15
+L17:
+  ret
+compute_iv_stdcall endp
+ALIGN 16
+gcm128_encrypt_opt proc
+  push r15
+  push r14
+  push r13
+  push r12
+  push rsi
+  push rdi
+  push rbp
+  push rbx
+  pextrq rax, xmm15, 0
+  push rax
+  pextrq rax, xmm15, 1
+  push rax
+  pextrq rax, xmm14, 0
+  push rax
+  pextrq rax, xmm14, 1
+  push rax
+  pextrq rax, xmm13, 0
+  push rax
+  pextrq rax, xmm13, 1
+  push rax
+  pextrq rax, xmm12, 0
+  push rax
+  pextrq rax, xmm12, 1
+  push rax
+  pextrq rax, xmm11, 0
+  push rax
+  pextrq rax, xmm11, 1
+  push rax
+  pextrq rax, xmm10, 0
+  push rax
+  pextrq rax, xmm10, 1
+  push rax
+  pextrq rax, xmm9, 0
+  push rax
+  pextrq rax, xmm9, 1
+  push rax
+  pextrq rax, xmm8, 0
+  push rax
+  pextrq rax, xmm8, 1
+  push rax
+  pextrq rax, xmm7, 0
+  push rax
+  pextrq rax, xmm7, 1
+  push rax
+  pextrq rax, xmm6, 0
+  push rax
+  pextrq rax, xmm6, 1
+  push rax
+  mov rdi, rcx
+  mov rsi, rdx
+  mov rdx, r8
+  mov rcx, r9
+  mov r8, qword ptr [rsp + 264]
+  mov r9, qword ptr [rsp + 272]
+  mov rbp, qword ptr [rsp + 352]
+  mov r13, rcx
+  lea r9, qword ptr [r9 + 32]
+  mov rbx, qword ptr [rsp + 280]
+  mov rcx, rdx
+  imul rcx, 16
+  mov r10, 579005069656919567
+  pinsrq xmm9, r10, 0
+  mov r10, 283686952306183
+  pinsrq xmm9, r10, 1
+  pxor xmm8, xmm8
+  mov r11, rdi
+  jmp L55
+ALIGN 16
+L54:
+  add r11, 80
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  add r11, 96
+  sub rdx, 6
+ALIGN 16
+L55:
+  cmp rdx, 6
+  jae L54
+  cmp rdx, 0
+  jbe L56
+  mov r10, rdx
+  sub r10, 1
+  imul r10, 16
+  add r11, r10
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  cmp rdx, 1
+  jne L58
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  jmp L59
+L58:
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 2
+  je L60
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 3
+  je L62
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 4
+  je L64
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  jmp L65
+L64:
+L65:
+  jmp L63
+L62:
+L63:
+  jmp L61
+L60:
+L61:
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+L59:
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L57
+L56:
+L57:
+  mov r15, rsi
+  cmp rsi, rcx
+  jbe L66
+  movdqu xmm0, xmmword ptr [rbx + 0]
+  mov r10, rsi
+  and r10, 15
+  cmp r10, 8
+  jae L68
+  mov rcx, 0
+  pinsrq xmm0, rcx, 1
+  mov rcx, r10
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 0
+  and rcx, r11
+  pinsrq xmm0, rcx, 0
+  jmp L69
+L68:
+  mov rcx, r10
+  sub rcx, 8
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 1
+  and rcx, r11
+  pinsrq xmm0, rcx, 1
+L69:
+  pshufb xmm0, xmm9
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L67
+L66:
+L67:
+  mov rdi, qword ptr [rsp + 288]
+  mov rsi, qword ptr [rsp + 296]
+  mov rdx, qword ptr [rsp + 304]
+  mov rcx, r13
+  movdqu xmm0, xmm9
+  movdqu xmm1, xmmword ptr [r8 + 0]
+  movdqu xmmword ptr [rbp + 0], xmm1
+  pxor xmm10, xmm10
+  mov r11, 1
+  pinsrq xmm10, r11, 0
+  vpaddd xmm1, xmm1, xmm10
+  cmp rdx, 0
+  jne L70
+  vpshufb xmm1, xmm1, xmm0
+  movdqu xmmword ptr [rbp + 32], xmm1
+  jmp L71
+L70:
+  movdqu xmmword ptr [rbp + 32], xmm8
+  add rcx, 128
+  pextrq rbx, xmm1, 0
+  and rbx, 255
+  vpshufb xmm1, xmm1, xmm0
+  lea r14, qword ptr [rsi + 96]
+  movdqu xmm4, xmmword ptr [rcx + -128]
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  movdqu xmm15, xmmword ptr [rcx + -112]
+  mov r12, rcx
+  sub r12, 96
+  vpxor xmm9, xmm1, xmm4
+  add rbx, 6
+  cmp rbx, 256
+  jae L72
+  vpaddd xmm10, xmm1, xmm2
+  vpaddd xmm11, xmm10, xmm2
+  vpxor xmm10, xmm10, xmm4
+  vpaddd xmm12, xmm11, xmm2
+  vpxor xmm11, xmm11, xmm4
+  vpaddd xmm13, xmm12, xmm2
+  vpxor xmm12, xmm12, xmm4
+  vpaddd xmm14, xmm13, xmm2
+  vpxor xmm13, xmm13, xmm4
+  vpaddd xmm1, xmm14, xmm2
+  vpxor xmm14, xmm14, xmm4
+  jmp L73
+L72:
+  sub rbx, 256
+  vpshufb xmm6, xmm1, xmm0
+  pxor xmm5, xmm5
+  mov r11, 1
+  pinsrq xmm5, r11, 0
+  vpaddd xmm10, xmm6, xmm5
+  pxor xmm5, xmm5
+  mov r11, 2
+  pinsrq xmm5, r11, 0
+  vpaddd xmm11, xmm6, xmm5
+  vpaddd xmm12, xmm10, xmm5
+  vpshufb xmm10, xmm10, xmm0
+  vpaddd xmm13, xmm11, xmm5
+  vpshufb xmm11, xmm11, xmm0
+  vpxor xmm10, xmm10, xmm4
+  vpaddd xmm14, xmm12, xmm5
+  vpshufb xmm12, xmm12, xmm0
+  vpxor xmm11, xmm11, xmm4
+  vpaddd xmm1, xmm13, xmm5
+  vpshufb xmm13, xmm13, xmm0
+  vpxor xmm12, xmm12, xmm4
+  vpshufb xmm14, xmm14, xmm0
+  vpxor xmm13, xmm13, xmm4
+  vpshufb xmm1, xmm1, xmm0
+  vpxor xmm14, xmm14, xmm4
+L73:
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -96]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -80]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -64]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -48]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -32]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -16]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 0]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 16]
+  movdqu xmm3, xmmword ptr [rcx + 32]
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm4, xmm3, xmmword ptr [rdi + 0]
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm5, xmm3, xmmword ptr [rdi + 16]
+  vaesenc xmm11, xmm11, xmm15
+  vpxor xmm6, xmm3, xmmword ptr [rdi + 32]
+  vaesenc xmm12, xmm12, xmm15
+  vpxor xmm8, xmm3, xmmword ptr [rdi + 48]
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm2, xmm3, xmmword ptr [rdi + 64]
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm3, xmm3, xmmword ptr [rdi + 80]
+  lea rdi, qword ptr [rdi + 96]
+  vaesenclast xmm9, xmm9, xmm4
+  vaesenclast xmm10, xmm10, xmm5
+  vaesenclast xmm11, xmm11, xmm6
+  vaesenclast xmm12, xmm12, xmm8
+  vaesenclast xmm13, xmm13, xmm2
+  vaesenclast xmm14, xmm14, xmm3
+  movdqu xmmword ptr [rsi + 0], xmm9
+  movdqu xmmword ptr [rsi + 16], xmm10
+  movdqu xmmword ptr [rsi + 32], xmm11
+  movdqu xmmword ptr [rsi + 48], xmm12
+  movdqu xmmword ptr [rsi + 64], xmm13
+  movdqu xmmword ptr [rsi + 80], xmm14
+  lea rsi, qword ptr [rsi + 96]
+  vpshufb xmm8, xmm9, xmm0
+  vpshufb xmm2, xmm10, xmm0
+  movdqu xmmword ptr [rbp + 112], xmm8
+  vpshufb xmm4, xmm11, xmm0
+  movdqu xmmword ptr [rbp + 96], xmm2
+  vpshufb xmm5, xmm12, xmm0
+  movdqu xmmword ptr [rbp + 80], xmm4
+  vpshufb xmm6, xmm13, xmm0
+  movdqu xmmword ptr [rbp + 64], xmm5
+  vpshufb xmm7, xmm14, xmm0
+  movdqu xmmword ptr [rbp + 48], xmm6
+  movdqu xmm4, xmmword ptr [rcx + -128]
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  movdqu xmm15, xmmword ptr [rcx + -112]
+  mov r12, rcx
+  sub r12, 96
+  vpxor xmm9, xmm1, xmm4
+  add rbx, 6
+  cmp rbx, 256
+  jae L74
+  vpaddd xmm10, xmm1, xmm2
+  vpaddd xmm11, xmm10, xmm2
+  vpxor xmm10, xmm10, xmm4
+  vpaddd xmm12, xmm11, xmm2
+  vpxor xmm11, xmm11, xmm4
+  vpaddd xmm13, xmm12, xmm2
+  vpxor xmm12, xmm12, xmm4
+  vpaddd xmm14, xmm13, xmm2
+  vpxor xmm13, xmm13, xmm4
+  vpaddd xmm1, xmm14, xmm2
+  vpxor xmm14, xmm14, xmm4
+  jmp L75
+L74:
+  sub rbx, 256
+  vpshufb xmm6, xmm1, xmm0
+  pxor xmm5, xmm5
+  mov r11, 1
+  pinsrq xmm5, r11, 0
+  vpaddd xmm10, xmm6, xmm5
+  pxor xmm5, xmm5
+  mov r11, 2
+  pinsrq xmm5, r11, 0
+  vpaddd xmm11, xmm6, xmm5
+  vpaddd xmm12, xmm10, xmm5
+  vpshufb xmm10, xmm10, xmm0
+  vpaddd xmm13, xmm11, xmm5
+  vpshufb xmm11, xmm11, xmm0
+  vpxor xmm10, xmm10, xmm4
+  vpaddd xmm14, xmm12, xmm5
+  vpshufb xmm12, xmm12, xmm0
+  vpxor xmm11, xmm11, xmm4
+  vpaddd xmm1, xmm13, xmm5
+  vpshufb xmm13, xmm13, xmm0
+  vpxor xmm12, xmm12, xmm4
+  vpshufb xmm14, xmm14, xmm0
+  vpxor xmm13, xmm13, xmm4
+  vpshufb xmm1, xmm1, xmm0
+  vpxor xmm14, xmm14, xmm4
+L75:
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -96]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -80]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -64]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -48]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -32]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -16]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 0]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 16]
+  movdqu xmm3, xmmword ptr [rcx + 32]
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm4, xmm3, xmmword ptr [rdi + 0]
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm5, xmm3, xmmword ptr [rdi + 16]
+  vaesenc xmm11, xmm11, xmm15
+  vpxor xmm6, xmm3, xmmword ptr [rdi + 32]
+  vaesenc xmm12, xmm12, xmm15
+  vpxor xmm8, xmm3, xmmword ptr [rdi + 48]
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm2, xmm3, xmmword ptr [rdi + 64]
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm3, xmm3, xmmword ptr [rdi + 80]
+  lea rdi, qword ptr [rdi + 96]
+  vaesenclast xmm9, xmm9, xmm4
+  vaesenclast xmm10, xmm10, xmm5
+  vaesenclast xmm11, xmm11, xmm6
+  vaesenclast xmm12, xmm12, xmm8
+  vaesenclast xmm13, xmm13, xmm2
+  vaesenclast xmm14, xmm14, xmm3
+  movdqu xmmword ptr [rsi + 0], xmm9
+  movdqu xmmword ptr [rsi + 16], xmm10
+  movdqu xmmword ptr [rsi + 32], xmm11
+  movdqu xmmword ptr [rsi + 48], xmm12
+  movdqu xmmword ptr [rsi + 64], xmm13
+  movdqu xmmword ptr [rsi + 80], xmm14
+  lea rsi, qword ptr [rsi + 96]
+  sub rdx, 12
+  movdqu xmm8, xmmword ptr [rbp + 32]
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  vpxor xmm4, xmm4, xmm4
+  movdqu xmm15, xmmword ptr [rcx + -128]
+  vpaddd xmm10, xmm1, xmm2
+  vpaddd xmm11, xmm10, xmm2
+  vpaddd xmm12, xmm11, xmm2
+  vpaddd xmm13, xmm12, xmm2
+  vpaddd xmm14, xmm13, xmm2
+  vpxor xmm9, xmm1, xmm15
+  movdqu xmmword ptr [rbp + 16], xmm4
+  jmp L77
+ALIGN 16
+L76:
+  add rbx, 6
+  cmp rbx, 256
+  jb L78
+  mov r11, 579005069656919567
+  pinsrq xmm0, r11, 0
+  mov r11, 283686952306183
+  pinsrq xmm0, r11, 1
+  vpshufb xmm6, xmm1, xmm0
+  pxor xmm5, xmm5
+  mov r11, 1
+  pinsrq xmm5, r11, 0
+  vpaddd xmm10, xmm6, xmm5
+  pxor xmm5, xmm5
+  mov r11, 2
+  pinsrq xmm5, r11, 0
+  vpaddd xmm11, xmm6, xmm5
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpaddd xmm12, xmm10, xmm5
+  vpshufb xmm10, xmm10, xmm0
+  vpaddd xmm13, xmm11, xmm5
+  vpshufb xmm11, xmm11, xmm0
+  vpxor xmm10, xmm10, xmm15
+  vpaddd xmm14, xmm12, xmm5
+  vpshufb xmm12, xmm12, xmm0
+  vpxor xmm11, xmm11, xmm15
+  vpaddd xmm1, xmm13, xmm5
+  vpshufb xmm13, xmm13, xmm0
+  vpshufb xmm14, xmm14, xmm0
+  vpshufb xmm1, xmm1, xmm0
+  sub rbx, 256
+  jmp L79
+L78:
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpaddd xmm1, xmm2, xmm14
+  vpxor xmm10, xmm10, xmm15
+  vpxor xmm11, xmm11, xmm15
+L79:
+  movdqu xmmword ptr [rbp + 128], xmm1
+  vpclmulqdq xmm5, xmm7, xmm3, 16
+  vpxor xmm12, xmm12, xmm15
+  movdqu xmm2, xmmword ptr [rcx + -112]
+  vpclmulqdq xmm6, xmm7, xmm3, 1
+  vaesenc xmm9, xmm9, xmm2
+  movdqu xmm0, xmmword ptr [rbp + 48]
+  vpxor xmm13, xmm13, xmm15
+  vpclmulqdq xmm1, xmm7, xmm3, 0
+  vaesenc xmm10, xmm10, xmm2
+  vpxor xmm14, xmm14, xmm15
+  vpclmulqdq xmm7, xmm7, xmm3, 17
+  vaesenc xmm11, xmm11, xmm2
+  movdqu xmm3, xmmword ptr [r9 + -16]
+  vaesenc xmm12, xmm12, xmm2
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm3, 0
+  vpxor xmm8, xmm8, xmm4
+  vaesenc xmm13, xmm13, xmm2
+  vpxor xmm4, xmm1, xmm5
+  vpclmulqdq xmm1, xmm0, xmm3, 16
+  vaesenc xmm14, xmm14, xmm2
+  movdqu xmm15, xmmword ptr [rcx + -96]
+  vpclmulqdq xmm2, xmm0, xmm3, 1
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpclmulqdq xmm3, xmm0, xmm3, 17
+  movdqu xmm0, xmmword ptr [rbp + 64]
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 88]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 80]
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 32], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 40], r12
+  movdqu xmm5, xmmword ptr [r9 + 16]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -80]
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm7, xmm7, xmm3
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vaesenc xmm11, xmm11, xmm15
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [rbp + 80]
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -64]
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm1, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm1, 16
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 72]
+  vpxor xmm7, xmm7, xmm5
+  vpclmulqdq xmm5, xmm0, xmm1, 1
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 64]
+  vpclmulqdq xmm1, xmm0, xmm1, 17
+  movdqu xmm0, xmmword ptr [rbp + 96]
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 48], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 56], r12
+  vpxor xmm4, xmm4, xmm2
+  movdqu xmm2, xmmword ptr [r9 + 64]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -48]
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm2, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm2, 16
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 56]
+  vpxor xmm7, xmm7, xmm1
+  vpclmulqdq xmm1, xmm0, xmm2, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 112]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 48]
+  vpclmulqdq xmm2, xmm0, xmm2, 17
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 64], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 72], r12
+  vpxor xmm4, xmm4, xmm3
+  movdqu xmm3, xmmword ptr [r9 + 80]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -32]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm8, xmm3, 16
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm8, xmm3, 1
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 40]
+  vpxor xmm7, xmm7, xmm2
+  vpclmulqdq xmm2, xmm8, xmm3, 0
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 32]
+  vpclmulqdq xmm8, xmm8, xmm3, 17
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 80], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 88], r12
+  vpxor xmm6, xmm6, xmm5
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm6, xmm6, xmm1
+  movdqu xmm15, xmmword ptr [rcx + -16]
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm2
+  pxor xmm3, xmm3
+  mov r11, 13979173243358019584
+  pinsrq xmm3, r11, 1
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm7, xmm7, xmm8
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm4, xmm4, xmm5
+  movbe r13, qword ptr [r14 + 24]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 16]
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  mov qword ptr [rbp + 96], r13
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 104], r12
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm1, xmmword ptr [rcx + 0]
+  vaesenc xmm9, xmm9, xmm1
+  movdqu xmm15, xmmword ptr [rcx + 16]
+  vaesenc xmm10, xmm10, xmm1
+  vpsrldq xmm6, xmm6, 8
+  vaesenc xmm11, xmm11, xmm1
+  vpxor xmm7, xmm7, xmm6
+  vaesenc xmm12, xmm12, xmm1
+  vpxor xmm4, xmm4, xmm0
+  movbe r13, qword ptr [r14 + 8]
+  vaesenc xmm13, xmm13, xmm1
+  movbe r12, qword ptr [r14 + 0]
+  vaesenc xmm14, xmm14, xmm1
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  vaesenc xmm9, xmm9, xmm15
+  movdqu xmmword ptr [rbp + 16], xmm7
+  vpalignr xmm8, xmm4, xmm4, 8
+  vaesenc xmm10, xmm10, xmm15
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm2, xmm1, xmmword ptr [rdi + 0]
+  vaesenc xmm11, xmm11, xmm15
+  vpxor xmm0, xmm1, xmmword ptr [rdi + 16]
+  vaesenc xmm12, xmm12, xmm15
+  vpxor xmm5, xmm1, xmmword ptr [rdi + 32]
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm6, xmm1, xmmword ptr [rdi + 48]
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm7, xmm1, xmmword ptr [rdi + 64]
+  vpxor xmm3, xmm1, xmmword ptr [rdi + 80]
+  movdqu xmm1, xmmword ptr [rbp + 128]
+  vaesenclast xmm9, xmm9, xmm2
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  vaesenclast xmm10, xmm10, xmm0
+  vpaddd xmm0, xmm1, xmm2
+  mov qword ptr [rbp + 112], r13
+  lea rdi, qword ptr [rdi + 96]
+  vaesenclast xmm11, xmm11, xmm5
+  vpaddd xmm5, xmm0, xmm2
+  mov qword ptr [rbp + 120], r12
+  lea rsi, qword ptr [rsi + 96]
+  movdqu xmm15, xmmword ptr [rcx + -128]
+  vaesenclast xmm12, xmm12, xmm6
+  vpaddd xmm6, xmm5, xmm2
+  vaesenclast xmm13, xmm13, xmm7
+  vpaddd xmm7, xmm6, xmm2
+  vaesenclast xmm14, xmm14, xmm3
+  vpaddd xmm3, xmm7, xmm2
+  sub rdx, 6
+  add r14, 96
+  cmp rdx, 0
+  jbe L80
+  movdqu xmmword ptr [rsi + -96], xmm9
+  vpxor xmm9, xmm1, xmm15
+  movdqu xmmword ptr [rsi + -80], xmm10
+  movdqu xmm10, xmm0
+  movdqu xmmword ptr [rsi + -64], xmm11
+  movdqu xmm11, xmm5
+  movdqu xmmword ptr [rsi + -48], xmm12
+  movdqu xmm12, xmm6
+  movdqu xmmword ptr [rsi + -32], xmm13
+  movdqu xmm13, xmm7
+  movdqu xmmword ptr [rsi + -16], xmm14
+  movdqu xmm14, xmm3
+  movdqu xmm7, xmmword ptr [rbp + 32]
+  jmp L81
+L80:
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpxor xmm8, xmm8, xmm4
+L81:
+ALIGN 16
+L77:
+  cmp rdx, 0
+  ja L76
+  movdqu xmm7, xmmword ptr [rbp + 32]
+  movdqu xmmword ptr [rbp + 32], xmm1
+  pxor xmm4, xmm4
+  movdqu xmmword ptr [rbp + 16], xmm4
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpclmulqdq xmm1, xmm7, xmm3, 0
+  vpclmulqdq xmm5, xmm7, xmm3, 16
+  movdqu xmm0, xmmword ptr [rbp + 48]
+  vpclmulqdq xmm6, xmm7, xmm3, 1
+  vpclmulqdq xmm7, xmm7, xmm3, 17
+  movdqu xmm3, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm3, 0
+  vpxor xmm8, xmm8, xmm4
+  vpxor xmm4, xmm1, xmm5
+  vpclmulqdq xmm1, xmm0, xmm3, 16
+  vpclmulqdq xmm2, xmm0, xmm3, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpclmulqdq xmm3, xmm0, xmm3, 17
+  movdqu xmm0, xmmword ptr [rbp + 64]
+  movdqu xmm5, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpxor xmm7, xmm7, xmm3
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [rbp + 80]
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm1, 0
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm1, 16
+  vpxor xmm7, xmm7, xmm5
+  vpclmulqdq xmm5, xmm0, xmm1, 1
+  vpclmulqdq xmm1, xmm0, xmm1, 17
+  movdqu xmm0, xmmword ptr [rbp + 96]
+  vpxor xmm4, xmm4, xmm2
+  movdqu xmm2, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm2, 0
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm2, 16
+  vpxor xmm7, xmm7, xmm1
+  vpclmulqdq xmm1, xmm0, xmm2, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 112]
+  vpclmulqdq xmm2, xmm0, xmm2, 17
+  vpxor xmm4, xmm4, xmm3
+  movdqu xmm3, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm8, xmm3, 16
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm8, xmm3, 1
+  vpxor xmm7, xmm7, xmm2
+  vpclmulqdq xmm2, xmm8, xmm3, 0
+  vpclmulqdq xmm8, xmm8, xmm3, 17
+  vpxor xmm6, xmm6, xmm5
+  vpxor xmm6, xmm6, xmm1
+  vpxor xmm4, xmm4, xmm2
+  pxor xmm3, xmm3
+  mov rax, 3254779904
+  pinsrd xmm3, eax, 3
+  vpxor xmm7, xmm7, xmm8
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  mov r12, 579005069656919567
+  pinsrq xmm0, r12, 0
+  mov r12, 283686952306183
+  pinsrq xmm0, r12, 1
+  movdqu xmmword ptr [rsi + -96], xmm9
+  vpshufb xmm9, xmm9, xmm0
+  vpxor xmm1, xmm1, xmm7
+  movdqu xmmword ptr [rsi + -80], xmm10
+  vpshufb xmm10, xmm10, xmm0
+  movdqu xmmword ptr [rsi + -64], xmm11
+  vpshufb xmm11, xmm11, xmm0
+  movdqu xmmword ptr [rsi + -48], xmm12
+  vpshufb xmm12, xmm12, xmm0
+  movdqu xmmword ptr [rsi + -32], xmm13
+  vpshufb xmm13, xmm13, xmm0
+  movdqu xmmword ptr [rsi + -16], xmm14
+  vpshufb xmm14, xmm14, xmm0
+  pxor xmm4, xmm4
+  movdqu xmm7, xmm14
+  movdqu xmmword ptr [rbp + 16], xmm4
+  movdqu xmmword ptr [rbp + 48], xmm13
+  movdqu xmmword ptr [rbp + 64], xmm12
+  movdqu xmmword ptr [rbp + 80], xmm11
+  movdqu xmmword ptr [rbp + 96], xmm10
+  movdqu xmmword ptr [rbp + 112], xmm9
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpclmulqdq xmm1, xmm7, xmm3, 0
+  vpclmulqdq xmm5, xmm7, xmm3, 16
+  movdqu xmm0, xmmword ptr [rbp + 48]
+  vpclmulqdq xmm6, xmm7, xmm3, 1
+  vpclmulqdq xmm7, xmm7, xmm3, 17
+  movdqu xmm3, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm3, 0
+  vpxor xmm8, xmm8, xmm4
+  vpxor xmm4, xmm1, xmm5
+  vpclmulqdq xmm1, xmm0, xmm3, 16
+  vpclmulqdq xmm2, xmm0, xmm3, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpclmulqdq xmm3, xmm0, xmm3, 17
+  movdqu xmm0, xmmword ptr [rbp + 64]
+  movdqu xmm5, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpxor xmm7, xmm7, xmm3
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [rbp + 80]
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm1, 0
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm1, 16
+  vpxor xmm7, xmm7, xmm5
+  vpclmulqdq xmm5, xmm0, xmm1, 1
+  vpclmulqdq xmm1, xmm0, xmm1, 17
+  movdqu xmm0, xmmword ptr [rbp + 96]
+  vpxor xmm4, xmm4, xmm2
+  movdqu xmm2, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm2, 0
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm2, 16
+  vpxor xmm7, xmm7, xmm1
+  vpclmulqdq xmm1, xmm0, xmm2, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 112]
+  vpclmulqdq xmm2, xmm0, xmm2, 17
+  vpxor xmm4, xmm4, xmm3
+  movdqu xmm3, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm8, xmm3, 16
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm8, xmm3, 1
+  vpxor xmm7, xmm7, xmm2
+  vpclmulqdq xmm2, xmm8, xmm3, 0
+  vpclmulqdq xmm8, xmm8, xmm3, 17
+  vpxor xmm6, xmm6, xmm5
+  vpxor xmm6, xmm6, xmm1
+  vpxor xmm4, xmm4, xmm2
+  pxor xmm3, xmm3
+  mov rax, 3254779904
+  pinsrd xmm3, eax, 3
+  vpxor xmm7, xmm7, xmm8
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  sub rcx, 128
+L71:
+  movdqu xmm11, xmmword ptr [rbp + 32]
+  mov r8, rcx
+  mov rax, qword ptr [rsp + 312]
+  mov rdi, qword ptr [rsp + 320]
+  mov rdx, qword ptr [rsp + 328]
+  mov r14, rdx
+  mov r12, 579005069656919567
+  pinsrq xmm9, r12, 0
+  mov r12, 283686952306183
+  pinsrq xmm9, r12, 1
+  pshufb xmm11, xmm9
+  pxor xmm10, xmm10
+  mov rbx, 1
+  pinsrd xmm10, ebx, 0
+  mov r11, rax
+  mov r10, rdi
+  mov rbx, 0
+  jmp L83
+ALIGN 16
+L82:
+  movdqu xmm0, xmm11
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  movdqu xmm2, xmmword ptr [r11 + 0]
+  pxor xmm2, xmm0
+  movdqu xmmword ptr [r10 + 0], xmm2
+  add rbx, 1
+  add r11, 16
+  add r10, 16
+  paddd xmm11, xmm10
+ALIGN 16
+L83:
+  cmp rbx, rdx
+  jne L82
+  mov r11, rdi
+  jmp L85
+ALIGN 16
+L84:
+  add r11, 80
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  add r11, 96
+  sub rdx, 6
+ALIGN 16
+L85:
+  cmp rdx, 6
+  jae L84
+  cmp rdx, 0
+  jbe L86
+  mov r10, rdx
+  sub r10, 1
+  imul r10, 16
+  add r11, r10
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  cmp rdx, 1
+  jne L88
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  jmp L89
+L88:
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 2
+  je L90
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 3
+  je L92
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 4
+  je L94
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  jmp L95
+L94:
+L95:
+  jmp L93
+L92:
+L93:
+  jmp L91
+L90:
+L91:
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+L89:
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L87
+L86:
+L87:
+  add r14, qword ptr [rsp + 304]
+  imul r14, 16
+  mov r13, qword ptr [rsp + 344]
+  cmp r13, r14
+  jbe L96
+  mov rax, qword ptr [rsp + 336]
+  mov r10, r13
+  and r10, 15
+  movdqu xmm0, xmm11
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  movdqu xmm4, xmmword ptr [rax + 0]
+  pxor xmm0, xmm4
+  movdqu xmmword ptr [rax + 0], xmm0
+  cmp r10, 8
+  jae L98
+  mov rcx, 0
+  pinsrq xmm0, rcx, 1
+  mov rcx, r10
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 0
+  and rcx, r11
+  pinsrq xmm0, rcx, 0
+  jmp L99
+L98:
+  mov rcx, r10
+  sub rcx, 8
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 1
+  and rcx, r11
+  pinsrq xmm0, rcx, 1
+L99:
+  pshufb xmm0, xmm9
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L97
+L96:
+L97:
+  mov r11, r15
+  pxor xmm0, xmm0
+  mov rax, r11
+  imul rax, 8
+  pinsrq xmm0, rax, 1
+  mov rax, r13
+  imul rax, 8
+  pinsrq xmm0, rax, 0
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  movdqu xmm0, xmmword ptr [rbp + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  pshufb xmm8, xmm9
+  pxor xmm8, xmm0
+  mov r15, qword ptr [rsp + 360]
+  movdqu xmmword ptr [r15 + 0], xmm8
+  pop rax
+  pinsrq xmm6, rax, 1
+  pop rax
+  pinsrq xmm6, rax, 0
+  pop rax
+  pinsrq xmm7, rax, 1
+  pop rax
+  pinsrq xmm7, rax, 0
+  pop rax
+  pinsrq xmm8, rax, 1
+  pop rax
+  pinsrq xmm8, rax, 0
+  pop rax
+  pinsrq xmm9, rax, 1
+  pop rax
+  pinsrq xmm9, rax, 0
+  pop rax
+  pinsrq xmm10, rax, 1
+  pop rax
+  pinsrq xmm10, rax, 0
+  pop rax
+  pinsrq xmm11, rax, 1
+  pop rax
+  pinsrq xmm11, rax, 0
+  pop rax
+  pinsrq xmm12, rax, 1
+  pop rax
+  pinsrq xmm12, rax, 0
+  pop rax
+  pinsrq xmm13, rax, 1
+  pop rax
+  pinsrq xmm13, rax, 0
+  pop rax
+  pinsrq xmm14, rax, 1
+  pop rax
+  pinsrq xmm14, rax, 0
+  pop rax
+  pinsrq xmm15, rax, 1
+  pop rax
+  pinsrq xmm15, rax, 0
+  pop rbx
+  pop rbp
+  pop rdi
+  pop rsi
+  pop r12
+  pop r13
+  pop r14
+  pop r15
+  ret
+gcm128_encrypt_opt endp
+ALIGN 16
+gcm256_encrypt_opt proc
+  push r15
+  push r14
+  push r13
+  push r12
+  push rsi
+  push rdi
+  push rbp
+  push rbx
+  pextrq rax, xmm15, 0
+  push rax
+  pextrq rax, xmm15, 1
+  push rax
+  pextrq rax, xmm14, 0
+  push rax
+  pextrq rax, xmm14, 1
+  push rax
+  pextrq rax, xmm13, 0
+  push rax
+  pextrq rax, xmm13, 1
+  push rax
+  pextrq rax, xmm12, 0
+  push rax
+  pextrq rax, xmm12, 1
+  push rax
+  pextrq rax, xmm11, 0
+  push rax
+  pextrq rax, xmm11, 1
+  push rax
+  pextrq rax, xmm10, 0
+  push rax
+  pextrq rax, xmm10, 1
+  push rax
+  pextrq rax, xmm9, 0
+  push rax
+  pextrq rax, xmm9, 1
+  push rax
+  pextrq rax, xmm8, 0
+  push rax
+  pextrq rax, xmm8, 1
+  push rax
+  pextrq rax, xmm7, 0
+  push rax
+  pextrq rax, xmm7, 1
+  push rax
+  pextrq rax, xmm6, 0
+  push rax
+  pextrq rax, xmm6, 1
+  push rax
+  mov rdi, rcx
+  mov rsi, rdx
+  mov rdx, r8
+  mov rcx, r9
+  mov r8, qword ptr [rsp + 264]
+  mov r9, qword ptr [rsp + 272]
+  mov rbp, qword ptr [rsp + 352]
+  mov r13, rcx
+  lea r9, qword ptr [r9 + 32]
+  mov rbx, qword ptr [rsp + 280]
+  mov rcx, rdx
+  imul rcx, 16
+  mov r10, 579005069656919567
+  pinsrq xmm9, r10, 0
+  mov r10, 283686952306183
+  pinsrq xmm9, r10, 1
+  pxor xmm8, xmm8
+  mov r11, rdi
+  jmp L101
+ALIGN 16
+L100:
+  add r11, 80
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  add r11, 96
+  sub rdx, 6
+ALIGN 16
+L101:
+  cmp rdx, 6
+  jae L100
+  cmp rdx, 0
+  jbe L102
+  mov r10, rdx
+  sub r10, 1
+  imul r10, 16
+  add r11, r10
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  cmp rdx, 1
+  jne L104
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  jmp L105
+L104:
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 2
+  je L106
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 3
+  je L108
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 4
+  je L110
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  jmp L111
+L110:
+L111:
+  jmp L109
+L108:
+L109:
+  jmp L107
+L106:
+L107:
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+L105:
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L103
+L102:
+L103:
+  mov r15, rsi
+  cmp rsi, rcx
+  jbe L112
+  movdqu xmm0, xmmword ptr [rbx + 0]
+  mov r10, rsi
+  and r10, 15
+  cmp r10, 8
+  jae L114
+  mov rcx, 0
+  pinsrq xmm0, rcx, 1
+  mov rcx, r10
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 0
+  and rcx, r11
+  pinsrq xmm0, rcx, 0
+  jmp L115
+L114:
+  mov rcx, r10
+  sub rcx, 8
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 1
+  and rcx, r11
+  pinsrq xmm0, rcx, 1
+L115:
+  pshufb xmm0, xmm9
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L113
+L112:
+L113:
+  mov rdi, qword ptr [rsp + 288]
+  mov rsi, qword ptr [rsp + 296]
+  mov rdx, qword ptr [rsp + 304]
+  mov rcx, r13
+  movdqu xmm0, xmm9
+  movdqu xmm1, xmmword ptr [r8 + 0]
+  movdqu xmmword ptr [rbp + 0], xmm1
+  pxor xmm10, xmm10
+  mov r11, 1
+  pinsrq xmm10, r11, 0
+  vpaddd xmm1, xmm1, xmm10
+  cmp rdx, 0
+  jne L116
+  vpshufb xmm1, xmm1, xmm0
+  movdqu xmmword ptr [rbp + 32], xmm1
+  jmp L117
+L116:
+  movdqu xmmword ptr [rbp + 32], xmm8
+  add rcx, 128
+  pextrq rbx, xmm1, 0
+  and rbx, 255
+  vpshufb xmm1, xmm1, xmm0
+  lea r14, qword ptr [rsi + 96]
+  movdqu xmm4, xmmword ptr [rcx + -128]
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  movdqu xmm15, xmmword ptr [rcx + -112]
+  mov r12, rcx
+  sub r12, 96
+  vpxor xmm9, xmm1, xmm4
+  add rbx, 6
+  cmp rbx, 256
+  jae L118
+  vpaddd xmm10, xmm1, xmm2
+  vpaddd xmm11, xmm10, xmm2
+  vpxor xmm10, xmm10, xmm4
+  vpaddd xmm12, xmm11, xmm2
+  vpxor xmm11, xmm11, xmm4
+  vpaddd xmm13, xmm12, xmm2
+  vpxor xmm12, xmm12, xmm4
+  vpaddd xmm14, xmm13, xmm2
+  vpxor xmm13, xmm13, xmm4
+  vpaddd xmm1, xmm14, xmm2
+  vpxor xmm14, xmm14, xmm4
+  jmp L119
+L118:
+  sub rbx, 256
+  vpshufb xmm6, xmm1, xmm0
+  pxor xmm5, xmm5
+  mov r11, 1
+  pinsrq xmm5, r11, 0
+  vpaddd xmm10, xmm6, xmm5
+  pxor xmm5, xmm5
+  mov r11, 2
+  pinsrq xmm5, r11, 0
+  vpaddd xmm11, xmm6, xmm5
+  vpaddd xmm12, xmm10, xmm5
+  vpshufb xmm10, xmm10, xmm0
+  vpaddd xmm13, xmm11, xmm5
+  vpshufb xmm11, xmm11, xmm0
+  vpxor xmm10, xmm10, xmm4
+  vpaddd xmm14, xmm12, xmm5
+  vpshufb xmm12, xmm12, xmm0
+  vpxor xmm11, xmm11, xmm4
+  vpaddd xmm1, xmm13, xmm5
+  vpshufb xmm13, xmm13, xmm0
+  vpxor xmm12, xmm12, xmm4
+  vpshufb xmm14, xmm14, xmm0
+  vpxor xmm13, xmm13, xmm4
+  vpshufb xmm1, xmm1, xmm0
+  vpxor xmm14, xmm14, xmm4
+L119:
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -96]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -80]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -64]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -48]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -32]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -16]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 0]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 16]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 32]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 48]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 64]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 80]
+  movdqu xmm3, xmmword ptr [rcx + 96]
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm4, xmm3, xmmword ptr [rdi + 0]
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm5, xmm3, xmmword ptr [rdi + 16]
+  vaesenc xmm11, xmm11, xmm15
+  vpxor xmm6, xmm3, xmmword ptr [rdi + 32]
+  vaesenc xmm12, xmm12, xmm15
+  vpxor xmm8, xmm3, xmmword ptr [rdi + 48]
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm2, xmm3, xmmword ptr [rdi + 64]
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm3, xmm3, xmmword ptr [rdi + 80]
+  lea rdi, qword ptr [rdi + 96]
+  vaesenclast xmm9, xmm9, xmm4
+  vaesenclast xmm10, xmm10, xmm5
+  vaesenclast xmm11, xmm11, xmm6
+  vaesenclast xmm12, xmm12, xmm8
+  vaesenclast xmm13, xmm13, xmm2
+  vaesenclast xmm14, xmm14, xmm3
+  movdqu xmmword ptr [rsi + 0], xmm9
+  movdqu xmmword ptr [rsi + 16], xmm10
+  movdqu xmmword ptr [rsi + 32], xmm11
+  movdqu xmmword ptr [rsi + 48], xmm12
+  movdqu xmmword ptr [rsi + 64], xmm13
+  movdqu xmmword ptr [rsi + 80], xmm14
+  lea rsi, qword ptr [rsi + 96]
+  vpshufb xmm8, xmm9, xmm0
+  vpshufb xmm2, xmm10, xmm0
+  movdqu xmmword ptr [rbp + 112], xmm8
+  vpshufb xmm4, xmm11, xmm0
+  movdqu xmmword ptr [rbp + 96], xmm2
+  vpshufb xmm5, xmm12, xmm0
+  movdqu xmmword ptr [rbp + 80], xmm4
+  vpshufb xmm6, xmm13, xmm0
+  movdqu xmmword ptr [rbp + 64], xmm5
+  vpshufb xmm7, xmm14, xmm0
+  movdqu xmmword ptr [rbp + 48], xmm6
+  movdqu xmm4, xmmword ptr [rcx + -128]
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  movdqu xmm15, xmmword ptr [rcx + -112]
+  mov r12, rcx
+  sub r12, 96
+  vpxor xmm9, xmm1, xmm4
+  add rbx, 6
+  cmp rbx, 256
+  jae L120
+  vpaddd xmm10, xmm1, xmm2
+  vpaddd xmm11, xmm10, xmm2
+  vpxor xmm10, xmm10, xmm4
+  vpaddd xmm12, xmm11, xmm2
+  vpxor xmm11, xmm11, xmm4
+  vpaddd xmm13, xmm12, xmm2
+  vpxor xmm12, xmm12, xmm4
+  vpaddd xmm14, xmm13, xmm2
+  vpxor xmm13, xmm13, xmm4
+  vpaddd xmm1, xmm14, xmm2
+  vpxor xmm14, xmm14, xmm4
+  jmp L121
+L120:
+  sub rbx, 256
+  vpshufb xmm6, xmm1, xmm0
+  pxor xmm5, xmm5
+  mov r11, 1
+  pinsrq xmm5, r11, 0
+  vpaddd xmm10, xmm6, xmm5
+  pxor xmm5, xmm5
+  mov r11, 2
+  pinsrq xmm5, r11, 0
+  vpaddd xmm11, xmm6, xmm5
+  vpaddd xmm12, xmm10, xmm5
+  vpshufb xmm10, xmm10, xmm0
+  vpaddd xmm13, xmm11, xmm5
+  vpshufb xmm11, xmm11, xmm0
+  vpxor xmm10, xmm10, xmm4
+  vpaddd xmm14, xmm12, xmm5
+  vpshufb xmm12, xmm12, xmm0
+  vpxor xmm11, xmm11, xmm4
+  vpaddd xmm1, xmm13, xmm5
+  vpshufb xmm13, xmm13, xmm0
+  vpxor xmm12, xmm12, xmm4
+  vpshufb xmm14, xmm14, xmm0
+  vpxor xmm13, xmm13, xmm4
+  vpshufb xmm1, xmm1, xmm0
+  vpxor xmm14, xmm14, xmm4
+L121:
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -96]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -80]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -64]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -48]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -32]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -16]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 0]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 16]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 32]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 48]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 64]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + 80]
+  movdqu xmm3, xmmword ptr [rcx + 96]
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm4, xmm3, xmmword ptr [rdi + 0]
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm5, xmm3, xmmword ptr [rdi + 16]
+  vaesenc xmm11, xmm11, xmm15
+  vpxor xmm6, xmm3, xmmword ptr [rdi + 32]
+  vaesenc xmm12, xmm12, xmm15
+  vpxor xmm8, xmm3, xmmword ptr [rdi + 48]
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm2, xmm3, xmmword ptr [rdi + 64]
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm3, xmm3, xmmword ptr [rdi + 80]
+  lea rdi, qword ptr [rdi + 96]
+  vaesenclast xmm9, xmm9, xmm4
+  vaesenclast xmm10, xmm10, xmm5
+  vaesenclast xmm11, xmm11, xmm6
+  vaesenclast xmm12, xmm12, xmm8
+  vaesenclast xmm13, xmm13, xmm2
+  vaesenclast xmm14, xmm14, xmm3
+  movdqu xmmword ptr [rsi + 0], xmm9
+  movdqu xmmword ptr [rsi + 16], xmm10
+  movdqu xmmword ptr [rsi + 32], xmm11
+  movdqu xmmword ptr [rsi + 48], xmm12
+  movdqu xmmword ptr [rsi + 64], xmm13
+  movdqu xmmword ptr [rsi + 80], xmm14
+  lea rsi, qword ptr [rsi + 96]
+  sub rdx, 12
+  movdqu xmm8, xmmword ptr [rbp + 32]
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  vpxor xmm4, xmm4, xmm4
+  movdqu xmm15, xmmword ptr [rcx + -128]
+  vpaddd xmm10, xmm1, xmm2
+  vpaddd xmm11, xmm10, xmm2
+  vpaddd xmm12, xmm11, xmm2
+  vpaddd xmm13, xmm12, xmm2
+  vpaddd xmm14, xmm13, xmm2
+  vpxor xmm9, xmm1, xmm15
+  movdqu xmmword ptr [rbp + 16], xmm4
+  jmp L123
+ALIGN 16
+L122:
+  add rbx, 6
+  cmp rbx, 256
+  jb L124
+  mov r11, 579005069656919567
+  pinsrq xmm0, r11, 0
+  mov r11, 283686952306183
+  pinsrq xmm0, r11, 1
+  vpshufb xmm6, xmm1, xmm0
+  pxor xmm5, xmm5
+  mov r11, 1
+  pinsrq xmm5, r11, 0
+  vpaddd xmm10, xmm6, xmm5
+  pxor xmm5, xmm5
+  mov r11, 2
+  pinsrq xmm5, r11, 0
+  vpaddd xmm11, xmm6, xmm5
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpaddd xmm12, xmm10, xmm5
+  vpshufb xmm10, xmm10, xmm0
+  vpaddd xmm13, xmm11, xmm5
+  vpshufb xmm11, xmm11, xmm0
+  vpxor xmm10, xmm10, xmm15
+  vpaddd xmm14, xmm12, xmm5
+  vpshufb xmm12, xmm12, xmm0
+  vpxor xmm11, xmm11, xmm15
+  vpaddd xmm1, xmm13, xmm5
+  vpshufb xmm13, xmm13, xmm0
+  vpshufb xmm14, xmm14, xmm0
+  vpshufb xmm1, xmm1, xmm0
+  sub rbx, 256
+  jmp L125
+L124:
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpaddd xmm1, xmm2, xmm14
+  vpxor xmm10, xmm10, xmm15
+  vpxor xmm11, xmm11, xmm15
+L125:
+  movdqu xmmword ptr [rbp + 128], xmm1
+  vpclmulqdq xmm5, xmm7, xmm3, 16
+  vpxor xmm12, xmm12, xmm15
+  movdqu xmm2, xmmword ptr [rcx + -112]
+  vpclmulqdq xmm6, xmm7, xmm3, 1
+  vaesenc xmm9, xmm9, xmm2
+  movdqu xmm0, xmmword ptr [rbp + 48]
+  vpxor xmm13, xmm13, xmm15
+  vpclmulqdq xmm1, xmm7, xmm3, 0
+  vaesenc xmm10, xmm10, xmm2
+  vpxor xmm14, xmm14, xmm15
+  vpclmulqdq xmm7, xmm7, xmm3, 17
+  vaesenc xmm11, xmm11, xmm2
+  movdqu xmm3, xmmword ptr [r9 + -16]
+  vaesenc xmm12, xmm12, xmm2
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm3, 0
+  vpxor xmm8, xmm8, xmm4
+  vaesenc xmm13, xmm13, xmm2
+  vpxor xmm4, xmm1, xmm5
+  vpclmulqdq xmm1, xmm0, xmm3, 16
+  vaesenc xmm14, xmm14, xmm2
+  movdqu xmm15, xmmword ptr [rcx + -96]
+  vpclmulqdq xmm2, xmm0, xmm3, 1
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpclmulqdq xmm3, xmm0, xmm3, 17
+  movdqu xmm0, xmmword ptr [rbp + 64]
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 88]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 80]
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 32], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 40], r12
+  movdqu xmm5, xmmword ptr [r9 + 16]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -80]
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm7, xmm7, xmm3
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vaesenc xmm11, xmm11, xmm15
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [rbp + 80]
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -64]
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm1, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm1, 16
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 72]
+  vpxor xmm7, xmm7, xmm5
+  vpclmulqdq xmm5, xmm0, xmm1, 1
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 64]
+  vpclmulqdq xmm1, xmm0, xmm1, 17
+  movdqu xmm0, xmmword ptr [rbp + 96]
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 48], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 56], r12
+  vpxor xmm4, xmm4, xmm2
+  movdqu xmm2, xmmword ptr [r9 + 64]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -48]
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm2, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm2, 16
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 56]
+  vpxor xmm7, xmm7, xmm1
+  vpclmulqdq xmm1, xmm0, xmm2, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 112]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 48]
+  vpclmulqdq xmm2, xmm0, xmm2, 17
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 64], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 72], r12
+  vpxor xmm4, xmm4, xmm3
+  movdqu xmm3, xmmword ptr [r9 + 80]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -32]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm8, xmm3, 16
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm8, xmm3, 1
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 40]
+  vpxor xmm7, xmm7, xmm2
+  vpclmulqdq xmm2, xmm8, xmm3, 0
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 32]
+  vpclmulqdq xmm8, xmm8, xmm3, 17
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 80], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 88], r12
+  vpxor xmm6, xmm6, xmm5
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm6, xmm6, xmm1
+  movdqu xmm15, xmmword ptr [rcx + -16]
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm2
+  pxor xmm3, xmm3
+  mov r11, 13979173243358019584
+  pinsrq xmm3, r11, 1
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm7, xmm7, xmm8
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm4, xmm4, xmm5
+  movbe r13, qword ptr [r14 + 24]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 16]
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  mov qword ptr [rbp + 96], r13
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 104], r12
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm1, xmmword ptr [rcx + 0]
+  vaesenc xmm9, xmm9, xmm1
+  movdqu xmm15, xmmword ptr [rcx + 16]
+  vaesenc xmm10, xmm10, xmm1
+  vpsrldq xmm6, xmm6, 8
+  vaesenc xmm11, xmm11, xmm1
+  vpxor xmm7, xmm7, xmm6
+  vaesenc xmm12, xmm12, xmm1
+  vpxor xmm4, xmm4, xmm0
+  movbe r13, qword ptr [r14 + 8]
+  vaesenc xmm13, xmm13, xmm1
+  movbe r12, qword ptr [r14 + 0]
+  vaesenc xmm14, xmm14, xmm1
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  vaesenc xmm9, xmm9, xmm1
+  vaesenc xmm10, xmm10, xmm1
+  vaesenc xmm11, xmm11, xmm1
+  vaesenc xmm12, xmm12, xmm1
+  vaesenc xmm13, xmm13, xmm1
+  movdqu xmm15, xmmword ptr [rcx + 48]
+  vaesenc xmm14, xmm14, xmm1
+  movdqu xmm1, xmmword ptr [rcx + 64]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  vaesenc xmm9, xmm9, xmm1
+  vaesenc xmm10, xmm10, xmm1
+  vaesenc xmm11, xmm11, xmm1
+  vaesenc xmm12, xmm12, xmm1
+  vaesenc xmm13, xmm13, xmm1
+  movdqu xmm15, xmmword ptr [rcx + 80]
+  vaesenc xmm14, xmm14, xmm1
+  movdqu xmm1, xmmword ptr [rcx + 96]
+  vaesenc xmm9, xmm9, xmm15
+  movdqu xmmword ptr [rbp + 16], xmm7
+  vpalignr xmm8, xmm4, xmm4, 8
+  vaesenc xmm10, xmm10, xmm15
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm2, xmm1, xmmword ptr [rdi + 0]
+  vaesenc xmm11, xmm11, xmm15
+  vpxor xmm0, xmm1, xmmword ptr [rdi + 16]
+  vaesenc xmm12, xmm12, xmm15
+  vpxor xmm5, xmm1, xmmword ptr [rdi + 32]
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm6, xmm1, xmmword ptr [rdi + 48]
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm7, xmm1, xmmword ptr [rdi + 64]
+  vpxor xmm3, xmm1, xmmword ptr [rdi + 80]
+  movdqu xmm1, xmmword ptr [rbp + 128]
+  vaesenclast xmm9, xmm9, xmm2
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  vaesenclast xmm10, xmm10, xmm0
+  vpaddd xmm0, xmm1, xmm2
+  mov qword ptr [rbp + 112], r13
+  lea rdi, qword ptr [rdi + 96]
+  vaesenclast xmm11, xmm11, xmm5
+  vpaddd xmm5, xmm0, xmm2
+  mov qword ptr [rbp + 120], r12
+  lea rsi, qword ptr [rsi + 96]
+  movdqu xmm15, xmmword ptr [rcx + -128]
+  vaesenclast xmm12, xmm12, xmm6
+  vpaddd xmm6, xmm5, xmm2
+  vaesenclast xmm13, xmm13, xmm7
+  vpaddd xmm7, xmm6, xmm2
+  vaesenclast xmm14, xmm14, xmm3
+  vpaddd xmm3, xmm7, xmm2
+  sub rdx, 6
+  add r14, 96
+  cmp rdx, 0
+  jbe L126
+  movdqu xmmword ptr [rsi + -96], xmm9
+  vpxor xmm9, xmm1, xmm15
+  movdqu xmmword ptr [rsi + -80], xmm10
+  movdqu xmm10, xmm0
+  movdqu xmmword ptr [rsi + -64], xmm11
+  movdqu xmm11, xmm5
+  movdqu xmmword ptr [rsi + -48], xmm12
+  movdqu xmm12, xmm6
+  movdqu xmmword ptr [rsi + -32], xmm13
+  movdqu xmm13, xmm7
+  movdqu xmmword ptr [rsi + -16], xmm14
+  movdqu xmm14, xmm3
+  movdqu xmm7, xmmword ptr [rbp + 32]
+  jmp L127
+L126:
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpxor xmm8, xmm8, xmm4
+L127:
+ALIGN 16
+L123:
+  cmp rdx, 0
+  ja L122
+  movdqu xmm7, xmmword ptr [rbp + 32]
+  movdqu xmmword ptr [rbp + 32], xmm1
+  pxor xmm4, xmm4
+  movdqu xmmword ptr [rbp + 16], xmm4
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpclmulqdq xmm1, xmm7, xmm3, 0
+  vpclmulqdq xmm5, xmm7, xmm3, 16
+  movdqu xmm0, xmmword ptr [rbp + 48]
+  vpclmulqdq xmm6, xmm7, xmm3, 1
+  vpclmulqdq xmm7, xmm7, xmm3, 17
+  movdqu xmm3, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm3, 0
+  vpxor xmm8, xmm8, xmm4
+  vpxor xmm4, xmm1, xmm5
+  vpclmulqdq xmm1, xmm0, xmm3, 16
+  vpclmulqdq xmm2, xmm0, xmm3, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpclmulqdq xmm3, xmm0, xmm3, 17
+  movdqu xmm0, xmmword ptr [rbp + 64]
+  movdqu xmm5, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpxor xmm7, xmm7, xmm3
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [rbp + 80]
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm1, 0
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm1, 16
+  vpxor xmm7, xmm7, xmm5
+  vpclmulqdq xmm5, xmm0, xmm1, 1
+  vpclmulqdq xmm1, xmm0, xmm1, 17
+  movdqu xmm0, xmmword ptr [rbp + 96]
+  vpxor xmm4, xmm4, xmm2
+  movdqu xmm2, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm2, 0
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm2, 16
+  vpxor xmm7, xmm7, xmm1
+  vpclmulqdq xmm1, xmm0, xmm2, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 112]
+  vpclmulqdq xmm2, xmm0, xmm2, 17
+  vpxor xmm4, xmm4, xmm3
+  movdqu xmm3, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm8, xmm3, 16
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm8, xmm3, 1
+  vpxor xmm7, xmm7, xmm2
+  vpclmulqdq xmm2, xmm8, xmm3, 0
+  vpclmulqdq xmm8, xmm8, xmm3, 17
+  vpxor xmm6, xmm6, xmm5
+  vpxor xmm6, xmm6, xmm1
+  vpxor xmm4, xmm4, xmm2
+  pxor xmm3, xmm3
+  mov rax, 3254779904
+  pinsrd xmm3, eax, 3
+  vpxor xmm7, xmm7, xmm8
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  mov r12, 579005069656919567
+  pinsrq xmm0, r12, 0
+  mov r12, 283686952306183
+  pinsrq xmm0, r12, 1
+  movdqu xmmword ptr [rsi + -96], xmm9
+  vpshufb xmm9, xmm9, xmm0
+  vpxor xmm1, xmm1, xmm7
+  movdqu xmmword ptr [rsi + -80], xmm10
+  vpshufb xmm10, xmm10, xmm0
+  movdqu xmmword ptr [rsi + -64], xmm11
+  vpshufb xmm11, xmm11, xmm0
+  movdqu xmmword ptr [rsi + -48], xmm12
+  vpshufb xmm12, xmm12, xmm0
+  movdqu xmmword ptr [rsi + -32], xmm13
+  vpshufb xmm13, xmm13, xmm0
+  movdqu xmmword ptr [rsi + -16], xmm14
+  vpshufb xmm14, xmm14, xmm0
+  pxor xmm4, xmm4
+  movdqu xmm7, xmm14
+  movdqu xmmword ptr [rbp + 16], xmm4
+  movdqu xmmword ptr [rbp + 48], xmm13
+  movdqu xmmword ptr [rbp + 64], xmm12
+  movdqu xmmword ptr [rbp + 80], xmm11
+  movdqu xmmword ptr [rbp + 96], xmm10
+  movdqu xmmword ptr [rbp + 112], xmm9
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpclmulqdq xmm1, xmm7, xmm3, 0
+  vpclmulqdq xmm5, xmm7, xmm3, 16
+  movdqu xmm0, xmmword ptr [rbp + 48]
+  vpclmulqdq xmm6, xmm7, xmm3, 1
+  vpclmulqdq xmm7, xmm7, xmm3, 17
+  movdqu xmm3, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm3, 0
+  vpxor xmm8, xmm8, xmm4
+  vpxor xmm4, xmm1, xmm5
+  vpclmulqdq xmm1, xmm0, xmm3, 16
+  vpclmulqdq xmm2, xmm0, xmm3, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpclmulqdq xmm3, xmm0, xmm3, 17
+  movdqu xmm0, xmmword ptr [rbp + 64]
+  movdqu xmm5, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpxor xmm7, xmm7, xmm3
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [rbp + 80]
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm1, 0
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm1, 16
+  vpxor xmm7, xmm7, xmm5
+  vpclmulqdq xmm5, xmm0, xmm1, 1
+  vpclmulqdq xmm1, xmm0, xmm1, 17
+  movdqu xmm0, xmmword ptr [rbp + 96]
+  vpxor xmm4, xmm4, xmm2
+  movdqu xmm2, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm2, 0
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm2, 16
+  vpxor xmm7, xmm7, xmm1
+  vpclmulqdq xmm1, xmm0, xmm2, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 112]
+  vpclmulqdq xmm2, xmm0, xmm2, 17
+  vpxor xmm4, xmm4, xmm3
+  movdqu xmm3, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm8, xmm3, 16
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm8, xmm3, 1
+  vpxor xmm7, xmm7, xmm2
+  vpclmulqdq xmm2, xmm8, xmm3, 0
+  vpclmulqdq xmm8, xmm8, xmm3, 17
+  vpxor xmm6, xmm6, xmm5
+  vpxor xmm6, xmm6, xmm1
+  vpxor xmm4, xmm4, xmm2
+  pxor xmm3, xmm3
+  mov rax, 3254779904
+  pinsrd xmm3, eax, 3
+  vpxor xmm7, xmm7, xmm8
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  sub rcx, 128
+L117:
+  movdqu xmm11, xmmword ptr [rbp + 32]
+  mov r8, rcx
+  mov rax, qword ptr [rsp + 312]
+  mov rdi, qword ptr [rsp + 320]
+  mov rdx, qword ptr [rsp + 328]
+  mov r14, rdx
+  mov r12, 579005069656919567
+  pinsrq xmm9, r12, 0
+  mov r12, 283686952306183
+  pinsrq xmm9, r12, 1
+  pshufb xmm11, xmm9
+  pxor xmm10, xmm10
+  mov rbx, 1
+  pinsrd xmm10, ebx, 0
+  mov r11, rax
+  mov r10, rdi
+  mov rbx, 0
+  jmp L129
+ALIGN 16
+L128:
+  movdqu xmm0, xmm11
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 176]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 192]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 208]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 224]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  movdqu xmm2, xmmword ptr [r11 + 0]
+  pxor xmm2, xmm0
+  movdqu xmmword ptr [r10 + 0], xmm2
+  add rbx, 1
+  add r11, 16
+  add r10, 16
+  paddd xmm11, xmm10
+ALIGN 16
+L129:
+  cmp rbx, rdx
+  jne L128
+  mov r11, rdi
+  jmp L131
+ALIGN 16
+L130:
+  add r11, 80
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  add r11, 96
+  sub rdx, 6
+ALIGN 16
+L131:
+  cmp rdx, 6
+  jae L130
+  cmp rdx, 0
+  jbe L132
+  mov r10, rdx
+  sub r10, 1
+  imul r10, 16
+  add r11, r10
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  cmp rdx, 1
+  jne L134
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  jmp L135
+L134:
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 2
+  je L136
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 3
+  je L138
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 4
+  je L140
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  jmp L141
+L140:
+L141:
+  jmp L139
+L138:
+L139:
+  jmp L137
+L136:
+L137:
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+L135:
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L133
+L132:
+L133:
+  add r14, qword ptr [rsp + 304]
+  imul r14, 16
+  mov r13, qword ptr [rsp + 344]
+  cmp r13, r14
+  jbe L142
+  mov rax, qword ptr [rsp + 336]
+  mov r10, r13
+  and r10, 15
+  movdqu xmm0, xmm11
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 176]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 192]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 208]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 224]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  movdqu xmm4, xmmword ptr [rax + 0]
+  pxor xmm0, xmm4
+  movdqu xmmword ptr [rax + 0], xmm0
+  cmp r10, 8
+  jae L144
+  mov rcx, 0
+  pinsrq xmm0, rcx, 1
+  mov rcx, r10
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 0
+  and rcx, r11
+  pinsrq xmm0, rcx, 0
+  jmp L145
+L144:
+  mov rcx, r10
+  sub rcx, 8
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 1
+  and rcx, r11
+  pinsrq xmm0, rcx, 1
+L145:
+  pshufb xmm0, xmm9
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L143
+L142:
+L143:
+  mov r11, r15
+  pxor xmm0, xmm0
+  mov rax, r11
+  imul rax, 8
+  pinsrq xmm0, rax, 1
+  mov rax, r13
+  imul rax, 8
+  pinsrq xmm0, rax, 0
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  movdqu xmm0, xmmword ptr [rbp + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 176]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 192]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 208]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 224]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  pshufb xmm8, xmm9
+  pxor xmm8, xmm0
+  mov r15, qword ptr [rsp + 360]
+  movdqu xmmword ptr [r15 + 0], xmm8
+  pop rax
+  pinsrq xmm6, rax, 1
+  pop rax
+  pinsrq xmm6, rax, 0
+  pop rax
+  pinsrq xmm7, rax, 1
+  pop rax
+  pinsrq xmm7, rax, 0
+  pop rax
+  pinsrq xmm8, rax, 1
+  pop rax
+  pinsrq xmm8, rax, 0
+  pop rax
+  pinsrq xmm9, rax, 1
+  pop rax
+  pinsrq xmm9, rax, 0
+  pop rax
+  pinsrq xmm10, rax, 1
+  pop rax
+  pinsrq xmm10, rax, 0
+  pop rax
+  pinsrq xmm11, rax, 1
+  pop rax
+  pinsrq xmm11, rax, 0
+  pop rax
+  pinsrq xmm12, rax, 1
+  pop rax
+  pinsrq xmm12, rax, 0
+  pop rax
+  pinsrq xmm13, rax, 1
+  pop rax
+  pinsrq xmm13, rax, 0
+  pop rax
+  pinsrq xmm14, rax, 1
+  pop rax
+  pinsrq xmm14, rax, 0
+  pop rax
+  pinsrq xmm15, rax, 1
+  pop rax
+  pinsrq xmm15, rax, 0
+  pop rbx
+  pop rbp
+  pop rdi
+  pop rsi
+  pop r12
+  pop r13
+  pop r14
+  pop r15
+  ret
+gcm256_encrypt_opt endp
+ALIGN 16
+gcm128_decrypt_opt proc
+  push r15
+  push r14
+  push r13
+  push r12
+  push rsi
+  push rdi
+  push rbp
+  push rbx
+  pextrq rax, xmm15, 0
+  push rax
+  pextrq rax, xmm15, 1
+  push rax
+  pextrq rax, xmm14, 0
+  push rax
+  pextrq rax, xmm14, 1
+  push rax
+  pextrq rax, xmm13, 0
+  push rax
+  pextrq rax, xmm13, 1
+  push rax
+  pextrq rax, xmm12, 0
+  push rax
+  pextrq rax, xmm12, 1
+  push rax
+  pextrq rax, xmm11, 0
+  push rax
+  pextrq rax, xmm11, 1
+  push rax
+  pextrq rax, xmm10, 0
+  push rax
+  pextrq rax, xmm10, 1
+  push rax
+  pextrq rax, xmm9, 0
+  push rax
+  pextrq rax, xmm9, 1
+  push rax
+  pextrq rax, xmm8, 0
+  push rax
+  pextrq rax, xmm8, 1
+  push rax
+  pextrq rax, xmm7, 0
+  push rax
+  pextrq rax, xmm7, 1
+  push rax
+  pextrq rax, xmm6, 0
+  push rax
+  pextrq rax, xmm6, 1
+  push rax
+  mov rdi, rcx
+  mov rsi, rdx
+  mov rdx, r8
+  mov rcx, r9
+  mov r8, qword ptr [rsp + 264]
+  mov r9, qword ptr [rsp + 272]
+  mov rbp, qword ptr [rsp + 352]
+  mov r13, rcx
+  lea r9, qword ptr [r9 + 32]
+  mov rbx, qword ptr [rsp + 280]
+  mov rcx, rdx
+  imul rcx, 16
+  mov r10, 579005069656919567
+  pinsrq xmm9, r10, 0
+  mov r10, 283686952306183
+  pinsrq xmm9, r10, 1
+  pxor xmm8, xmm8
+  mov r11, rdi
+  jmp L147
+ALIGN 16
+L146:
+  add r11, 80
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  add r11, 96
+  sub rdx, 6
+ALIGN 16
+L147:
+  cmp rdx, 6
+  jae L146
+  cmp rdx, 0
+  jbe L148
+  mov r10, rdx
+  sub r10, 1
+  imul r10, 16
+  add r11, r10
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  cmp rdx, 1
+  jne L150
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  jmp L151
+L150:
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 2
+  je L152
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 3
+  je L154
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 4
+  je L156
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  jmp L157
+L156:
+L157:
+  jmp L155
+L154:
+L155:
+  jmp L153
+L152:
+L153:
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+L151:
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L149
+L148:
+L149:
+  mov r15, rsi
+  cmp rsi, rcx
+  jbe L158
+  movdqu xmm0, xmmword ptr [rbx + 0]
+  mov r10, rsi
+  and r10, 15
+  cmp r10, 8
+  jae L160
+  mov rcx, 0
+  pinsrq xmm0, rcx, 1
+  mov rcx, r10
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 0
+  and rcx, r11
+  pinsrq xmm0, rcx, 0
+  jmp L161
+L160:
+  mov rcx, r10
+  sub rcx, 8
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 1
+  and rcx, r11
+  pinsrq xmm0, rcx, 1
+L161:
+  pshufb xmm0, xmm9
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L159
+L158:
+L159:
+  mov rdi, qword ptr [rsp + 288]
+  mov rsi, qword ptr [rsp + 296]
+  mov rdx, qword ptr [rsp + 304]
+  mov rcx, r13
+  movdqu xmm0, xmm9
+  movdqu xmm1, xmmword ptr [r8 + 0]
+  movdqu xmmword ptr [rbp + 0], xmm1
+  pxor xmm10, xmm10
+  mov r11, 1
+  pinsrq xmm10, r11, 0
+  vpaddd xmm1, xmm1, xmm10
+  cmp rdx, 0
+  jne L162
+  vpshufb xmm1, xmm1, xmm0
+  movdqu xmmword ptr [rbp + 32], xmm1
+  jmp L163
+L162:
+  movdqu xmmword ptr [rbp + 32], xmm8
+  add rcx, 128
+  pextrq rbx, xmm1, 0
+  and rbx, 255
+  vpshufb xmm1, xmm1, xmm0
+  lea r14, qword ptr [rdi + 96]
+  movdqu xmm8, xmmword ptr [rbp + 32]
+  movdqu xmm7, xmmword ptr [rdi + 80]
+  movdqu xmm4, xmmword ptr [rdi + 64]
+  movdqu xmm5, xmmword ptr [rdi + 48]
+  movdqu xmm6, xmmword ptr [rdi + 32]
+  vpshufb xmm7, xmm7, xmm0
+  movdqu xmm2, xmmword ptr [rdi + 16]
+  vpshufb xmm4, xmm4, xmm0
+  movdqu xmm3, xmmword ptr [rdi + 0]
+  vpshufb xmm5, xmm5, xmm0
+  movdqu xmmword ptr [rbp + 48], xmm4
+  vpshufb xmm6, xmm6, xmm0
+  movdqu xmmword ptr [rbp + 64], xmm5
+  vpshufb xmm2, xmm2, xmm0
+  movdqu xmmword ptr [rbp + 80], xmm6
+  vpshufb xmm3, xmm3, xmm0
+  movdqu xmmword ptr [rbp + 96], xmm2
+  movdqu xmmword ptr [rbp + 112], xmm3
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  vpxor xmm4, xmm4, xmm4
+  movdqu xmm15, xmmword ptr [rcx + -128]
+  vpaddd xmm10, xmm1, xmm2
+  vpaddd xmm11, xmm10, xmm2
+  vpaddd xmm12, xmm11, xmm2
+  vpaddd xmm13, xmm12, xmm2
+  vpaddd xmm14, xmm13, xmm2
+  vpxor xmm9, xmm1, xmm15
+  movdqu xmmword ptr [rbp + 16], xmm4
+  cmp rdx, 6
+  jne L164
+  sub r14, 96
+  jmp L165
+L164:
+L165:
+  jmp L167
+ALIGN 16
+L166:
+  add rbx, 6
+  cmp rbx, 256
+  jb L168
+  mov r11, 579005069656919567
+  pinsrq xmm0, r11, 0
+  mov r11, 283686952306183
+  pinsrq xmm0, r11, 1
+  vpshufb xmm6, xmm1, xmm0
+  pxor xmm5, xmm5
+  mov r11, 1
+  pinsrq xmm5, r11, 0
+  vpaddd xmm10, xmm6, xmm5
+  pxor xmm5, xmm5
+  mov r11, 2
+  pinsrq xmm5, r11, 0
+  vpaddd xmm11, xmm6, xmm5
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpaddd xmm12, xmm10, xmm5
+  vpshufb xmm10, xmm10, xmm0
+  vpaddd xmm13, xmm11, xmm5
+  vpshufb xmm11, xmm11, xmm0
+  vpxor xmm10, xmm10, xmm15
+  vpaddd xmm14, xmm12, xmm5
+  vpshufb xmm12, xmm12, xmm0
+  vpxor xmm11, xmm11, xmm15
+  vpaddd xmm1, xmm13, xmm5
+  vpshufb xmm13, xmm13, xmm0
+  vpshufb xmm14, xmm14, xmm0
+  vpshufb xmm1, xmm1, xmm0
+  sub rbx, 256
+  jmp L169
+L168:
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpaddd xmm1, xmm2, xmm14
+  vpxor xmm10, xmm10, xmm15
+  vpxor xmm11, xmm11, xmm15
+L169:
+  movdqu xmmword ptr [rbp + 128], xmm1
+  vpclmulqdq xmm5, xmm7, xmm3, 16
+  vpxor xmm12, xmm12, xmm15
+  movdqu xmm2, xmmword ptr [rcx + -112]
+  vpclmulqdq xmm6, xmm7, xmm3, 1
+  vaesenc xmm9, xmm9, xmm2
+  movdqu xmm0, xmmword ptr [rbp + 48]
+  vpxor xmm13, xmm13, xmm15
+  vpclmulqdq xmm1, xmm7, xmm3, 0
+  vaesenc xmm10, xmm10, xmm2
+  vpxor xmm14, xmm14, xmm15
+  vpclmulqdq xmm7, xmm7, xmm3, 17
+  vaesenc xmm11, xmm11, xmm2
+  movdqu xmm3, xmmword ptr [r9 + -16]
+  vaesenc xmm12, xmm12, xmm2
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm3, 0
+  vpxor xmm8, xmm8, xmm4
+  vaesenc xmm13, xmm13, xmm2
+  vpxor xmm4, xmm1, xmm5
+  vpclmulqdq xmm1, xmm0, xmm3, 16
+  vaesenc xmm14, xmm14, xmm2
+  movdqu xmm15, xmmword ptr [rcx + -96]
+  vpclmulqdq xmm2, xmm0, xmm3, 1
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpclmulqdq xmm3, xmm0, xmm3, 17
+  movdqu xmm0, xmmword ptr [rbp + 64]
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 88]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 80]
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 32], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 40], r12
+  movdqu xmm5, xmmword ptr [r9 + 16]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -80]
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm7, xmm7, xmm3
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vaesenc xmm11, xmm11, xmm15
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [rbp + 80]
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -64]
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm1, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm1, 16
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 72]
+  vpxor xmm7, xmm7, xmm5
+  vpclmulqdq xmm5, xmm0, xmm1, 1
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 64]
+  vpclmulqdq xmm1, xmm0, xmm1, 17
+  movdqu xmm0, xmmword ptr [rbp + 96]
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 48], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 56], r12
+  vpxor xmm4, xmm4, xmm2
+  movdqu xmm2, xmmword ptr [r9 + 64]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -48]
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm2, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm2, 16
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 56]
+  vpxor xmm7, xmm7, xmm1
+  vpclmulqdq xmm1, xmm0, xmm2, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 112]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 48]
+  vpclmulqdq xmm2, xmm0, xmm2, 17
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 64], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 72], r12
+  vpxor xmm4, xmm4, xmm3
+  movdqu xmm3, xmmword ptr [r9 + 80]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -32]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm8, xmm3, 16
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm8, xmm3, 1
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 40]
+  vpxor xmm7, xmm7, xmm2
+  vpclmulqdq xmm2, xmm8, xmm3, 0
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 32]
+  vpclmulqdq xmm8, xmm8, xmm3, 17
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 80], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 88], r12
+  vpxor xmm6, xmm6, xmm5
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm6, xmm6, xmm1
+  movdqu xmm15, xmmword ptr [rcx + -16]
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm2
+  pxor xmm3, xmm3
+  mov r11, 13979173243358019584
+  pinsrq xmm3, r11, 1
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm7, xmm7, xmm8
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm4, xmm4, xmm5
+  movbe r13, qword ptr [r14 + 24]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 16]
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  mov qword ptr [rbp + 96], r13
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 104], r12
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm1, xmmword ptr [rcx + 0]
+  vaesenc xmm9, xmm9, xmm1
+  movdqu xmm15, xmmword ptr [rcx + 16]
+  vaesenc xmm10, xmm10, xmm1
+  vpsrldq xmm6, xmm6, 8
+  vaesenc xmm11, xmm11, xmm1
+  vpxor xmm7, xmm7, xmm6
+  vaesenc xmm12, xmm12, xmm1
+  vpxor xmm4, xmm4, xmm0
+  movbe r13, qword ptr [r14 + 8]
+  vaesenc xmm13, xmm13, xmm1
+  movbe r12, qword ptr [r14 + 0]
+  vaesenc xmm14, xmm14, xmm1
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  vaesenc xmm9, xmm9, xmm15
+  movdqu xmmword ptr [rbp + 16], xmm7
+  vpalignr xmm8, xmm4, xmm4, 8
+  vaesenc xmm10, xmm10, xmm15
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm2, xmm1, xmmword ptr [rdi + 0]
+  vaesenc xmm11, xmm11, xmm15
+  vpxor xmm0, xmm1, xmmword ptr [rdi + 16]
+  vaesenc xmm12, xmm12, xmm15
+  vpxor xmm5, xmm1, xmmword ptr [rdi + 32]
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm6, xmm1, xmmword ptr [rdi + 48]
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm7, xmm1, xmmword ptr [rdi + 64]
+  vpxor xmm3, xmm1, xmmword ptr [rdi + 80]
+  movdqu xmm1, xmmword ptr [rbp + 128]
+  vaesenclast xmm9, xmm9, xmm2
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  vaesenclast xmm10, xmm10, xmm0
+  vpaddd xmm0, xmm1, xmm2
+  mov qword ptr [rbp + 112], r13
+  lea rdi, qword ptr [rdi + 96]
+  vaesenclast xmm11, xmm11, xmm5
+  vpaddd xmm5, xmm0, xmm2
+  mov qword ptr [rbp + 120], r12
+  lea rsi, qword ptr [rsi + 96]
+  movdqu xmm15, xmmword ptr [rcx + -128]
+  vaesenclast xmm12, xmm12, xmm6
+  vpaddd xmm6, xmm5, xmm2
+  vaesenclast xmm13, xmm13, xmm7
+  vpaddd xmm7, xmm6, xmm2
+  vaesenclast xmm14, xmm14, xmm3
+  vpaddd xmm3, xmm7, xmm2
+  sub rdx, 6
+  cmp rdx, 6
+  jbe L170
+  add r14, 96
+  jmp L171
+L170:
+L171:
+  cmp rdx, 0
+  jbe L172
+  movdqu xmmword ptr [rsi + -96], xmm9
+  vpxor xmm9, xmm1, xmm15
+  movdqu xmmword ptr [rsi + -80], xmm10
+  movdqu xmm10, xmm0
+  movdqu xmmword ptr [rsi + -64], xmm11
+  movdqu xmm11, xmm5
+  movdqu xmmword ptr [rsi + -48], xmm12
+  movdqu xmm12, xmm6
+  movdqu xmmword ptr [rsi + -32], xmm13
+  movdqu xmm13, xmm7
+  movdqu xmmword ptr [rsi + -16], xmm14
+  movdqu xmm14, xmm3
+  movdqu xmm7, xmmword ptr [rbp + 32]
+  jmp L173
+L172:
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpxor xmm8, xmm8, xmm4
+L173:
+ALIGN 16
+L167:
+  cmp rdx, 0
+  ja L166
+  movdqu xmmword ptr [rbp + 32], xmm1
+  movdqu xmmword ptr [rsi + -96], xmm9
+  movdqu xmmword ptr [rsi + -80], xmm10
+  movdqu xmmword ptr [rsi + -64], xmm11
+  movdqu xmmword ptr [rsi + -48], xmm12
+  movdqu xmmword ptr [rsi + -32], xmm13
+  movdqu xmmword ptr [rsi + -16], xmm14
+  sub rcx, 128
+L163:
+  movdqu xmm11, xmmword ptr [rbp + 32]
+  mov r8, rcx
+  mov rax, qword ptr [rsp + 312]
+  mov rdi, qword ptr [rsp + 320]
+  mov rdx, qword ptr [rsp + 328]
+  mov r14, rdx
+  mov r12, 579005069656919567
+  pinsrq xmm9, r12, 0
+  mov r12, 283686952306183
+  pinsrq xmm9, r12, 1
+  pshufb xmm11, xmm9
+  mov rbx, rdi
+  mov r12, rdx
+  mov rdi, rax
+  mov r11, rdi
+  jmp L175
+ALIGN 16
+L174:
+  add r11, 80
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  add r11, 96
+  sub rdx, 6
+ALIGN 16
+L175:
+  cmp rdx, 6
+  jae L174
+  cmp rdx, 0
+  jbe L176
+  mov r10, rdx
+  sub r10, 1
+  imul r10, 16
+  add r11, r10
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  cmp rdx, 1
+  jne L178
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  jmp L179
+L178:
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 2
+  je L180
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 3
+  je L182
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 4
+  je L184
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  jmp L185
+L184:
+L185:
+  jmp L183
+L182:
+L183:
+  jmp L181
+L180:
+L181:
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+L179:
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L177
+L176:
+L177:
+  mov rdi, rbx
+  mov rdx, r12
+  pxor xmm10, xmm10
+  mov rbx, 1
+  pinsrd xmm10, ebx, 0
+  mov r11, rax
+  mov r10, rdi
+  mov rbx, 0
+  jmp L187
+ALIGN 16
+L186:
+  movdqu xmm0, xmm11
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  movdqu xmm2, xmmword ptr [r11 + 0]
+  pxor xmm2, xmm0
+  movdqu xmmword ptr [r10 + 0], xmm2
+  add rbx, 1
+  add r11, 16
+  add r10, 16
+  paddd xmm11, xmm10
+ALIGN 16
+L187:
+  cmp rbx, rdx
+  jne L186
+  add r14, qword ptr [rsp + 304]
+  imul r14, 16
+  mov r13, qword ptr [rsp + 344]
+  cmp r13, r14
+  jbe L188
+  mov rax, qword ptr [rsp + 336]
+  mov r10, r13
+  and r10, 15
+  movdqu xmm0, xmmword ptr [rax + 0]
+  movdqu xmm10, xmm0
+  cmp r10, 8
+  jae L190
+  mov rcx, 0
+  pinsrq xmm0, rcx, 1
+  mov rcx, r10
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 0
+  and rcx, r11
+  pinsrq xmm0, rcx, 0
+  jmp L191
+L190:
+  mov rcx, r10
+  sub rcx, 8
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 1
+  and rcx, r11
+  pinsrq xmm0, rcx, 1
+L191:
+  pshufb xmm0, xmm9
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  movdqu xmm0, xmm11
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  pxor xmm10, xmm0
+  movdqu xmmword ptr [rax + 0], xmm10
+  jmp L189
+L188:
+L189:
+  mov r11, r15
+  pxor xmm0, xmm0
+  mov rax, r11
+  imul rax, 8
+  pinsrq xmm0, rax, 1
+  mov rax, r13
+  imul rax, 8
+  pinsrq xmm0, rax, 0
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  movdqu xmm0, xmmword ptr [rbp + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  pshufb xmm8, xmm9
+  pxor xmm8, xmm0
+  mov r15, qword ptr [rsp + 360]
+  movdqu xmm0, xmmword ptr [r15 + 0]
+  pcmpeqd xmm0, xmm8
+  pextrq rdx, xmm0, 0
+  sub rdx, 18446744073709551615
+  mov rax, 0
+  adc rax, 0
+  pextrq rdx, xmm0, 1
+  sub rdx, 18446744073709551615
+  mov rdx, 0
+  adc rdx, 0
+  add rax, rdx
+  mov rcx, rax
+  pop rax
+  pinsrq xmm6, rax, 1
+  pop rax
+  pinsrq xmm6, rax, 0
+  pop rax
+  pinsrq xmm7, rax, 1
+  pop rax
+  pinsrq xmm7, rax, 0
+  pop rax
+  pinsrq xmm8, rax, 1
+  pop rax
+  pinsrq xmm8, rax, 0
+  pop rax
+  pinsrq xmm9, rax, 1
+  pop rax
+  pinsrq xmm9, rax, 0
+  pop rax
+  pinsrq xmm10, rax, 1
+  pop rax
+  pinsrq xmm10, rax, 0
+  pop rax
+  pinsrq xmm11, rax, 1
+  pop rax
+  pinsrq xmm11, rax, 0
+  pop rax
+  pinsrq xmm12, rax, 1
+  pop rax
+  pinsrq xmm12, rax, 0
+  pop rax
+  pinsrq xmm13, rax, 1
+  pop rax
+  pinsrq xmm13, rax, 0
+  pop rax
+  pinsrq xmm14, rax, 1
+  pop rax
+  pinsrq xmm14, rax, 0
+  pop rax
+  pinsrq xmm15, rax, 1
+  pop rax
+  pinsrq xmm15, rax, 0
+  pop rbx
+  pop rbp
+  pop rdi
+  pop rsi
+  pop r12
+  pop r13
+  pop r14
+  pop r15
+  mov rax, rcx
+  ret
+gcm128_decrypt_opt endp
+ALIGN 16
+gcm256_decrypt_opt proc
+  push r15
+  push r14
+  push r13
+  push r12
+  push rsi
+  push rdi
+  push rbp
+  push rbx
+  pextrq rax, xmm15, 0
+  push rax
+  pextrq rax, xmm15, 1
+  push rax
+  pextrq rax, xmm14, 0
+  push rax
+  pextrq rax, xmm14, 1
+  push rax
+  pextrq rax, xmm13, 0
+  push rax
+  pextrq rax, xmm13, 1
+  push rax
+  pextrq rax, xmm12, 0
+  push rax
+  pextrq rax, xmm12, 1
+  push rax
+  pextrq rax, xmm11, 0
+  push rax
+  pextrq rax, xmm11, 1
+  push rax
+  pextrq rax, xmm10, 0
+  push rax
+  pextrq rax, xmm10, 1
+  push rax
+  pextrq rax, xmm9, 0
+  push rax
+  pextrq rax, xmm9, 1
+  push rax
+  pextrq rax, xmm8, 0
+  push rax
+  pextrq rax, xmm8, 1
+  push rax
+  pextrq rax, xmm7, 0
+  push rax
+  pextrq rax, xmm7, 1
+  push rax
+  pextrq rax, xmm6, 0
+  push rax
+  pextrq rax, xmm6, 1
+  push rax
+  mov rdi, rcx
+  mov rsi, rdx
+  mov rdx, r8
+  mov rcx, r9
+  mov r8, qword ptr [rsp + 264]
+  mov r9, qword ptr [rsp + 272]
+  mov rbp, qword ptr [rsp + 352]
+  mov r13, rcx
+  lea r9, qword ptr [r9 + 32]
+  mov rbx, qword ptr [rsp + 280]
+  mov rcx, rdx
+  imul rcx, 16
+  mov r10, 579005069656919567
+  pinsrq xmm9, r10, 0
+  mov r10, 283686952306183
+  pinsrq xmm9, r10, 1
+  pxor xmm8, xmm8
+  mov r11, rdi
+  jmp L193
+ALIGN 16
+L192:
+  add r11, 80
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  add r11, 96
+  sub rdx, 6
+ALIGN 16
+L193:
+  cmp rdx, 6
+  jae L192
+  cmp rdx, 0
+  jbe L194
+  mov r10, rdx
+  sub r10, 1
+  imul r10, 16
+  add r11, r10
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  cmp rdx, 1
+  jne L196
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  jmp L197
+L196:
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 2
+  je L198
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 3
+  je L200
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 4
+  je L202
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  jmp L203
+L202:
+L203:
+  jmp L201
+L200:
+L201:
+  jmp L199
+L198:
+L199:
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+L197:
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L195
+L194:
+L195:
+  mov r15, rsi
+  cmp rsi, rcx
+  jbe L204
+  movdqu xmm0, xmmword ptr [rbx + 0]
+  mov r10, rsi
+  and r10, 15
+  cmp r10, 8
+  jae L206
+  mov rcx, 0
+  pinsrq xmm0, rcx, 1
+  mov rcx, r10
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 0
+  and rcx, r11
+  pinsrq xmm0, rcx, 0
+  jmp L207
+L206:
+  mov rcx, r10
+  sub rcx, 8
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 1
+  and rcx, r11
+  pinsrq xmm0, rcx, 1
+L207:
+  pshufb xmm0, xmm9
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L205
+L204:
+L205:
+  mov rdi, qword ptr [rsp + 288]
+  mov rsi, qword ptr [rsp + 296]
+  mov rdx, qword ptr [rsp + 304]
+  mov rcx, r13
+  movdqu xmm0, xmm9
+  movdqu xmm1, xmmword ptr [r8 + 0]
+  movdqu xmmword ptr [rbp + 0], xmm1
+  pxor xmm10, xmm10
+  mov r11, 1
+  pinsrq xmm10, r11, 0
+  vpaddd xmm1, xmm1, xmm10
+  cmp rdx, 0
+  jne L208
+  vpshufb xmm1, xmm1, xmm0
+  movdqu xmmword ptr [rbp + 32], xmm1
+  jmp L209
+L208:
+  movdqu xmmword ptr [rbp + 32], xmm8
+  add rcx, 128
+  pextrq rbx, xmm1, 0
+  and rbx, 255
+  vpshufb xmm1, xmm1, xmm0
+  lea r14, qword ptr [rdi + 96]
+  movdqu xmm8, xmmword ptr [rbp + 32]
+  movdqu xmm7, xmmword ptr [rdi + 80]
+  movdqu xmm4, xmmword ptr [rdi + 64]
+  movdqu xmm5, xmmword ptr [rdi + 48]
+  movdqu xmm6, xmmword ptr [rdi + 32]
+  vpshufb xmm7, xmm7, xmm0
+  movdqu xmm2, xmmword ptr [rdi + 16]
+  vpshufb xmm4, xmm4, xmm0
+  movdqu xmm3, xmmword ptr [rdi + 0]
+  vpshufb xmm5, xmm5, xmm0
+  movdqu xmmword ptr [rbp + 48], xmm4
+  vpshufb xmm6, xmm6, xmm0
+  movdqu xmmword ptr [rbp + 64], xmm5
+  vpshufb xmm2, xmm2, xmm0
+  movdqu xmmword ptr [rbp + 80], xmm6
+  vpshufb xmm3, xmm3, xmm0
+  movdqu xmmword ptr [rbp + 96], xmm2
+  movdqu xmmword ptr [rbp + 112], xmm3
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  vpxor xmm4, xmm4, xmm4
+  movdqu xmm15, xmmword ptr [rcx + -128]
+  vpaddd xmm10, xmm1, xmm2
+  vpaddd xmm11, xmm10, xmm2
+  vpaddd xmm12, xmm11, xmm2
+  vpaddd xmm13, xmm12, xmm2
+  vpaddd xmm14, xmm13, xmm2
+  vpxor xmm9, xmm1, xmm15
+  movdqu xmmword ptr [rbp + 16], xmm4
+  cmp rdx, 6
+  jne L210
+  sub r14, 96
+  jmp L211
+L210:
+L211:
+  jmp L213
+ALIGN 16
+L212:
+  add rbx, 6
+  cmp rbx, 256
+  jb L214
+  mov r11, 579005069656919567
+  pinsrq xmm0, r11, 0
+  mov r11, 283686952306183
+  pinsrq xmm0, r11, 1
+  vpshufb xmm6, xmm1, xmm0
+  pxor xmm5, xmm5
+  mov r11, 1
+  pinsrq xmm5, r11, 0
+  vpaddd xmm10, xmm6, xmm5
+  pxor xmm5, xmm5
+  mov r11, 2
+  pinsrq xmm5, r11, 0
+  vpaddd xmm11, xmm6, xmm5
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpaddd xmm12, xmm10, xmm5
+  vpshufb xmm10, xmm10, xmm0
+  vpaddd xmm13, xmm11, xmm5
+  vpshufb xmm11, xmm11, xmm0
+  vpxor xmm10, xmm10, xmm15
+  vpaddd xmm14, xmm12, xmm5
+  vpshufb xmm12, xmm12, xmm0
+  vpxor xmm11, xmm11, xmm15
+  vpaddd xmm1, xmm13, xmm5
+  vpshufb xmm13, xmm13, xmm0
+  vpshufb xmm14, xmm14, xmm0
+  vpshufb xmm1, xmm1, xmm0
+  sub rbx, 256
+  jmp L215
+L214:
+  movdqu xmm3, xmmword ptr [r9 + -32]
+  vpaddd xmm1, xmm2, xmm14
+  vpxor xmm10, xmm10, xmm15
+  vpxor xmm11, xmm11, xmm15
+L215:
+  movdqu xmmword ptr [rbp + 128], xmm1
+  vpclmulqdq xmm5, xmm7, xmm3, 16
+  vpxor xmm12, xmm12, xmm15
+  movdqu xmm2, xmmword ptr [rcx + -112]
+  vpclmulqdq xmm6, xmm7, xmm3, 1
+  vaesenc xmm9, xmm9, xmm2
+  movdqu xmm0, xmmword ptr [rbp + 48]
+  vpxor xmm13, xmm13, xmm15
+  vpclmulqdq xmm1, xmm7, xmm3, 0
+  vaesenc xmm10, xmm10, xmm2
+  vpxor xmm14, xmm14, xmm15
+  vpclmulqdq xmm7, xmm7, xmm3, 17
+  vaesenc xmm11, xmm11, xmm2
+  movdqu xmm3, xmmword ptr [r9 + -16]
+  vaesenc xmm12, xmm12, xmm2
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm3, 0
+  vpxor xmm8, xmm8, xmm4
+  vaesenc xmm13, xmm13, xmm2
+  vpxor xmm4, xmm1, xmm5
+  vpclmulqdq xmm1, xmm0, xmm3, 16
+  vaesenc xmm14, xmm14, xmm2
+  movdqu xmm15, xmmword ptr [rcx + -96]
+  vpclmulqdq xmm2, xmm0, xmm3, 1
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpclmulqdq xmm3, xmm0, xmm3, 17
+  movdqu xmm0, xmmword ptr [rbp + 64]
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 88]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 80]
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 32], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 40], r12
+  movdqu xmm5, xmmword ptr [r9 + 16]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -80]
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm7, xmm7, xmm3
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vaesenc xmm11, xmm11, xmm15
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [rbp + 80]
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -64]
+  vpxor xmm6, xmm6, xmm2
+  vpclmulqdq xmm2, xmm0, xmm1, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm1, 16
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 72]
+  vpxor xmm7, xmm7, xmm5
+  vpclmulqdq xmm5, xmm0, xmm1, 1
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 64]
+  vpclmulqdq xmm1, xmm0, xmm1, 17
+  movdqu xmm0, xmmword ptr [rbp + 96]
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 48], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 56], r12
+  vpxor xmm4, xmm4, xmm2
+  movdqu xmm2, xmmword ptr [r9 + 64]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -48]
+  vpxor xmm6, xmm6, xmm3
+  vpclmulqdq xmm3, xmm0, xmm2, 0
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm0, xmm2, 16
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 56]
+  vpxor xmm7, xmm7, xmm1
+  vpclmulqdq xmm1, xmm0, xmm2, 1
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 112]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 48]
+  vpclmulqdq xmm2, xmm0, xmm2, 17
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 64], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 72], r12
+  vpxor xmm4, xmm4, xmm3
+  movdqu xmm3, xmmword ptr [r9 + 80]
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm15, xmmword ptr [rcx + -32]
+  vpxor xmm6, xmm6, xmm5
+  vpclmulqdq xmm5, xmm8, xmm3, 16
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm6, xmm6, xmm1
+  vpclmulqdq xmm1, xmm8, xmm3, 1
+  vaesenc xmm10, xmm10, xmm15
+  movbe r13, qword ptr [r14 + 40]
+  vpxor xmm7, xmm7, xmm2
+  vpclmulqdq xmm2, xmm8, xmm3, 0
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 32]
+  vpclmulqdq xmm8, xmm8, xmm3, 17
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 80], r13
+  vaesenc xmm13, xmm13, xmm15
+  mov qword ptr [rbp + 88], r12
+  vpxor xmm6, xmm6, xmm5
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm6, xmm6, xmm1
+  movdqu xmm15, xmmword ptr [rcx + -16]
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm2
+  pxor xmm3, xmm3
+  mov r11, 13979173243358019584
+  pinsrq xmm3, r11, 1
+  vaesenc xmm9, xmm9, xmm15
+  vpxor xmm7, xmm7, xmm8
+  vaesenc xmm10, xmm10, xmm15
+  vpxor xmm4, xmm4, xmm5
+  movbe r13, qword ptr [r14 + 24]
+  vaesenc xmm11, xmm11, xmm15
+  movbe r12, qword ptr [r14 + 16]
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  mov qword ptr [rbp + 96], r13
+  vaesenc xmm12, xmm12, xmm15
+  mov qword ptr [rbp + 104], r12
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  movdqu xmm1, xmmword ptr [rcx + 0]
+  vaesenc xmm9, xmm9, xmm1
+  movdqu xmm15, xmmword ptr [rcx + 16]
+  vaesenc xmm10, xmm10, xmm1
+  vpsrldq xmm6, xmm6, 8
+  vaesenc xmm11, xmm11, xmm1
+  vpxor xmm7, xmm7, xmm6
+  vaesenc xmm12, xmm12, xmm1
+  vpxor xmm4, xmm4, xmm0
+  movbe r13, qword ptr [r14 + 8]
+  vaesenc xmm13, xmm13, xmm1
+  movbe r12, qword ptr [r14 + 0]
+  vaesenc xmm14, xmm14, xmm1
+  movdqu xmm1, xmmword ptr [rcx + 32]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  vaesenc xmm9, xmm9, xmm1
+  vaesenc xmm10, xmm10, xmm1
+  vaesenc xmm11, xmm11, xmm1
+  vaesenc xmm12, xmm12, xmm1
+  vaesenc xmm13, xmm13, xmm1
+  movdqu xmm15, xmmword ptr [rcx + 48]
+  vaesenc xmm14, xmm14, xmm1
+  movdqu xmm1, xmmword ptr [rcx + 64]
+  vaesenc xmm9, xmm9, xmm15
+  vaesenc xmm10, xmm10, xmm15
+  vaesenc xmm11, xmm11, xmm15
+  vaesenc xmm12, xmm12, xmm15
+  vaesenc xmm13, xmm13, xmm15
+  vaesenc xmm14, xmm14, xmm15
+  vaesenc xmm9, xmm9, xmm1
+  vaesenc xmm10, xmm10, xmm1
+  vaesenc xmm11, xmm11, xmm1
+  vaesenc xmm12, xmm12, xmm1
+  vaesenc xmm13, xmm13, xmm1
+  movdqu xmm15, xmmword ptr [rcx + 80]
+  vaesenc xmm14, xmm14, xmm1
+  movdqu xmm1, xmmword ptr [rcx + 96]
+  vaesenc xmm9, xmm9, xmm15
+  movdqu xmmword ptr [rbp + 16], xmm7
+  vpalignr xmm8, xmm4, xmm4, 8
+  vaesenc xmm10, xmm10, xmm15
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm2, xmm1, xmmword ptr [rdi + 0]
+  vaesenc xmm11, xmm11, xmm15
+  vpxor xmm0, xmm1, xmmword ptr [rdi + 16]
+  vaesenc xmm12, xmm12, xmm15
+  vpxor xmm5, xmm1, xmmword ptr [rdi + 32]
+  vaesenc xmm13, xmm13, xmm15
+  vpxor xmm6, xmm1, xmmword ptr [rdi + 48]
+  vaesenc xmm14, xmm14, xmm15
+  vpxor xmm7, xmm1, xmmword ptr [rdi + 64]
+  vpxor xmm3, xmm1, xmmword ptr [rdi + 80]
+  movdqu xmm1, xmmword ptr [rbp + 128]
+  vaesenclast xmm9, xmm9, xmm2
+  pxor xmm2, xmm2
+  mov r11, 72057594037927936
+  pinsrq xmm2, r11, 1
+  vaesenclast xmm10, xmm10, xmm0
+  vpaddd xmm0, xmm1, xmm2
+  mov qword ptr [rbp + 112], r13
+  lea rdi, qword ptr [rdi + 96]
+  vaesenclast xmm11, xmm11, xmm5
+  vpaddd xmm5, xmm0, xmm2
+  mov qword ptr [rbp + 120], r12
+  lea rsi, qword ptr [rsi + 96]
+  movdqu xmm15, xmmword ptr [rcx + -128]
+  vaesenclast xmm12, xmm12, xmm6
+  vpaddd xmm6, xmm5, xmm2
+  vaesenclast xmm13, xmm13, xmm7
+  vpaddd xmm7, xmm6, xmm2
+  vaesenclast xmm14, xmm14, xmm3
+  vpaddd xmm3, xmm7, xmm2
+  sub rdx, 6
+  cmp rdx, 6
+  jbe L216
+  add r14, 96
+  jmp L217
+L216:
+L217:
+  cmp rdx, 0
+  jbe L218
+  movdqu xmmword ptr [rsi + -96], xmm9
+  vpxor xmm9, xmm1, xmm15
+  movdqu xmmword ptr [rsi + -80], xmm10
+  movdqu xmm10, xmm0
+  movdqu xmmword ptr [rsi + -64], xmm11
+  movdqu xmm11, xmm5
+  movdqu xmmword ptr [rsi + -48], xmm12
+  movdqu xmm12, xmm6
+  movdqu xmmword ptr [rsi + -32], xmm13
+  movdqu xmm13, xmm7
+  movdqu xmmword ptr [rsi + -16], xmm14
+  movdqu xmm14, xmm3
+  movdqu xmm7, xmmword ptr [rbp + 32]
+  jmp L219
+L218:
+  vpxor xmm8, xmm8, xmmword ptr [rbp + 16]
+  vpxor xmm8, xmm8, xmm4
+L219:
+ALIGN 16
+L213:
+  cmp rdx, 0
+  ja L212
+  movdqu xmmword ptr [rbp + 32], xmm1
+  movdqu xmmword ptr [rsi + -96], xmm9
+  movdqu xmmword ptr [rsi + -80], xmm10
+  movdqu xmmword ptr [rsi + -64], xmm11
+  movdqu xmmword ptr [rsi + -48], xmm12
+  movdqu xmmword ptr [rsi + -32], xmm13
+  movdqu xmmword ptr [rsi + -16], xmm14
+  sub rcx, 128
+L209:
+  movdqu xmm11, xmmword ptr [rbp + 32]
+  mov r8, rcx
+  mov rax, qword ptr [rsp + 312]
+  mov rdi, qword ptr [rsp + 320]
+  mov rdx, qword ptr [rsp + 328]
+  mov r14, rdx
+  mov r12, 579005069656919567
+  pinsrq xmm9, r12, 0
+  mov r12, 283686952306183
+  pinsrq xmm9, r12, 1
+  pshufb xmm11, xmm9
+  mov rbx, rdi
+  mov r12, rdx
+  mov rdi, rax
+  mov r11, rdi
+  jmp L221
+ALIGN 16
+L220:
+  add r11, 80
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 80]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  add r11, 96
+  sub rdx, 6
+ALIGN 16
+L221:
+  cmp rdx, 6
+  jae L220
+  cmp rdx, 0
+  jbe L222
+  mov r10, rdx
+  sub r10, 1
+  imul r10, 16
+  add r11, r10
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  cmp rdx, 1
+  jne L224
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  jmp L225
+L224:
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + -16]
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 2
+  je L226
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 16]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 3
+  je L228
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 32]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  cmp rdx, 4
+  je L230
+  sub r11, 16
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm0, xmmword ptr [r11 + 0]
+  pshufb xmm0, xmm9
+  vpxor xmm4, xmm4, xmm1
+  movdqu xmm1, xmmword ptr [r9 + 64]
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+  movdqu xmm5, xmm1
+  jmp L231
+L230:
+L231:
+  jmp L229
+L228:
+L229:
+  jmp L227
+L226:
+L227:
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  vpxor xmm4, xmm4, xmm1
+  vpxor xmm6, xmm6, xmm2
+  vpxor xmm6, xmm6, xmm3
+  vpxor xmm7, xmm7, xmm5
+L225:
+  pxor xmm3, xmm3
+  mov r10, 3254779904
+  pinsrd xmm3, r10d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  jmp L223
+L222:
+L223:
+  mov rdi, rbx
+  mov rdx, r12
+  pxor xmm10, xmm10
+  mov rbx, 1
+  pinsrd xmm10, ebx, 0
+  mov r11, rax
+  mov r10, rdi
+  mov rbx, 0
+  jmp L233
+ALIGN 16
+L232:
+  movdqu xmm0, xmm11
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 176]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 192]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 208]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 224]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  movdqu xmm2, xmmword ptr [r11 + 0]
+  pxor xmm2, xmm0
+  movdqu xmmword ptr [r10 + 0], xmm2
+  add rbx, 1
+  add r11, 16
+  add r10, 16
+  paddd xmm11, xmm10
+ALIGN 16
+L233:
+  cmp rbx, rdx
+  jne L232
+  add r14, qword ptr [rsp + 304]
+  imul r14, 16
+  mov r13, qword ptr [rsp + 344]
+  cmp r13, r14
+  jbe L234
+  mov rax, qword ptr [rsp + 336]
+  mov r10, r13
+  and r10, 15
+  movdqu xmm0, xmmword ptr [rax + 0]
+  movdqu xmm10, xmm0
+  cmp r10, 8
+  jae L236
+  mov rcx, 0
+  pinsrq xmm0, rcx, 1
+  mov rcx, r10
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 0
+  and rcx, r11
+  pinsrq xmm0, rcx, 0
+  jmp L237
+L236:
+  mov rcx, r10
+  sub rcx, 8
+  shl rcx, 3
+  mov r11, 1
+  shl r11, cl
+  sub r11, 1
+  pextrq rcx, xmm0, 1
+  and rcx, r11
+  pinsrq xmm0, rcx, 1
+L237:
+  pshufb xmm0, xmm9
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  movdqu xmm0, xmm11
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 176]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 192]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 208]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 224]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  pxor xmm10, xmm0
+  movdqu xmmword ptr [rax + 0], xmm10
+  jmp L235
+L234:
+L235:
+  mov r11, r15
+  pxor xmm0, xmm0
+  mov rax, r11
+  imul rax, 8
+  pinsrq xmm0, rax, 1
+  mov rax, r13
+  imul rax, 8
+  pinsrq xmm0, rax, 0
+  movdqu xmm5, xmmword ptr [r9 + -32]
+  vpxor xmm0, xmm8, xmm0
+  vpclmulqdq xmm1, xmm0, xmm5, 0
+  vpclmulqdq xmm2, xmm0, xmm5, 16
+  vpclmulqdq xmm3, xmm0, xmm5, 1
+  vpclmulqdq xmm5, xmm0, xmm5, 17
+  movdqu xmm4, xmm1
+  vpxor xmm6, xmm2, xmm3
+  movdqu xmm7, xmm5
+  pxor xmm3, xmm3
+  mov r11, 3254779904
+  pinsrd xmm3, r11d, 3
+  vpslldq xmm5, xmm6, 8
+  vpxor xmm4, xmm4, xmm5
+  vpalignr xmm0, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpsrldq xmm6, xmm6, 8
+  vpxor xmm7, xmm7, xmm6
+  vpxor xmm4, xmm4, xmm0
+  vpalignr xmm8, xmm4, xmm4, 8
+  vpclmulqdq xmm4, xmm4, xmm3, 16
+  vpxor xmm8, xmm8, xmm7
+  vpxor xmm8, xmm8, xmm4
+  movdqu xmm0, xmmword ptr [rbp + 0]
+  pshufb xmm0, xmm9
+  movdqu xmm2, xmmword ptr [r8 + 0]
+  pxor xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 16]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 32]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 48]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 64]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 80]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 96]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 112]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 128]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 144]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 160]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 176]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 192]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 208]
+  aesenc xmm0, xmm2
+  movdqu xmm2, xmmword ptr [r8 + 224]
+  aesenclast xmm0, xmm2
+  pxor xmm2, xmm2
+  pshufb xmm8, xmm9
+  pxor xmm8, xmm0
+  mov r15, qword ptr [rsp + 360]
+  movdqu xmm0, xmmword ptr [r15 + 0]
+  pcmpeqd xmm0, xmm8
+  pextrq rdx, xmm0, 0
+  sub rdx, 18446744073709551615
+  mov rax, 0
+  adc rax, 0
+  pextrq rdx, xmm0, 1
+  sub rdx, 18446744073709551615
+  mov rdx, 0
+  adc rdx, 0
+  add rax, rdx
+  mov rcx, rax
+  pop rax
+  pinsrq xmm6, rax, 1
+  pop rax
+  pinsrq xmm6, rax, 0
+  pop rax
+  pinsrq xmm7, rax, 1
+  pop rax
+  pinsrq xmm7, rax, 0
+  pop rax
+  pinsrq xmm8, rax, 1
+  pop rax
+  pinsrq xmm8, rax, 0
+  pop rax
+  pinsrq xmm9, rax, 1
+  pop rax
+  pinsrq xmm9, rax, 0
+  pop rax
+  pinsrq xmm10, rax, 1
+  pop rax
+  pinsrq xmm10, rax, 0
+  pop rax
+  pinsrq xmm11, rax, 1
+  pop rax
+  pinsrq xmm11, rax, 0
+  pop rax
+  pinsrq xmm12, rax, 1
+  pop rax
+  pinsrq xmm12, rax, 0
+  pop rax
+  pinsrq xmm13, rax, 1
+  pop rax
+  pinsrq xmm13, rax, 0
+  pop rax
+  pinsrq xmm14, rax, 1
+  pop rax
+  pinsrq xmm14, rax, 0
+  pop rax
+  pinsrq xmm15, rax, 1
+  pop rax
+  pinsrq xmm15, rax, 0
+  pop rbx
+  pop rbp
+  pop rdi
+  pop rsi
+  pop r12
+  pop r13
+  pop r14
+  pop r15
+  mov rax, rcx
+  ret
+gcm256_decrypt_opt endp
+end


### PR DESCRIPTION
This patch imports Vale assembly files of AES-GCM mode and supports building these files in Hacl.