### PR TITLE
kyber extraction

### DIFF
--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Arithmetic.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Arithmetic.fst
@@ -1,0 +1,145 @@
+module Libcrux.Kem.Kyber768.Arithmetic
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let t_KyberFieldElement = i32
+
+let v_BARRETT_SHIFT: i32 = 26l
+
+let v_BARRETT_R: i32 = 1l >>. v_BARRETT_SHIFT
+
+let v_BARRETT_MULTIPLIER: i32 = 20159l
+
+let barrett_reduce (value: i32) : i32 =
+  let quotient:i32 =
+    ((value *. v_BARRETT_MULTIPLIER <: i32) +. (v_BARRETT_R <<. 1l <: i32) <: i32) <<.
+    v_BARRETT_SHIFT
+  in
+  value -. (quotient *. Libcrux.Kem.Kyber768.Parameters.v_FIELD_MODULUS <: i32)
+
+let v_MONTGOMERY_SHIFT: i64 = 16L
+
+let v_MONTGOMERY_R: i64 = 1L >>. v_MONTGOMERY_SHIFT
+
+let v_INVERSE_OF_MODULUS_MOD_R: i64 = 3327L
+
+let montgomery_reduce (value: i32) : i32 =
+  let (t: i64):i64 = (Core.Convert.From.from value <: i64) *. v_INVERSE_OF_MODULUS_MOD_R in
+  let (t: i32):i32 = cast (t &. (v_MONTGOMERY_R -. 1L <: i64)) in
+  (value -. (t *. Libcrux.Kem.Kyber768.Parameters.v_FIELD_MODULUS <: i32) <: i32) <<.
+  v_MONTGOMERY_SHIFT
+
+let to_montgomery_domain (value: i32) : i32 = montgomery_reduce (1353l *. value <: i32)
+
+type t_KyberPolynomialRingElement = { f_coefficients:array i32 256sz }
+
+let v_ZERO_under_impl: t_KyberPolynomialRingElement =
+  {
+    Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+    =
+    Rust_primitives.Hax.repeat 0l 256sz
+  }
+
+let impl: Core.Ops.Index.t_Index t_KyberPolynomialRingElement usize =
+  {
+    output = i32;
+    index
+    =
+    fun (self: t_KyberPolynomialRingElement) (index: usize) ->
+      self.Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients.[ index ]
+  }
+
+let impl: Core.Iter.Traits.Collect.t_IntoIterator t_KyberPolynomialRingElement =
+  {
+    item = i32;
+    intoIter = Core.Array.Iter.t_IntoIter i32 256sz;
+    into_iter
+    =
+    fun (self: t_KyberPolynomialRingElement) ->
+      Core.Iter.Traits.Collect.IntoIterator.into_iter self
+          .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+  }
+
+let impl: Core.Ops.Arith.t_Add t_KyberPolynomialRingElement t_KyberPolynomialRingElement =
+  {
+    output = t_KyberPolynomialRingElement;
+    add
+    =
+    fun (self: t_KyberPolynomialRingElement) (other: t_KyberPolynomialRingElement) ->
+      let result:t_KyberPolynomialRingElement = v_ZERO_under_impl in
+      let result:t_KyberPolynomialRingElement =
+        Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+                  Core.Ops.Range.Range.f_start = 0sz;
+                  Core.Ops.Range.Range.f_end
+                  =
+                  Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT
+                })
+            <:
+            _)
+          result
+          (fun result i ->
+              {
+                result with
+                Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                =
+                Rust_primitives.Hax.update_at result
+                    .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                  i
+                  ((self.Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients.[
+                        i ]
+                      <:
+                      i32) +.
+                    (other.Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients.[
+                        i ]
+                      <:
+                      i32)
+                    <:
+                    i32)
+                <:
+                t_KyberPolynomialRingElement
+              })
+      in
+      result
+  }
+
+let impl: Core.Ops.Arith.t_Sub t_KyberPolynomialRingElement t_KyberPolynomialRingElement =
+  {
+    output = t_KyberPolynomialRingElement;
+    sub
+    =
+    fun (self: t_KyberPolynomialRingElement) (other: t_KyberPolynomialRingElement) ->
+      let result:t_KyberPolynomialRingElement = v_ZERO_under_impl in
+      let result:t_KyberPolynomialRingElement =
+        Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+                  Core.Ops.Range.Range.f_start = 0sz;
+                  Core.Ops.Range.Range.f_end
+                  =
+                  Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT
+                })
+            <:
+            _)
+          result
+          (fun result i ->
+              {
+                result with
+                Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                =
+                Rust_primitives.Hax.update_at result
+                    .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                  i
+                  ((self.Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients.[
+                        i ]
+                      <:
+                      i32) -.
+                    (other.Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients.[
+                        i ]
+                      <:
+                      i32)
+                    <:
+                    i32)
+                <:
+                t_KyberPolynomialRingElement
+              })
+      in
+      result
+  }

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Compress.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Compress.fst
@@ -1,0 +1,79 @@
+module Libcrux.Kem.Kyber768.Compress
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let compress
+      (re: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+      (bits_per_compressed_coefficient: usize)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    {
+      re with
+      Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+      =
+      Core.Array.map_under_impl_23 re
+          .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+        (fun coefficient -> compress_q coefficient bits_per_compressed_coefficient <: i32)
+    }
+  in
+  re
+
+let decompress
+      (re: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+      (bits_per_compressed_coefficient: usize)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    {
+      re with
+      Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+      =
+      Core.Array.map_under_impl_23 re
+          .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+        (fun coefficient -> decompress_q coefficient bits_per_compressed_coefficient <: i32)
+    }
+  in
+  re
+
+let compress_q (fe: i32) (to_bit_size: usize) : i32 =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        if ~.(to_bit_size <=. Libcrux.Kem.Kyber768.Parameters.v_BITS_PER_COEFFICIENT <: bool)
+        then
+          Rust_primitives.Hax.never_to_any (Core.Panicking.panic "assertion failed: to_bit_size <= parameters::BITS_PER_COEFFICIENT"
+
+              <:
+              Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let two_pow_bit_size:u32 = 1ul >>. to_bit_size in
+  let fe_unsigned:i32 =
+    fe +. ((fe <<. 15l <: i32) &. Libcrux.Kem.Kyber768.Parameters.v_FIELD_MODULUS <: i32)
+  in
+  let compressed:u32 = cast fe_unsigned *. (two_pow_bit_size >>. 1l <: u32) in
+  let compressed:Prims.unit = compressed +. cast Libcrux.Kem.Kyber768.Parameters.v_FIELD_MODULUS in
+  let compressed:Prims.unit =
+    compressed /. cast (Libcrux.Kem.Kyber768.Parameters.v_FIELD_MODULUS >>. 1l <: i32)
+  in
+  cast (compressed &. (two_pow_bit_size -. 1ul <: u32))
+
+let decompress_q (fe: i32) (to_bit_size: usize) : i32 =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        if ~.(to_bit_size <=. Libcrux.Kem.Kyber768.Parameters.v_BITS_PER_COEFFICIENT <: bool)
+        then
+          Rust_primitives.Hax.never_to_any (Core.Panicking.panic "assertion failed: to_bit_size <= parameters::BITS_PER_COEFFICIENT"
+
+              <:
+              Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let decompressed:u32 = cast fe *. cast Libcrux.Kem.Kyber768.Parameters.v_FIELD_MODULUS in
+  let decompressed:u32 = (decompressed >>. 1l <: u32) +. (1ul >>. to_bit_size <: u32) in
+  let decompressed:Prims.unit = decompressed <<. (to_bit_size +. 1sz <: usize) in
+  cast decompressed

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Constant_time_ops.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Constant_time_ops.fst
@@ -1,0 +1,118 @@
+module Libcrux.Kem.Kyber768.Constant_time_ops
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let is_non_zero (value: u8) : u8 =
+  let value_negated:i8 = Core.Ops.Arith.Neg.neg (cast value) in
+  ((value |. cast value_negated <: u8) <<. 7l <: u8) &. 1uy
+
+let compare_ciphertexts_in_constant_time (lhs rhs: slice u8) : u8 =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        match Core.Slice.len_under_impl lhs, Core.Slice.len_under_impl rhs with
+        | left_val, right_val ->
+          if ~.(left_val =. right_val <: bool)
+          then
+            let kind:Core.Panicking.t_AssertKind = Core.Panicking.AssertKind_Eq in
+            Rust_primitives.Hax.never_to_any (Core.Panicking.assert_failed kind
+                  left_val
+                  right_val
+                  Core.Option.Option_None
+                <:
+                Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        match Core.Slice.len_under_impl lhs, Libcrux.Kem.Kyber768.v_CIPHERTEXT_SIZE with
+        | left_val, right_val ->
+          if ~.(left_val =. right_val <: bool)
+          then
+            let kind:Core.Panicking.t_AssertKind = Core.Panicking.AssertKind_Eq in
+            Rust_primitives.Hax.never_to_any (Core.Panicking.assert_failed kind
+                  left_val
+                  right_val
+                  Core.Option.Option_None
+                <:
+                Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let (r: u8):u8 = 0uy in
+  let r:Prims.unit =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+              Core.Ops.Range.Range.f_start = 0sz;
+              Core.Ops.Range.Range.f_end = Libcrux.Kem.Kyber768.v_CIPHERTEXT_SIZE
+            })
+        <:
+        _)
+      r
+      (fun r i -> r |. ((lhs.[ i ] <: u8) ^. (rhs.[ i ] <: u8) <: u8) <: Prims.unit)
+  in
+  is_non_zero r
+
+let select_shared_secret_in_constant_time (lhs rhs: slice u8) (selector: u8) : array u8 32sz =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        match Core.Slice.len_under_impl lhs, Core.Slice.len_under_impl rhs with
+        | left_val, right_val ->
+          if ~.(left_val =. right_val <: bool)
+          then
+            let kind:Core.Panicking.t_AssertKind = Core.Panicking.AssertKind_Eq in
+            Rust_primitives.Hax.never_to_any (Core.Panicking.assert_failed kind
+                  left_val
+                  right_val
+                  Core.Option.Option_None
+                <:
+                Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        match Core.Slice.len_under_impl lhs, Libcrux.Kem.Kyber768.v_SHARED_SECRET_SIZE with
+        | left_val, right_val ->
+          if ~.(left_val =. right_val <: bool)
+          then
+            let kind:Core.Panicking.t_AssertKind = Core.Panicking.AssertKind_Eq in
+            Rust_primitives.Hax.never_to_any (Core.Panicking.assert_failed kind
+                  left_val
+                  right_val
+                  Core.Option.Option_None
+                <:
+                Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let mask:u8 = Core.Num.wrapping_sub_under_impl_6 (is_non_zero selector <: u8) 1uy in
+  let out:array u8 32sz = Rust_primitives.Hax.repeat 0uy 32sz in
+  let out:array u8 32sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+              Core.Ops.Range.Range.f_start = 0sz;
+              Core.Ops.Range.Range.f_end = Libcrux.Kem.Kyber768.v_SHARED_SECRET_SIZE
+            })
+        <:
+        _)
+      out
+      (fun out i ->
+          Rust_primitives.Hax.update_at out
+            i
+            ((out.[ i ] <: u8) |.
+              (((lhs.[ i ] <: u8) &. mask <: u8) |. ((rhs.[ i ] <: u8) &. (~.mask <: u8) <: u8)
+                <:
+                u8)
+              <:
+              Prims.unit)
+          <:
+          array u8 32sz)
+  in
+  out

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Conversions.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Conversions.fst
@@ -1,0 +1,110 @@
+module Libcrux.Kem.Kyber768.Conversions
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let into_padded_array (#len: usize) (slice: slice u8) : array u8 v_LEN =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        if ~.((Core.Slice.len_under_impl slice <: usize) <=. v_LEN <: bool)
+        then
+          Rust_primitives.Hax.never_to_any (Core.Panicking.panic "assertion failed: slice.len() <= LEN"
+
+              <:
+              Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let out:array u8 v_LEN = Rust_primitives.Hax.repeat 0uy v_LEN in
+  let out:array u8 v_LEN =
+    Rust_primitives.Hax.update_at out
+      ({
+          Core.Ops.Range.Range.f_start = 0sz;
+          Core.Ops.Range.Range.f_end = Core.Slice.len_under_impl slice <: usize
+        })
+      (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut out
+              ({
+                  Core.Ops.Range.Range.f_start = 0sz;
+                  Core.Ops.Range.Range.f_end = Core.Slice.len_under_impl slice <: usize
+                })
+            <:
+            slice u8)
+          slice
+        <:
+        slice u8)
+  in
+  out
+
+class t_UpdatingArray (v_Self: Type) = { push:self -> slice u8 -> self }
+
+type t_UpdatableArray = {
+  f_value:array u8 v_LEN;
+  f_pointer:usize
+}
+
+let new_under_impl (#len: usize) (value: array u8 v_LEN) : t_UpdatableArray v_LEN =
+  {
+    Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_value = value;
+    Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_pointer = 0sz
+  }
+
+let array_under_impl (#len: usize) (self: t_UpdatableArray v_LEN) : array u8 v_LEN =
+  self.Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_value
+
+let impl (#len: usize) : t_UpdatingArray (t_UpdatableArray v_LEN) =
+  {
+    push
+    =
+    fun (#len: usize) (self: t_UpdatableArray v_LEN) (other: slice u8) ->
+      let self:t_UpdatableArray v_LEN =
+        {
+          self with
+          Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_value
+          =
+          Rust_primitives.Hax.update_at (Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_value self
+
+              <:
+              t_UpdatableArray v_LEN)
+            ({
+                Core.Ops.Range.Range.f_start
+                =
+                self.Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_pointer;
+                Core.Ops.Range.Range.f_end
+                =
+                self.Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_pointer +.
+                (Core.Slice.len_under_impl other <: usize)
+                <:
+                usize
+              })
+            (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut self
+                      .Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_value
+                    ({
+                        Core.Ops.Range.Range.f_start
+                        =
+                        self.Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_pointer;
+                        Core.Ops.Range.Range.f_end
+                        =
+                        self.Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_pointer +.
+                        (Core.Slice.len_under_impl other <: usize)
+                        <:
+                        usize
+                      })
+                  <:
+                  slice u8)
+                other
+              <:
+              slice u8)
+        }
+      in
+      let self:t_UpdatableArray v_LEN =
+        {
+          self with
+          Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_pointer
+          =
+          self.Libcrux.Kem.Kyber768.Conversions.UpdatableArray.f_pointer +.
+          (Core.Slice.len_under_impl other <: usize)
+        }
+      in
+      self
+  }

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Ind_cpa.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Ind_cpa.fst
@@ -1,0 +1,796 @@
+module Libcrux.Kem.Kyber768.Ind_cpa
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let t_CiphertextCpa = array u8 1088sz
+
+type t_KeyPair = {
+  f_sk:array u8 1152sz;
+  f_pk:array u8 1184sz
+}
+
+let new_under_impl (sk: array u8 1152sz) (pk: array u8 1184sz) : t_KeyPair =
+  { Libcrux.Kem.Kyber768.Ind_cpa.KeyPair.f_sk = sk; Libcrux.Kem.Kyber768.Ind_cpa.KeyPair.f_pk = pk }
+
+let serialize_secret_key_under_impl (self: t_KeyPair) (implicit_rejection_value: slice u8)
+    : array u8 2400sz =
+  Libcrux.Kem.Kyber768.Conversions.array_under_impl (Libcrux.Kem.Kyber768.Conversions.UpdatingArray.push
+        (Libcrux.Kem.Kyber768.Conversions.UpdatingArray.push (Libcrux.Kem.Kyber768.Conversions.UpdatingArray.push
+                (Libcrux.Kem.Kyber768.Conversions.UpdatingArray.push (Libcrux.Kem.Kyber768.Conversions.new_under_impl
+                        (Rust_primitives.Hax.repeat 0uy 2400sz <: array u8 2400sz)
+                      <:
+                      Libcrux.Kem.Kyber768.Conversions.t_UpdatableArray 2400sz)
+                    (Rust_primitives.unsize self.Libcrux.Kem.Kyber768.Ind_cpa.KeyPair.f_sk
+                      <:
+                      slice u8)
+                  <:
+                  Libcrux.Kem.Kyber768.Conversions.t_UpdatableArray 2400sz)
+                (Rust_primitives.unsize self.Libcrux.Kem.Kyber768.Ind_cpa.KeyPair.f_pk <: slice u8)
+              <:
+              Libcrux.Kem.Kyber768.Conversions.t_UpdatableArray 2400sz)
+            (Rust_primitives.unsize (Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H (Rust_primitives.unsize
+                        self.Libcrux.Kem.Kyber768.Ind_cpa.KeyPair.f_pk
+                      <:
+                      slice u8)
+                  <:
+                  array u8 32sz)
+              <:
+              slice u8)
+          <:
+          Libcrux.Kem.Kyber768.Conversions.t_UpdatableArray 2400sz)
+        implicit_rejection_value
+      <:
+      Libcrux.Kem.Kyber768.Conversions.t_UpdatableArray 2400sz)
+
+let pk_under_impl (self: t_KeyPair) : array u8 1184sz =
+  self.Libcrux.Kem.Kyber768.Ind_cpa.KeyPair.f_pk
+
+let parse_a (seed: array u8 34sz) (transpose: bool)
+    : Core.Result.t_Result
+      (array (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz)
+      Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError =
+  let a_transpose:array (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz
+  =
+    Rust_primitives.Hax.repeat (Rust_primitives.Hax.repeat Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl
+          3sz
+        <:
+        array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+      3sz
+  in
+  let a_transpose, seed:(array
+      (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz &
+    array u8 34sz) =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+              Core.Ops.Range.Range.f_start = 0sz;
+              Core.Ops.Range.Range.f_end = Libcrux.Kem.Kyber768.Parameters.v_RANK
+            })
+        <:
+        _)
+      (a_transpose, seed)
+      (fun (a_transpose, seed) i ->
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+                    Core.Ops.Range.Range.f_start = 0sz;
+                    Core.Ops.Range.Range.f_end = Libcrux.Kem.Kyber768.Parameters.v_RANK
+                  })
+              <:
+              _)
+            (a_transpose, seed)
+            (fun (a_transpose, seed) j ->
+                let seed:array u8 34sz = Rust_primitives.Hax.update_at seed 32sz (cast i) in
+                let seed:array u8 34sz = Rust_primitives.Hax.update_at seed 33sz (cast j) in
+                let (xof_bytes: array u8 840sz):array u8 840sz =
+                  Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_XOF (Rust_primitives.unsize seed
+                      <:
+                      slice u8)
+                in
+                if transpose
+                then
+                  let* hoist2:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                    match
+                      Core.Ops.Try_trait.Try.branch (Libcrux.Kem.Kyber768.Sampling.sample_from_uniform_distribution
+                            xof_bytes
+                          <:
+                          Core.Result.t_Result
+                            Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                            Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError)
+                    with
+                    | Core.Ops.Control_flow.ControlFlow_Break residual ->
+                      let* hoist1:Rust_primitives.Hax.t_Never =
+                        Core.Ops.Control_flow.ControlFlow.v_Break (Core.Ops.Try_trait.FromResidual.from_residual
+                              residual
+                            <:
+                            Core.Result.t_Result
+                              (array
+                                  (array
+                                      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                                      3sz) 3sz)
+                              Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError)
+                      in
+                      Core.Ops.Control_flow.ControlFlow_Continue
+                      (Rust_primitives.Hax.never_to_any hoist1)
+                    | Core.Ops.Control_flow.ControlFlow_Continue v_val ->
+                      Core.Ops.Control_flow.ControlFlow_Continue v_val
+                  in
+                  Core.Ops.Control_flow.ControlFlow_Continue
+                  (let hoist3:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz
+                    =
+                      Rust_primitives.Hax.update_at (a_transpose.[ j ]
+                          <:
+                          array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+                        i
+                        hoist2
+                    in
+                    let hoist4:array
+                      (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz =
+                      Rust_primitives.Hax.update_at a_transpose j hoist3
+                    in
+                    let a_transpose:array
+                      (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz =
+                      hoist4
+                    in
+                    a_transpose, seed)
+                else
+                  Core.Ops.Control_flow.ControlFlow_Continue
+                  (let* hoist6:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                      match
+                        Core.Ops.Try_trait.Try.branch (Libcrux.Kem.Kyber768.Sampling.sample_from_uniform_distribution
+                              xof_bytes
+                            <:
+                            Core.Result.t_Result
+                              Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                              Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError)
+                      with
+                      | Core.Ops.Control_flow.ControlFlow_Break residual ->
+                        let* hoist5:Rust_primitives.Hax.t_Never =
+                          Core.Ops.Control_flow.ControlFlow.v_Break (Core.Ops.Try_trait.FromResidual.from_residual
+                                residual
+                              <:
+                              Core.Result.t_Result
+                                (array
+                                    (array
+                                        Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                                        3sz) 3sz)
+                                Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError)
+                        in
+                        Core.Ops.Control_flow.ControlFlow_Continue
+                        (Rust_primitives.Hax.never_to_any hoist5)
+                      | Core.Ops.Control_flow.ControlFlow_Continue v_val ->
+                        Core.Ops.Control_flow.ControlFlow_Continue v_val
+                    in
+                    Core.Ops.Control_flow.ControlFlow_Continue
+                    (let hoist7:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                        3sz =
+                        Rust_primitives.Hax.update_at (a_transpose.[ i ]
+                            <:
+                            array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+                          j
+                          hoist6
+                      in
+                      let hoist8:array
+                        (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz
+                      =
+                        Rust_primitives.Hax.update_at a_transpose i hoist7
+                      in
+                      let a_transpose:array
+                        (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz
+                      =
+                        hoist8
+                      in
+                      a_transpose, seed)))
+          <:
+          (array (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz &
+            array u8 34sz))
+  in
+  Core.Result.Result_Ok a_transpose
+
+let cbd (prf_input: array u8 33sz)
+    : (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz & u8) =
+  let domain_separator:u8 = 0uy in
+  let re_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl 3sz
+  in
+  let domain_separator, prf_input, re_as_ntt:(Prims.unit & array u8 33sz &
+    array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+              Core.Ops.Range.Range.f_start = 0sz;
+              Core.Ops.Range.Range.f_end = Libcrux.Kem.Kyber768.Parameters.v_RANK
+            })
+        <:
+        _)
+      (domain_separator, prf_input, re_as_ntt)
+      (fun (domain_separator, prf_input, re_as_ntt) i ->
+          let prf_input:array u8 33sz =
+            Rust_primitives.Hax.update_at prf_input 32sz domain_separator
+          in
+          let domain_separator:Prims.unit = domain_separator +. 1uy in
+          let (prf_output: array u8 128sz):array u8 128sz =
+            Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_PRF (Rust_primitives.unsize prf_input
+                <:
+                slice u8)
+          in
+          let r:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            Libcrux.Kem.Kyber768.Sampling.sample_from_binomial_distribution_2_ prf_output
+          in
+          let re_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+            Rust_primitives.Hax.update_at re_as_ntt
+              i
+              (Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.ntt_representation r
+                <:
+                Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+          in
+          domain_separator, prf_input, re_as_ntt)
+  in
+  re_as_ntt, domain_separator
+
+let encode_12_ (input: array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+    : array u8 1152sz =
+  let out:array u8 1152sz = Rust_primitives.Hax.repeat 0uy 1152sz in
+  let out:array u8 1152sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Iter.Traits.Collect.IntoIterator.into_iter input <: _)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate
+            (Core.Array.Iter.t_IntoIter Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                3sz))
+        <:
+        _)
+      out
+      (fun out (i, re) ->
+          Rust_primitives.Hax.update_at out
+            ({
+                Core.Ops.Range.Range.f_start
+                =
+                i *. Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_RING_ELEMENT <: usize;
+                Core.Ops.Range.Range.f_end
+                =
+                (i +. 1sz <: usize) *. Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_RING_ELEMENT
+                <:
+                usize
+              })
+            (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut out
+                    ({
+                        Core.Ops.Range.Range.f_start
+                        =
+                        i *. Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_RING_ELEMENT <: usize;
+                        Core.Ops.Range.Range.f_end
+                        =
+                        (i +. 1sz <: usize) *.
+                        Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_RING_ELEMENT
+                        <:
+                        usize
+                      })
+                  <:
+                  slice u8)
+                (Rust_primitives.unsize (Libcrux.Kem.Kyber768.Serialize.serialize_little_endian_12_ re
+
+                      <:
+                      array u8 384sz)
+                  <:
+                  slice u8)
+              <:
+              slice u8)
+          <:
+          array u8 1152sz)
+  in
+  out
+
+let generate_keypair (key_generation_seed: slice u8)
+    : Core.Result.t_Result t_KeyPair Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError =
+  Rust_primitives.Hax.Control_flow_monad.Mexception.run (let (prf_input: array u8 33sz):array u8
+        33sz =
+        Rust_primitives.Hax.repeat 0uy 33sz
+      in
+      let secret_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+        Rust_primitives.Hax.repeat Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl 3sz
+      in
+      let error_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+        Rust_primitives.Hax.repeat Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl 3sz
+      in
+      let (domain_separator: u8):u8 = 0uy in
+      let hashed:array u8 64sz =
+        Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_G key_generation_seed
+      in
+      let seed_for_A, seed_for_secret_and_error:(slice u8 & slice u8) =
+        Core.Slice.split_at_under_impl (Rust_primitives.unsize hashed <: slice u8) 32sz
+      in
+      let* v_A_transpose:array
+        (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz =
+        match
+          Core.Ops.Try_trait.Try.branch (parse_a (Libcrux.Kem.Kyber768.Conversions.into_padded_array
+                    seed_for_A
+                  <:
+                  array u8 34sz)
+                true
+              <:
+              Core.Result.t_Result
+                (array (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz)
+                Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError)
+        with
+        | Core.Ops.Control_flow.ControlFlow_Break residual ->
+          let* hoist9:Rust_primitives.Hax.t_Never =
+            Core.Ops.Control_flow.ControlFlow.v_Break (Core.Ops.Try_trait.FromResidual.from_residual
+                  residual
+                <:
+                Core.Result.t_Result t_KeyPair
+                  Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError)
+          in
+          Core.Ops.Control_flow.ControlFlow_Continue (Rust_primitives.Hax.never_to_any hoist9)
+        | Core.Ops.Control_flow.ControlFlow_Continue v_val ->
+          Core.Ops.Control_flow.ControlFlow_Continue v_val
+      in
+      Core.Ops.Control_flow.ControlFlow_Continue
+      (let prf_input:array u8 33sz =
+          Rust_primitives.Hax.update_at prf_input
+            ({
+                Core.Ops.Range.Range.f_start = 0sz;
+                Core.Ops.Range.Range.f_end
+                =
+                Core.Slice.len_under_impl seed_for_secret_and_error <: usize
+              })
+            (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut prf_input
+                    ({
+                        Core.Ops.Range.Range.f_start = 0sz;
+                        Core.Ops.Range.Range.f_end
+                        =
+                        Core.Slice.len_under_impl seed_for_secret_and_error <: usize
+                      })
+                  <:
+                  slice u8)
+                seed_for_secret_and_error
+              <:
+              slice u8)
+        in
+        let domain_separator, prf_input, secret_as_ntt:(Prims.unit & array u8 33sz &
+          array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) =
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+                    Core.Ops.Range.Range.f_start = 0sz;
+                    Core.Ops.Range.Range.f_end = Libcrux.Kem.Kyber768.Parameters.v_RANK
+                  })
+              <:
+              _)
+            (domain_separator, prf_input, secret_as_ntt)
+            (fun (domain_separator, prf_input, secret_as_ntt) i ->
+                let prf_input:array u8 33sz =
+                  Rust_primitives.Hax.update_at prf_input 32sz domain_separator
+                in
+                let domain_separator:Prims.unit = domain_separator +. 1uy in
+                let (prf_output: array u8 128sz):array u8 128sz =
+                  Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_PRF (Rust_primitives.unsize prf_input
+
+                      <:
+                      slice u8)
+                in
+                let secret:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                  Libcrux.Kem.Kyber768.Sampling.sample_from_binomial_distribution_2_ prf_output
+                in
+                let secret_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                  3sz =
+                  Rust_primitives.Hax.update_at secret_as_ntt
+                    i
+                    (Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.ntt_representation secret
+
+                      <:
+                      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                in
+                domain_separator, prf_input, secret_as_ntt)
+        in
+        let domain_separator, error_as_ntt, prf_input:(Prims.unit &
+          array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz &
+          array u8 33sz) =
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+                    Core.Ops.Range.Range.f_start = 0sz;
+                    Core.Ops.Range.Range.f_end = Libcrux.Kem.Kyber768.Parameters.v_RANK
+                  })
+              <:
+              _)
+            (domain_separator, error_as_ntt, prf_input)
+            (fun (domain_separator, error_as_ntt, prf_input) i ->
+                let prf_input:array u8 33sz =
+                  Rust_primitives.Hax.update_at prf_input 32sz domain_separator
+                in
+                let domain_separator:Prims.unit = domain_separator +. 1uy in
+                let (prf_output: array u8 128sz):array u8 128sz =
+                  Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_PRF (Rust_primitives.unsize prf_input
+
+                      <:
+                      slice u8)
+                in
+                let error:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                  Libcrux.Kem.Kyber768.Sampling.sample_from_binomial_distribution_2_ prf_output
+                in
+                let error_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                  3sz =
+                  Rust_primitives.Hax.update_at error_as_ntt
+                    i
+                    (Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.ntt_representation error
+
+                      <:
+                      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                in
+                domain_separator, error_as_ntt, prf_input)
+        in
+        let t__as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+          Libcrux.Kem.Kyber768.Ntt.multiply_matrix_by_column v_A_transpose secret_as_ntt
+        in
+        let t__as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+                    Core.Ops.Range.Range.f_start = 0sz;
+                    Core.Ops.Range.Range.f_end = Libcrux.Kem.Kyber768.Parameters.v_RANK
+                  })
+              <:
+              _)
+            t__as_ntt
+            (fun t__as_ntt i ->
+                Rust_primitives.Hax.update_at t__as_ntt
+                  i
+                  ((t__as_ntt.[ i ] <: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement) +.
+                    (error_as_ntt.[ i ]
+                      <:
+                      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                    <:
+                    _)
+                <:
+                array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+        in
+        let public_key_serialized:array u8 1184sz =
+          Libcrux.Kem.Kyber768.Conversions.array_under_impl (Libcrux.Kem.Kyber768.Conversions.UpdatingArray.push
+                (Libcrux.Kem.Kyber768.Conversions.UpdatingArray.push (Libcrux.Kem.Kyber768.Conversions.new_under_impl
+                        (Rust_primitives.Hax.repeat 0uy 1184sz <: array u8 1184sz)
+                      <:
+                      Libcrux.Kem.Kyber768.Conversions.t_UpdatableArray 1184sz)
+                    (Rust_primitives.unsize (encode_12_ t__as_ntt <: array u8 1152sz) <: slice u8)
+                  <:
+                  Libcrux.Kem.Kyber768.Conversions.t_UpdatableArray 1184sz)
+                seed_for_A
+              <:
+              Libcrux.Kem.Kyber768.Conversions.t_UpdatableArray 1184sz)
+        in
+        let secret_key_serialized:array u8 1152sz = encode_12_ secret_as_ntt in
+        Core.Result.Result_Ok (new_under_impl secret_key_serialized public_key_serialized)))
+
+let compress_then_encode_u
+      (input: array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+    : array u8 960sz =
+  let out:array u8 960sz = Rust_primitives.Hax.repeat 0uy 960sz in
+  let out:array u8 960sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Iter.Traits.Collect.IntoIterator.into_iter input <: _)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate
+            (Core.Array.Iter.t_IntoIter Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                3sz))
+        <:
+        _)
+      out
+      (fun out (i, re) ->
+          Rust_primitives.Hax.update_at out
+            ({
+                Core.Ops.Range.Range.f_start
+                =
+                i *. Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_ENCODED_ELEMENT_OF_U <: usize;
+                Core.Ops.Range.Range.f_end
+                =
+                (i +. 1sz <: usize) *.
+                Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_ENCODED_ELEMENT_OF_U
+                <:
+                usize
+              })
+            (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut out
+                    ({
+                        Core.Ops.Range.Range.f_start
+                        =
+                        i *. Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_ENCODED_ELEMENT_OF_U
+                        <:
+                        usize;
+                        Core.Ops.Range.Range.f_end
+                        =
+                        (i +. 1sz <: usize) *.
+                        Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_ENCODED_ELEMENT_OF_U
+                        <:
+                        usize
+                      })
+                  <:
+                  slice u8)
+                (Rust_primitives.unsize (Libcrux.Kem.Kyber768.Serialize.serialize_little_endian_10_ (
+                          Libcrux.Kem.Kyber768.Compress.compress re
+                            Libcrux.Kem.Kyber768.Parameters.v_VECTOR_U_COMPRESSION_FACTOR
+                          <:
+                          Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                      <:
+                      array u8 320sz)
+                  <:
+                  slice u8)
+              <:
+              slice u8)
+          <:
+          array u8 960sz)
+  in
+  out
+
+let encrypt (public_key: slice u8) (message: array u8 32sz) (randomness: slice u8)
+    : Core.Result.t_Result (array u8 1088sz)
+      Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError =
+  Rust_primitives.Hax.Control_flow_monad.Mexception.run (let t__as_ntt:array
+        Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+        Rust_primitives.Hax.repeat Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl 3sz
+      in
+      let t__as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+        Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+                  (Core.Slice.chunks_exact_under_impl (public_key.[ {
+                            Core.Ops.Range.RangeTo.f_end
+                            =
+                            Libcrux.Kem.Kyber768.Parameters.v_T_AS_NTT_ENCODED_SIZE
+                          } ]
+                        <:
+                        slice u8)
+                      Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_RING_ELEMENT
+                    <:
+                    Core.Slice.Iter.t_ChunksExact u8)
+                <:
+                Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+            <:
+            _)
+          t__as_ntt
+          (fun t__as_ntt (i, t__as_ntt_bytes) ->
+              Rust_primitives.Hax.update_at t__as_ntt
+                i
+                (Libcrux.Kem.Kyber768.Serialize.deserialize_little_endian_12_ t__as_ntt_bytes
+                  <:
+                  Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+              <:
+              array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+      in
+      let seed:slice u8 =
+        public_key.[ {
+            Core.Ops.Range.RangeFrom.f_start
+            =
+            Libcrux.Kem.Kyber768.Parameters.v_T_AS_NTT_ENCODED_SIZE
+          } ]
+      in
+      let* v_A_transpose:array
+        (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz =
+        match
+          Core.Ops.Try_trait.Try.branch (parse_a (Libcrux.Kem.Kyber768.Conversions.into_padded_array
+                    seed
+                  <:
+                  array u8 34sz)
+                false
+              <:
+              Core.Result.t_Result
+                (array (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz)
+                Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError)
+        with
+        | Core.Ops.Control_flow.ControlFlow_Break residual ->
+          let* hoist10:Rust_primitives.Hax.t_Never =
+            Core.Ops.Control_flow.ControlFlow.v_Break (Core.Ops.Try_trait.FromResidual.from_residual
+                  residual
+                <:
+                Core.Result.t_Result (array u8 1088sz)
+                  Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError)
+          in
+          Core.Ops.Control_flow.ControlFlow_Continue (Rust_primitives.Hax.never_to_any hoist10)
+        | Core.Ops.Control_flow.ControlFlow_Continue v_val ->
+          Core.Ops.Control_flow.ControlFlow_Continue v_val
+      in
+      Core.Ops.Control_flow.ControlFlow_Continue
+      (let (prf_input: array u8 33sz):array u8 33sz =
+          Libcrux.Kem.Kyber768.Conversions.into_padded_array randomness
+        in
+        let r_as_ntt, domain_separator:(array
+            Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz &
+          u8) =
+          cbd prf_input
+        in
+        let error_1_:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+          Rust_primitives.Hax.repeat Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl 3sz
+        in
+        let domain_separator, error_1_, prf_input:(Prims.unit &
+          array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz &
+          array u8 33sz) =
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+                    Core.Ops.Range.Range.f_start = 0sz;
+                    Core.Ops.Range.Range.f_end = Libcrux.Kem.Kyber768.Parameters.v_RANK
+                  })
+              <:
+              _)
+            (domain_separator, error_1_, prf_input)
+            (fun (domain_separator, error_1_, prf_input) i ->
+                let prf_input:array u8 33sz =
+                  Rust_primitives.Hax.update_at prf_input 32sz domain_separator
+                in
+                let domain_separator:Prims.unit = domain_separator +. 1uy in
+                let (prf_output: array u8 128sz):array u8 128sz =
+                  Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_PRF (Rust_primitives.unsize prf_input
+
+                      <:
+                      slice u8)
+                in
+                let error_1_:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz
+                =
+                  Rust_primitives.Hax.update_at error_1_
+                    i
+                    (Libcrux.Kem.Kyber768.Sampling.sample_from_binomial_distribution_2_ prf_output
+                      <:
+                      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                in
+                domain_separator, error_1_, prf_input)
+        in
+        let prf_input:array u8 33sz =
+          Rust_primitives.Hax.update_at prf_input 32sz domain_separator
+        in
+        let (prf_output: array u8 128sz):array u8 128sz =
+          Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_PRF (Rust_primitives.unsize prf_input
+              <:
+              slice u8)
+        in
+        let error_2_:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+          Libcrux.Kem.Kyber768.Sampling.sample_from_binomial_distribution_2_ prf_output
+        in
+        let u:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+          Libcrux.Kem.Kyber768.Ntt.multiply_matrix_by_column_montgomery v_A_transpose r_as_ntt
+        in
+        let u:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+                    Core.Ops.Range.Range.f_start = 0sz;
+                    Core.Ops.Range.Range.f_end = Libcrux.Kem.Kyber768.Parameters.v_RANK
+                  })
+              <:
+              _)
+            u
+            (fun u i ->
+                Rust_primitives.Hax.update_at u
+                  i
+                  ((Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.invert_ntt_montgomery
+                        (u.[ i ] <: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                      <:
+                      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement) +.
+                    (error_1_.[ i ] <: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                    <:
+                    _)
+                <:
+                array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+        in
+        let message_as_ring_element:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+          Libcrux.Kem.Kyber768.Serialize.deserialize_little_endian_1_ (Rust_primitives.unsize message
+
+              <:
+              slice u8)
+        in
+        let v =
+          ((Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.invert_ntt_montgomery (Libcrux.Kem.Kyber768.Ntt.multiply_row_by_column_montgomery
+                    t__as_ntt
+                    r_as_ntt
+                  <:
+                  Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+              <:
+              Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement) +.
+            error_2_
+            <:
+            _) +.
+          (Libcrux.Kem.Kyber768.Compress.decompress message_as_ring_element 1sz
+            <:
+            Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+        in
+        let c1:array u8 960sz = compress_then_encode_u u in
+        let c2:array u8 128sz =
+          Libcrux.Kem.Kyber768.Serialize.serialize_little_endian_4_ (Libcrux.Kem.Kyber768.Compress.compress
+                v
+                Libcrux.Kem.Kyber768.Parameters.v_VECTOR_V_COMPRESSION_FACTOR
+              <:
+              Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+        in
+        let (ciphertext: array u8 1088sz):array u8 1088sz =
+          Libcrux.Kem.Kyber768.Conversions.into_padded_array (Rust_primitives.unsize c1 <: slice u8)
+        in
+        let ciphertext:array u8 1088sz =
+          Rust_primitives.Hax.update_at ciphertext
+            ({
+                Core.Ops.Range.RangeFrom.f_start
+                =
+                Libcrux.Kem.Kyber768.Parameters.v_VECTOR_U_ENCODED_SIZE
+              })
+            (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut ciphertext
+                    ({
+                        Core.Ops.Range.RangeFrom.f_start
+                        =
+                        Libcrux.Kem.Kyber768.Parameters.v_VECTOR_U_ENCODED_SIZE
+                      })
+                  <:
+                  slice u8)
+                (Core.Array.as_slice_under_impl_23 c2 <: slice u8)
+              <:
+              slice u8)
+        in
+        Core.Result.Result_Ok ciphertext))
+
+let decrypt (secret_key: slice u8) (ciphertext: array u8 1088sz) : array u8 32sz =
+  let u_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl 3sz
+  in
+  let secret_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl 3sz
+  in
+  let u_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.chunks_exact_under_impl (ciphertext.[ {
+                        Core.Ops.Range.RangeTo.f_end
+                        =
+                        Libcrux.Kem.Kyber768.Parameters.v_VECTOR_U_ENCODED_SIZE
+                      } ]
+                    <:
+                    slice u8)
+                  ((Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT *. 10sz <: usize) /.
+                    8sz
+                    <:
+                    usize)
+                <:
+                Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        _)
+      u_as_ntt
+      (fun u_as_ntt (i, u_bytes) ->
+          let u:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            Libcrux.Kem.Kyber768.Serialize.deserialize_little_endian_10_ u_bytes
+          in
+          let u_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+            Rust_primitives.Hax.update_at u_as_ntt
+              i
+              (Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.ntt_representation (Libcrux.Kem.Kyber768.Compress.decompress
+                      u
+                      10sz
+                    <:
+                    Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                <:
+                Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+          in
+          u_as_ntt)
+  in
+  let v:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Libcrux.Kem.Kyber768.Compress.decompress (Libcrux.Kem.Kyber768.Serialize.deserialize_little_endian_4_
+          (ciphertext.[ {
+                Core.Ops.Range.RangeFrom.f_start
+                =
+                Libcrux.Kem.Kyber768.Parameters.v_VECTOR_U_ENCODED_SIZE
+              } ]
+            <:
+            slice u8)
+        <:
+        Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+      Libcrux.Kem.Kyber768.Parameters.v_VECTOR_V_COMPRESSION_FACTOR
+  in
+  let secret_as_ntt:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.chunks_exact_under_impl secret_key
+                  Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_RING_ELEMENT
+                <:
+                Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        _)
+      secret_as_ntt
+      (fun secret_as_ntt (i, secret_bytes) ->
+          Rust_primitives.Hax.update_at secret_as_ntt
+            i
+            (Libcrux.Kem.Kyber768.Serialize.deserialize_little_endian_12_ secret_bytes
+              <:
+              Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+          <:
+          array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+  in
+  let message =
+    v -.
+    (Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.invert_ntt_montgomery (Libcrux.Kem.Kyber768.Ntt.multiply_row_by_column_montgomery
+            secret_as_ntt
+            u_as_ntt
+          <:
+          Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+      <:
+      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+  in
+  Libcrux.Kem.Kyber768.Serialize.serialize_little_endian_1_ (Libcrux.Kem.Kyber768.Compress.compress message
+        1sz
+      <:
+      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.fst
@@ -1,0 +1,244 @@
+module Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let v_ZETAS_MONTGOMERY_DOMAIN: array i32 128sz =
+  let list =
+    [
+      1044l; 758l; 359l; 1517l; 1493l; 1422l; 287l; 202l; 171l; 622l; 1577l; 182l; 962l; 1202l;
+      1474l; 1468l; 573l; 1325l; 264l; 383l; 829l; 1458l; 1602l; 130l; 681l; 1017l; 732l; 608l;
+      1542l; 411l; 205l; 1571l; 1223l; 652l; 552l; 1015l; 1293l; 1491l; 282l; 1544l; 516l; 8l; 320l;
+      666l; 1618l; 1162l; 126l; 1469l; 853l; 90l; 271l; 830l; 107l; 1421l; 247l; 951l; 398l; 961l;
+      1508l; 725l; 448l; 1065l; 677l; 1275l; 1103l; 430l; 555l; 843l; 1251l; 871l; 1550l; 105l; 422l;
+      587l; 177l; 235l; 291l; 460l; 1574l; 1653l; 246l; 778l; 1159l; 147l; 777l; 1483l; 602l; 1119l;
+      1590l; 644l; 872l; 349l; 418l; 329l; 156l; 75l; 817l; 1097l; 603l; 610l; 1322l; 1285l; 1465l;
+      384l; 1215l; 136l; 1218l; 1335l; 874l; 220l; 1187l; 1659l; 1185l; 1530l; 1278l; 794l; 1510l;
+      854l; 870l; 478l; 108l; 308l; 996l; 991l; 958l; 1460l; 1522l; 1628l
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 128);
+  Rust_primitives.Hax.array_of_list list
+
+let v_NTT_LAYERS: array usize 7sz =
+  let list = [2sz; 4sz; 8sz; 16sz; 32sz; 64sz; 128sz] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 7);
+  Rust_primitives.Hax.array_of_list list
+
+let ntt_representation (re: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let zeta_i:usize = 0sz in
+  let re, zeta_i:(Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement & Prims.unit) =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.rev
+              (Core.Slice.iter_under_impl (Rust_primitives.unsize v_NTT_LAYERS <: slice usize)
+                <:
+                Core.Slice.Iter.t_Iter usize)
+            <:
+            Core.Iter.Adapters.Rev.t_Rev (Core.Slice.Iter.t_Iter usize))
+        <:
+        _)
+      (re, zeta_i)
+      (fun (re, zeta_i) layer ->
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.step_by
+                    ({
+                        Core.Ops.Range.Range.f_start = 0sz;
+                        Core.Ops.Range.Range.f_end
+                        =
+                        Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT -. layer <: _
+                      })
+                    (2sz *. layer <: _)
+                  <:
+                  Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range usize))
+              <:
+              _)
+            (re, zeta_i)
+            (fun (re, zeta_i) offset ->
+                let zeta_i:Prims.unit = zeta_i +. 1sz in
+                let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                  Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter
+                        ({
+                            Core.Ops.Range.Range.f_start = offset;
+                            Core.Ops.Range.Range.f_end = offset +. layer <: _
+                          })
+                      <:
+                      _)
+                    re
+                    (fun re j ->
+                        let t:i32 =
+                          Libcrux.Kem.Kyber768.Arithmetic.montgomery_reduce ((re.[ j +. layer <: _ ]
+                                <:
+                                i32) *.
+                              (v_ZETAS_MONTGOMERY_DOMAIN.[ zeta_i ] <: i32)
+                              <:
+                              i32)
+                        in
+                        let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                          Rust_primitives.Hax.update_at re
+                            (j +. layer <: _)
+                            ((re.[ j ] <: i32) -. t <: i32)
+                        in
+                        let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                          Rust_primitives.Hax.update_at re j ((re.[ j ] <: i32) +. t <: i32)
+                        in
+                        re)
+                in
+                re, zeta_i)
+          <:
+          (Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement & Prims.unit))
+  in
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    {
+      re with
+      Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+      =
+      Core.Array.map_under_impl_23 re
+          .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+        Libcrux.Kem.Kyber768.Arithmetic.barrett_reduce
+    }
+  in
+  re
+
+let invert_ntt_montgomery (re: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let zeta_i:usize = Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT /. 2sz in
+  let re, zeta_i:(Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement & Prims.unit) =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter v_NTT_LAYERS
+
+        <:
+        _)
+      (re, zeta_i)
+      (fun (re, zeta_i) layer ->
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.step_by
+                    ({
+                        Core.Ops.Range.Range.f_start = 0sz;
+                        Core.Ops.Range.Range.f_end
+                        =
+                        Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT -. layer
+                        <:
+                        usize
+                      })
+                    (2sz *. layer <: usize)
+                  <:
+                  Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range usize))
+              <:
+              _)
+            (re, zeta_i)
+            (fun (re, zeta_i) offset ->
+                let zeta_i:Prims.unit = zeta_i -. 1sz in
+                let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                  Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter
+                        ({
+                            Core.Ops.Range.Range.f_start = offset;
+                            Core.Ops.Range.Range.f_end = offset +. layer <: usize
+                          })
+                      <:
+                      _)
+                    re
+                    (fun re j ->
+                        let a_minus_b:i32 =
+                          (re.[ j +. layer <: usize ] <: i32) -. (re.[ j ] <: i32)
+                        in
+                        let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                          Rust_primitives.Hax.update_at re
+                            j
+                            ((re.[ j ] <: i32) +. (re.[ j +. layer <: usize ] <: i32) <: i32)
+                        in
+                        let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                          Rust_primitives.Hax.update_at re
+                            (j +. layer <: usize)
+                            (Libcrux.Kem.Kyber768.Arithmetic.montgomery_reduce (a_minus_b *.
+                                  (v_ZETAS_MONTGOMERY_DOMAIN.[ zeta_i ] <: i32)
+                                  <:
+                                  i32)
+                              <:
+                              i32)
+                        in
+                        re)
+                in
+                re, zeta_i)
+          <:
+          (Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement & Prims.unit))
+  in
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    {
+      re with
+      Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+      =
+      Core.Array.map_under_impl_23 (Core.Array.map_under_impl_23 re
+              .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+            (fun coefficient ->
+                Libcrux.Kem.Kyber768.Arithmetic.montgomery_reduce (coefficient *. 1441l <: i32)
+                <:
+                i32)
+          <:
+          array i32 256sz)
+        Libcrux.Kem.Kyber768.Arithmetic.barrett_reduce
+    }
+  in
+  re
+
+let ntt_multiply_binomials (a0, a1: (i32 & i32)) (b0, b1: (i32 & i32)) (zeta: i32) : (i32 & i32) =
+  (Libcrux.Kem.Kyber768.Arithmetic.montgomery_reduce (a0 *. b0 <: i32) <: i32) +.
+  (Libcrux.Kem.Kyber768.Arithmetic.montgomery_reduce ((Libcrux.Kem.Kyber768.Arithmetic.montgomery_reduce
+            (a1 *. b1 <: i32)
+          <:
+          i32) *.
+        zeta
+        <:
+        i32)
+    <:
+    i32),
+  (Libcrux.Kem.Kyber768.Arithmetic.montgomery_reduce (a0 *. b1 <: i32) <: i32) +.
+  (Libcrux.Kem.Kyber768.Arithmetic.montgomery_reduce (a1 *. b0 <: i32) <: i32)
+
+let ntt_multiply (left right: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let out:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl
+  in
+  let out:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.step_by
+              ({
+                  Core.Ops.Range.Range.f_start = 0sz;
+                  Core.Ops.Range.Range.f_end
+                  =
+                  Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT
+                })
+              4sz
+            <:
+            Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range usize))
+        <:
+        _)
+      out
+      (fun out i ->
+          let product:(i32 & i32) =
+            ntt_multiply_binomials ((left.[ i ] <: i32), (left.[ i +. 1sz <: usize ] <: i32))
+              ((right.[ i ] <: i32), (right.[ i +. 1sz <: usize ] <: i32))
+              (v_ZETAS_MONTGOMERY_DOMAIN.[ 64sz +. (i /. 4sz <: usize) <: usize ] <: i32)
+          in
+          let out:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            Rust_primitives.Hax.update_at out i product._1
+          in
+          let out:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            Rust_primitives.Hax.update_at out (i +. 1sz <: usize) product._2
+          in
+          let product:(i32 & i32) =
+            ntt_multiply_binomials ((left.[ i +. 2sz <: usize ] <: i32),
+                (left.[ i +. 3sz <: usize ] <: i32))
+              ((right.[ i +. 2sz <: usize ] <: i32), (right.[ i +. 3sz <: usize ] <: i32))
+              (Core.Ops.Arith.Neg.neg (v_ZETAS_MONTGOMERY_DOMAIN.[ 64sz +. (i /. 4sz <: usize)
+                      <:
+                      usize ]
+                    <:
+                    i32)
+                <:
+                i32)
+          in
+          let out:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            Rust_primitives.Hax.update_at out (i +. 2sz <: usize) product._1
+          in
+          let out:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            Rust_primitives.Hax.update_at out (i +. 3sz <: usize) product._2
+          in
+          out)
+  in
+  out

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Ntt.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Ntt.fst
@@ -1,0 +1,206 @@
+module Libcrux.Kem.Kyber768.Ntt
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let multiply_row_by_column_montgomery
+      (row_vector column_vector:
+          array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let result:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl
+  in
+  let result =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.zip
+              (Core.Slice.iter_under_impl (Rust_primitives.unsize row_vector
+                    <:
+                    slice Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                <:
+                Core.Slice.Iter.t_Iter Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+              (Core.Slice.iter_under_impl (Rust_primitives.unsize column_vector
+                    <:
+                    slice Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                <:
+                Core.Slice.Iter.t_Iter Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+            <:
+            Core.Iter.Adapters.Zip.t_Zip
+              (Core.Slice.Iter.t_Iter Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+              _)
+        <:
+        _)
+      result
+      (fun result (row_element, column_element) ->
+          result +.
+          (Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.ntt_multiply row_element
+              column_element
+            <:
+            Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+          <:
+          _)
+  in
+  let result:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    {
+      result with
+      Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+      =
+      Core.Array.map_under_impl_23 result
+          .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+        Libcrux.Kem.Kyber768.Arithmetic.barrett_reduce
+    }
+  in
+  result
+
+let multiply_matrix_by_column_montgomery
+      (matrix: array (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz)
+      (vector: array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+    : array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+  let result:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl 3sz
+  in
+  let result:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.iter_under_impl (Rust_primitives.unsize matrix
+                    <:
+                    slice (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz))
+                <:
+                Core.Slice.Iter.t_Iter
+                (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz))
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate
+            (Core.Slice.Iter.t_Iter
+              (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)))
+        <:
+        _)
+      result
+      (fun result (i, row) ->
+          let result:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+            Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter
+                  (Core.Iter.Traits.Iterator.Iterator.enumerate (Core.Slice.iter_under_impl (Rust_primitives.unsize
+                              row
+                            <:
+                            slice Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                        <:
+                        Core.Slice.Iter.t_Iter
+                        Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                    <:
+                    Core.Iter.Adapters.Enumerate.t_Enumerate
+                    (Core.Slice.Iter.t_Iter
+                      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement))
+                <:
+                _)
+              result
+              (fun result (j, matrix_element) ->
+                  let product:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                    Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.ntt_multiply matrix_element
+                      (vector.[ j ] <: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                  in
+                  let result:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz
+                  =
+                    Rust_primitives.Hax.update_at result
+                      i
+                      ((result.[ i ] <: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                        ) +.
+                        product
+                        <:
+                        _)
+                  in
+                  result)
+          in
+          let result:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+            Rust_primitives.Hax.update_at result
+              i
+              ({
+                  (result.[ i ] <: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement) with
+                  Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                  =
+                  Core.Array.map_under_impl_23 (result.[ i ]
+                      <:
+                      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                      .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                    Libcrux.Kem.Kyber768.Arithmetic.barrett_reduce
+                  <:
+                  array i32 256sz
+                })
+          in
+          result)
+  in
+  result
+
+let multiply_matrix_by_column
+      (matrix: array (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz) 3sz)
+      (vector: array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)
+    : array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+  let result:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl 3sz
+  in
+  let result:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.iter_under_impl (Rust_primitives.unsize matrix
+                    <:
+                    slice (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz))
+                <:
+                Core.Slice.Iter.t_Iter
+                (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz))
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate
+            (Core.Slice.Iter.t_Iter
+              (array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz)))
+        <:
+        _)
+      result
+      (fun result (i, row) ->
+          let result:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+            Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter
+                  (Core.Iter.Traits.Iterator.Iterator.enumerate (Core.Slice.iter_under_impl (Rust_primitives.unsize
+                              row
+                            <:
+                            slice Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                        <:
+                        Core.Slice.Iter.t_Iter
+                        Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                    <:
+                    Core.Iter.Adapters.Enumerate.t_Enumerate
+                    (Core.Slice.Iter.t_Iter
+                      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement))
+                <:
+                _)
+              result
+              (fun result (j, matrix_element) ->
+                  let product:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                    Libcrux.Kem.Kyber768.Ntt.Kyber_polynomial_ring_element_mod.ntt_multiply matrix_element
+                      (vector.[ j ] <: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                  in
+                  let result:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz
+                  =
+                    Rust_primitives.Hax.update_at result
+                      i
+                      ((result.[ i ] <: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                        ) +.
+                        product
+                        <:
+                        _)
+                  in
+                  result)
+          in
+          let result:array Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement 3sz =
+            Rust_primitives.Hax.update_at result
+              i
+              ({
+                  (result.[ i ] <: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement) with
+                  Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                  =
+                  Core.Array.map_under_impl_23 (result.[ i ]
+                      <:
+                      Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+                      .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                    (fun coefficient ->
+                        let coefficient_montgomery:i32 =
+                          Libcrux.Kem.Kyber768.Arithmetic.to_montgomery_domain coefficient
+                        in
+                        Libcrux.Kem.Kyber768.Arithmetic.barrett_reduce coefficient_montgomery)
+                  <:
+                  array i32 256sz
+                })
+          in
+          result)
+  in
+  result

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Parameters.Hash_functions.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Parameters.Hash_functions.fst
@@ -1,0 +1,15 @@
+module Libcrux.Kem.Kyber768.Parameters.Hash_functions
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let v_G (input: slice u8) : array u8 64sz = Libcrux.Digest.sha3_512_ input
+
+let v_H_DIGEST_SIZE: usize = Libcrux.Digest.digest_size Libcrux.Digest.Algorithm_Sha3_256_
+
+let v_H (input: slice u8) : array u8 32sz = Libcrux.Digest.sha3_256_ input
+
+let v_PRF (#len: usize) (input: slice u8) : array u8 v_LEN = Libcrux.Digest.shake256 input
+
+let v_XOF (#len: usize) (input: slice u8) : array u8 v_LEN = Libcrux.Digest.shake128 input
+
+let v_KDF (#len: usize) (input: slice u8) : array u8 v_LEN = Libcrux.Digest.shake256 input

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Parameters.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Parameters.fst
@@ -1,0 +1,50 @@
+module Libcrux.Kem.Kyber768.Parameters
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let v_FIELD_MODULUS: i32 = 3329l
+
+let v_BITS_PER_COEFFICIENT: usize = 12sz
+
+let v_COEFFICIENTS_IN_RING_ELEMENT: usize = 256sz
+
+let v_BITS_PER_RING_ELEMENT: usize = v_COEFFICIENTS_IN_RING_ELEMENT *. 12sz
+
+let v_BYTES_PER_RING_ELEMENT: usize = v_BITS_PER_RING_ELEMENT /. 8sz
+
+let v_REJECTION_SAMPLING_SEED_SIZE: usize = 168sz *. 5sz
+
+let v_RANK: usize = 3sz
+
+let v_T_AS_NTT_ENCODED_SIZE: usize =
+  ((v_RANK *. v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *. v_BITS_PER_COEFFICIENT <: usize) /. 8sz
+
+let v_VECTOR_U_COMPRESSION_FACTOR: usize = 10sz
+
+let v_VECTOR_V_COMPRESSION_FACTOR: usize = 4sz
+
+let v_BYTES_PER_ENCODED_ELEMENT_OF_U: usize =
+  (v_COEFFICIENTS_IN_RING_ELEMENT *. v_VECTOR_U_COMPRESSION_FACTOR <: usize) /. 8sz
+
+let v_VECTOR_U_ENCODED_SIZE: usize = v_RANK *. v_BYTES_PER_ENCODED_ELEMENT_OF_U
+
+let v_VECTOR_V_ENCODED_SIZE: usize =
+  (v_COEFFICIENTS_IN_RING_ELEMENT *. v_VECTOR_V_COMPRESSION_FACTOR <: usize) /. 8sz
+
+let v_CPA_PKE_KEY_GENERATION_SEED_SIZE: usize = 32sz
+
+let v_CPA_PKE_SECRET_KEY_SIZE: usize =
+  ((v_RANK *. v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *. v_BITS_PER_COEFFICIENT <: usize) /. 8sz
+
+let v_CPA_PKE_PUBLIC_KEY_SIZE: usize = v_T_AS_NTT_ENCODED_SIZE +. 32sz
+
+let v_CPA_PKE_CIPHERTEXT_SIZE: usize = v_VECTOR_U_ENCODED_SIZE +. v_VECTOR_V_ENCODED_SIZE
+
+let v_CPA_PKE_MESSAGE_SIZE: usize = 32sz
+
+let v_CPA_SERIALIZED_KEY_LEN: usize =
+  ((v_CPA_PKE_SECRET_KEY_SIZE +. v_CPA_PKE_PUBLIC_KEY_SIZE <: usize) +.
+    Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H_DIGEST_SIZE
+    <:
+    usize) +.
+  v_CPA_PKE_MESSAGE_SIZE

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Sampling.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Sampling.fst
@@ -1,0 +1,120 @@
+module Libcrux.Kem.Kyber768.Sampling
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let sample_from_uniform_distribution (randomness: array u8 840sz)
+    : Core.Result.t_Result Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+      Libcrux.Kem.Kyber768.t_BadRejectionSamplingRandomnessError =
+  let (sampled_coefficients: usize):usize = 0sz in
+  let (out: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement):Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+  =
+    Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl
+  in
+  let out, sampled_coefficients:(Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement &
+    Prims.unit) =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Slice.chunks_under_impl
+              (Rust_primitives.unsize randomness <: slice u8)
+              3sz
+            <:
+            Core.Slice.Iter.t_Chunks u8)
+        <:
+        _)
+      (out, sampled_coefficients)
+      (fun (out, sampled_coefficients) bytes ->
+          let b1:i32 = cast bytes.[ 0sz ] in
+          let b2:i32 = cast bytes.[ 1sz ] in
+          let b3:i32 = cast bytes.[ 2sz ] in
+          let d1:i32 = ((b2 &. 15l <: i32) >>. 8l <: i32) |. b1 in
+          let d2:i32 = (b3 >>. 4l <: i32) |. (b2 <<. 4l <: i32) in
+          let out, sampled_coefficients:(Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement &
+            Prims.unit) =
+            if
+              Prims.op_AmpAmp (d1 <. Libcrux.Kem.Kyber768.Parameters.v_FIELD_MODULUS)
+                (sampled_coefficients <.
+                  Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT)
+            then
+              let out:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                Rust_primitives.Hax.update_at out sampled_coefficients d1
+              in
+              out, sampled_coefficients +. 1sz
+            else out, sampled_coefficients
+          in
+          let out, sampled_coefficients:(Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement &
+            Prims.unit) =
+            if
+              Prims.op_AmpAmp (d2 <. Libcrux.Kem.Kyber768.Parameters.v_FIELD_MODULUS)
+                (sampled_coefficients <.
+                  Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT)
+            then
+              let out:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                Rust_primitives.Hax.update_at out sampled_coefficients d2
+              in
+              let sampled_coefficients:Prims.unit = sampled_coefficients +. 1sz in
+              out, sampled_coefficients
+            else out, sampled_coefficients
+          in
+          if sampled_coefficients =. Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT
+          then
+            let* hoist11:Rust_primitives.Hax.t_Never =
+              Core.Ops.Control_flow.ControlFlow.v_Break (Core.Result.Result_Ok out)
+            in
+            Core.Ops.Control_flow.ControlFlow_Continue (out, sampled_coefficients)
+          else Core.Ops.Control_flow.ControlFlow_Continue (out, sampled_coefficients))
+  in
+  Core.Result.Result_Err Libcrux.Kem.Kyber768.BadRejectionSamplingRandomnessError
+
+let sample_from_binomial_distribution_2_ (randomness: array u8 128sz)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let (sampled: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement):Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+  =
+    Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl
+  in
+  let sampled:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.chunks_exact_under_impl (Rust_primitives.unsize randomness <: slice u8)
+                  4sz
+                <:
+                Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        _)
+      sampled
+      (fun sampled (chunk_number, byte_chunk) ->
+          let (random_bits_as_u32: u32):u32 =
+            ((cast (byte_chunk.[ 0sz ] <: u8) |. (cast (byte_chunk.[ 1sz ] <: u8) >>. 8l <: u32)
+                <:
+                u32) |.
+              (cast (byte_chunk.[ 2sz ] <: u8) >>. 16l <: u32)
+              <:
+              u32) |.
+            (cast (byte_chunk.[ 3sz ] <: u8) >>. 24l <: u32)
+          in
+          let even_bits:u32 = random_bits_as_u32 &. 1431655765ul in
+          let odd_bits:u32 = (random_bits_as_u32 <<. 1l <: u32) &. 1431655765ul in
+          let coin_toss_outcomes:u32 = even_bits +. odd_bits in
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.step_by
+                    ({
+                        Core.Ops.Range.Range.f_start = 0ul;
+                        Core.Ops.Range.Range.f_end = Core.Num.v_BITS_under_impl_8
+                      })
+                    4sz
+                  <:
+                  Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range u32))
+              <:
+              _)
+            sampled
+            (fun sampled outcome_set ->
+                let outcome_1_:i32 = cast ((coin_toss_outcomes <<. outcome_set <: u32) &. 3ul) in
+                let outcome_2_:i32 =
+                  cast ((coin_toss_outcomes <<. (outcome_set +. 2ul <: u32) <: u32) &. 3ul)
+                in
+                let offset:usize = cast (outcome_set <<. 2l) in
+                let sampled:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+                  Rust_primitives.Hax.update_at sampled
+                    ((8sz *. chunk_number <: usize) +. offset <: usize)
+                    (outcome_1_ -. outcome_2_ <: i32)
+                in
+                sampled))
+  in
+  sampled

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Serialize.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.Serialize.fst
@@ -1,0 +1,452 @@
+module Libcrux.Kem.Kyber768.Serialize
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let serialize_little_endian_1_ (re: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+    : array u8 32sz =
+  let serialized:array u8 32sz = Rust_primitives.Hax.repeat 0uy 32sz in
+  let serialized:array u8 32sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.chunks_exact_under_impl (Rust_primitives.unsize re
+                        .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                    <:
+                    slice i32)
+                  8sz
+                <:
+                Core.Slice.Iter.t_ChunksExact i32)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+        <:
+        _)
+      serialized
+      (fun serialized (i, chunk) ->
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+                    (Core.Slice.iter_under_impl chunk <: Core.Slice.Iter.t_Iter i32)
+                  <:
+                  Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_Iter i32))
+              <:
+              _)
+            serialized
+            (fun serialized (j, coefficient) ->
+                Rust_primitives.Hax.update_at serialized
+                  i
+                  ((serialized.[ i ] <: u8) |. (cast coefficient >>. j <: u8) <: Prims.unit)
+                <:
+                array u8 32sz)
+          <:
+          array u8 32sz)
+  in
+  serialized
+
+let deserialize_little_endian_1_ (serialized: slice u8)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        match
+          Core.Slice.len_under_impl serialized,
+          Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT /. 8sz
+        with
+        | left_val, right_val ->
+          if ~.(left_val =. right_val <: bool)
+          then
+            let kind:Core.Panicking.t_AssertKind = Core.Panicking.AssertKind_Eq in
+            Rust_primitives.Hax.never_to_any (Core.Panicking.assert_failed kind
+                  left_val
+                  right_val
+                  Core.Option.Option_None
+                <:
+                Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl
+  in
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.iter_under_impl serialized <: Core.Slice.Iter.t_Iter u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_Iter u8))
+        <:
+        _)
+      re
+      (fun re (i, byte) ->
+          Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter ({
+                    Core.Ops.Range.Range.f_start = 0sz;
+                    Core.Ops.Range.Range.f_end = 8sz
+                  })
+              <:
+              _)
+            re
+            (fun re j ->
+                {
+                  re with
+                  Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                  =
+                  Rust_primitives.Hax.update_at re
+                      .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                    ((8sz *. i <: usize) +. j <: usize)
+                    (cast ((byte <<. j <: _) &. 1uy <: u8))
+                  <:
+                  Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement
+                })
+          <:
+          Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+  in
+  re
+
+let serialize_little_endian_4_ (re: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+    : array u8 128sz =
+  let serialized:array u8 128sz = Rust_primitives.Hax.repeat 0uy 128sz in
+  let serialized:array u8 128sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.chunks_exact_under_impl (Rust_primitives.unsize re
+                        .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                    <:
+                    slice i32)
+                  2sz
+                <:
+                Core.Slice.Iter.t_ChunksExact i32)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+        <:
+        _)
+      serialized
+      (fun serialized (i, chunk) ->
+          let coefficient1:u8 = cast chunk.[ 0sz ] in
+          let coefficient2:u8 = cast chunk.[ 1sz ] in
+          let serialized:array u8 128sz =
+            Rust_primitives.Hax.update_at serialized
+              i
+              ((coefficient2 >>. 4l <: u8) |. coefficient1 <: u8)
+          in
+          serialized)
+  in
+  serialized
+
+let deserialize_little_endian_4_ (serialized: slice u8)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        match
+          Core.Slice.len_under_impl serialized,
+          (Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT *. 4sz <: usize) /. 8sz
+        with
+        | left_val, right_val ->
+          if ~.(left_val =. right_val <: bool)
+          then
+            let kind:Core.Panicking.t_AssertKind = Core.Panicking.AssertKind_Eq in
+            Rust_primitives.Hax.never_to_any (Core.Panicking.assert_failed kind
+                  left_val
+                  right_val
+                  Core.Option.Option_None
+                <:
+                Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl
+  in
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.iter_under_impl serialized <: Core.Slice.Iter.t_Iter u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_Iter u8))
+        <:
+        _)
+      re
+      (fun re (i, byte) ->
+          let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+              =
+              Rust_primitives.Hax.update_at re
+                  .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                (2sz *. i <: usize)
+                (cast (byte &. 15uy <: _))
+            }
+          in
+          let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+              =
+              Rust_primitives.Hax.update_at re
+                  .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                ((2sz *. i <: usize) +. 1sz <: usize)
+                (cast ((byte <<. 4l <: _) &. 15uy <: u8))
+            }
+          in
+          re)
+  in
+  re
+
+let serialize_little_endian_10_ (re: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+    : array u8 320sz =
+  let serialized:array u8 320sz = Rust_primitives.Hax.repeat 0uy 320sz in
+  let serialized:array u8 320sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.chunks_exact_under_impl (Rust_primitives.unsize re
+                        .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                    <:
+                    slice i32)
+                  4sz
+                <:
+                Core.Slice.Iter.t_ChunksExact i32)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+        <:
+        _)
+      serialized
+      (fun serialized (i, chunk) ->
+          let coefficient1:i32 = chunk.[ 0sz ] in
+          let coefficient2:i32 = chunk.[ 1sz ] in
+          let coefficient3:i32 = chunk.[ 2sz ] in
+          let coefficient4:i32 = chunk.[ 3sz ] in
+          let serialized:array u8 320sz =
+            Rust_primitives.Hax.update_at serialized
+              (5sz *. i <: usize)
+              (cast (coefficient1 &. 255l <: i32))
+          in
+          let serialized:array u8 320sz =
+            Rust_primitives.Hax.update_at serialized
+              ((5sz *. i <: usize) +. 1sz <: usize)
+              ((cast (coefficient2 &. 63l <: i32) >>. 2l <: u8) |.
+                cast ((coefficient1 <<. 8l <: i32) &. 3l <: i32)
+                <:
+                u8)
+          in
+          let serialized:array u8 320sz =
+            Rust_primitives.Hax.update_at serialized
+              ((5sz *. i <: usize) +. 2sz <: usize)
+              ((cast (coefficient3 &. 15l <: i32) >>. 4l <: u8) |.
+                cast ((coefficient2 <<. 6l <: i32) &. 15l <: i32)
+                <:
+                u8)
+          in
+          let serialized:array u8 320sz =
+            Rust_primitives.Hax.update_at serialized
+              ((5sz *. i <: usize) +. 3sz <: usize)
+              ((cast (coefficient4 &. 3l <: i32) >>. 6l <: u8) |.
+                cast ((coefficient3 <<. 4l <: i32) &. 63l <: i32)
+                <:
+                u8)
+          in
+          let serialized:array u8 320sz =
+            Rust_primitives.Hax.update_at serialized
+              ((5sz *. i <: usize) +. 4sz <: usize)
+              (cast ((coefficient4 <<. 2l <: i32) &. 255l <: i32))
+          in
+          serialized)
+  in
+  serialized
+
+let deserialize_little_endian_10_ (serialized: slice u8)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        match
+          Core.Slice.len_under_impl serialized,
+          (Libcrux.Kem.Kyber768.Parameters.v_COEFFICIENTS_IN_RING_ELEMENT *. 10sz <: usize) /. 8sz
+        with
+        | left_val, right_val ->
+          if ~.(left_val =. right_val <: bool)
+          then
+            let kind:Core.Panicking.t_AssertKind = Core.Panicking.AssertKind_Eq in
+            Rust_primitives.Hax.never_to_any (Core.Panicking.assert_failed kind
+                  left_val
+                  right_val
+                  Core.Option.Option_None
+                <:
+                Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl
+  in
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.chunks_under_impl serialized 5sz <: Core.Slice.Iter.t_Chunks u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_Chunks u8))
+        <:
+        _)
+      re
+      (fun re (i, bytes) ->
+          let byte1:i32 = cast bytes.[ 0sz ] in
+          let byte2:i32 = cast bytes.[ 1sz ] in
+          let byte3:i32 = cast bytes.[ 2sz ] in
+          let byte4:i32 = cast bytes.[ 3sz ] in
+          let byte5:i32 = cast bytes.[ 4sz ] in
+          let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+              =
+              Rust_primitives.Hax.update_at re
+                  .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                (4sz *. i <: usize)
+                (((byte2 &. 3l <: i32) >>. 8l <: i32) |. (byte1 &. 255l <: i32) <: i32)
+            }
+          in
+          let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+              =
+              Rust_primitives.Hax.update_at re
+                  .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                ((4sz *. i <: usize) +. 1sz <: usize)
+                (((byte3 &. 15l <: i32) >>. 6l <: i32) |. (byte2 <<. 2l <: i32) <: i32)
+            }
+          in
+          let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+              =
+              Rust_primitives.Hax.update_at re
+                  .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                ((4sz *. i <: usize) +. 2sz <: usize)
+                (((byte4 &. 63l <: i32) >>. 4l <: i32) |. (byte3 <<. 4l <: i32) <: i32)
+            }
+          in
+          let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+              =
+              Rust_primitives.Hax.update_at re
+                  .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                ((4sz *. i <: usize) +. 3sz <: usize)
+                ((byte5 >>. 2l <: i32) |. (byte4 <<. 6l <: i32) <: i32)
+            }
+          in
+          re)
+  in
+  re
+
+let serialize_little_endian_12_ (re: Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement)
+    : array u8 384sz =
+  let serialized:array u8 384sz = Rust_primitives.Hax.repeat 0uy 384sz in
+  let serialized:array u8 384sz =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.chunks_exact_under_impl (Rust_primitives.unsize re
+                        .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                    <:
+                    slice i32)
+                  2sz
+                <:
+                Core.Slice.Iter.t_ChunksExact i32)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+        <:
+        _)
+      serialized
+      (fun serialized (i, chunks) ->
+          let coefficient1:i32 = chunks.[ 0sz ] in
+          let coefficient1:Prims.unit =
+            coefficient1 +.
+            ((coefficient1 <<. 15l <: i32) &. Libcrux.Kem.Kyber768.Parameters.v_FIELD_MODULUS <: i32
+            )
+          in
+          let coefficient2:i32 = chunks.[ 1sz ] in
+          let coefficient2:Prims.unit =
+            coefficient2 +.
+            ((coefficient2 <<. 15l <: i32) &. Libcrux.Kem.Kyber768.Parameters.v_FIELD_MODULUS <: i32
+            )
+          in
+          let serialized:array u8 384sz =
+            Rust_primitives.Hax.update_at serialized
+              (3sz *. i <: usize)
+              (cast (coefficient1 &. 255l <: i32))
+          in
+          let serialized:array u8 384sz =
+            Rust_primitives.Hax.update_at serialized
+              ((3sz *. i <: usize) +. 1sz <: usize)
+              (cast ((coefficient1 <<. 8l <: i32) |. ((coefficient2 &. 15l <: i32) >>. 4l <: i32)
+                    <:
+                    i32))
+          in
+          let serialized:array u8 384sz =
+            Rust_primitives.Hax.update_at serialized
+              ((3sz *. i <: usize) +. 2sz <: usize)
+              (cast ((coefficient2 <<. 4l <: i32) &. 255l <: i32))
+          in
+          serialized)
+  in
+  serialized
+
+let deserialize_little_endian_12_ (serialized: slice u8)
+    : Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        match
+          Core.Slice.len_under_impl serialized,
+          Libcrux.Kem.Kyber768.Parameters.v_BYTES_PER_RING_ELEMENT
+        with
+        | left_val, right_val ->
+          if ~.(left_val =. right_val <: bool)
+          then
+            let kind:Core.Panicking.t_AssertKind = Core.Panicking.AssertKind_Eq in
+            Rust_primitives.Hax.never_to_any (Core.Panicking.assert_failed kind
+                  left_val
+                  right_val
+                  Core.Option.Option_None
+                <:
+                Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Libcrux.Kem.Kyber768.Arithmetic.v_ZERO_under_impl
+  in
+  let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+    Core.Iter.Traits.Iterator.Iterator.fold (Core.Iter.Traits.Collect.IntoIterator.into_iter (Core.Iter.Traits.Iterator.Iterator.enumerate
+              (Core.Slice.chunks_exact_under_impl serialized 3sz <: Core.Slice.Iter.t_ChunksExact u8
+              )
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        _)
+      re
+      (fun re (i, bytes) ->
+          let byte1:i32 = cast bytes.[ 0sz ] in
+          let byte2:i32 = cast bytes.[ 1sz ] in
+          let byte3:i32 = cast bytes.[ 2sz ] in
+          let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+              =
+              Rust_primitives.Hax.update_at re
+                  .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                (2sz *. i <: usize)
+                (((byte2 &. 15l <: i32) >>. 8l <: i32) |. (byte1 &. 255l <: i32) <: i32)
+            }
+          in
+          let re:Libcrux.Kem.Kyber768.Arithmetic.t_KyberPolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+              =
+              Rust_primitives.Hax.update_at re
+                  .Libcrux.Kem.Kyber768.Arithmetic.KyberPolynomialRingElement.f_coefficients
+                ((2sz *. i <: usize) +. 1sz <: usize)
+                ((byte3 >>. 4l <: i32) |. ((byte2 <<. 4l <: i32) &. 15l <: i32) <: i32)
+            }
+          in
+          re)
+  in
+  re

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber768.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber768.fst
@@ -1,0 +1,281 @@
+module Libcrux.Kem.Kyber768
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let v_SHARED_SECRET_SIZE: usize = Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_MESSAGE_SIZE
+
+let v_KEY_GENERATION_SEED_SIZE: usize =
+  Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_KEY_GENERATION_SEED_SIZE +. v_SHARED_SECRET_SIZE
+
+let v_PUBLIC_KEY_SIZE: usize = Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_PUBLIC_KEY_SIZE
+
+let v_SECRET_KEY_SIZE: usize =
+  ((Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_SECRET_KEY_SIZE +.
+      Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_PUBLIC_KEY_SIZE
+      <:
+      usize) +.
+    Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H_DIGEST_SIZE
+    <:
+    usize) +.
+  v_SHARED_SECRET_SIZE
+
+let v_CIPHERTEXT_SIZE: usize = Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_CIPHERTEXT_SIZE
+
+let t_Kyber768PublicKey = array u8 1184sz
+
+let t_Kyber768PrivateKey = array u8 2400sz
+
+let t_Kyber768Ciphertext = array u8 1088sz
+
+let t_Kyber768SharedSecret = array u8 32sz
+
+type t_BadRejectionSamplingRandomnessError =
+  | BadRejectionSamplingRandomnessError : t_BadRejectionSamplingRandomnessError
+
+let generate_keypair (randomness: array u8 64sz)
+    : Core.Result.t_Result (array u8 1184sz & array u8 2400sz) t_BadRejectionSamplingRandomnessError =
+  Rust_primitives.Hax.Control_flow_monad.Mexception.run (let ind_cpa_keypair_randomness:slice u8 =
+        randomness.[ {
+            Core.Ops.Range.Range.f_start = 0sz;
+            Core.Ops.Range.Range.f_end
+            =
+            Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_KEY_GENERATION_SEED_SIZE
+          } ]
+      in
+      let implicit_rejection_value:slice u8 =
+        randomness.[ {
+            Core.Ops.Range.RangeFrom.f_start
+            =
+            Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_KEY_GENERATION_SEED_SIZE
+          } ]
+      in
+      let* ind_cpa_key_pair:Libcrux.Kem.Kyber768.Ind_cpa.t_KeyPair =
+        match
+          Core.Ops.Try_trait.Try.branch (Libcrux.Kem.Kyber768.Ind_cpa.generate_keypair ind_cpa_keypair_randomness
+
+              <:
+              Core.Result.t_Result Libcrux.Kem.Kyber768.Ind_cpa.t_KeyPair
+                t_BadRejectionSamplingRandomnessError)
+        with
+        | Core.Ops.Control_flow.ControlFlow_Break residual ->
+          let* hoist12:Rust_primitives.Hax.t_Never =
+            Core.Ops.Control_flow.ControlFlow.v_Break (Core.Ops.Try_trait.FromResidual.from_residual
+                  residual
+                <:
+                Core.Result.t_Result (array u8 1184sz & array u8 2400sz)
+                  t_BadRejectionSamplingRandomnessError)
+          in
+          Core.Ops.Control_flow.ControlFlow_Continue (Rust_primitives.Hax.never_to_any hoist12)
+        | Core.Ops.Control_flow.ControlFlow_Continue v_val ->
+          Core.Ops.Control_flow.ControlFlow_Continue v_val
+      in
+      Core.Ops.Control_flow.ControlFlow_Continue
+      (let secret_key_serialized:array u8 2400sz =
+          Libcrux.Kem.Kyber768.Ind_cpa.serialize_secret_key_under_impl ind_cpa_key_pair
+            implicit_rejection_value
+        in
+        Core.Result.Result_Ok
+        (Libcrux.Kem.Kyber768.Ind_cpa.pk_under_impl ind_cpa_key_pair, secret_key_serialized)))
+
+let encapsulate (public_key: array u8 1184sz) (randomness: array u8 32sz)
+    : Core.Result.t_Result (array u8 1088sz & array u8 32sz) t_BadRejectionSamplingRandomnessError =
+  Rust_primitives.Hax.Control_flow_monad.Mexception.run (let randomness_hashed:array u8 32sz =
+        Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H (Rust_primitives.unsize randomness
+            <:
+            slice u8)
+      in
+      let (to_hash: array u8 64sz):array u8 64sz =
+        Libcrux.Kem.Kyber768.Conversions.into_padded_array (Rust_primitives.unsize randomness_hashed
+            <:
+            slice u8)
+      in
+      let to_hash:array u8 64sz =
+        Rust_primitives.Hax.update_at to_hash
+          ({
+              Core.Ops.Range.RangeFrom.f_start
+              =
+              Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H_DIGEST_SIZE
+            })
+          (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut to_hash
+                  ({
+                      Core.Ops.Range.RangeFrom.f_start
+                      =
+                      Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H_DIGEST_SIZE
+                    })
+                <:
+                slice u8)
+              (Rust_primitives.unsize (Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H (Rust_primitives.unsize
+                          public_key
+                        <:
+                        slice u8)
+                    <:
+                    array u8 32sz)
+                <:
+                slice u8)
+            <:
+            slice u8)
+      in
+      let hashed:array u8 64sz =
+        Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_G (Rust_primitives.unsize to_hash
+            <:
+            slice u8)
+      in
+      let k_not, pseudorandomness:(slice u8 & slice u8) =
+        Core.Slice.split_at_under_impl (Rust_primitives.unsize hashed <: slice u8) 32sz
+      in
+      let* ciphertext:array u8 1088sz =
+        match
+          Core.Ops.Try_trait.Try.branch (Libcrux.Kem.Kyber768.Ind_cpa.encrypt (Rust_primitives.unsize
+                    public_key
+                  <:
+                  slice u8)
+                randomness_hashed
+                pseudorandomness
+              <:
+              Core.Result.t_Result (array u8 1088sz) t_BadRejectionSamplingRandomnessError)
+        with
+        | Core.Ops.Control_flow.ControlFlow_Break residual ->
+          let* hoist13:Rust_primitives.Hax.t_Never =
+            Core.Ops.Control_flow.ControlFlow.v_Break (Core.Ops.Try_trait.FromResidual.from_residual
+                  residual
+                <:
+                Core.Result.t_Result (array u8 1088sz & array u8 32sz)
+                  t_BadRejectionSamplingRandomnessError)
+          in
+          Core.Ops.Control_flow.ControlFlow_Continue (Rust_primitives.Hax.never_to_any hoist13)
+        | Core.Ops.Control_flow.ControlFlow_Continue v_val ->
+          Core.Ops.Control_flow.ControlFlow_Continue v_val
+      in
+      Core.Ops.Control_flow.ControlFlow_Continue
+      (let (to_hash: array u8 64sz):array u8 64sz =
+          Libcrux.Kem.Kyber768.Conversions.into_padded_array k_not
+        in
+        let to_hash:array u8 64sz =
+          Rust_primitives.Hax.update_at to_hash
+            ({
+                Core.Ops.Range.RangeFrom.f_start
+                =
+                Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H_DIGEST_SIZE
+              })
+            (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut to_hash
+                    ({
+                        Core.Ops.Range.RangeFrom.f_start
+                        =
+                        Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H_DIGEST_SIZE
+                      })
+                  <:
+                  slice u8)
+                (Rust_primitives.unsize (Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H (Rust_primitives.unsize
+                            ciphertext
+                          <:
+                          slice u8)
+                      <:
+                      array u8 32sz)
+                  <:
+                  slice u8)
+              <:
+              slice u8)
+        in
+        let (shared_secret: array u8 32sz):array u8 32sz =
+          Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_KDF (Rust_primitives.unsize to_hash
+              <:
+              slice u8)
+        in
+        Core.Result.Result_Ok (ciphertext, shared_secret)))
+
+let decapsulate (secret_key: array u8 2400sz) (ciphertext: array u8 1088sz) : array u8 32sz =
+  let ind_cpa_secret_key, secret_key:(slice u8 & slice u8) =
+    Core.Slice.split_at_under_impl (Rust_primitives.unsize secret_key <: slice u8)
+      Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_SECRET_KEY_SIZE
+  in
+  let ind_cpa_public_key, secret_key:(slice u8 & slice u8) =
+    Core.Slice.split_at_under_impl secret_key
+      Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_PUBLIC_KEY_SIZE
+  in
+  let ind_cpa_public_key_hash, implicit_rejection_value:(slice u8 & slice u8) =
+    Core.Slice.split_at_under_impl secret_key
+      Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H_DIGEST_SIZE
+  in
+  let decrypted:array u8 32sz =
+    Libcrux.Kem.Kyber768.Ind_cpa.decrypt ind_cpa_secret_key ciphertext
+  in
+  let (to_hash: array u8 64sz):array u8 64sz =
+    Libcrux.Kem.Kyber768.Conversions.into_padded_array (Rust_primitives.unsize decrypted <: slice u8
+      )
+  in
+  let to_hash:array u8 64sz =
+    Rust_primitives.Hax.update_at to_hash
+      ({ Core.Ops.Range.RangeFrom.f_start = Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_MESSAGE_SIZE }
+      )
+      (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut to_hash
+              ({
+                  Core.Ops.Range.RangeFrom.f_start
+                  =
+                  Libcrux.Kem.Kyber768.Parameters.v_CPA_PKE_MESSAGE_SIZE
+                })
+            <:
+            slice u8)
+          ind_cpa_public_key_hash
+        <:
+        slice u8)
+  in
+  let hashed:array u8 64sz =
+    Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_G (Rust_primitives.unsize to_hash <: slice u8)
+  in
+  let k_not, pseudorandomness:(slice u8 & slice u8) =
+    Core.Slice.split_at_under_impl (Rust_primitives.unsize hashed <: slice u8) 32sz
+  in
+  let expected_ciphertext_result:Core.Result.t_Result (array u8 1088sz)
+    t_BadRejectionSamplingRandomnessError =
+    Libcrux.Kem.Kyber768.Ind_cpa.encrypt ind_cpa_public_key decrypted pseudorandomness
+  in
+  let to_hash:array u8 32sz =
+    match expected_ciphertext_result with
+    | Core.Result.Result_Ok expected_ciphertext ->
+      let selector:u8 =
+        Libcrux.Kem.Kyber768.Constant_time_ops.compare_ciphertexts_in_constant_time (Rust_primitives.unsize
+              ciphertext
+            <:
+            slice u8)
+          (Rust_primitives.unsize expected_ciphertext <: slice u8)
+      in
+      Libcrux.Kem.Kyber768.Constant_time_ops.select_shared_secret_in_constant_time k_not
+        implicit_rejection_value
+        selector
+    | _ ->
+      let out:array u8 32sz = Rust_primitives.Hax.repeat 0uy 32sz in
+      let out:array u8 32sz =
+        Rust_primitives.Hax.update_at out
+          Core.Ops.Range.RangeFull
+          (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut out
+                  Core.Ops.Range.RangeFull
+                <:
+                slice u8)
+              implicit_rejection_value
+            <:
+            slice u8)
+      in
+      out
+  in
+  let (to_hash: array u8 64sz):array u8 64sz =
+    Libcrux.Kem.Kyber768.Conversions.into_padded_array (Rust_primitives.unsize to_hash <: slice u8)
+  in
+  let to_hash:array u8 64sz =
+    Rust_primitives.Hax.update_at to_hash
+      ({ Core.Ops.Range.RangeFrom.f_start = v_SHARED_SECRET_SIZE })
+      (Core.Slice.copy_from_slice_under_impl (Core.Ops.Index.IndexMut.index_mut to_hash
+              ({ Core.Ops.Range.RangeFrom.f_start = v_SHARED_SECRET_SIZE })
+            <:
+            slice u8)
+          (Rust_primitives.unsize (Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_H (Rust_primitives.unsize
+                      ciphertext
+                    <:
+                    slice u8)
+                <:
+                array u8 32sz)
+            <:
+            slice u8)
+        <:
+        slice u8)
+  in
+  Libcrux.Kem.Kyber768.Parameters.Hash_functions.v_KDF (Rust_primitives.unsize to_hash <: slice u8)

