### PR TITLE
Kyber: F*: enable the `--interfaces` option for most modules

### DIFF
--- a/hax-driver.py
+++ b/hax-driver.py
@@ -123,6 +123,8 @@ elif options.kyber_reference:
                 exclude_sha3_implementations
             ),
             "fstar",
+            "--interfaces",
+            "+* -libcrux::kem::kyber::types"
         ],
         cwd=".",
         env=hax_env,

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Arithmetic.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Arithmetic.fst
@@ -3,49 +3,11 @@ module Libcrux.Kem.Kyber.Arithmetic
 open Core
 open FStar.Mul
 
-unfold
-let t_FieldElement = i32
-
-unfold
-let t_FieldElementTimesMontgomeryR = i32
-
-unfold
-let t_MontgomeryFieldElement = i32
-
-let v_BARRETT_MULTIPLIER: i64 = 20159L
-
-let v_BARRETT_SHIFT: i64 = 26L
-
-let v_BARRETT_R: i64 = 1L <<! v_BARRETT_SHIFT
-
-let v_INVERSE_OF_MODULUS_MOD_R: u32 = 62209ul
-
-let v_MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS: i32 = 1353l
-
-let v_MONTGOMERY_SHIFT: u8 = 16uy
-
-let v_MONTGOMERY_R: i32 = 1l <<! v_MONTGOMERY_SHIFT
-
-let get_n_least_significant_bits (n: u8) (value: u32)
-    : Prims.Pure u32
-      (requires n =. 4uy || n =. 5uy || n =. 10uy || n =. 11uy || n =. v_MONTGOMERY_SHIFT)
-      (ensures
-        fun result ->
-          let result:u32 = result in
-          result <. (Core.Num.impl__u32__pow 2ul (Core.Convert.f_into n <: u32) <: u32)) =
+let get_n_least_significant_bits (n: u8) (value: u32) =
   let _:Prims.unit = () <: Prims.unit in
   value &. ((1ul <<! n <: u32) -! 1ul <: u32)
 
-let barrett_reduce (value: i32)
-    : Prims.Pure i32
-      (requires
-        (Core.Convert.f_from value <: i64) >. (Core.Ops.Arith.Neg.neg v_BARRETT_R <: i64) &&
-        (Core.Convert.f_from value <: i64) <. v_BARRETT_R)
-      (ensures
-        fun result ->
-          let result:i32 = result in
-          result >. (Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) &&
-          result <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS) =
+let barrett_reduce (value: i32) =
   let _:Prims.unit = () <: Prims.unit in
   let t:i64 =
     ((Core.Convert.f_from value <: i64) *! v_BARRETT_MULTIPLIER <: i64) +!
@@ -56,25 +18,7 @@ let barrett_reduce (value: i32)
   let _:Prims.unit = () <: Prims.unit in
   result
 
