### PR TITLE
Secret independence for Kyber

### DIFF
--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst
@@ -78,7 +78,7 @@ let shr_i32_b #b #t x y =
         r <: i32_b (nat_div_ceil b (pow2 (v y))))
 #pop-options
 
-let v_BARRETT_R: i64 = 1L <<! v_BARRETT_SHIFT
+let v_BARRETT_R: i64 = (1L <<! v_BARRETT_SHIFT)
 let v_MONTGOMERY_R: i32 = 1l <<! v_MONTGOMERY_SHIFT
 let v_MONTGOMERY_R_INV = 
   assert_norm((v 169l * pow2 16) % 3329 == 1);

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti
@@ -17,7 +17,7 @@ val add_i32_b (#b1:nat) (#b2:nat{b1 + b2 < pow2_31}) (x:i32_b b1) (y: i32_b b2):
   (ensures fun r -> v r == v x + v y)
 val sub_i32_b (#b1:nat) (#b2:nat{b1 + b2 < pow2_31}) (x:i32_b b1) (y: i32_b b2): r:i32_b (b1 + b2){v r == v x - v y}
 val cast_i32_b (#b1:nat) (#b2:nat{b1 <= b2 /\ b2 < pow2_31}) (x:i32_b b1): r:i32_b b2{v r == v x}
-val shr_i32_b (#b:nat) (#t:inttype) (x:i32_b b) (y:int_t t{v y>0 /\ v y<32}): r:i32_b (nat_div_ceil b (pow2 (v y)))
+val shr_i32_b (#b:nat) (#t:inttype) (x:i32_b b) (y:pub_int_t t{v y>0 /\ v y<32}): r:i32_b (nat_div_ceil b (pow2 (v y)))
 
 unfold
 let t_FieldElement = i32
@@ -36,7 +36,7 @@ let t_MontgomeryFieldElement = i32
 
 let v_BARRETT_MULTIPLIER: i64 = 20159L
 
-let v_BARRETT_SHIFT: i64 = 26L
+let v_BARRETT_SHIFT: pub_i64 = 26L
 
 val v_BARRETT_R: x:i64{v x = pow2 26 /\ x = 67108864L}
 
@@ -44,7 +44,7 @@ let v_INVERSE_OF_MODULUS_MOD_R: u32 = 62209ul
 
 let v_MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS: i32 = 1353l
 
-let v_MONTGOMERY_SHIFT: u8 = 16uy
+let v_MONTGOMERY_SHIFT: pub_u8 = 16uy
 
 val v_MONTGOMERY_R: x:i32{v x = pow2 16 /\ x = 65536l}
 
@@ -66,7 +66,7 @@ let to_spec_fe_b #b (m:i32_b b) : Spec.Kyber.field_element = to_spec_fe m
 let mont_to_spec_fe (m:t_FieldElement) : Spec.Kyber.field_element =
     int_to_spec_fe (v m * v v_MONTGOMERY_R_INV)
 
-val get_n_least_significant_bits (n: u8 {v n > 0 /\ v n < 32}) (value: u32)
+val get_n_least_significant_bits (n: pub_u8 {v n > 0 /\ v n < 32}) (value: u32)
     : Prims.Pure (int_t_d u32_inttype (v n))
       (requires v n < 32)
       (ensures
@@ -123,8 +123,8 @@ val to_unsigned_representative (fe: wfFieldElement)
         fun result ->
           let result:u16 = result in
           v result == to_spec_fe fe /\
-          result >=. 0us &&
-          result <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+          v result >= 0 &&
+          v result < v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
 
 type t_PolynomialRingElement = { f_coefficients:t_Array (t_FieldElement) (sz 256) }
 

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti
@@ -9,7 +9,6 @@ let i32_range (n:i32) (b:nat) =
 
 type i32_b b = x:i32{i32_range x b}
 let nat_div_ceil (x:nat) (y:pos) : nat = if (x % y = 0) then x/y else (x/y)+1
-//(x + y - 1)/y
 
 val mul_i32_b (#b1:nat) (#b2:nat{b1 * b2 < pow2_31}) (x:i32_b b1) (y: i32_b b2): r:i32_b (b1 * b2){v r == v x * v y}
 val add_i32_b (#b1:nat) (#b2:nat{b1 + b2 < pow2_31}) (x:i32_b b1) (y: i32_b b2): 

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Compress.fst
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Compress.fst
@@ -42,12 +42,11 @@ let compress_ciphertext_coefficient coefficient_bits fe =
   let compressed:u32 =
     compressed +! (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u32)
   in
- (* LEAK: *)
- (*
-  let compressed:u32 =
+  (* Potential Timing Leak: division is not secret indepdnent *)
+(*  let compressed:u32 =
     compressed /! (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <<! 1l <: i32) <: u32)
   in
-  *)
+*)
   let res = cast (Libcrux.Kem.Kyber.Arithmetic.get_n_least_significant_bits coefficient_bits compressed <: u32
     )
   <:

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Compress.fst
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Compress.fst
@@ -38,13 +38,16 @@ let compress_message_coefficient fe =
 let compress_ciphertext_coefficient coefficient_bits fe =
   let _:Prims.unit = () <: Prims.unit in
   let _:Prims.unit = () <: Prims.unit in
-  let compressed:u32 = (cast (fe <: u16) <: u32) <<! (coefficient_bits +! 1uy <: u8) in
+  let compressed:u32 = (cast (fe <: u16) <: u32) <<! (coefficient_bits +! 1uy <: pub_u8) in
   let compressed:u32 =
     compressed +! (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u32)
   in
+ (* LEAK: *)
+ (*
   let compressed:u32 =
     compressed /! (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <<! 1l <: i32) <: u32)
   in
+  *)
   let res = cast (Libcrux.Kem.Kyber.Arithmetic.get_n_least_significant_bits coefficient_bits compressed <: u32
     )
   <:
@@ -61,8 +64,8 @@ let decompress_ciphertext_coefficient coefficient_bits fe =
   let decompressed:u32 =
     (cast (fe <: i32) <: u32) *! (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u32)
   in
-  let decompressed:u32 = (decompressed <<! 1l <: u32) +! (1ul <<! coefficient_bits <: u32) in
-  let decompressed:u32 = decompressed >>! (coefficient_bits +! 1uy <: u8) in
+  let decompressed:u32 = (decompressed <<! 1l <: u32) +! (1ul <<! coefficient_bits <: pub_u32) in
+  let decompressed:u32 = decompressed >>! (coefficient_bits +! 1uy <: pub_u8) in
   let res = cast (decompressed <: u32) <: i32 in
   let res : Libcrux.Kem.Kyber.Arithmetic.i32_b 3328 = res in
   res
@@ -73,7 +76,7 @@ let decompress_message_coefficient fe =
   assert (v ((Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS +! 1l <: i32) /! 2l <: i32) == 1665);
   assert (res == logand #i32_inttype (Core.Ops.Arith.Neg.neg fe) 1665l);
   assert (v fe == 0 ==> Core.Ops.Arith.Neg.neg fe = zero);
-  logand_lemma 1665l zero;
+  logand_lemma 1665l (zero #i32_inttype #Lib.IntTypes.SEC);
   assert (v fe == 0 ==> res == zero);
   res <: Libcrux.Kem.Kyber.Arithmetic.i32_b 3328
 #pop-options

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Compress.fsti
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Compress.fsti
@@ -14,29 +14,29 @@ val compress_message_coefficient (fe: u16)
           else result =. 0uy)
 
 
-val compress_ciphertext_coefficient (coefficient_bits: u8 {v coefficient_bits > 0 /\ v coefficient_bits <= 32}) (fe: u16)
+val compress_ciphertext_coefficient (coefficient_bits: pub_u8 {v coefficient_bits > 0 /\ v coefficient_bits <= 32}) (fe: u16)
     : Prims.Pure (int_t_d i32_inttype (v coefficient_bits))
       (requires
         (coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy ||
         coefficient_bits =. 11uy) &&
-        fe <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+        v fe < (v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS))
       (ensures
         fun result ->
           let result:i32 = result in
-          result >=. 0l &&
-          result <. (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32))
+          v result >= 0 &&
+          v result < pow2 (v coefficient_bits))
 
 open Rust_primitives.Integers
 
 val decompress_ciphertext_coefficient
-    (coefficient_bits: u8 {coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy || coefficient_bits =. 11uy})
+    (coefficient_bits: pub_u8 {coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy || coefficient_bits =. 11uy})
     (fe: int_t_d i32_inttype (v coefficient_bits))
     : Prims.Pure (Libcrux.Kem.Kyber.Arithmetic.i32_b (v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS - 1))
       (requires True)
       (ensures
         fun result ->
           let result:i32 = result in
-          result <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
+          v result < v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
 
 val decompress_message_coefficient (fe: i32)
     : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.wfFieldElement

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst
@@ -13,7 +13,7 @@ let is_non_zero (value: u8) =
     lognot_lemma value;
     assert((~.value +. 1us) == zero);
     assert((Core.Num.impl__u16__wrapping_add (~.value <: u16) 1us <: u16) == zero);
-    logor_lemma value zero;
+    logor_lemma value (zero #u16_inttype #Lib.IntTypes.SEC);
     assert((value |. (Core.Num.impl__u16__wrapping_add (~.value <: u16) 1us <: u16) <: u16) == value);
     assert (v result == v ((value >>! 8l)));
     assert ((v value / pow2 8) == 0);
@@ -141,8 +141,8 @@ let select_shared_secret_in_constant_time (lhs rhs: t_Slice u8) (selector: u8) =
             assert (((lhs.[ i ] <: u8) &. mask <: u8) == zero);
             logand_lemma (rhs.[ i ] <: u8) (~.mask);
             assert (((rhs.[ i ] <: u8) &. (~.mask <: u8) <: u8) == (rhs.[ i ] <: u8));
-            logor_lemma (rhs.[ i ] <: u8) zero;
-            assert ((logor zero (rhs.[ i ] <: u8)) == (rhs.[ i ] <: u8));
+            logor_lemma (rhs.[ i ] <: u8) (zero #u8_inttype #Lib.IntTypes.SEC);
+            assert ((logor (zero #u8_inttype #Lib.IntTypes.SEC) (rhs.[ i ] <: u8)) == (rhs.[ i ] <: u8));
             assert ((((lhs.[ i ] <: u8) &. mask <: u8) |. ((rhs.[ i ] <: u8) &. (~.mask <: u8) <: u8)) == (rhs.[ i ] <: u8));
             logor_lemma (out.[ i ] <: u8) (rhs.[ i ] <: u8);
             assert (((out.[ i ] <: u8) |. (((lhs.[ i ] <: u8) &. mask <: u8) |. ((rhs.[ i ] <: u8) &. (~.mask <: u8) <: u8) <: u8) <: u8) == (rhs.[ i ] <: u8));

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti
@@ -25,14 +25,8 @@ val compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_
       (ensures
         fun result ->
           let result:u8 = result in
-          Hax_lib.implies (lhs =. rhs <: bool)
-            (fun temp_0_ ->
-                let _:Prims.unit = temp_0_ in
-                result =. 0uy <: bool) &&
-          Hax_lib.implies (lhs <>. rhs <: bool)
-            (fun temp_0_ ->
-                let _:Prims.unit = temp_0_ in
-                result =. 1uy <: bool))
+          (lhs == rhs ==> v result = 0) /\
+          (lhs =!= rhs ==> v result = 1))
 
 val select_shared_secret_in_constant_time (lhs rhs: t_Slice u8) (selector: u8)
     : Prims.Pure (t_Array u8 (sz 32))
@@ -41,5 +35,5 @@ val select_shared_secret_in_constant_time (lhs rhs: t_Slice u8) (selector: u8)
       (ensures
         fun result ->
           let result:t_Array u8 (sz 32) = result in
-          Hax_lib.implies (selector =. 0uy <: bool) (fun _ -> result =. lhs <: bool) &&
-          Hax_lib.implies (selector <>. 0uy <: bool) (fun _ -> result =. rhs <: bool))
+          (v selector == 0) ==> (result == lhs) /\
+          (v selector =!= 0) ==> (result == rhs))

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst
@@ -28,7 +28,7 @@ let v_XOFx4 (v_K: usize) (input: t_Array (t_Array u8 (sz 34)) v_K) =
       Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
                 Core.Ops.Range.f_start = sz 0;
                 Core.Ops.Range.f_end = v_K
-              }
+                }
               <:
               Core.Ops.Range.t_Range usize)
           <:
@@ -47,7 +47,7 @@ let v_XOFx4 (v_K: usize) (input: t_Array (t_Array u8 (sz 34)) v_K) =
             t_Array (t_Array u8 (sz 840)) v_K)
     else
       let out:t_Array (t_Array u8 (sz 840)) v_K =
-        match cast (v_K <: usize) <: u8 with
+        match cast (v_K <: usize) <: pub_int_t u8_inttype with
         | 2uy ->
           let d0, d1, _, _:(t_Array u8 (sz 840) & t_Array u8 (sz 840) & t_Array u8 (sz 840) &
             t_Array u8 (sz 840)) =

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Matrix.fst
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Matrix.fst
@@ -451,7 +451,7 @@ let sample_matrix_A (v_K: usize) (seed: t_Array u8 (sz 34)) (transpose: bool) =
                             <:
                             t_Array u8 (sz 34))
                           (sz 32)
-                          (cast (i <: usize) <: u8)
+                          (classify (cast (i <: usize) <: pub_u8))
                         <:
                         t_Array u8 (sz 34))
                   in
@@ -462,7 +462,7 @@ let sample_matrix_A (v_K: usize) (seed: t_Array u8 (sz 34)) (transpose: bool) =
                             <:
                             t_Array u8 (sz 34))
                           (sz 33)
-                          (cast (j <: usize) <: u8)
+                          (classify (cast (j <: usize) <: pub_u8))
                         <:
                         t_Array u8 (sz 34))
                   in

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Ntt.fst
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Ntt.fst
@@ -366,7 +366,8 @@ let ntt_at_layer_3328_ zeta_i re layer =
   let hax_temp_output = out in
   zeta_i, hax_temp_output
 
-#push-options "--ifuel 0 --z3rlimit 900"
+#push-options "--ifuel 0 --z3rlimit 1500"
+#restart-solver
 let ntt_binomially_sampled_ring_element re =
   let _:Prims.unit = () <: Prims.unit in
   let zeta_i:usize = sz 1 in
@@ -475,6 +476,7 @@ let ntt_binomially_sampled_ring_element re =
   let re:Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement = down_cast_poly_b #(6*3328+11207) #3328 re in
   re 
 #pop-options
+
 
 #push-options "--z3rlimit 100"
 let ntt_multiply lhs rhs =

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Sampling.fst
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Sampling.fst
@@ -56,17 +56,17 @@ let sample_from_binomial_distribution_2_ (randomness: t_Slice u8) =
                         Core.Ops.Range.f_end = Core.Num.impl__u32__BITS
                         }
                         <:
-                        Core.Ops.Range.t_Range u32)
+                        Core.Ops.Range.t_Range pub_u32)
             (sz 4)
             sampled
             (fun sampled outcome_set ->
-                let outcome_set:u32 = outcome_set in
+                let outcome_set:pub_u32 = outcome_set in
                 assert (v outcome_set + 4 <= 32);
                 let out_1 = ((coin_toss_outcomes >>! outcome_set <: u32) &. 3ul <: u32) in
                 let outcome_1_:i32 =
                   cast out_1  <: i32
                 in
-                let out_2 = ((coin_toss_outcomes >>! (outcome_set +! 2ul <: u32) <: u32) &. 3ul <: u32) in
+                let out_2 = ((coin_toss_outcomes >>! (outcome_set +! 2ul <: pub_u32) <: u32) &. 3ul <: u32) in
                 let outcome_2_:i32 =
                   cast out_2  <: i32
                 in
@@ -77,14 +77,14 @@ let sample_from_binomial_distribution_2_ (randomness: t_Slice u8) =
                 Math.Lemmas.small_modulo_lemma_1 (v out_1) (pow2 32);
                 assert (v outcome_1_ == v out_1);
                 assert (v outcome_1_ >= 0 /\ v outcome_1_ <= 3);
-                logand_lemma (coin_toss_outcomes >>! (outcome_set +! 2ul <: u32) <: u32) 3ul;
+                logand_lemma (coin_toss_outcomes >>! (outcome_set +! 2ul <: pub_u32) <: u32) 3ul;
                 assert (v out_2 >= 0);
                 assert (v out_2 <= 3);
                 assert (v outcome_2_ == v out_2 @% pow2 32);
                 Math.Lemmas.small_modulo_lemma_1 (v out_2) (pow2 32);
                 assert (v outcome_2_ == v out_2);
                 assert (v outcome_2_ >= 0 /\ v outcome_2_ <= 3);
-                let offset:usize = cast (outcome_set >>! 2l <: u32) <: usize in
+                let offset:usize = cast (outcome_set >>! 2l <: pub_u32) <: usize in
                 assert (outcome_set <. 32ul);
                 assert (v (outcome_set >>! 2l <: u32) = v outcome_set / 4);
                 assert (v (outcome_set >>! 2l <: u32) < 8);
@@ -159,27 +159,27 @@ let sample_from_binomial_distribution_3_ (randomness: t_Slice u8) =
                         Core.Ops.Range.f_end = 24l
                         }
                         <:
-                        Core.Ops.Range.t_Range i32)
+                        Core.Ops.Range.t_Range pub_i32)
             (sz 6)
             sampled
             (fun sampled outcome_set ->
                 let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement_b 7 = sampled in
-                let outcome_set:i32 = outcome_set in
+                let outcome_set:pub_i32 = outcome_set in
                 let outcome_1_:i32 =
                   cast ((coin_toss_outcomes >>! outcome_set <: u32) &. 7ul <: u32) <: i32
                 in
                 let outcome_2_:i32 =
-                  cast ((coin_toss_outcomes >>! (outcome_set +! 3l <: i32) <: u32) &. 7ul <: u32)
+                  cast ((coin_toss_outcomes >>! (outcome_set +! 3l <: pub_i32) <: u32) &. 7ul <: u32)
                   <:
                   i32
                 in
                 logand_lemma (coin_toss_outcomes >>! outcome_set <: u32) 7ul;
-                Math.Lemmas.small_modulo_lemma_1 (v ((coin_toss_outcomes >>! outcome_set <: u32) &. 7ul <: u32)) (pow2 32);
+                Math.Lemmas.small_modulo_lemma_1 (v ((coin_toss_outcomes >>! outcome_set) &. 7ul <: u32)) (pow2 32);
                 assert (v outcome_1_ >= 0 /\ v outcome_1_ <= 7);
-                logand_lemma (coin_toss_outcomes >>! (outcome_set +! 3l <: i32) <: u32) 7ul;
-                Math.Lemmas.small_modulo_lemma_1 (v ((coin_toss_outcomes >>! (outcome_set +! 3l <: i32) <: u32) &. 7ul <: u32)) (pow2 32);
+                logand_lemma (coin_toss_outcomes >>! (outcome_set +! 3l <: pub_i32) <: u32) 7ul;
+                Math.Lemmas.small_modulo_lemma_1 (v ((coin_toss_outcomes >>! (outcome_set +! 3l <: pub_i32) <: u32) &. 7ul <: u32)) (pow2 32);
                 assert (v outcome_2_ >= 0 /\ v outcome_2_ <= 7);
-                let offset:usize = cast (outcome_set /! 6l <: i32) <: usize in
+                let offset:usize = cast (outcome_set /! 6l <: pub_i32) <: usize in
                 assert (outcome_set <. 24l);
                 assert (v (outcome_set /! 6l <: i32) = v outcome_set / 6);
                 assert (v (outcome_set /! 6l <: i32) < 4);
@@ -211,7 +211,7 @@ let sample_from_binomial_distribution_3_ (randomness: t_Slice u8) =
 let sample_from_binomial_distribution (v_ETA: usize) (randomness: t_Slice u8) =
   let _:Prims.unit = () <: Prims.unit in
   Rust_primitives.Integers.mk_int_equiv_lemma #u32_inttype (v v_ETA);
-  match cast (v_ETA <: usize) <: u32 with
+  match cast (v_ETA <: usize) <: pub_u32 with
   | 2ul -> sample_from_binomial_distribution_2_ randomness
   | 3ul -> sample_from_binomial_distribution_3_ randomness
   | _ ->
@@ -259,7 +259,6 @@ let sample_from_uniform_distribution (randomness: t_Array u8 (sz 840)) =
             let d1:i32 = ((b2 &. 15l <: i32) <<! 8l <: i32) |. b1 in
             assert (15 = pow2 4 - 1);
             mk_int_equiv_lemma #i32_inttype 15;
-            assert (15l = mk_int (pow2 4) -! mk_int 1);
             logand_mask_lemma b2 4;
             assert (v ((b2 &. 15l <: i32) <<! 8l <: i32) == (v b2 % 16) * pow2 8);
             logor_lemma ((b2 &. 15l <: i32) <<! 8l <: i32) b1;
@@ -272,7 +271,7 @@ let sample_from_uniform_distribution (randomness: t_Array u8 (sz 840)) =
             let out, sampled_coefficients:(Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement &
               usize) =
               if
-                d1 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &&
+                (* LEAK d1 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS && *)
                 sampled_coefficients <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
               then
                 let out:Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement =
@@ -299,7 +298,7 @@ let sample_from_uniform_distribution (randomness: t_Array u8 (sz 840)) =
             let out, sampled_coefficients:(Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement &
               usize) =
               if
-                d2 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &&
+               (* LEAK d2 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS && *)
                 sampled_coefficients <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
               then
                 let out:Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement =

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Serialize.PartB.fst
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.Serialize.PartB.fst
@@ -526,11 +526,11 @@ let compress_then_serialize_ring_element_u #p
       (re: Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement) =
   let _:Prims.unit = () <: Prims.unit in
   assert (
-    (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 11) \/
-    (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 10)
+    (v (cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32) == 11) \/
+    (v (cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32) == 10)
   );
   Rust_primitives.Integers.mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR);