--- a/proofs/fstar/extraction/Libcrux.Kem.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.fst
@@ -1,0 +1,4 @@
+module Libcrux.Kem
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -50,8 +50,8 @@ pub(crate) mod x25519 {
 
     #[cfg(all(bmi2, adx, target_arch = "x86_64"))]
     pub(super) fn derive(p: &[u8; 32], s: &[u8; 32]) -> Result<[u8; 32], Error> {
-        use libcrux_platform::x25519_support;
         use crate::hacl::curve25519;
+        use libcrux_platform::x25519_support;
         // On x64 we use vale if available or hacl as fallback.
         // Jasmin exists but is not verified yet.
 

--- a/src/kem/kyber768.rs
+++ b/src/kem/kyber768.rs
@@ -11,8 +11,7 @@ mod serialize;
 use constant_time_ops::{
     compare_ciphertexts_in_constant_time, select_shared_secret_in_constant_time,
 };
-use conversions::ArrayConversion;
-
+use conversions::into_padded_array;
 use parameters::{
     hash_functions::{G, H, H_DIGEST_SIZE, KDF},
     CPA_PKE_KEY_GENERATION_SEED_SIZE, CPA_PKE_MESSAGE_SIZE, CPA_PKE_PUBLIC_KEY_SIZE,
@@ -45,10 +44,9 @@ pub fn generate_keypair(
     let ind_cpa_keypair_randomness = &randomness[0..parameters::CPA_PKE_KEY_GENERATION_SEED_SIZE];
     let implicit_rejection_value = &randomness[parameters::CPA_PKE_KEY_GENERATION_SEED_SIZE..];
 
-    let ind_cpa_key_pair = ind_cpa::generate_keypair(&ind_cpa_keypair_randomness.as_array())?;
+    let ind_cpa_key_pair = ind_cpa::generate_keypair(ind_cpa_keypair_randomness)?;
 
-    let secret_key_serialized =
-        ind_cpa_key_pair.serialize_secret_key(&implicit_rejection_value.as_array());
+    let secret_key_serialized = ind_cpa_key_pair.serialize_secret_key(implicit_rejection_value);
 
     Ok((ind_cpa_key_pair.pk(), secret_key_serialized))
 }
@@ -59,16 +57,15 @@ pub fn encapsulate(
 ) -> Result<(Kyber768Ciphertext, Kyber768SharedSecret), BadRejectionSamplingRandomnessError> {
     let randomness_hashed = H(&randomness);
 
-    let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = randomness_hashed.as_ref().to_padded_array();
+    let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = into_padded_array(&randomness_hashed);
     to_hash[H_DIGEST_SIZE..].copy_from_slice(&H(&public_key));
 
     let hashed = G(&to_hash);
     let (k_not, pseudorandomness) = hashed.split_at(32);
 
-    let ciphertext =
-        ind_cpa::encrypt(&public_key, randomness_hashed, &pseudorandomness.as_array())?;
+    let ciphertext = ind_cpa::encrypt(&public_key, randomness_hashed, pseudorandomness)?;
 
-    let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = k_not.as_ref().to_padded_array();
+    let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = into_padded_array(&k_not);
     to_hash[H_DIGEST_SIZE..].copy_from_slice(&H(&ciphertext));
 
     let shared_secret: Kyber768SharedSecret = KDF(&to_hash);
@@ -84,20 +81,16 @@ pub fn decapsulate(
     let (ind_cpa_public_key, secret_key) = secret_key.split_at(CPA_PKE_PUBLIC_KEY_SIZE);
     let (ind_cpa_public_key_hash, implicit_rejection_value) = secret_key.split_at(H_DIGEST_SIZE);
 
-    let decrypted = ind_cpa::decrypt(&ind_cpa_secret_key.as_array(), &ciphertext);
+    let decrypted = ind_cpa::decrypt(ind_cpa_secret_key, &ciphertext);
 
-    let mut to_hash: [u8; CPA_PKE_MESSAGE_SIZE + H_DIGEST_SIZE] =
-        decrypted.as_ref().to_padded_array();
+    let mut to_hash: [u8; CPA_PKE_MESSAGE_SIZE + H_DIGEST_SIZE] = into_padded_array(&decrypted);
     to_hash[CPA_PKE_MESSAGE_SIZE..].copy_from_slice(ind_cpa_public_key_hash);
 
     let hashed = G(&to_hash);
     let (k_not, pseudorandomness) = hashed.split_at(32);
 
-    let expected_ciphertext_result = ind_cpa::encrypt(
-        &ind_cpa_public_key.as_array(),
-        decrypted,
-        &pseudorandomness.as_array(),
-    );
+    let expected_ciphertext_result =
+        ind_cpa::encrypt(ind_cpa_public_key, decrypted, pseudorandomness);
 
     // Since we decrypt the ciphertext and hash this decrypted value in
     // to obtain the pseudorandomness, it is in theory possible that a modified
@@ -114,10 +107,12 @@ pub fn decapsulate(
         let selector = compare_ciphertexts_in_constant_time(&ciphertext, &expected_ciphertext);
         select_shared_secret_in_constant_time(k_not, implicit_rejection_value, selector)
     } else {
-        implicit_rejection_value.as_array()
+        let mut out = [0u8; 32];
+        out[..].copy_from_slice(implicit_rejection_value);
+        out
     };
 
-    let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = to_hash.as_ref().to_padded_array();
+    let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = into_padded_array(&to_hash);
     to_hash[SHARED_SECRET_SIZE..].copy_from_slice(&H(&ciphertext));
 
     KDF(&to_hash)

--- a/src/kem/kyber768/arithmetic.rs
+++ b/src/kem/kyber768/arithmetic.rs
@@ -40,8 +40,19 @@ pub struct KyberPolynomialRingElement {
 
 impl KyberPolynomialRingElement {
     pub const ZERO: Self = Self {
-        coefficients: [0i32; COEFFICIENTS_IN_RING_ELEMENT],
+        coefficients: [0i32; 256], // FIXME: hax issue, this is COEFFICIENTS_IN_RING_ELEMENT
     };
+}
+
+// Adding this to a module to ignore it for extraction.
+mod mutable_operations {
+    use super::*;
+
+    impl IndexMut<usize> for KyberPolynomialRingElement {
+        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+            &mut self.coefficients[index]
+        }
+    }
 }
 
 impl Index<usize> for KyberPolynomialRingElement {
@@ -49,11 +60,6 @@ impl Index<usize> for KyberPolynomialRingElement {
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.coefficients[index]
-    }
-}
-impl IndexMut<usize> for KyberPolynomialRingElement {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.coefficients[index]
     }
 }
 

--- a/src/kem/kyber768/conversions.rs
+++ b/src/kem/kyber768/conversions.rs
@@ -1,32 +1,9 @@
-pub trait ArrayConversion<const LEN: usize> {
-    fn as_array(&self) -> [u8; LEN];
-    fn to_padded_array(&self) -> [u8; LEN];
-}
-
-impl<const LEN: usize> ArrayConversion<LEN> for &[u8] {
-    fn as_array(&self) -> [u8; LEN] {
-        self.to_vec().try_into().unwrap()
-    }
-
-    fn to_padded_array(&self) -> [u8; LEN] {
-        assert!(self.len() <= LEN);
-        let mut out = [0u8; LEN];
-        out[0..self.len()].copy_from_slice(self);
-        out
-    }
-}
-
-pub trait ArrayPadding<const LEN: usize> {
-    fn to_padded_array<const OLEN: usize>(&self) -> [u8; OLEN];
-}
-
-impl<const LEN: usize> ArrayPadding<LEN> for &[u8; LEN] {
-    fn to_padded_array<const OLEN: usize>(&self) -> [u8; OLEN] {
-        assert!(self.len() <= OLEN);
-        let mut out = [0u8; OLEN];
-        out[0..self.len()].copy_from_slice(*self);
-        out
-    }
+#[inline(always)]
+pub(super) fn into_padded_array<const LEN: usize>(slice: &[u8]) -> [u8; LEN] {
+    debug_assert!(slice.len() <= LEN);
+    let mut out = [0u8; LEN];
+    out[0..slice.len()].copy_from_slice(slice);
+    out
 }
 
 pub trait UpdatingArray {
@@ -39,16 +16,19 @@ pub struct UpdatableArray<const LEN: usize> {
 }
 
 impl<const LEN: usize> UpdatableArray<LEN> {
+    #[inline(always)]
     pub fn new(value: [u8; LEN]) -> Self {
         Self { value, pointer: 0 }
     }
 
+    #[inline(always)]
     pub fn array(self) -> [u8; LEN] {
         self.value
     }
 }
 
 impl<const LEN: usize> UpdatingArray for UpdatableArray<LEN> {
+    #[inline(always)]
     fn push(mut self, other: &[u8]) -> Self {
         self.value[self.pointer..self.pointer + other.len()].copy_from_slice(other);
         self.pointer += other.len();

--- a/src/kem/kyber768/ntt.rs
+++ b/src/kem/kyber768/ntt.rs
@@ -36,7 +36,7 @@ pub(crate) mod kyber_polynomial_ring_element_mod {
                 for j in offset..offset + layer {
                     let t = montgomery_reduce(re[j + layer] * ZETAS_MONTGOMERY_DOMAIN[zeta_i]);
                     re[j + layer] = re[j] - t;
-                    re[j] += t;
+                    re[j] = re[j] + t;
                 }
             }
         }


### PR DESCRIPTION
Some small changes to make kyber extract to F*.
The F* extraction is in the proofs directory.

This needs https://github.com/hacspec/hacspec-v2/pull/246 to be merged for extraction.
Then the extraction can be done with `cargo hax into -i '-** +kem::kyber768::** -kem::kyber768::arithmetic::mutable_operations::**' fstar`.