-let montgomery_reduce (value: i32)
-    : Prims.Pure i32
-      (requires
-        value >=.
-        ((Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) *!
-          v_MONTGOMERY_R
-          <:
-          i32) &&
-        value <=. (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS *! v_MONTGOMERY_R <: i32))
-      (ensures
-        fun result ->
-          let result:i32 = result in
-          result >=.
-          ((Core.Ops.Arith.Neg.neg (3l *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: i32
-            ) /!
-            2l
-            <:
-            i32) &&
-          result <=. ((3l *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) /! 2l <: i32)) =
+let montgomery_reduce (value: i32) =
   let _:i32 = v_MONTGOMERY_R in
   let _:Prims.unit = () <: Prims.unit in
   let t:u32 =
@@ -89,77 +33,18 @@ let montgomery_reduce (value: i32)
   let value_high:i32 = value >>! v_MONTGOMERY_SHIFT in
   value_high -! c
 
-let montgomery_multiply_sfe_by_fer (fe fer: i32) : i32 = montgomery_reduce (fe *! fer <: i32)
+let montgomery_multiply_sfe_by_fer (fe fer: i32) = montgomery_reduce (fe *! fer <: i32)
 
-let to_standard_domain (mfe: i32) : i32 =
+let to_standard_domain (mfe: i32) =
   montgomery_reduce (mfe *! v_MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS <: i32)
 
-let to_unsigned_representative (fe: i32)
-    : Prims.Pure u16
-      (requires
-        fe >=. (Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) &&
-        fe <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
-      (ensures
-        fun result ->
-          let result:u16 = result in
-          result >=. 0us &&
-          result <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16)) =
+let to_unsigned_representative (fe: i32) =
   let _:Prims.unit = () <: Prims.unit in
   cast (fe +! (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &. (fe >>! 31l <: i32) <: i32) <: i32)
   <:
   u16
 
-type t_PolynomialRingElement = { f_coefficients:t_Array i32 (sz 256) }
-
-let impl__PolynomialRingElement__ZERO: t_PolynomialRingElement =
-  { f_coefficients = Rust_primitives.Hax.repeat 0l (sz 256) } <: t_PolynomialRingElement
-
-let add_to_ring_element (v_K: usize) (lhs rhs: t_PolynomialRingElement)
-    : Prims.Pure t_PolynomialRingElement
-      (requires
-        Hax_lib.v_forall (fun i ->
-              let i:usize = i in
-              Hax_lib.implies (i <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
-                  <:
-                  bool)
-                (fun temp_0_ ->
-                    let _:Prims.unit = temp_0_ in
-                    ((Core.Num.impl__i32__abs (lhs.f_coefficients.[ i ] <: i32) <: i32) <=.
-                      (((cast (v_K <: usize) <: i32) -! 1l <: i32) *!
-                        Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
-                        <:
-                        i32)
-                      <:
-                      bool) &&
-                    ((Core.Num.impl__i32__abs (rhs.f_coefficients.[ i ] <: i32) <: i32) <=.
-                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
-                      <:
-                      bool))
-              <:
-              bool))
-      (ensures
-        fun result ->
-          let result:t_PolynomialRingElement = result in
-          Hax_lib.v_forall (fun i ->
-                let i:usize = i in
-                Hax_lib.implies (i <.
-                    (Core.Slice.impl__len (Rust_primitives.unsize result.f_coefficients
-                          <:
-                          t_Slice i32)
-                      <:
-                      usize)
-                    <:
-                    bool)
-                  (fun temp_0_ ->
-                      let _:Prims.unit = temp_0_ in
-                      (Core.Num.impl__i32__abs (result.f_coefficients.[ i ] <: i32) <: i32) <=.
-                      ((cast (v_K <: usize) <: i32) *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
-                        <:
-                        i32)
-                      <:
-                      bool)
-                <:
-                bool)) =
+let add_to_ring_element (v_K: usize) (lhs rhs: t_PolynomialRingElement) =
   let _:Prims.unit = () <: Prims.unit in
   let _:Prims.unit = () <: Prims.unit in
   let lhs:t_PolynomialRingElement =

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Arithmetic.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Arithmetic.fsti
@@ -1,0 +1,134 @@
+module Libcrux.Kem.Kyber.Arithmetic
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+unfold
+let t_FieldElement = i32
+
+unfold
+let t_FieldElementTimesMontgomeryR = i32
+
+unfold
+let t_MontgomeryFieldElement = i32
+
+let v_BARRETT_MULTIPLIER: i64 = 20159L
+
+let v_BARRETT_SHIFT: i64 = 26L
+
+let v_BARRETT_R: i64 = 1L <<! v_BARRETT_SHIFT
+
+let v_INVERSE_OF_MODULUS_MOD_R: u32 = 62209ul
+
+let v_MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS: i32 = 1353l
+
+let v_MONTGOMERY_SHIFT: u8 = 16uy
+
+let v_MONTGOMERY_R: i32 = 1l <<! v_MONTGOMERY_SHIFT
+
+val get_n_least_significant_bits (n: u8) (value: u32)
+    : Prims.Pure u32
+      (requires n =. 4uy || n =. 5uy || n =. 10uy || n =. 11uy || n =. v_MONTGOMERY_SHIFT)
+      (ensures
+        fun result ->
+          let result:u32 = result in
+          result <. (Core.Num.impl__u32__pow 2ul (Core.Convert.f_into n <: u32) <: u32))
+
+val barrett_reduce (value: i32)
+    : Prims.Pure i32
+      (requires
+        (Core.Convert.f_from value <: i64) >. (Core.Ops.Arith.Neg.neg v_BARRETT_R <: i64) &&
+        (Core.Convert.f_from value <: i64) <. v_BARRETT_R)
+      (ensures
+        fun result ->
+          let result:i32 = result in
+          result >. (Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) &&
+          result <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
+
+val montgomery_reduce (value: i32)
+    : Prims.Pure i32
+      (requires
+        value >=.
+        ((Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) *!
+          v_MONTGOMERY_R
+          <:
+          i32) &&
+        value <=. (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS *! v_MONTGOMERY_R <: i32))
+      (ensures
+        fun result ->
+          let result:i32 = result in
+          result >=.
+          ((Core.Ops.Arith.Neg.neg (3l *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: i32
+            ) /!
+            2l
+            <:
+            i32) &&
+          result <=. ((3l *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) /! 2l <: i32))
+
+val montgomery_multiply_sfe_by_fer (fe fer: i32)
+    : Prims.Pure i32 Prims.l_True (fun _ -> Prims.l_True)
+
+val to_standard_domain (mfe: i32) : Prims.Pure i32 Prims.l_True (fun _ -> Prims.l_True)
+
+val to_unsigned_representative (fe: i32)
+    : Prims.Pure u16
+      (requires
+        fe >=. (Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) &&
+        fe <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
+      (ensures
+        fun result ->
+          let result:u16 = result in
+          result >=. 0us &&
+          result <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+
+type t_PolynomialRingElement = { f_coefficients:t_Array i32 (sz 256) }
+
+let impl__PolynomialRingElement__ZERO: t_PolynomialRingElement =
+  { f_coefficients = Rust_primitives.Hax.repeat 0l (sz 256) } <: t_PolynomialRingElement
+
+val add_to_ring_element (v_K: usize) (lhs rhs: t_PolynomialRingElement)
+    : Prims.Pure t_PolynomialRingElement
+      (requires
+        Hax_lib.v_forall (fun i ->
+              let i:usize = i in
+              Hax_lib.implies (i <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+                  <:
+                  bool)
+                (fun temp_0_ ->
+                    let _:Prims.unit = temp_0_ in
+                    ((Core.Num.impl__i32__abs (lhs.f_coefficients.[ i ] <: i32) <: i32) <=.
+                      (((cast (v_K <: usize) <: i32) -! 1l <: i32) *!
+                        Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                        <:
+                        i32)
+                      <:
+                      bool) &&
+                    ((Core.Num.impl__i32__abs (rhs.f_coefficients.[ i ] <: i32) <: i32) <=.
+                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      <:
+                      bool))
+              <:
+              bool))
+      (ensures
+        fun result ->
+          let result:t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.f_coefficients.[ i ] <: i32) <: i32) <=.
+                      ((cast (v_K <: usize) <: i32) *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                        <:
+                        i32)
+                      <:
+                      bool)
+                <:
+                bool))

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Compress.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Compress.fst
@@ -3,17 +3,7 @@ module Libcrux.Kem.Kyber.Compress
 open Core
 open FStar.Mul
 
-let compress_ciphertext_coefficient (coefficient_bits: u8) (fe: u16)
-    : Prims.Pure i32
-      (requires
-        (coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy ||
-        coefficient_bits =. 11uy) &&
-        fe <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
-      (ensures
-        fun result ->
-          let result:i32 = result in
-          result >=. 0l &&
-          result <. (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32)) =
+let compress_ciphertext_coefficient (coefficient_bits: u8) (fe: u16) =
   let _:Prims.unit = () <: Prims.unit in
   let _:Prims.unit = () <: Prims.unit in
   let compressed:u64 = (cast (fe <: u16) <: u64) <<! coefficient_bits in
@@ -27,37 +17,14 @@ let compress_ciphertext_coefficient (coefficient_bits: u8) (fe: u16)
   <:
   i32
 
-let compress_message_coefficient (fe: u16)
-    : Prims.Pure u8
-      (requires fe <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
-      (ensures
-        fun result ->
-          let result:u8 = result in
-          Hax_lib.implies ((833us <=. fe <: bool) && (fe <=. 2596us <: bool))
-            (fun temp_0_ ->
-                let _:Prims.unit = temp_0_ in
-                result =. 1uy <: bool) &&
-          Hax_lib.implies (~.((833us <=. fe <: bool) && (fe <=. 2596us <: bool)) <: bool)
-            (fun temp_0_ ->
-                let _:Prims.unit = temp_0_ in
-                result =. 0uy <: bool)) =
+let compress_message_coefficient (fe: u16) =
   let (shifted: i16):i16 = 1664s -! (cast (fe <: u16) <: i16) in
   let mask:i16 = shifted >>! 15l in
   let shifted_to_positive:i16 = mask ^. shifted in
   let shifted_positive_in_range:i16 = shifted_to_positive -! 832s in
   cast ((shifted_positive_in_range >>! 15l <: i16) &. 1s <: i16) <: u8
 
-let decompress_ciphertext_coefficient (coefficient_bits: u8) (fe: i32)
-    : Prims.Pure i32
-      (requires
-        (coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy ||
-        coefficient_bits =. 11uy) &&
-        fe >=. 0l &&
-        fe <. (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32))
-      (ensures
-        fun result ->
-          let result:i32 = result in
-          result <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS) =
+let decompress_ciphertext_coefficient (coefficient_bits: u8) (fe: i32) =
   let _:Prims.unit = () <: Prims.unit in
   let _:Prims.unit = () <: Prims.unit in
   let decompressed:u32 =
@@ -67,7 +34,6 @@ let decompress_ciphertext_coefficient (coefficient_bits: u8) (fe: i32)
   let decompressed:u32 = decompressed >>! (coefficient_bits +! 1uy <: u8) in
   cast (decompressed <: u32) <: i32
 
-let decompress_message_coefficient (fe: i32)
-    : Prims.Pure i32 (requires fe =. 0l || fe =. 1l) (fun _ -> Prims.l_True) =
+let decompress_message_coefficient (fe: i32) =
   (Core.Ops.Arith.Neg.neg fe <: i32) &.
   ((Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS +! 1l <: i32) /! 2l <: i32)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Compress.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Compress.fsti
@@ -1,0 +1,46 @@
+module Libcrux.Kem.Kyber.Compress
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val compress_ciphertext_coefficient (coefficient_bits: u8) (fe: u16)
+    : Prims.Pure i32
+      (requires
+        (coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy ||
+        coefficient_bits =. 11uy) &&
+        fe <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+      (ensures
+        fun result ->
+          let result:i32 = result in
+          result >=. 0l &&
+          result <. (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32))
+
+val compress_message_coefficient (fe: u16)
+    : Prims.Pure u8
+      (requires fe <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+      (ensures
+        fun result ->
+          let result:u8 = result in
+          Hax_lib.implies ((833us <=. fe <: bool) && (fe <=. 2596us <: bool))
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 1uy <: bool) &&
+          Hax_lib.implies (~.((833us <=. fe <: bool) && (fe <=. 2596us <: bool)) <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 0uy <: bool))
+
+val decompress_ciphertext_coefficient (coefficient_bits: u8) (fe: i32)
+    : Prims.Pure i32
+      (requires
+        (coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy ||
+        coefficient_bits =. 11uy) &&
+        fe >=. 0l &&
+        fe <. (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32))
+      (ensures
+        fun result ->
+          let result:i32 = result in
+          result <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
+
+val decompress_message_coefficient (fe: i32)
+    : Prims.Pure i32 (requires fe =. 0l || fe =. 1l) (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Constant_time_ops.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Constant_time_ops.fst
@@ -3,20 +3,7 @@ module Libcrux.Kem.Kyber.Constant_time_ops
 open Core
 open FStar.Mul
 
-let is_non_zero (value: u8)
-    : Prims.Pure u8
-      Prims.l_True
-      (ensures
-        fun result ->
-          let result:u8 = result in
-          Hax_lib.implies (value =. 0uy <: bool)
-            (fun temp_0_ ->
-                let _:Prims.unit = temp_0_ in
-                result =. 0uy <: bool) &&
-          Hax_lib.implies (value <>. 0uy <: bool)
-            (fun temp_0_ ->
-                let _:Prims.unit = temp_0_ in
-                result =. 1uy <: bool)) =
+let is_non_zero (value: u8) =
   let value:u16 = cast (value <: u8) <: u16 in
   let result:u16 =
     ((value |. (Core.Num.impl__u16__wrapping_add (~.value <: u16) 1us <: u16) <: u16) >>! 8l <: u16) &.
@@ -24,20 +11,7 @@ let is_non_zero (value: u8)
   in
   cast (result <: u16) <: u8
 
-let compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_Slice u8)
-    : Prims.Pure u8
-      Prims.l_True
-      (ensures
-        fun result ->
-          let result:u8 = result in
-          Hax_lib.implies (lhs =. rhs <: bool)
-            (fun temp_0_ ->
-                let _:Prims.unit = temp_0_ in
-                result =. 0uy <: bool) &&
-          Hax_lib.implies (lhs <>. rhs <: bool)
-            (fun temp_0_ ->
-                let _:Prims.unit = temp_0_ in
-                result =. 1uy <: bool)) =
+let compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_Slice u8) =
   let _:Prims.unit = () <: Prims.unit in
   let _:Prims.unit = () <: Prims.unit in
   let (r: u8):u8 = 0uy in
@@ -58,20 +32,7 @@ let compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_
   in
   is_non_zero r
 
-let select_shared_secret_in_constant_time (lhs rhs: t_Slice u8) (selector: u8)
-    : Prims.Pure (t_Array u8 (sz 32))
-      Prims.l_True
-      (ensures
-        fun result ->
-          let result:t_Array u8 (sz 32) = result in
-          Hax_lib.implies (selector =. 0uy <: bool)
-            (fun temp_0_ ->
-                let _:Prims.unit = temp_0_ in
-                result =. lhs <: bool) &&
-          Hax_lib.implies (selector <>. 0uy <: bool)
-            (fun temp_0_ ->
-                let _:Prims.unit = temp_0_ in
-                result =. rhs <: bool)) =
+let select_shared_secret_in_constant_time (lhs rhs: t_Slice u8) (selector: u8) =
   let _:Prims.unit = () <: Prims.unit in
   let _:Prims.unit = () <: Prims.unit in
   let mask:u8 = Core.Num.impl__u8__wrapping_sub (is_non_zero selector <: u8) 1uy in

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Constant_time_ops.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Constant_time_ops.fsti
@@ -1,0 +1,49 @@
+module Libcrux.Kem.Kyber.Constant_time_ops
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val is_non_zero (value: u8)
+    : Prims.Pure u8
+      Prims.l_True
+      (ensures
+        fun result ->
+          let result:u8 = result in
+          Hax_lib.implies (value =. 0uy <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 0uy <: bool) &&
+          Hax_lib.implies (value <>. 0uy <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 1uy <: bool))
+
+val compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_Slice u8)
+    : Prims.Pure u8
+      Prims.l_True
+      (ensures
+        fun result ->
+          let result:u8 = result in
+          Hax_lib.implies (lhs =. rhs <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 0uy <: bool) &&
+          Hax_lib.implies (lhs <>. rhs <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 1uy <: bool))
+
+val select_shared_secret_in_constant_time (lhs rhs: t_Slice u8) (selector: u8)
+    : Prims.Pure (t_Array u8 (sz 32))
+      Prims.l_True
+      (ensures
+        fun result ->
+          let result:t_Array u8 (sz 32) = result in
+          Hax_lib.implies (selector =. 0uy <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. lhs <: bool) &&
+          Hax_lib.implies (selector <>. 0uy <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. rhs <: bool))

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Constants.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Constants.fsti
@@ -1,0 +1,22 @@
+module Libcrux.Kem.Kyber.Constants
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_BITS_PER_COEFFICIENT: usize = sz 12
+
+let v_COEFFICIENTS_IN_RING_ELEMENT: usize = sz 256
+
+let v_BITS_PER_RING_ELEMENT: usize = v_COEFFICIENTS_IN_RING_ELEMENT *! sz 12
+
+let v_BYTES_PER_RING_ELEMENT: usize = v_BITS_PER_RING_ELEMENT /! sz 8
+
+let v_CPA_PKE_KEY_GENERATION_SEED_SIZE: usize = sz 32
+
+let v_FIELD_MODULUS: i32 = 3329l
+
+let v_H_DIGEST_SIZE: usize = sz 32
+
+let v_REJECTION_SAMPLING_SEED_SIZE: usize = sz 168 *! sz 5
+
+let v_SHARED_SECRET_SIZE: usize = sz 32

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Conversions.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Conversions.fst
@@ -1,0 +1,87 @@
+module Libcrux.Kem.Kyber.Conversions
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let into_padded_array (#v_LEN: usize) (slice: t_Slice u8) : t_Array u8 v_LEN =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        if ~.((Core.Slice.impl__len slice <: usize) <=. v_LEN <: bool)
+        then
+          Rust_primitives.Hax.never_to_any (Core.Panicking.panic "assertion failed: slice.len() <= LEN"
+
+              <:
+              Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let out:t_Array u8 v_LEN = Rust_primitives.Hax.repeat 0uy v_LEN in
+  let out:t_Array u8 v_LEN =
+    Rust_primitives.Hax.update_at out
+      ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = Core.Slice.impl__len slice <: usize }
+      )
+      (Core.Slice.impl__copy_from_slice (Core.Ops.Index.IndexMut.index_mut out
+              ({
+                  Core.Ops.Range.f_start = sz 0;
+                  Core.Ops.Range.f_end = Core.Slice.impl__len slice <: usize
+                })
+            <:
+            t_Slice u8)
+          slice
+        <:
+        t_Slice u8)
+  in
+  out
+
+class t_UpdatingArray (#v_Self: Type) = { f_push:v_Self -> t_Slice u8 -> v_Self }
+
+type t_UpdatableArray (v_LEN: usize) = {
+  f_value:t_Array u8 v_LEN;
+  f_pointer:usize
+}
+
+let impl__new (#v_LEN: usize) (value: t_Array u8 v_LEN) : t_UpdatableArray v_LEN =
+  { f_value = value; f_pointer = sz 0 }
+
+let impl__array (#v_LEN: usize) (self: t_UpdatableArray v_LEN) : t_Array u8 v_LEN = self.f_value
+
+let impl_1 (#v_LEN: usize) : t_UpdatingArray (t_UpdatableArray v_LEN) =
+  {
+    f_push
+    =
+    fun (self: t_UpdatableArray v_LEN) (other: t_Slice u8) ->
+      let self:t_UpdatableArray v_LEN =
+        {
+          self with
+          f_value
+          =
+          Rust_primitives.Hax.update_at (f_value self <: t_UpdatableArray v_LEN)
+            ({
+                Core.Ops.Range.f_start = self.f_pointer;
+                Core.Ops.Range.f_end
+                =
+                self.f_pointer +! (Core.Slice.impl__len other <: usize) <: usize
+              })
+            (Core.Slice.impl__copy_from_slice (Core.Ops.Index.IndexMut.index_mut self.f_value
+                    ({
+                        Core.Ops.Range.f_start = self.f_pointer;
+                        Core.Ops.Range.f_end
+                        =
+                        self.f_pointer +! (Core.Slice.impl__len other <: usize) <: usize
+                      })
+                  <:
+                  t_Slice u8)
+                other
+              <:
+              t_Slice u8)
+        }
+      in
+      let self:t_UpdatableArray v_LEN =
+        { self with f_pointer = self.f_pointer +! (Core.Slice.impl__len other <: usize) }
+      in
+      self
+  }
+
+let to_unsigned_representative (fe: i32) : u16 =
+  cast (fe +! ((fe >>! 15l <: i32) &. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32)) <: u16

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Hash_functions.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Hash_functions.fst
@@ -3,20 +3,18 @@ module Libcrux.Kem.Kyber.Hash_functions
 open Core
 open FStar.Mul
 
-let v_G (input: t_Slice u8) : t_Array u8 (sz 64) = Libcrux.Digest.sha3_512_ input
+let v_G (input: t_Slice u8) = Libcrux.Digest.sha3_512_ input
 
-let v_H (input: t_Slice u8) : t_Array u8 (sz 32) = Libcrux.Digest.sha3_256_ input
+let v_H (input: t_Slice u8) = Libcrux.Digest.sha3_256_ input
 
-let v_PRF (v_LEN: usize) (input: t_Slice u8) : t_Array u8 v_LEN =
-  Libcrux.Digest.shake256 v_LEN input
+let v_PRF (v_LEN: usize) (input: t_Slice u8) = Libcrux.Digest.shake256 v_LEN input
 
-let v_XOFx4 (v_K: usize) (input: t_Array (t_Array u8 (sz 34)) v_K)
-    : t_Array (t_Array u8 (sz 840)) v_K =
+let v_XOFx4 (v_K: usize) (input: t_Array (t_Array u8 (sz 34)) v_K) =
   let out:t_Array (t_Array u8 (sz 840)) v_K =
     Rust_primitives.Hax.repeat (Rust_primitives.Hax.repeat 0uy (sz 840) <: t_Array u8 (sz 840)) v_K
   in
   let out:t_Array (t_Array u8 (sz 840)) v_K =
-    if ~.(Libcrux_platform.simd256_support () <: bool) || ~.false
+    if ~.(Libcrux_platform.simd256_support () <: bool) || ~.true
     then
       Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
                 Core.Ops.Range.f_start = sz 0;

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Hash_functions.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Hash_functions.fsti
@@ -1,0 +1,14 @@
+module Libcrux.Kem.Kyber.Hash_functions
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val v_G (input: t_Slice u8) : Prims.Pure (t_Array u8 (sz 64)) Prims.l_True (fun _ -> Prims.l_True)
+
+val v_H (input: t_Slice u8) : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val v_PRF (v_LEN: usize) (input: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val v_XOFx4 (v_K: usize) (input: t_Array (t_Array u8 (sz 34)) v_K)
+    : Prims.Pure (t_Array (t_Array u8 (sz 840)) v_K) Prims.l_True (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ind_cpa.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ind_cpa.fst
@@ -3,7 +3,7 @@ module Libcrux.Kem.Kyber.Ind_cpa
 open Core
 open FStar.Mul
 
-let into_padded_array (v_LEN: usize) (slice: t_Slice u8) : t_Array u8 v_LEN =
+let into_padded_array (v_LEN: usize) (slice: t_Slice u8) =
   let _:Prims.unit =
     if true
     then
@@ -41,7 +41,7 @@ let sample_ring_element_cbd
       (v_K v_ETA2_RANDOMNESS_SIZE v_ETA2: usize)
       (prf_input: t_Array u8 (sz 33))
       (domain_separator: u8)
-    : (t_Array u8 (sz 33) & u8 & t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+     =
   let error_1_:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
     Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
   in
@@ -99,7 +99,7 @@ let sample_vector_cbd_then_ntt
       (v_K v_ETA v_ETA_RANDOMNESS_SIZE: usize)
       (prf_input: t_Array u8 (sz 33))
       (domain_separator: u8)
-    : (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K & u8) =
+     =
   let re_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
     Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
   in
@@ -156,7 +156,7 @@ let sample_vector_cbd_then_ntt
 let compress_then_serialize_u
       (v_K v_OUT_LEN v_COMPRESSION_FACTOR v_BLOCK_LEN: usize)
       (input: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
-    : t_Array u8 v_OUT_LEN =
+     =
   let out:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
   let out:t_Array u8 v_OUT_LEN =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
@@ -208,7 +208,7 @@ let compress_then_serialize_u
 let deserialize_then_decompress_u
       (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
       (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
-    : t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+     =
   let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
     Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
   in
@@ -249,8 +249,7 @@ let deserialize_then_decompress_u
   in
   u_as_ntt
 
-let deserialize_public_key (v_K: usize) (public_key: t_Slice u8)
-    : t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+let deserialize_public_key (v_K: usize) (public_key: t_Slice u8) =
   let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
     Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
   in
@@ -280,8 +279,7 @@ let deserialize_public_key (v_K: usize) (public_key: t_Slice u8)
   in
   tt_as_ntt
 
-let deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8)
-    : t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+let deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8) =
   let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
     Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
   in
@@ -316,7 +314,7 @@ let decrypt
           usize)
       (secret_key: t_Slice u8)
       (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
-    : t_Array u8 (sz 32) =
+     =
   let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
     deserialize_then_decompress_u v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR ciphertext
   in
@@ -342,7 +340,7 @@ let encrypt
       (public_key: t_Slice u8)
       (message: t_Array u8 (sz 32))
       (randomness: t_Slice u8)
-    : t_Array u8 v_CIPHERTEXT_SIZE =
+     =
   let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
     deserialize_public_key v_K public_key
   in
@@ -420,7 +418,7 @@ let encrypt
 let serialize_secret_key
       (v_K v_OUT_LEN: usize)
       (key: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
-    : t_Array u8 v_OUT_LEN =
+     =
   let out:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
   let out:t_Array u8 v_OUT_LEN =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
@@ -481,7 +479,7 @@ let serialize_public_key
       (v_K v_RANKED_BYTES_PER_RING_ELEMENT v_PUBLIC_KEY_SIZE: usize)
       (tt_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
       (seed_for_a: t_Slice u8)
-    : t_Array u8 v_PUBLIC_KEY_SIZE =
+     =
   let public_key_serialized:t_Array u8 v_PUBLIC_KEY_SIZE =
     Rust_primitives.Hax.repeat 0uy v_PUBLIC_KEY_SIZE
   in
@@ -530,7 +528,7 @@ let generate_keypair
       (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
           usize)
       (key_generation_seed: t_Slice u8)
-    : (t_Array u8 v_PRIVATE_KEY_SIZE & t_Array u8 v_PUBLIC_KEY_SIZE) =
+     =
   let hashed:t_Array u8 (sz 64) = Libcrux.Kem.Kyber.Hash_functions.v_G key_generation_seed in
   let seed_for_A, seed_for_secret_and_error:(t_Slice u8 & t_Slice u8) =
     Core.Slice.impl__split_at (Rust_primitives.unsize hashed <: t_Slice u8) (sz 32)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti
@@ -1,0 +1,80 @@
+module Libcrux.Kem.Kyber.Ind_cpa
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val into_padded_array (v_LEN: usize) (slice: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val sample_ring_element_cbd
+      (v_K v_ETA2_RANDOMNESS_SIZE v_ETA2: usize)
+      (prf_input: t_Array u8 (sz 33))
+      (domain_separator: u8)
+    : Prims.Pure
+      (t_Array u8 (sz 33) & u8 & t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val sample_vector_cbd_then_ntt
+      (v_K v_ETA v_ETA_RANDOMNESS_SIZE: usize)
+      (prf_input: t_Array u8 (sz 33))
+      (domain_separator: u8)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K & u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compress_then_serialize_u
+      (v_K v_OUT_LEN v_COMPRESSION_FACTOR v_BLOCK_LEN: usize)
+      (input: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_u
+      (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
+      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_public_key (v_K: usize) (public_key: t_Slice u8)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val decrypt
+      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
+          usize)
+      (secret_key: t_Slice u8)
+      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encrypt
+      (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+          usize)
+      (public_key: t_Slice u8)
+      (message: t_Array u8 (sz 32))
+      (randomness: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_CIPHERTEXT_SIZE) Prims.l_True (fun _ -> Prims.l_True)
+
+val serialize_secret_key
+      (v_K v_OUT_LEN: usize)
+      (key: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val serialize_public_key
+      (v_K v_RANKED_BYTES_PER_RING_ELEMENT v_PUBLIC_KEY_SIZE: usize)
+      (tt_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      (seed_for_a: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_PUBLIC_KEY_SIZE) Prims.l_True (fun _ -> Prims.l_True)
+
+val generate_keypair
+      (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+          usize)
+      (key_generation_seed: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_PRIVATE_KEY_SIZE & t_Array u8 v_PUBLIC_KEY_SIZE)
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber1024.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber1024.fst
@@ -3,90 +3,21 @@ module Libcrux.Kem.Kyber.Kyber1024
 open Core
 open FStar.Mul
 
-let v_ETA1: usize = sz 2
-
-let v_ETA1_RANDOMNESS_SIZE: usize = v_ETA1 *! sz 64
-
-let v_ETA2: usize = sz 2
-
-let v_ETA2_RANDOMNESS_SIZE: usize = v_ETA2 *! sz 64
-
-let v_RANK_1024_: usize = sz 4
-
-let v_CPA_PKE_SECRET_KEY_SIZE_1024_: usize =
-  ((v_RANK_1024_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
-    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
-    <:
-    usize) /!
-  sz 8
-
-let v_RANKED_BYTES_PER_RING_ELEMENT_1024_: usize =
-  (v_RANK_1024_ *! Libcrux.Kem.Kyber.Constants.v_BITS_PER_RING_ELEMENT <: usize) /! sz 8
-
-let v_T_AS_NTT_ENCODED_SIZE_1024_: usize =
-  ((v_RANK_1024_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
-    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
-    <:
-    usize) /!
-  sz 8
-
-let v_CPA_PKE_PUBLIC_KEY_SIZE_1024_: usize = v_T_AS_NTT_ENCODED_SIZE_1024_ +! sz 32
-
-let v_SECRET_KEY_SIZE_1024_: usize =
-  ((v_CPA_PKE_SECRET_KEY_SIZE_1024_ +! v_CPA_PKE_PUBLIC_KEY_SIZE_1024_ <: usize) +!
-    Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
-    <:
-    usize) +!
-  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
-
-let v_VECTOR_U_COMPRESSION_FACTOR_1024_: usize = sz 11
-
-let v_C1_BLOCK_SIZE_1024_: usize =
-  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_U_COMPRESSION_FACTOR_1024_
-    <:
-    usize) /!
-  sz 8
-
-let v_C1_SIZE_1024_: usize = v_C1_BLOCK_SIZE_1024_ *! v_RANK_1024_
-
-let v_VECTOR_V_COMPRESSION_FACTOR_1024_: usize = sz 5
-
-let v_C2_SIZE_1024_: usize =
-  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_V_COMPRESSION_FACTOR_1024_
-    <:
-    usize) /!
-  sz 8
-
-let v_CPA_PKE_CIPHERTEXT_SIZE_1024_: usize = v_C1_SIZE_1024_ +! v_C2_SIZE_1024_
-
-let v_IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize =
-  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_1024_
-
-unfold
-let t_Kyber1024Ciphertext = Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1568)
-
-unfold
-let t_Kyber1024PrivateKey = Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 3168)
-
-unfold
-let t_Kyber1024PublicKey = Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1568)
-
 let decapsulate_1024_
       (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 3168))
       (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1568))
-    : t_Array u8 (sz 32) =
+     =
   Libcrux.Kem.Kyber.decapsulate (sz 4) (sz 3168) (sz 1536) (sz 1568) (sz 1568) (sz 1536) (sz 1408)
     (sz 160) (sz 11) (sz 5) (sz 352) (sz 2) (sz 128) (sz 2) (sz 128) (sz 1600) secret_key ciphertext
 
 let encapsulate_1024_
       (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1568))
       (randomness: t_Array u8 (sz 32))
-    : (Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1568) & t_Array u8 (sz 32)) =
+     =
   Libcrux.Kem.Kyber.encapsulate (sz 4) (sz 1568) (sz 1568) (sz 1536) (sz 1408) (sz 160) (sz 11)
     (sz 5) (sz 352) (sz 2) (sz 128) (sz 2) (sz 128) public_key randomness
 
-let generate_key_pair_1024_ (randomness: t_Array u8 (sz 64))
-    : Libcrux.Kem.Kyber.Types.t_KyberKeyPair (sz 3168) (sz 1568) =
+let generate_key_pair_1024_ (randomness: t_Array u8 (sz 64)) =
   Libcrux.Kem.Kyber.generate_keypair (sz 4)
     (sz 1536)
     (sz 3168)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber1024.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber1024.fsti
@@ -1,0 +1,89 @@
+module Libcrux.Kem.Kyber.Kyber1024
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_ETA1: usize = sz 2
+
+let v_ETA1_RANDOMNESS_SIZE: usize = v_ETA1 *! sz 64
+
+let v_ETA2: usize = sz 2
+
+let v_ETA2_RANDOMNESS_SIZE: usize = v_ETA2 *! sz 64
+
+let v_RANK_1024_: usize = sz 4
+
+let v_CPA_PKE_SECRET_KEY_SIZE_1024_: usize =
+  ((v_RANK_1024_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_RANKED_BYTES_PER_RING_ELEMENT_1024_: usize =
+  (v_RANK_1024_ *! Libcrux.Kem.Kyber.Constants.v_BITS_PER_RING_ELEMENT <: usize) /! sz 8
+
+let v_T_AS_NTT_ENCODED_SIZE_1024_: usize =
+  ((v_RANK_1024_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_PUBLIC_KEY_SIZE_1024_: usize = v_T_AS_NTT_ENCODED_SIZE_1024_ +! sz 32
+
+let v_SECRET_KEY_SIZE_1024_: usize =
+  ((v_CPA_PKE_SECRET_KEY_SIZE_1024_ +! v_CPA_PKE_PUBLIC_KEY_SIZE_1024_ <: usize) +!
+    Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
+    <:
+    usize) +!
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+
+let v_VECTOR_U_COMPRESSION_FACTOR_1024_: usize = sz 11
+
+let v_C1_BLOCK_SIZE_1024_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_U_COMPRESSION_FACTOR_1024_
+    <:
+    usize) /!
+  sz 8
+
+let v_C1_SIZE_1024_: usize = v_C1_BLOCK_SIZE_1024_ *! v_RANK_1024_
+
+let v_VECTOR_V_COMPRESSION_FACTOR_1024_: usize = sz 5
+
+let v_C2_SIZE_1024_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_V_COMPRESSION_FACTOR_1024_
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_CIPHERTEXT_SIZE_1024_: usize = v_C1_SIZE_1024_ +! v_C2_SIZE_1024_
+
+let v_IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize =
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_1024_
+
+unfold
+let t_Kyber1024Ciphertext = Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1568)
+
+unfold
+let t_Kyber1024PrivateKey = Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 3168)
+
+unfold
+let t_Kyber1024PublicKey = Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1568)
+
+val decapsulate_1024_
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 3168))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1568))
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encapsulate_1024_
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1568))
+      (randomness: t_Array u8 (sz 32))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1568) & t_Array u8 (sz 32))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_key_pair_1024_ (randomness: t_Array u8 (sz 64))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberKeyPair (sz 3168) (sz 1568))
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber512.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber512.fst
@@ -3,90 +3,21 @@ module Libcrux.Kem.Kyber.Kyber512
 open Core
 open FStar.Mul
 
-let v_ETA1: usize = sz 3
-
-let v_ETA1_RANDOMNESS_SIZE: usize = v_ETA1 *! sz 64
-
-let v_ETA2: usize = sz 2
-
-let v_ETA2_RANDOMNESS_SIZE: usize = v_ETA2 *! sz 64
-
-let v_RANK_512_: usize = sz 2
-
-let v_CPA_PKE_SECRET_KEY_SIZE_512_: usize =
-  ((v_RANK_512_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
-    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
-    <:
-    usize) /!
-  sz 8
-
-let v_RANKED_BYTES_PER_RING_ELEMENT_512_: usize =
-  (v_RANK_512_ *! Libcrux.Kem.Kyber.Constants.v_BITS_PER_RING_ELEMENT <: usize) /! sz 8
-
-let v_T_AS_NTT_ENCODED_SIZE_512_: usize =
-  ((v_RANK_512_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
-    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
-    <:
-    usize) /!
-  sz 8
-
-let v_CPA_PKE_PUBLIC_KEY_SIZE_512_: usize = v_T_AS_NTT_ENCODED_SIZE_512_ +! sz 32
-
-let v_SECRET_KEY_SIZE_512_: usize =
-  ((v_CPA_PKE_SECRET_KEY_SIZE_512_ +! v_CPA_PKE_PUBLIC_KEY_SIZE_512_ <: usize) +!
-    Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
-    <:
-    usize) +!
-  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
-
-let v_VECTOR_U_COMPRESSION_FACTOR_512_: usize = sz 10
-
-let v_C1_BLOCK_SIZE_512_: usize =
-  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_U_COMPRESSION_FACTOR_512_
-    <:
-    usize) /!
-  sz 8
-
-let v_C1_SIZE_512_: usize = v_C1_BLOCK_SIZE_512_ *! v_RANK_512_
-
-let v_VECTOR_V_COMPRESSION_FACTOR_512_: usize = sz 4
-
-let v_C2_SIZE_512_: usize =
-  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_V_COMPRESSION_FACTOR_512_
-    <:
-    usize) /!
-  sz 8
-
-let v_CPA_PKE_CIPHERTEXT_SIZE_512_: usize = v_C1_SIZE_512_ +! v_C2_SIZE_512_
-
-let v_IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize =
-  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_512_
-
-unfold
-let t_Kyber512Ciphertext = Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 768)
-
-unfold
-let t_Kyber512PrivateKey = Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 1632)
-
-unfold
-let t_Kyber512PublicKey = Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 800)
-
 let decapsulate_512_
       (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 1632))
       (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 768))