-  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  match cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32 with
   | 10ul -> compress_then_serialize_10_ v_OUT_LEN re
   | 11ul -> compress_then_serialize_11_ v_OUT_LEN re
   | _ ->
@@ -543,10 +543,10 @@ let compress_then_serialize_ring_element_v #p v_COMPRESSION_FACTOR v_OUT_LEN re 
   Rust_primitives.Integers.mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR);
   let res = 
   assert (
-    (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 4) \/
-    (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 5)
+    (v (cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32) == 4) \/
+    (v (cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32) == 5)
   );
-  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  match cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32 with
   | 4ul -> compress_then_serialize_4_ v_OUT_LEN re
   | 5ul -> compress_then_serialize_5_ v_OUT_LEN re
   | _ ->
@@ -1069,8 +1069,9 @@ let deserialize_then_decompress_message (serialized: t_Array u8 (sz 32)) =
 let deserialize_then_decompress_ring_element_u v_COMPRESSION_FACTOR serialized = 
   let _:Prims.unit = () <: Prims.unit in
   mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR);
-  assert (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 10 \/ v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 11);
-  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  assert (v (cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32) == 10 \/ 
+          v (cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32) == 11);
+  match cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32 with
   | 10ul -> deserialize_then_decompress_10_ serialized
   | 11ul -> deserialize_then_decompress_11_ serialized
   | _ ->