-    : t_Array u8 (sz 32) =
+     =
   Libcrux.Kem.Kyber.decapsulate (sz 2) (sz 1632) (sz 768) (sz 800) (sz 768) (sz 768) (sz 640)
     (sz 128) (sz 10) (sz 4) (sz 320) (sz 3) (sz 192) (sz 2) (sz 128) (sz 800) secret_key ciphertext
 
 let encapsulate_512_
       (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 800))
       (randomness: t_Array u8 (sz 32))
-    : (Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 768) & t_Array u8 (sz 32)) =
+     =
   Libcrux.Kem.Kyber.encapsulate (sz 2) (sz 768) (sz 800) (sz 768) (sz 640) (sz 128) (sz 10) (sz 4)
     (sz 320) (sz 3) (sz 192) (sz 2) (sz 128) public_key randomness
 
-let generate_key_pair_512_ (randomness: t_Array u8 (sz 64))
-    : Libcrux.Kem.Kyber.Types.t_KyberKeyPair (sz 1632) (sz 800) =
+let generate_key_pair_512_ (randomness: t_Array u8 (sz 64)) =
   Libcrux.Kem.Kyber.generate_keypair (sz 2)
     (sz 768)
     (sz 1632)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber512.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber512.fsti
@@ -1,0 +1,89 @@
+module Libcrux.Kem.Kyber.Kyber512
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_ETA1: usize = sz 3
+
+let v_ETA1_RANDOMNESS_SIZE: usize = v_ETA1 *! sz 64
+
+let v_ETA2: usize = sz 2
+
+let v_ETA2_RANDOMNESS_SIZE: usize = v_ETA2 *! sz 64
+
+let v_RANK_512_: usize = sz 2
+
+let v_CPA_PKE_SECRET_KEY_SIZE_512_: usize =
+  ((v_RANK_512_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_RANKED_BYTES_PER_RING_ELEMENT_512_: usize =
+  (v_RANK_512_ *! Libcrux.Kem.Kyber.Constants.v_BITS_PER_RING_ELEMENT <: usize) /! sz 8
+
+let v_T_AS_NTT_ENCODED_SIZE_512_: usize =
+  ((v_RANK_512_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_PUBLIC_KEY_SIZE_512_: usize = v_T_AS_NTT_ENCODED_SIZE_512_ +! sz 32
+
+let v_SECRET_KEY_SIZE_512_: usize =
+  ((v_CPA_PKE_SECRET_KEY_SIZE_512_ +! v_CPA_PKE_PUBLIC_KEY_SIZE_512_ <: usize) +!
+    Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
+    <:
+    usize) +!
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+
+let v_VECTOR_U_COMPRESSION_FACTOR_512_: usize = sz 10
+
+let v_C1_BLOCK_SIZE_512_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_U_COMPRESSION_FACTOR_512_
+    <:
+    usize) /!
+  sz 8
+
+let v_C1_SIZE_512_: usize = v_C1_BLOCK_SIZE_512_ *! v_RANK_512_
+
+let v_VECTOR_V_COMPRESSION_FACTOR_512_: usize = sz 4
+
+let v_C2_SIZE_512_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_V_COMPRESSION_FACTOR_512_
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_CIPHERTEXT_SIZE_512_: usize = v_C1_SIZE_512_ +! v_C2_SIZE_512_
+
+let v_IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize =
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_512_
+
+unfold
+let t_Kyber512Ciphertext = Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 768)
+
+unfold
+let t_Kyber512PrivateKey = Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 1632)
+
+unfold
+let t_Kyber512PublicKey = Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 800)
+
+val decapsulate_512_
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 1632))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 768))
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encapsulate_512_
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 800))
+      (randomness: t_Array u8 (sz 32))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 768) & t_Array u8 (sz 32))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_key_pair_512_ (randomness: t_Array u8 (sz 64))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberKeyPair (sz 1632) (sz 800))
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber768.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber768.fst
@@ -3,90 +3,21 @@ module Libcrux.Kem.Kyber.Kyber768
 open Core
 open FStar.Mul
 
-let v_ETA1: usize = sz 2
-
-let v_ETA1_RANDOMNESS_SIZE: usize = v_ETA1 *! sz 64
-
-let v_ETA2: usize = sz 2
-
-let v_ETA2_RANDOMNESS_SIZE: usize = v_ETA2 *! sz 64
-
-let v_RANK_768_: usize = sz 3
-
-let v_CPA_PKE_SECRET_KEY_SIZE_768_: usize =
-  ((v_RANK_768_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
-    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
-    <:
-    usize) /!
-  sz 8
-
-let v_RANKED_BYTES_PER_RING_ELEMENT_768_: usize =
-  (v_RANK_768_ *! Libcrux.Kem.Kyber.Constants.v_BITS_PER_RING_ELEMENT <: usize) /! sz 8
-
-let v_T_AS_NTT_ENCODED_SIZE_768_: usize =
-  ((v_RANK_768_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
-    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
-    <:
-    usize) /!
-  sz 8
-
-let v_CPA_PKE_PUBLIC_KEY_SIZE_768_: usize = v_T_AS_NTT_ENCODED_SIZE_768_ +! sz 32
-
-let v_SECRET_KEY_SIZE_768_: usize =
-  ((v_CPA_PKE_SECRET_KEY_SIZE_768_ +! v_CPA_PKE_PUBLIC_KEY_SIZE_768_ <: usize) +!
-    Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
-    <:
-    usize) +!
-  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
-
-let v_VECTOR_U_COMPRESSION_FACTOR_768_: usize = sz 10
-
-let v_C1_BLOCK_SIZE_768_: usize =
-  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_U_COMPRESSION_FACTOR_768_
-    <:
-    usize) /!
-  sz 8
-
-let v_C1_SIZE_768_: usize = v_C1_BLOCK_SIZE_768_ *! v_RANK_768_
-
-let v_VECTOR_V_COMPRESSION_FACTOR_768_: usize = sz 4
-
-let v_C2_SIZE_768_: usize =
-  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_V_COMPRESSION_FACTOR_768_
-    <:
-    usize) /!
-  sz 8
-
-let v_CPA_PKE_CIPHERTEXT_SIZE_768_: usize = v_C1_SIZE_768_ +! v_C2_SIZE_768_
-
-let v_IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize =
-  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_768_
-
-unfold
-let t_Kyber768Ciphertext = Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1088)
-
-unfold
-let t_Kyber768PrivateKey = Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 2400)
-
-unfold
-let t_Kyber768PublicKey = Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1184)
-
 let decapsulate_768_
       (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 2400))
       (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1088))