@@ -1082,9 +1083,10 @@ let deserialize_then_decompress_ring_element_u v_COMPRESSION_FACTOR serialized =
 let deserialize_then_decompress_ring_element_v v_COMPRESSION_FACTOR serialized =
   let _:Prims.unit = () <: Prims.unit in
   mk_int_equiv_lemma #u32_inttype (v v_COMPRESSION_FACTOR);
-  assert (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 4 \/ v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 5);
+  assert (v (cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32) == 4 \/ 
+          v (cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32) == 5);
   let res = 
-  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  match cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32 with
   | 4ul -> deserialize_then_decompress_4_ serialized
   | 5ul -> deserialize_then_decompress_5_ serialized
   | _ ->

--- a/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.fst
+++ b/proofs/fstar/extraction-edited/Libcrux.Kem.Kyber.fst
@@ -3,9 +3,9 @@ module Libcrux.Kem.Kyber
 open Core
 open FStar.Mul
 
-let update_at_range_lemma #n
+let update_at_range_lemma #t
   (s: t_Slice 't)
-  (i: Core.Ops.Range.t_Range (int_t n) {(Core.Ops.Range.impl_index_range_slice 't n).in_range s i}) 
+  (i: Core.Ops.Range.t_Range (pub_int_t t) {(Core.Ops.Range.impl_index_range_slice 't t).in_range s i}) 
   (x: t_Slice 't)
   : Lemma
     (requires (Seq.length x == v i.f_end - v i.f_start))

--- a/proofs/fstar/extraction-edited/Makefile
+++ b/proofs/fstar/extraction-edited/Makefile
@@ -44,6 +44,10 @@ HINT_DIR      ?= .hints
 .PHONY: all verify verify-lax clean
 
 all:
+	@echo "==============================================="
+	@echo "VERIFYING SECRET INDEPENDENCE ONLY"
+	@echo "Run this with the secret_integers branch of hax"
+	@echo "==============================================="
 	rm -f .depend && $(MAKE) .depend
 	$(MAKE) verify
 
@@ -97,8 +101,7 @@ FSTAR_FLAGS = --cmi \
   --warn_error -331 \
   --warn_error -321 \
   --warn_error -274 \
-  --query_stats \
-  --log_queries \
+  --admit_smt_queries true \
   --cache_checked_modules --cache_dir $(CACHE_DIR) \
   --already_cached "+Prims+FStar+LowStar+C+Spec.Loops+TestLib" \
   $(addprefix --include ,$(FSTAR_INCLUDE_DIRS))


### PR DESCRIPTION
This PR adds secret independence proofs on top of the existing proofs for Kyber.

It correctly flags the timing leak in this older version of our code:
https://github.com/cryspen/libcrux/blob/2a3cd5d4b09de1fb214c0ae9c6ee915877794bbc/src/kem/kyber/compress.rs#L59

It also flags potential leaks in these lines:
https://github.com/cryspen/libcrux/blob/ea52806f4961c53f71e819740370f05895ac16e7/src/kem/kyber/sampling.rs#L33

https://github.com/cryspen/libcrux/blob/ea52806f4961c53f71e819740370f05895ac16e7/src/kem/kyber/sampling.rs#L37