-    : t_Array u8 (sz 32) =
+     =
   Libcrux.Kem.Kyber.decapsulate (sz 3) (sz 2400) (sz 1152) (sz 1184) (sz 1088) (sz 1152) (sz 960)
     (sz 128) (sz 10) (sz 4) (sz 320) (sz 2) (sz 128) (sz 2) (sz 128) (sz 1120) secret_key ciphertext
 
 let encapsulate_768_
       (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1184))
       (randomness: t_Array u8 (sz 32))
-    : (Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1088) & t_Array u8 (sz 32)) =
+     =
   Libcrux.Kem.Kyber.encapsulate (sz 3) (sz 1088) (sz 1184) (sz 1152) (sz 960) (sz 128) (sz 10)
     (sz 4) (sz 320) (sz 2) (sz 128) (sz 2) (sz 128) public_key randomness
 
-let generate_key_pair_768_ (randomness: t_Array u8 (sz 64))
-    : Libcrux.Kem.Kyber.Types.t_KyberKeyPair (sz 2400) (sz 1184) =
+let generate_key_pair_768_ (randomness: t_Array u8 (sz 64)) =
   Libcrux.Kem.Kyber.generate_keypair (sz 3)
     (sz 1152)
     (sz 2400)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber768.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber768.fsti
@@ -1,0 +1,89 @@
+module Libcrux.Kem.Kyber.Kyber768
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_ETA1: usize = sz 2
+
+let v_ETA1_RANDOMNESS_SIZE: usize = v_ETA1 *! sz 64
+
+let v_ETA2: usize = sz 2
+
+let v_ETA2_RANDOMNESS_SIZE: usize = v_ETA2 *! sz 64
+
+let v_RANK_768_: usize = sz 3
+
+let v_CPA_PKE_SECRET_KEY_SIZE_768_: usize =
+  ((v_RANK_768_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_RANKED_BYTES_PER_RING_ELEMENT_768_: usize =
+  (v_RANK_768_ *! Libcrux.Kem.Kyber.Constants.v_BITS_PER_RING_ELEMENT <: usize) /! sz 8
+
+let v_T_AS_NTT_ENCODED_SIZE_768_: usize =
+  ((v_RANK_768_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_PUBLIC_KEY_SIZE_768_: usize = v_T_AS_NTT_ENCODED_SIZE_768_ +! sz 32
+
+let v_SECRET_KEY_SIZE_768_: usize =
+  ((v_CPA_PKE_SECRET_KEY_SIZE_768_ +! v_CPA_PKE_PUBLIC_KEY_SIZE_768_ <: usize) +!
+    Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
+    <:
+    usize) +!
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+
+let v_VECTOR_U_COMPRESSION_FACTOR_768_: usize = sz 10
+
+let v_C1_BLOCK_SIZE_768_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_U_COMPRESSION_FACTOR_768_
+    <:
+    usize) /!
+  sz 8
+
+let v_C1_SIZE_768_: usize = v_C1_BLOCK_SIZE_768_ *! v_RANK_768_
+
+let v_VECTOR_V_COMPRESSION_FACTOR_768_: usize = sz 4
+
+let v_C2_SIZE_768_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_V_COMPRESSION_FACTOR_768_
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_CIPHERTEXT_SIZE_768_: usize = v_C1_SIZE_768_ +! v_C2_SIZE_768_
+
+let v_IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize =
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_768_
+
+unfold
+let t_Kyber768Ciphertext = Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1088)
+
+unfold
+let t_Kyber768PrivateKey = Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 2400)
+
+unfold
+let t_Kyber768PublicKey = Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1184)
+
+val decapsulate_768_
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 2400))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1088))
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encapsulate_768_
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1184))
+      (randomness: t_Array u8 (sz 32))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1088) & t_Array u8 (sz 32))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_key_pair_768_ (randomness: t_Array u8 (sz 64))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberKeyPair (sz 2400) (sz 1184))
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Matrix.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Matrix.fst
@@ -7,7 +7,7 @@ let compute_As_plus_e
       (v_K: usize)
       (matrix_A: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
       (s_as_ntt error_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
-    : t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+     =
   let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
     Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
   in
@@ -127,7 +127,7 @@ let compute_message
       (v_K: usize)
       (v: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
       (secret_as_ntt u_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+     =
   let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
   in
@@ -209,7 +209,7 @@ let compute_ring_element_v
       (v_K: usize)
       (tt_as_ntt r_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
       (error_2_ message: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+     =
   let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
   in
@@ -291,7 +291,7 @@ let compute_vector_u
       (v_K: usize)
       (a_as_ntt: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
       (r_as_ntt error_1_: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
-    : t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+     =
   let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
     Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
   in
@@ -420,8 +420,7 @@ let compute_vector_u
   in
   result
 
-let sample_matrix_A (v_K: usize) (seed: t_Array u8 (sz 34)) (transpose: bool)
-    : t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+let sample_matrix_A (v_K: usize) (seed: t_Array u8 (sz 34)) (transpose: bool) =
   let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
     Rust_primitives.Hax.repeat (Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
           v_K

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Matrix.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Matrix.fsti
@@ -1,0 +1,41 @@
+module Libcrux.Kem.Kyber.Matrix
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val compute_As_plus_e
+      (v_K: usize)
+      (matrix_A: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+      (s_as_ntt error_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compute_message
+      (v_K: usize)
+      (v: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (secret_as_ntt u_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compute_ring_element_v
+      (v_K: usize)
+      (tt_as_ntt r_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      (error_2_ message: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compute_vector_u
+      (v_K: usize)
+      (a_as_ntt: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+      (r_as_ntt error_1_: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val sample_matrix_A (v_K: usize) (seed: t_Array u8 (sz 34)) (transpose: bool)
+    : Prims.Pure (t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ntt.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ntt.fst
@@ -3,26 +3,7 @@ module Libcrux.Kem.Kyber.Ntt
 open Core
 open FStar.Mul
 
-let v_ZETAS_TIMES_MONTGOMERY_R: t_Array i32 (sz 128) =
-  let list =
-    [
-      (-1044l); (-758l); (-359l); (-1517l); 1493l; 1422l; 287l; 202l; (-171l); 622l; 1577l; 182l;
-      962l; (-1202l); (-1474l); 1468l; 573l; (-1325l); 264l; 383l; (-829l); 1458l; (-1602l); (-130l);
-      (-681l); 1017l; 732l; 608l; (-1542l); 411l; (-205l); (-1571l); 1223l; 652l; (-552l); 1015l;
-      (-1293l); 1491l; (-282l); (-1544l); 516l; (-8l); (-320l); (-666l); (-1618l); (-1162l); 126l;
-      1469l; (-853l); (-90l); (-271l); 830l; 107l; (-1421l); (-247l); (-951l); (-398l); 961l;
-      (-1508l); (-725l); 448l; (-1065l); 677l; (-1275l); (-1103l); 430l; 555l; 843l; (-1251l); 871l;
-      1550l; 105l; 422l; 587l; 177l; (-235l); (-291l); (-460l); 1574l; 1653l; (-246l); 778l; 1159l;
-      (-147l); (-777l); 1483l; (-602l); 1119l; (-1590l); 644l; (-872l); 349l; 418l; 329l; (-156l);
-      (-75l); 817l; 1097l; 603l; 610l; 1322l; (-1285l); (-1465l); 384l; (-1215l); (-136l); 1218l;
-      (-1335l); (-874l); 220l; (-1187l); (-1659l); (-1185l); (-1530l); (-1278l); 794l; (-1510l);
-      (-854l); (-870l); 478l; (-108l); (-308l); 996l; 991l; 958l; (-1460l); 1522l; 1628l
-    ]
-  in
-  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 128);
-  Rust_primitives.Hax.array_of_list list
-
-let ntt_multiply_binomials (a0, a1: (i32 & i32)) (b0, b1: (i32 & i32)) (zeta: i32) : (i32 & i32) =
+let ntt_multiply_binomials (a0, a1: (i32 & i32)) (b0, b1: (i32 & i32)) (zeta: i32) =
   Libcrux.Kem.Kyber.Arithmetic.montgomery_reduce ((a0 *! b0 <: i32) +!
       ((Libcrux.Kem.Kyber.Arithmetic.montgomery_reduce (a1 *! b1 <: i32) <: i32) *! zeta <: i32)
       <:
@@ -35,7 +16,7 @@ let invert_ntt_at_layer
       (zeta_i: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
       (layer: usize)
-    : (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+     =
   let step:usize = sz 1 <<! layer in
   let re, zeta_i:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize) =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
@@ -112,8 +93,7 @@ let invert_ntt_at_layer
   let hax_temp_output:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
   zeta_i, hax_temp_output <: (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
 
-let invert_ntt_montgomery (v_K: usize) (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+let invert_ntt_montgomery (v_K: usize) (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
   let _:Prims.unit = () <: Prims.unit in
   let zeta_i:usize = Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT /! sz 2 in
   let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
@@ -198,7 +178,7 @@ let ntt_at_layer
       (zeta_i: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
       (layer initial_coefficient_bound: usize)
-    : (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+     =
   let step:usize = sz 1 <<! layer in
   let re, zeta_i:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize) =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
@@ -273,7 +253,7 @@ let ntt_at_layer_3_
       (zeta_i: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
       (layer: usize)
-    : (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+     =
   let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
     ntt_at_layer zeta_i re layer (sz 3)
   in
@@ -285,7 +265,7 @@ let ntt_at_layer_3328_
       (zeta_i: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
       (layer: usize)
-    : (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+     =
   let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
     ntt_at_layer zeta_i re layer (sz 3328)
   in
@@ -293,59 +273,7 @@ let ntt_at_layer_3328_
   let hax_temp_output:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
   zeta_i, hax_temp_output <: (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
 
-let ntt_binomially_sampled_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
-      (requires
-        Hax_lib.v_forall (fun i ->
-              let i:usize = i in
-              Hax_lib.implies (i <.
-                  (Core.Slice.impl__len (Rust_primitives.unsize re
-                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
-                        <:
-                        t_Slice i32)
-                    <:
-                    usize)
-                  <:
-                  bool)
-                (fun temp_0_ ->
-                    let _:Prims.unit = temp_0_ in
-                    (Core.Num.impl__i32__abs (re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
-                          <:
-                          i32)
-                      <:
-                      i32) <=.
-                    3l
-                    <:
-                    bool)
-              <:
-              bool))
-      (ensures
-        fun result ->
-          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
-          Hax_lib.v_forall (fun i ->
-                let i:usize = i in
-                Hax_lib.implies (i <.
-                    (Core.Slice.impl__len (Rust_primitives.unsize result
-                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
-                          <:
-                          t_Slice i32)
-                      <:
-                      usize)
-                    <:
-                    bool)
-                  (fun temp_0_ ->
-                      let _:Prims.unit = temp_0_ in
-                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
-                              i ]
-                            <:
-                            i32)
-                        <:
-                        i32) <.
-                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
-                      <:
-                      bool)
-                <:
-                bool)) =
+let ntt_binomially_sampled_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
   let _:Prims.unit = () <: Prims.unit in
   let zeta_i:usize = sz 1 in
   let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
@@ -464,56 +392,7 @@ let ntt_binomially_sampled_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_Poly
   in
   re
 
-let ntt_multiply (lhs rhs: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
-      (requires
-        Hax_lib.v_forall (fun i ->
-              let i:usize = i in
-              Hax_lib.implies (i <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
-                  <:
-                  bool)
-                (fun temp_0_ ->
-                    let _:Prims.unit = temp_0_ in
-                    ((lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ] <: i32) >=. 0l <: bool) &&
-                    ((lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ] <: i32) <. 4096l <: bool
-                    ) &&
-                    ((Core.Num.impl__i32__abs (rhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
-                            <:
-                            i32)
-                        <:
-                        i32) <=.
-                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
-                      <:
-                      bool))
-              <:
-              bool))
-      (ensures
-        fun result ->
-          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
-          Hax_lib.v_forall (fun i ->
-                let i:usize = i in
-                Hax_lib.implies (i <.
-                    (Core.Slice.impl__len (Rust_primitives.unsize result
-                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
-                          <:
-                          t_Slice i32)
-                      <:
-                      usize)
-                    <:
-                    bool)
-                  (fun temp_0_ ->
-                      let _:Prims.unit = temp_0_ in
-                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
-                              i ]
-                            <:
-                            i32)
-                        <:
-                        i32) <=.
-                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
-                      <:
-                      bool)
-                <:
-                bool)) =
+let ntt_multiply (lhs rhs: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
   let _:Prims.unit = () <: Prims.unit in
   let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
@@ -647,58 +526,7 @@ let ntt_multiply (lhs rhs: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
 let ntt_vector_u
       (v_VECTOR_U_COMPRESSION_FACTOR: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
-      (requires
-        Hax_lib.v_forall (fun i ->
-              let i:usize = i in
-              Hax_lib.implies (i <.
-                  (Core.Slice.impl__len (Rust_primitives.unsize re
-                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
-                        <:
-                        t_Slice i32)
-                    <:
-                    usize)
-                  <:
-                  bool)
-                (fun temp_0_ ->
-                    let _:Prims.unit = temp_0_ in
-                    (Core.Num.impl__i32__abs (re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
-                          <:
-                          i32)
-                      <:
-                      i32) <=.
-                    3328l
-                    <:
-                    bool)
-              <:
-              bool))
-      (ensures
-        fun result ->
-          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
-          Hax_lib.v_forall (fun i ->
-                let i:usize = i in
-                Hax_lib.implies (i <.
-                    (Core.Slice.impl__len (Rust_primitives.unsize result
-                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
-                          <:
-                          t_Slice i32)
-                      <:
-                      usize)
-                    <:
-                    bool)
-                  (fun temp_0_ ->
-                      let _:Prims.unit = temp_0_ in
-                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
-                              i ]
-                            <:
-                            i32)
-                        <:
-                        i32) <.
-                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
-                      <:
-                      bool)
-                <:
-                bool)) =
+     =
   let _:Prims.unit = () <: Prims.unit in
   let zeta_i:usize = sz 0 in
   let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ntt.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ntt.fsti
@@ -1,0 +1,224 @@
+module Libcrux.Kem.Kyber.Ntt
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_ZETAS_TIMES_MONTGOMERY_R: t_Array i32 (sz 128) =
+  let list =
+    [
+      (-1044l); (-758l); (-359l); (-1517l); 1493l; 1422l; 287l; 202l; (-171l); 622l; 1577l; 182l;
+      962l; (-1202l); (-1474l); 1468l; 573l; (-1325l); 264l; 383l; (-829l); 1458l; (-1602l); (-130l);
+      (-681l); 1017l; 732l; 608l; (-1542l); 411l; (-205l); (-1571l); 1223l; 652l; (-552l); 1015l;
+      (-1293l); 1491l; (-282l); (-1544l); 516l; (-8l); (-320l); (-666l); (-1618l); (-1162l); 126l;
+      1469l; (-853l); (-90l); (-271l); 830l; 107l; (-1421l); (-247l); (-951l); (-398l); 961l;
+      (-1508l); (-725l); 448l; (-1065l); 677l; (-1275l); (-1103l); 430l; 555l; 843l; (-1251l); 871l;
+      1550l; 105l; 422l; 587l; 177l; (-235l); (-291l); (-460l); 1574l; 1653l; (-246l); 778l; 1159l;
+      (-147l); (-777l); 1483l; (-602l); 1119l; (-1590l); 644l; (-872l); 349l; 418l; 329l; (-156l);
+      (-75l); 817l; 1097l; 603l; 610l; 1322l; (-1285l); (-1465l); 384l; (-1215l); (-136l); 1218l;
+      (-1335l); (-874l); 220l; (-1187l); (-1659l); (-1185l); (-1530l); (-1278l); 794l; (-1510l);
+      (-854l); (-870l); 478l; (-108l); (-308l); 996l; 991l; 958l; (-1460l); 1522l; 1628l
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 128);
+  Rust_primitives.Hax.array_of_list list
+
+val ntt_multiply_binomials: (i32 & i32) -> (i32 & i32) -> zeta: i32
+  -> Prims.Pure (i32 & i32) Prims.l_True (fun _ -> Prims.l_True)
+
+val invert_ntt_at_layer
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer: usize)
+    : Prims.Pure (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val invert_ntt_montgomery (v_K: usize) (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val ntt_at_layer
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer initial_coefficient_bound: usize)
+    : Prims.Pure (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val ntt_at_layer_3_
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer: usize)
+    : Prims.Pure (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val ntt_at_layer_3328_
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer: usize)
+    : Prims.Pure (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val ntt_binomially_sampled_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      (requires
+        Hax_lib.v_forall (fun i ->
+              let i:usize = i in
+              Hax_lib.implies (i <.
+                  (Core.Slice.impl__len (Rust_primitives.unsize re
+                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        <:
+                        t_Slice i32)
+                    <:
+                    usize)
+                  <:
+                  bool)
+                (fun temp_0_ ->
+                    let _:Prims.unit = temp_0_ in
+                    (Core.Num.impl__i32__abs (re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                          <:
+                          i32)
+                      <:
+                      i32) <=.
+                    3l
+                    <:
+                    bool)
+              <:
+              bool))
+      (ensures
+        fun result ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result
+                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                              i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <.
+                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      <:
+                      bool)
+                <:
+                bool))
+
+val ntt_multiply (lhs rhs: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      (requires
+        Hax_lib.v_forall (fun i ->
+              let i:usize = i in
+              Hax_lib.implies (i <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+                  <:
+                  bool)
+                (fun temp_0_ ->
+                    let _:Prims.unit = temp_0_ in
+                    ((lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ] <: i32) >=. 0l <: bool) &&
+                    ((lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ] <: i32) <. 4096l <: bool
+                    ) &&
+                    ((Core.Num.impl__i32__abs (rhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <=.
+                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      <:
+                      bool))
+              <:
+              bool))
+      (ensures
+        fun result ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result
+                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                              i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <=.
+                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      <:
+                      bool)
+                <:
+                bool))
+
+val ntt_vector_u
+      (v_VECTOR_U_COMPRESSION_FACTOR: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      (requires
+        Hax_lib.v_forall (fun i ->
+              let i:usize = i in
+              Hax_lib.implies (i <.
+                  (Core.Slice.impl__len (Rust_primitives.unsize re
+                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        <:
+                        t_Slice i32)
+                    <:
+                    usize)
+                  <:
+                  bool)
+                (fun temp_0_ ->
+                    let _:Prims.unit = temp_0_ in
+                    (Core.Num.impl__i32__abs (re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                          <:
+                          i32)
+                      <:
+                      i32) <=.
+                    3328l
+                    <:
+                    bool)
+              <:
+              bool))
+      (ensures
+        fun result ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result
+                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                              i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <.
+                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      <:
+                      bool)
+                <:
+                bool))

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Sampling.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Sampling.fst
@@ -3,41 +3,12 @@ module Libcrux.Kem.Kyber.Sampling
 open Core
 open FStar.Mul
 
-let rejection_sampling_panic_with_diagnostic (_: Prims.unit) : Prims.unit =
+let rejection_sampling_panic_with_diagnostic (_: Prims.unit) =
   Rust_primitives.Hax.never_to_any (Core.Panicking.panic "explicit panic"
       <:
       Rust_primitives.Hax.t_Never)
 
-let sample_from_binomial_distribution_2_ (randomness: t_Slice u8)
-    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
-      (requires (Core.Slice.impl__len randomness <: usize) =. (sz 2 *! sz 64 <: usize))
-      (ensures
-        fun result ->
-          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
-          Hax_lib.v_forall (fun i ->
-                let i:usize = i in
-                Hax_lib.implies (i <.
-                    (Core.Slice.impl__len (Rust_primitives.unsize result
-                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
-                          <:
-                          t_Slice i32)
-                      <:
-                      usize)
-                    <:
-                    bool)
-                  (fun temp_0_ ->
-                      let _:Prims.unit = temp_0_ in
-                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
-                              i ]
-                            <:
-                            i32)
-                        <:
-                        i32) <=.
-                      2l
-                      <:
-                      bool)
-                <:
-                bool)) =
+let sample_from_binomial_distribution_2_ (randomness: t_Slice u8) =
   let (sampled: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement):Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
   =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
@@ -109,36 +80,7 @@ let sample_from_binomial_distribution_2_ (randomness: t_Slice u8)
   let _:Prims.unit = () <: Prims.unit in
   sampled
 
-let sample_from_binomial_distribution_3_ (randomness: t_Slice u8)
-    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
-      (requires (Core.Slice.impl__len randomness <: usize) =. (sz 3 *! sz 64 <: usize))
-      (ensures
-        fun result ->
-          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
-          Hax_lib.v_forall (fun i ->
-                let i:usize = i in
-                Hax_lib.implies (i <.
-                    (Core.Slice.impl__len (Rust_primitives.unsize result
-                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
-                          <:
-                          t_Slice i32)
-                      <:
-                      usize)
-                    <:
-                    bool)
-                  (fun temp_0_ ->
-                      let _:Prims.unit = temp_0_ in
-                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
-                              i ]
-                            <:
-                            i32)
-                        <:
-                        i32) <=.
-                      3l
-                      <:
-                      bool)
-                <:
-                bool)) =
+let sample_from_binomial_distribution_3_ (randomness: t_Slice u8) =
   let (sampled: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement):Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
   =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
@@ -205,8 +147,7 @@ let sample_from_binomial_distribution_3_ (randomness: t_Slice u8)
   let _:Prims.unit = () <: Prims.unit in
   sampled
 
-let sample_from_binomial_distribution (v_ETA: usize) (randomness: t_Slice u8)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+let sample_from_binomial_distribution (v_ETA: usize) (randomness: t_Slice u8) =
   let _:Prims.unit = () <: Prims.unit in
   match cast (v_ETA <: usize) <: u32 with
   | 2ul -> sample_from_binomial_distribution_2_ randomness
@@ -217,8 +158,7 @@ let sample_from_binomial_distribution (v_ETA: usize) (randomness: t_Slice u8)
         <:
         Rust_primitives.Hax.t_Never)
 
-let sample_from_uniform_distribution (randomness: t_Array u8 (sz 840))
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+let sample_from_uniform_distribution (randomness: t_Array u8 (sz 840)) =
   let (sampled_coefficients: usize):usize = sz 0 in
   let (out: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement):Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
   =

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Sampling.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Sampling.fsti
@@ -1,0 +1,79 @@
+module Libcrux.Kem.Kyber.Sampling
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val rejection_sampling_panic_with_diagnostic: Prims.unit
+  -> Prims.Pure Prims.unit Prims.l_True (fun _ -> Prims.l_True)
+
+val sample_from_binomial_distribution_2_ (randomness: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      (requires (Core.Slice.impl__len randomness <: usize) =. (sz 2 *! sz 64 <: usize))
+      (ensures
+        fun result ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result
+                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                              i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <=.
+                      2l
+                      <:
+                      bool)
+                <:
+                bool))
+
+val sample_from_binomial_distribution_3_ (randomness: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      (requires (Core.Slice.impl__len randomness <: usize) =. (sz 3 *! sz 64 <: usize))
+      (ensures
+        fun result ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result
+                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                              i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <=.
+                      3l
+                      <:
+                      bool)
+                <:
+                bool))
+
+val sample_from_binomial_distribution (v_ETA: usize) (randomness: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val sample_from_uniform_distribution (randomness: t_Array u8 (sz 840))
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Serialize.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Serialize.fst
@@ -3,8 +3,7 @@ module Libcrux.Kem.Kyber.Serialize
 open Core
 open FStar.Mul
 
-let compress_coefficients_10_ (coefficient1 coefficient2 coefficient3 coefficient4: i32)
-    : (u8 & u8 & u8 & u8 & u8) =
+let compress_coefficients_10_ (coefficient1 coefficient2 coefficient3 coefficient4: i32) =
   let coef1:u8 = cast (coefficient1 &. 255l <: i32) <: u8 in
   let coef2:u8 =
     ((cast (coefficient2 &. 63l <: i32) <: u8) <<! 2l <: u8) |.
@@ -24,7 +23,7 @@ let compress_coefficients_10_ (coefficient1 coefficient2 coefficient3 coefficien
 let compress_coefficients_11_
       (coefficient1 coefficient2 coefficient3 coefficient4 coefficient5 coefficient6 coefficient7 coefficient8:
           i32)
-    : (u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8) =
+     =
   let coef1:u8 = cast (coefficient1 <: i32) <: u8 in
   let coef2:u8 =
     ((cast (coefficient2 &. 31l <: i32) <: u8) <<! 3l <: u8) |.
@@ -61,7 +60,7 @@ let compress_coefficients_11_
   <:
   (u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8)
 
-let compress_coefficients_3_ (coefficient1 coefficient2: u16) : (u8 & u8 & u8) =
+let compress_coefficients_3_ (coefficient1 coefficient2: u16) =
   let coef1:u8 = cast (coefficient1 &. 255us <: u16) <: u8 in
   let coef2:u8 =
     cast ((coefficient1 >>! 8l <: u16) |. ((coefficient2 &. 15us <: u16) <<! 4l <: u16) <: u16)
@@ -74,7 +73,7 @@ let compress_coefficients_3_ (coefficient1 coefficient2: u16) : (u8 & u8 & u8) =
 let compress_coefficients_5_
       (coefficient2 coefficient1 coefficient4 coefficient3 coefficient5 coefficient7 coefficient6 coefficient8:
           u8)
-    : (u8 & u8 & u8 & u8 & u8) =
+     =
   let coef1:u8 = ((coefficient2 &. 7uy <: u8) <<! 5l <: u8) |. coefficient1 in
   let coef2:u8 =
     (((coefficient4 &. 1uy <: u8) <<! 7l <: u8) |. (coefficient3 <<! 2l <: u8) <: u8) |.
@@ -88,7 +87,7 @@ let compress_coefficients_5_
   let coef5:u8 = (coefficient8 <<! 3l <: u8) |. (coefficient7 >>! 2l <: u8) in
   coef1, coef2, coef3, coef4, coef5 <: (u8 & u8 & u8 & u8 & u8)
 
-let decompress_coefficients_10_ (byte2 byte1 byte3 byte4 byte5: i32) : (i32 & i32 & i32 & i32) =
+let decompress_coefficients_10_ (byte2 byte1 byte3 byte4 byte5: i32) =
   let coefficient1:i32 = ((byte2 &. 3l <: i32) <<! 8l <: i32) |. (byte1 &. 255l <: i32) in
   let coefficient2:i32 = ((byte3 &. 15l <: i32) <<! 6l <: i32) |. (byte2 >>! 2l <: i32) in
   let coefficient3:i32 = ((byte4 &. 63l <: i32) <<! 4l <: i32) |. (byte3 >>! 4l <: i32) in
@@ -97,7 +96,7 @@ let decompress_coefficients_10_ (byte2 byte1 byte3 byte4 byte5: i32) : (i32 & i3
 
 let decompress_coefficients_11_
       (byte2 byte1 byte3 byte5 byte4 byte6 byte7 byte9 byte8 byte10 byte11: i32)
-    : (i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32) =
+     =
   let coefficient1:i32 = ((byte2 &. 7l <: i32) <<! 8l <: i32) |. byte1 in
   let coefficient2:i32 = ((byte3 &. 63l <: i32) <<! 5l <: i32) |. (byte2 >>! 3l <: i32) in
   let coefficient3:i32 =
@@ -121,13 +120,12 @@ let decompress_coefficients_11_
   <:
   (i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32)
 
-let decompress_coefficients_4_ (byte: u8) : (i32 & i32) =
+let decompress_coefficients_4_ (byte: u8) =
   let coefficient1:i32 = cast (byte &. 15uy <: u8) <: i32 in
   let coefficient2:i32 = cast ((byte >>! 4l <: u8) &. 15uy <: u8) <: i32 in
   coefficient1, coefficient2 <: (i32 & i32)
 
-let decompress_coefficients_5_ (byte1 byte2 byte3 byte4 byte5: i32)
-    : (i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32) =
+let decompress_coefficients_5_ (byte1 byte2 byte3 byte4 byte5: i32) =
   let coefficient1:i32 = byte1 &. 31l in
   let coefficient2:i32 = ((byte2 &. 3l <: i32) <<! 3l <: i32) |. (byte1 >>! 5l <: i32) in
   let coefficient3:i32 = (byte2 >>! 2l <: i32) &. 31l in
@@ -150,7 +148,7 @@ let decompress_coefficients_5_ (byte1 byte2 byte3 byte4 byte5: i32)
 let compress_then_serialize_10_
       (v_OUT_LEN: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : t_Array u8 v_OUT_LEN =
+     =
   let serialized:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
   let serialized:t_Array u8 v_OUT_LEN =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
@@ -232,7 +230,7 @@ let compress_then_serialize_10_
 let compress_then_serialize_11_
       (v_OUT_LEN: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : t_Array u8 v_OUT_LEN =
+     =
   let serialized:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
   let serialized:t_Array u8 v_OUT_LEN =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
@@ -388,7 +386,7 @@ let compress_then_serialize_11_
 let compress_then_serialize_4_
       (v_OUT_LEN: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : t_Array u8 v_OUT_LEN =
+     =
   let serialized:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
   let serialized:t_Array u8 v_OUT_LEN =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
@@ -443,7 +441,7 @@ let compress_then_serialize_4_
 let compress_then_serialize_5_
       (v_OUT_LEN: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : t_Array u8 v_OUT_LEN =
+     =
   let serialized:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
   let serialized:t_Array u8 v_OUT_LEN =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
@@ -597,8 +595,7 @@ let compress_then_serialize_5_
   in
   serialized
 
-let compress_then_serialize_message (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : t_Array u8 (sz 32) =
+let compress_then_serialize_message (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
   let serialized:t_Array u8 (sz 32) = Rust_primitives.Hax.repeat 0uy (sz 32) in
   let serialized:t_Array u8 (sz 32) =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
@@ -644,7 +641,7 @@ let compress_then_serialize_message (re: Libcrux.Kem.Kyber.Arithmetic.t_Polynomi
 let compress_then_serialize_ring_element_u
       (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : t_Array u8 v_OUT_LEN =
+     =
   let _:Prims.unit = () <: Prims.unit in
   match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
   | 10ul -> compress_then_serialize_10_ v_OUT_LEN re
@@ -658,7 +655,7 @@ let compress_then_serialize_ring_element_u
 let compress_then_serialize_ring_element_v
       (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : t_Array u8 v_OUT_LEN =
+     =
   let _:Prims.unit = () <: Prims.unit in
   match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
   | 4ul -> compress_then_serialize_4_ v_OUT_LEN re
@@ -669,8 +666,7 @@ let compress_then_serialize_ring_element_v
         <:
         Rust_primitives.Hax.t_Never)
 
-let deserialize_then_decompress_10_ (serialized: t_Slice u8)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+let deserialize_then_decompress_10_ (serialized: t_Slice u8) =
   let _:Prims.unit = () <: Prims.unit in
   let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
@@ -758,8 +754,7 @@ let deserialize_then_decompress_10_ (serialized: t_Slice u8)
   in
   re
 
-let deserialize_then_decompress_11_ (serialized: t_Slice u8)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+let deserialize_then_decompress_11_ (serialized: t_Slice u8) =
   let _:Prims.unit = () <: Prims.unit in
   let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
@@ -922,8 +917,7 @@ let deserialize_then_decompress_11_ (serialized: t_Slice u8)
   in
   re
 
-let deserialize_then_decompress_4_ (serialized: t_Slice u8)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+let deserialize_then_decompress_4_ (serialized: t_Slice u8) =
   let _:Prims.unit = () <: Prims.unit in
   let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
@@ -974,8 +968,7 @@ let deserialize_then_decompress_4_ (serialized: t_Slice u8)
   in
   re
 
-let deserialize_then_decompress_5_ (serialized: t_Slice u8)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+let deserialize_then_decompress_5_ (serialized: t_Slice u8) =
   let _:Prims.unit = () <: Prims.unit in
   let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
@@ -1131,8 +1124,7 @@ let deserialize_then_decompress_5_ (serialized: t_Slice u8)
   in
   re
 
-let deserialize_then_decompress_message (serialized: t_Array u8 (sz 32))
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+let deserialize_then_decompress_message (serialized: t_Array u8 (sz 32)) =
   let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
   in
@@ -1187,7 +1179,7 @@ let deserialize_then_decompress_message (serialized: t_Array u8 (sz 32))
 let deserialize_then_decompress_ring_element_u
       (v_COMPRESSION_FACTOR: usize)
       (serialized: t_Slice u8)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+     =
   let _:Prims.unit = () <: Prims.unit in
   match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
   | 10ul -> deserialize_then_decompress_10_ serialized
@@ -1201,7 +1193,7 @@ let deserialize_then_decompress_ring_element_u
 let deserialize_then_decompress_ring_element_v
       (v_COMPRESSION_FACTOR: usize)
       (serialized: t_Slice u8)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+     =
   let _:Prims.unit = () <: Prims.unit in
   match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
   | 4ul -> deserialize_then_decompress_4_ serialized
@@ -1212,8 +1204,7 @@ let deserialize_then_decompress_ring_element_v
         <:
         Rust_primitives.Hax.t_Never)
 
-let deserialize_to_uncompressed_ring_element (serialized: t_Slice u8)
-    : Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+let deserialize_to_uncompressed_ring_element (serialized: t_Slice u8) =
   let _:Prims.unit = () <: Prims.unit in
   let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
     Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
@@ -1262,8 +1253,7 @@ let deserialize_to_uncompressed_ring_element (serialized: t_Slice u8)
   in
   re
 
-let serialize_uncompressed_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
-    : t_Array u8 (sz 384) =
+let serialize_uncompressed_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
   let serialized:t_Array u8 (sz 384) = Rust_primitives.Hax.repeat 0uy (sz 384) in
   let serialized:t_Array u8 (sz 384) =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Serialize.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Serialize.fsti
@@ -1,0 +1,119 @@
+module Libcrux.Kem.Kyber.Serialize
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val compress_coefficients_10_ (coefficient1 coefficient2 coefficient3 coefficient4: i32)
+    : Prims.Pure (u8 & u8 & u8 & u8 & u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_coefficients_11_
+      (coefficient1 coefficient2 coefficient3 coefficient4 coefficient5 coefficient6 coefficient7 coefficient8:
+          i32)
+    : Prims.Pure (u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compress_coefficients_3_ (coefficient1 coefficient2: u16)
+    : Prims.Pure (u8 & u8 & u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_coefficients_5_
+      (coefficient2 coefficient1 coefficient4 coefficient3 coefficient5 coefficient7 coefficient6 coefficient8:
+          u8)
+    : Prims.Pure (u8 & u8 & u8 & u8 & u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val decompress_coefficients_10_ (byte2 byte1 byte3 byte4 byte5: i32)
+    : Prims.Pure (i32 & i32 & i32 & i32) Prims.l_True (fun _ -> Prims.l_True)
+
+val decompress_coefficients_11_
+      (byte2 byte1 byte3 byte5 byte4 byte6 byte7 byte9 byte8 byte10 byte11: i32)
+    : Prims.Pure (i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val decompress_coefficients_4_ (byte: u8)
+    : Prims.Pure (i32 & i32) Prims.l_True (fun _ -> Prims.l_True)
+
+val decompress_coefficients_5_ (byte1 byte2 byte3 byte4 byte5: i32)
+    : Prims.Pure (i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compress_then_serialize_10_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_11_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_4_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_5_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_message (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_ring_element_u
+      (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_ring_element_v
+      (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_10_ (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_11_ (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_4_ (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_5_ (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_message (serialized: t_Array u8 (sz 32))
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_ring_element_u
+      (v_COMPRESSION_FACTOR: usize)
+      (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_ring_element_v
+      (v_COMPRESSION_FACTOR: usize)
+      (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_to_uncompressed_ring_element (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val serialize_uncompressed_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 (sz 384)) Prims.l_True (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.fst
@@ -3,17 +3,10 @@ module Libcrux.Kem.Kyber
 open Core
 open FStar.Mul
 
-unfold
-let t_KyberSharedSecret = t_Array u8 (sz 32)
-
-let v_KEY_GENERATION_SEED_SIZE: usize =
-  Libcrux.Kem.Kyber.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE +!
-  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
-
 let serialize_kem_secret_key
       (v_SERIALIZED_KEY_LEN: usize)
       (private_key public_key implicit_rejection_value: t_Slice u8)
-    : t_Array u8 v_SERIALIZED_KEY_LEN =
+     =
   let out:t_Array u8 v_SERIALIZED_KEY_LEN = Rust_primitives.Hax.repeat 0uy v_SERIALIZED_KEY_LEN in
   let pointer:usize = sz 0 in
   let out:t_Array u8 v_SERIALIZED_KEY_LEN =
@@ -120,7 +113,7 @@ let decapsulate
           usize)
       (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey v_SECRET_KEY_SIZE)
       (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext v_CIPHERTEXT_SIZE)
-    : t_Array u8 (sz 32) =
+     =
   let ind_cpa_secret_key, secret_key:(t_Slice u8 & t_Slice u8) =
     Libcrux.Kem.Kyber.Types.impl_12__split_at v_SECRET_KEY_SIZE secret_key v_CPA_SECRET_KEY_SIZE
   in
@@ -210,7 +203,7 @@ let encapsulate
           usize)
       (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey v_PUBLIC_KEY_SIZE)
       (randomness: t_Array u8 (sz 32))
-    : (Libcrux.Kem.Kyber.Types.t_KyberCiphertext v_CIPHERTEXT_SIZE & t_Array u8 (sz 32)) =
+     =
   let (to_hash: t_Array u8 (sz 64)):t_Array u8 (sz 64) =
     Libcrux.Kem.Kyber.Ind_cpa.into_padded_array (sz 64)
       (Rust_primitives.unsize randomness <: t_Slice u8)
@@ -275,7 +268,7 @@ let generate_keypair
       (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
           usize)
       (randomness: t_Array u8 (sz 64))
-    : Libcrux.Kem.Kyber.Types.t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE =
+     =
   let ind_cpa_keypair_randomness:t_Slice u8 =
     randomness.[ {
         Core.Ops.Range.f_start = sz 0;

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.fsti
@@ -1,0 +1,40 @@
+module Libcrux.Kem.Kyber
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+unfold
+let t_KyberSharedSecret = t_Array u8 (sz 32)
+
+let v_KEY_GENERATION_SEED_SIZE: usize =
+  Libcrux.Kem.Kyber.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE +!
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+
+val serialize_kem_secret_key
+      (v_SERIALIZED_KEY_LEN: usize)
+      (private_key public_key implicit_rejection_value: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_SERIALIZED_KEY_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val decapsulate
+      (v_K v_SECRET_KEY_SIZE v_CPA_SECRET_KEY_SIZE v_PUBLIC_KEY_SIZE v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_C1_BLOCK_SIZE v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE v_IMPLICIT_REJECTION_HASH_INPUT_SIZE:
+          usize)
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey v_SECRET_KEY_SIZE)
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext v_CIPHERTEXT_SIZE)
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encapsulate
+      (v_K v_CIPHERTEXT_SIZE v_PUBLIC_KEY_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_VECTOR_U_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+          usize)
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey v_PUBLIC_KEY_SIZE)
+      (randomness: t_Array u8 (sz 32))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberCiphertext v_CIPHERTEXT_SIZE & t_Array u8 (sz 32))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_keypair
+      (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+          usize)
+      (randomness: t_Array u8 (sz 64))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
+      Prims.l_True
+      (fun _ -> Prims.l_True)


### PR DESCRIPTION
This PR enables the `--interfaces` option to `cargo hax` and refreshes the extraction of Kyber