### PR TITLE
Secret Independence for Kyber 

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -80,6 +80,14 @@ jobs:
               PATH="${PATH}:${{ github.workspace }}/fstar/bin" \
               make -C proofs/fstar/extraction-edited
 
+      - name: 🏃 Verify Kyber `extraction-secret-independent` F* code
+        run: |
+          env FSTAR_HOME=${{ github.workspace }}/fstar \
+              HACL_HOME=${{ github.workspace }}/hacl-star \
+              HAX_HOME=${{ github.workspace }}/hax \
+              PATH="${PATH}:${{ github.workspace }}/fstar/bin" \
+              make -C proofs/fstar/extraction-secret-independent
+
       - name: 🏃 Extract the Kyber specification
         run: |
           eval $(opam env)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Digest.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Digest.fsti
@@ -1,0 +1,41 @@
+module Libcrux.Digest
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Rust_primitives
+open Core
+
+type t_Algorithm =
+  | Algorithm_Sha1 : t_Algorithm
+  | Algorithm_Sha224 : t_Algorithm
+  | Algorithm_Sha256 : t_Algorithm
+  | Algorithm_Sha384 : t_Algorithm
+  | Algorithm_Sha512 : t_Algorithm
+  | Algorithm_Blake2s : t_Algorithm
+  | Algorithm_Blake2b : t_Algorithm
+  | Algorithm_Sha3_224_ : t_Algorithm
+  | Algorithm_Sha3_256_ : t_Algorithm
+  | Algorithm_Sha3_384_ : t_Algorithm
+  | Algorithm_Sha3_512_ : t_Algorithm
+
+let digest_size (mode: t_Algorithm) : usize =
+  match mode with
+  | Algorithm_Sha1  -> sz 20
+  | Algorithm_Sha224  -> sz 28
+  | Algorithm_Sha256  -> sz 32
+  | Algorithm_Sha384  -> sz 48
+  | Algorithm_Sha512  -> sz 64
+  | Algorithm_Blake2s  -> sz 32
+  | Algorithm_Blake2b  -> sz 64
+  | Algorithm_Sha3_224_  -> sz 28
+  | Algorithm_Sha3_256_  -> sz 32
+  | Algorithm_Sha3_384_  -> sz 48
+  | Algorithm_Sha3_512_  -> sz 64
+
+val sha3_256_ (payload: t_Slice u8) : t_Array u8 (sz 32)
+
+val sha3_512_ (payload: t_Slice u8) : t_Array u8 (sz 64)
+
+val shake128 (v_LEN: usize) (data: t_Slice u8) : t_Array u8 v_LEN
+
+val shake128x4 (v_LEN: usize) (data0: t_Slice u8) (data1: t_Slice u8) (data2: t_Slice u8) (data3: t_Slice u8): (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
+
+val shake256 (v_LEN: usize) (data: t_Slice u8) : t_Array u8 v_LEN

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fst
@@ -3,7 +3,7 @@ module Libcrux.Kem.Kyber.Arithmetic
 open Core
 open FStar.Mul
 
-let get_n_least_significant_bits (n: u8) (value: u32) =
+let get_n_least_significant_bits (n: pub_u8) (value: u32) =
   let _:Prims.unit = () <: Prims.unit in
   value &. ((1ul <<! n <: u32) -! 1ul <: u32)
 

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fst
@@ -1,0 +1,81 @@
+module Libcrux.Kem.Kyber.Arithmetic
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let get_n_least_significant_bits (n: u8) (value: u32) =
+  let _:Prims.unit = () <: Prims.unit in
+  value &. ((1ul <<! n <: u32) -! 1ul <: u32)
+
+let barrett_reduce (value: i32) =
+  let _:Prims.unit = () <: Prims.unit in
+  let t:i64 =
+    ((Core.Convert.f_from value <: i64) *! v_BARRETT_MULTIPLIER <: i64) +!
+    (v_BARRETT_R >>! 1l <: i64)
+  in
+  let quotient:i32 = cast (t >>! v_BARRETT_SHIFT <: i64) <: i32 in
+  let result:i32 = value -! (quotient *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) in
+  let _:Prims.unit = () <: Prims.unit in
+  result
+
+let montgomery_reduce (value: i32) =
+  let _:i32 = v_MONTGOMERY_R in
+  let _:Prims.unit = () <: Prims.unit in
+  let t:u32 =
+    (get_n_least_significant_bits v_MONTGOMERY_SHIFT (cast (value <: i32) <: u32) <: u32) *!
+    v_INVERSE_OF_MODULUS_MOD_R
+  in
+  let k:i16 = cast (get_n_least_significant_bits v_MONTGOMERY_SHIFT t <: u32) <: i16 in
+  let k_times_modulus:i32 =
+    (cast (k <: i16) <: i32) *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+  in
+  let c:i32 = k_times_modulus >>! v_MONTGOMERY_SHIFT in
+  let value_high:i32 = value >>! v_MONTGOMERY_SHIFT in
+  value_high -! c
+
+let montgomery_multiply_sfe_by_fer (fe fer: i32) = montgomery_reduce (fe *! fer <: i32)
+
+let to_standard_domain (mfe: i32) =
+  montgomery_reduce (mfe *! v_MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS <: i32)
+
+let to_unsigned_representative (fe: i32) =
+  let _:Prims.unit = () <: Prims.unit in
+  cast (fe +! (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &. (fe >>! 31l <: i32) <: i32) <: i32)
+  <:
+  u16
+
+let add_to_ring_element (v_K: usize) (lhs rhs: t_PolynomialRingElement) =
+  let _:Prims.unit = () <: Prims.unit in
+  let _:Prims.unit = () <: Prims.unit in
+  let lhs:t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end
+              =
+              Core.Slice.impl__len (Rust_primitives.unsize lhs.f_coefficients <: t_Slice i32)
+              <:
+              usize
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      lhs
+      (fun lhs i ->
+          let lhs:t_PolynomialRingElement = lhs in
+          let i:usize = i in
+          {
+            lhs with
+            f_coefficients
+            =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize lhs.f_coefficients
+              i
+              ((lhs.f_coefficients.[ i ] <: i32) +! (rhs.f_coefficients.[ i ] <: i32) <: i32)
+            <:
+            t_Array i32 (sz 256)
+          }
+          <:
+          t_PolynomialRingElement)
+  in
+  let _:Prims.unit = () <: Prims.unit in
+  lhs

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fsti
@@ -1,0 +1,134 @@
+module Libcrux.Kem.Kyber.Arithmetic
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+unfold
+let t_FieldElement = i32
+
+unfold
+let t_FieldElementTimesMontgomeryR = i32
+
+unfold
+let t_MontgomeryFieldElement = i32
+
+let v_BARRETT_MULTIPLIER: i64 = 20159L
+
+let v_BARRETT_SHIFT: i64 = 26L
+
+let v_BARRETT_R: i64 = 1L <<! v_BARRETT_SHIFT
+
+let v_INVERSE_OF_MODULUS_MOD_R: u32 = 62209ul
+
+let v_MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS: i32 = 1353l
+
+let v_MONTGOMERY_SHIFT: u8 = 16uy
+
+let v_MONTGOMERY_R: i32 = 1l <<! v_MONTGOMERY_SHIFT
+
+val get_n_least_significant_bits (n: u8) (value: u32)
+    : Prims.Pure u32
+      (requires n =. 4uy || n =. 5uy || n =. 10uy || n =. 11uy || n =. v_MONTGOMERY_SHIFT)
+      (ensures
+        fun result ->
+          let result:u32 = result in
+          result <. (Core.Num.impl__u32__pow 2ul (Core.Convert.f_into n <: u32) <: u32))
+
+val barrett_reduce (value: i32)
+    : Prims.Pure i32
+      (requires
+        (Core.Convert.f_from value <: i64) >. (Core.Ops.Arith.Neg.neg v_BARRETT_R <: i64) &&
+        (Core.Convert.f_from value <: i64) <. v_BARRETT_R)
+      (ensures
+        fun result ->
+          let result:i32 = result in
+          result >. (Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) &&
+          result <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
+
+val montgomery_reduce (value: i32)
+    : Prims.Pure i32
+      (requires
+        value >=.
+        ((Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) *!
+          v_MONTGOMERY_R
+          <:
+          i32) &&
+        value <=. (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS *! v_MONTGOMERY_R <: i32))
+      (ensures
+        fun result ->
+          let result:i32 = result in
+          result >=.
+          ((Core.Ops.Arith.Neg.neg (3l *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: i32
+            ) /!
+            2l
+            <:
+            i32) &&
+          result <=. ((3l *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) /! 2l <: i32))
+
+val montgomery_multiply_sfe_by_fer (fe fer: i32)
+    : Prims.Pure i32 Prims.l_True (fun _ -> Prims.l_True)
+
+val to_standard_domain (mfe: i32) : Prims.Pure i32 Prims.l_True (fun _ -> Prims.l_True)
+
+val to_unsigned_representative (fe: i32)
+    : Prims.Pure u16
+      (requires
+        fe >=. (Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) &&
+        fe <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
+      (ensures
+        fun result ->
+          let result:u16 = result in
+          result >=. 0us &&
+          result <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+
+type t_PolynomialRingElement = { f_coefficients:t_Array i32 (sz 256) }
+
+let impl__PolynomialRingElement__ZERO: t_PolynomialRingElement =
+  { f_coefficients = Rust_primitives.Hax.repeat 0l (sz 256) } <: t_PolynomialRingElement
+
+val add_to_ring_element (v_K: usize) (lhs rhs: t_PolynomialRingElement)
+    : Prims.Pure t_PolynomialRingElement
+      (requires
+        Hax_lib.v_forall (fun i ->
+              let i:usize = i in
+              Hax_lib.implies (i <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+                  <:
+                  bool)
+                (fun temp_0_ ->
+                    let _:Prims.unit = temp_0_ in
+                    ((Core.Num.impl__i32__abs (lhs.f_coefficients.[ i ] <: i32) <: i32) <=.
+                      (((cast (v_K <: usize) <: i32) -! 1l <: i32) *!
+                        Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                        <:
+                        i32)
+                      <:
+                      bool) &&
+                    ((Core.Num.impl__i32__abs (rhs.f_coefficients.[ i ] <: i32) <: i32) <=.
+                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      <:
+                      bool))
+              <:
+              bool))
+      (ensures
+        fun result ->
+          let result:t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.f_coefficients.[ i ] <: i32) <: i32) <=.
+                      ((cast (v_K <: usize) <: i32) *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                        <:
+                        i32)
+                      <:
+                      bool)
+                <:
+                bool))

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fsti
@@ -14,7 +14,7 @@ let t_MontgomeryFieldElement = i32
 
 let v_BARRETT_MULTIPLIER: i64 = 20159L
 
-let v_BARRETT_SHIFT: i64 = 26L
+let v_BARRETT_SHIFT: pub_i64 = 26L
 
 let v_BARRETT_R: i64 = 1L <<! v_BARRETT_SHIFT
 
@@ -22,7 +22,7 @@ let v_INVERSE_OF_MODULUS_MOD_R: u32 = 62209ul
 
 let v_MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS: i32 = 1353l
 
-let v_MONTGOMERY_SHIFT: u8 = 16uy
+let v_MONTGOMERY_SHIFT: pub_u8 = 16uy
 
 let v_MONTGOMERY_R: i32 = 1l <<! v_MONTGOMERY_SHIFT
 
@@ -32,38 +32,38 @@ val get_n_least_significant_bits (n: u8) (value: u32)
       (ensures
         fun result ->
           let result:u32 = result in
-          result <. (Core.Num.impl__u32__pow 2ul (Core.Convert.f_into n <: u32) <: u32))
+          v result < v (Core.Num.impl__u32__pow 2ul (Core.Convert.f_into n <: u32) <: u32))
 
 val barrett_reduce (value: i32)
     : Prims.Pure i32
       (requires
-        (Core.Convert.f_from value <: i64) >. (Core.Ops.Arith.Neg.neg v_BARRETT_R <: i64) &&
-        (Core.Convert.f_from value <: i64) <. v_BARRETT_R)
+        v (Core.Convert.f_from value <: i64) > v (Core.Ops.Arith.Neg.neg v_BARRETT_R <: i64) &&
+        v (Core.Convert.f_from value <: i64) < v v_BARRETT_R)
       (ensures
         fun result ->
           let result:i32 = result in
-          result >. (Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) &&
-          result <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
+          v result > v (Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) &&
+          v result < v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
 
 val montgomery_reduce (value: i32)
     : Prims.Pure i32
       (requires
-        value >=.
-        ((Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) *!
+       v value >=
+       v ((Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) *!
           v_MONTGOMERY_R
           <:
           i32) &&
-        value <=. (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS *! v_MONTGOMERY_R <: i32))
+        v value <= v (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS *! v_MONTGOMERY_R <: i32))
       (ensures
         fun result ->
           let result:i32 = result in
-          result >=.
-          ((Core.Ops.Arith.Neg.neg (3l *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: i32
+          v result >=
+          v ((Core.Ops.Arith.Neg.neg (3l *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: i32
             ) /!
             2l
             <:
             i32) &&
-          result <=. ((3l *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) /! 2l <: i32))
+          v result <= v ((3l *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) /! 2l <: i32))
 
 val montgomery_multiply_sfe_by_fer (fe fer: i32)
     : Prims.Pure i32 Prims.l_True (fun _ -> Prims.l_True)
@@ -73,13 +73,13 @@ val to_standard_domain (mfe: i32) : Prims.Pure i32 Prims.l_True (fun _ -> Prims.
 val to_unsigned_representative (fe: i32)
     : Prims.Pure u16
       (requires
-        fe >=. (Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) &&
-        fe <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
+        v fe >= v (Core.Ops.Arith.Neg.neg Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) &&
+        v fe < v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
       (ensures
         fun result ->
           let result:u16 = result in
-          result >=. 0us &&
-          result <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+          v result >= v 0us &&
+          v result < v (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
 
 type t_PolynomialRingElement = { f_coefficients:t_Array i32 (sz 256) }
 
@@ -96,15 +96,15 @@ val add_to_ring_element (v_K: usize) (lhs rhs: t_PolynomialRingElement)
                   bool)
                 (fun temp_0_ ->
                     let _:Prims.unit = temp_0_ in
-                    ((Core.Num.impl__i32__abs (lhs.f_coefficients.[ i ] <: i32) <: i32) <=.
-                      (((cast (v_K <: usize) <: i32) -! 1l <: i32) *!
+                    (v (Core.Num.impl__i32__abs (lhs.f_coefficients.[ i ] <: i32) <: i32) <=
+                      v (((cast (v_K <: usize) <: pub_i32) -! 1l <: i32) *!
                         Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
                         <:
                         i32)
                       <:
                       bool) &&
-                    ((Core.Num.impl__i32__abs (rhs.f_coefficients.[ i ] <: i32) <: i32) <=.
-                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                    (v (Core.Num.impl__i32__abs (rhs.f_coefficients.[ i ] <: i32) <: i32) <=
+                      v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
                       <:
                       bool))
               <:
@@ -124,8 +124,8 @@ val add_to_ring_element (v_K: usize) (lhs rhs: t_PolynomialRingElement)
                     bool)
                   (fun temp_0_ ->
                       let _:Prims.unit = temp_0_ in
-                      (Core.Num.impl__i32__abs (result.f_coefficients.[ i ] <: i32) <: i32) <=.
-                      ((cast (v_K <: usize) <: i32) *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      v (Core.Num.impl__i32__abs (result.f_coefficients.[ i ] <: i32) <: i32) <=
+                      v ((cast (v_K <: usize) <: pub_i32) *! Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
                         <:
                         i32)
                       <:

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fst
@@ -1,0 +1,39 @@
+module Libcrux.Kem.Kyber.Compress
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let compress_ciphertext_coefficient (coefficient_bits: u8) (fe: u16) =
+  let _:Prims.unit = () <: Prims.unit in
+  let _:Prims.unit = () <: Prims.unit in
+  let compressed:u64 = (cast (fe <: u16) <: u64) <<! coefficient_bits in
+  let compressed:u64 = compressed +! 1664uL in
+  let compressed:u64 = compressed *! 10321340uL in
+  let compressed:u64 = compressed >>! 35l in
+  cast (Libcrux.Kem.Kyber.Arithmetic.get_n_least_significant_bits coefficient_bits
+        (cast (compressed <: u64) <: u32)
+      <:
+      u32)
+  <:
+  i32
+
+let compress_message_coefficient (fe: u16) =
+  let (shifted: i16):i16 = 1664s -! (cast (fe <: u16) <: i16) in
+  let mask:i16 = shifted >>! 15l in
+  let shifted_to_positive:i16 = mask ^. shifted in
+  let shifted_positive_in_range:i16 = shifted_to_positive -! 832s in
+  cast ((shifted_positive_in_range >>! 15l <: i16) &. 1s <: i16) <: u8
+
+let decompress_ciphertext_coefficient (coefficient_bits: u8) (fe: i32) =
+  let _:Prims.unit = () <: Prims.unit in
+  let _:Prims.unit = () <: Prims.unit in
+  let decompressed:u32 =
+    (cast (fe <: i32) <: u32) *! (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u32)
+  in
+  let decompressed:u32 = (decompressed <<! 1l <: u32) +! (1ul <<! coefficient_bits <: u32) in
+  let decompressed:u32 = decompressed >>! (coefficient_bits +! 1uy <: u8) in
+  cast (decompressed <: u32) <: i32
+
+let decompress_message_coefficient (fe: i32) =
+  (Core.Ops.Arith.Neg.neg fe <: i32) &.
+  ((Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS +! 1l <: i32) /! 2l <: i32)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fst
@@ -3,7 +3,7 @@ module Libcrux.Kem.Kyber.Compress
 open Core
 open FStar.Mul
 
-let compress_ciphertext_coefficient (coefficient_bits: u8) (fe: u16) =
+let compress_ciphertext_coefficient (coefficient_bits: pub_u8) (fe: u16) =
   let _:Prims.unit = () <: Prims.unit in
   let _:Prims.unit = () <: Prims.unit in
   let compressed:u64 = (cast (fe <: u16) <: u64) <<! coefficient_bits in
@@ -24,14 +24,14 @@ let compress_message_coefficient (fe: u16) =
   let shifted_positive_in_range:i16 = shifted_to_positive -! 832s in
   cast ((shifted_positive_in_range >>! 15l <: i16) &. 1s <: i16) <: u8
 
-let decompress_ciphertext_coefficient (coefficient_bits: u8) (fe: i32) =
+let decompress_ciphertext_coefficient (coefficient_bits: pub_u8) (fe: i32) =
   let _:Prims.unit = () <: Prims.unit in
   let _:Prims.unit = () <: Prims.unit in
   let decompressed:u32 =
     (cast (fe <: i32) <: u32) *! (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u32)
   in
   let decompressed:u32 = (decompressed <<! 1l <: u32) +! (1ul <<! coefficient_bits <: u32) in
-  let decompressed:u32 = decompressed >>! (coefficient_bits +! 1uy <: u8) in
+  let decompressed:u32 = decompressed >>! (coefficient_bits +! 1uy <: pub_u8) in
   cast (decompressed <: u32) <: i32
 
 let decompress_message_coefficient (fe: i32) =

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fsti
@@ -1,0 +1,46 @@
+module Libcrux.Kem.Kyber.Compress
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val compress_ciphertext_coefficient (coefficient_bits: u8) (fe: u16)
+    : Prims.Pure i32
+      (requires
+        (coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy ||
+        coefficient_bits =. 11uy) &&
+        fe <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+      (ensures
+        fun result ->
+          let result:i32 = result in
+          result >=. 0l &&
+          result <. (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32))
+
+val compress_message_coefficient (fe: u16)
+    : Prims.Pure u8
+      (requires fe <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+      (ensures
+        fun result ->
+          let result:u8 = result in
+          Hax_lib.implies ((833us <=. fe <: bool) && (fe <=. 2596us <: bool))
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 1uy <: bool) &&
+          Hax_lib.implies (~.((833us <=. fe <: bool) && (fe <=. 2596us <: bool)) <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 0uy <: bool))
+
+val decompress_ciphertext_coefficient (coefficient_bits: u8) (fe: i32)
+    : Prims.Pure i32
+      (requires
+        (coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy ||
+        coefficient_bits =. 11uy) &&
+        fe >=. 0l &&
+        fe <. (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32))
+      (ensures
+        fun result ->
+          let result:i32 = result in
+          result <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
+
+val decompress_message_coefficient (fe: i32)
+    : Prims.Pure i32 (requires fe =. 0l || fe =. 1l) (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fsti
@@ -8,39 +8,39 @@ val compress_ciphertext_coefficient (coefficient_bits: u8) (fe: u16)
       (requires
         (coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy ||
         coefficient_bits =. 11uy) &&
-        fe <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+        v fe < v (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
       (ensures
         fun result ->
           let result:i32 = result in
-          result >=. 0l &&
-          result <. (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32))
+          v result >= v 0l &&
+          v result < v (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32))
 
 val compress_message_coefficient (fe: u16)
     : Prims.Pure u8
-      (requires fe <. (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
+      (requires v fe < v (cast (Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32) <: u16))
       (ensures
         fun result ->
           let result:u8 = result in
           Hax_lib.implies ((833us <=. fe <: bool) && (fe <=. 2596us <: bool))
             (fun temp_0_ ->
                 let _:Prims.unit = temp_0_ in
-                result =. 1uy <: bool) &&
+                v result = v 1uy <: bool) &&
           Hax_lib.implies (~.((833us <=. fe <: bool) && (fe <=. 2596us <: bool)) <: bool)
             (fun temp_0_ ->
                 let _:Prims.unit = temp_0_ in
-                result =. 0uy <: bool))
+                v result = v 0uy <: bool))
 
 val decompress_ciphertext_coefficient (coefficient_bits: u8) (fe: i32)
     : Prims.Pure i32
       (requires
         (coefficient_bits =. 4uy || coefficient_bits =. 5uy || coefficient_bits =. 10uy ||
         coefficient_bits =. 11uy) &&
-        fe >=. 0l &&
-        fe <. (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32))
+        v fe >= v 0l &&
+        v fe < v (Core.Num.impl__i32__pow 2l (cast (coefficient_bits <: u8) <: u32) <: i32))
       (ensures
         fun result ->
           let result:i32 = result in
-          result <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
+          v result < v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS)
 
 val decompress_message_coefficient (fe: i32)
     : Prims.Pure i32 (requires fe =. 0l || fe =. 1l) (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fst
@@ -1,0 +1,64 @@
+module Libcrux.Kem.Kyber.Constant_time_ops
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let is_non_zero (value: u8) =
+  let value:u16 = cast (value <: u8) <: u16 in
+  let result:u16 =
+    ((value |. (Core.Num.impl__u16__wrapping_add (~.value <: u16) 1us <: u16) <: u16) >>! 8l <: u16) &.
+    1us
+  in
+  cast (result <: u16) <: u8
+
+let compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_Slice u8) =
+  let _:Prims.unit = () <: Prims.unit in
+  let _:Prims.unit = () <: Prims.unit in
+  let (r: u8):u8 = 0uy in
+  let r:u8 =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = v_CIPHERTEXT_SIZE
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      r
+      (fun r i ->
+          let r:u8 = r in
+          let i:usize = i in
+          r |. ((lhs.[ i ] <: u8) ^. (rhs.[ i ] <: u8) <: u8) <: u8)
+  in
+  is_non_zero r
+
+let select_shared_secret_in_constant_time (lhs rhs: t_Slice u8) (selector: u8) =
+  let _:Prims.unit = () <: Prims.unit in
+  let _:Prims.unit = () <: Prims.unit in
+  let mask:u8 = Core.Num.impl__u8__wrapping_sub (is_non_zero selector <: u8) 1uy in
+  let out:t_Array u8 (sz 32) = Rust_primitives.Hax.repeat 0uy (sz 32) in
+  let out:t_Array u8 (sz 32) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      out
+      (fun out i ->
+          let out:t_Array u8 (sz 32) = out in
+          let i:usize = i in
+          Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out
+            i
+            ((out.[ i ] <: u8) |.
+              (((lhs.[ i ] <: u8) &. mask <: u8) |. ((rhs.[ i ] <: u8) &. (~.mask <: u8) <: u8)
+                <:
+                u8)
+              <:
+              u8)
+          <:
+          t_Array u8 (sz 32))
+  in
+  out

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fsti
@@ -1,0 +1,49 @@
+module Libcrux.Kem.Kyber.Constant_time_ops
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val is_non_zero (value: u8)
+    : Prims.Pure u8
+      Prims.l_True
+      (ensures
+        fun result ->
+          let result:u8 = result in
+          Hax_lib.implies (value =. 0uy <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 0uy <: bool) &&
+          Hax_lib.implies (value <>. 0uy <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 1uy <: bool))
+
+val compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_Slice u8)
+    : Prims.Pure u8
+      Prims.l_True
+      (ensures
+        fun result ->
+          let result:u8 = result in
+          Hax_lib.implies (lhs =. rhs <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 0uy <: bool) &&
+          Hax_lib.implies (lhs <>. rhs <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. 1uy <: bool))
+
+val select_shared_secret_in_constant_time (lhs rhs: t_Slice u8) (selector: u8)
+    : Prims.Pure (t_Array u8 (sz 32))
+      Prims.l_True
+      (ensures
+        fun result ->
+          let result:t_Array u8 (sz 32) = result in
+          Hax_lib.implies (selector =. 0uy <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. lhs <: bool) &&
+          Hax_lib.implies (selector <>. 0uy <: bool)
+            (fun temp_0_ ->
+                let _:Prims.unit = temp_0_ in
+                result =. rhs <: bool))

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fsti
@@ -24,14 +24,14 @@ val compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_
       (ensures
         fun result ->
           let result:u8 = result in
-          Hax_lib.implies (lhs =. rhs <: bool)
+          Hax_lib.implies (lhs = rhs)
             (fun temp_0_ ->
                 let _:Prims.unit = temp_0_ in
-                result =. 0uy <: bool) &&
-          Hax_lib.implies (lhs <>. rhs <: bool)
+                v result = v 0uy <: bool) &&
+          Hax_lib.implies (lhs <> rhs)
             (fun temp_0_ ->
                 let _:Prims.unit = temp_0_ in
-                result =. 1uy <: bool))
+                v result = v 1uy <: bool))
 
 val select_shared_secret_in_constant_time (lhs rhs: t_Slice u8) (selector: u8)
     : Prims.Pure (t_Array u8 (sz 32))
@@ -42,8 +42,8 @@ val select_shared_secret_in_constant_time (lhs rhs: t_Slice u8) (selector: u8)
           Hax_lib.implies (selector =. 0uy <: bool)
             (fun temp_0_ ->
                 let _:Prims.unit = temp_0_ in
-                result =. lhs <: bool) &&
+                result = lhs <: bool) &&
           Hax_lib.implies (selector <>. 0uy <: bool)
             (fun temp_0_ ->
                 let _:Prims.unit = temp_0_ in
-                result =. rhs <: bool))
+                result = rhs <: bool))

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Constants.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Constants.fsti
@@ -1,0 +1,22 @@
+module Libcrux.Kem.Kyber.Constants
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_BITS_PER_COEFFICIENT: usize = sz 12
+
+let v_COEFFICIENTS_IN_RING_ELEMENT: usize = sz 256
+
+let v_BITS_PER_RING_ELEMENT: usize = v_COEFFICIENTS_IN_RING_ELEMENT *! sz 12
+
+let v_BYTES_PER_RING_ELEMENT: usize = v_BITS_PER_RING_ELEMENT /! sz 8
+
+let v_CPA_PKE_KEY_GENERATION_SEED_SIZE: usize = sz 32
+
+let v_FIELD_MODULUS: i32 = 3329l
+
+let v_H_DIGEST_SIZE: usize = sz 32
+
+let v_REJECTION_SAMPLING_SEED_SIZE: usize = sz 168 *! sz 5
+
+let v_SHARED_SECRET_SIZE: usize = sz 32

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Conversions.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Conversions.fst
@@ -1,0 +1,87 @@
+module Libcrux.Kem.Kyber.Conversions
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+
+let into_padded_array (#v_LEN: usize) (slice: t_Slice u8) : t_Array u8 v_LEN =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        if ~.((Core.Slice.impl__len slice <: usize) <=. v_LEN <: bool)
+        then
+          Rust_primitives.Hax.never_to_any (Core.Panicking.panic "assertion failed: slice.len() <= LEN"
+
+              <:
+              Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let out:t_Array u8 v_LEN = Rust_primitives.Hax.repeat 0uy v_LEN in
+  let out:t_Array u8 v_LEN =
+    Rust_primitives.Hax.update_at out
+      ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = Core.Slice.impl__len slice <: usize }
+      )
+      (Core.Slice.impl__copy_from_slice (Core.Ops.Index.IndexMut.index_mut out
+              ({
+                  Core.Ops.Range.f_start = sz 0;
+                  Core.Ops.Range.f_end = Core.Slice.impl__len slice <: usize
+                })
+            <:
+            t_Slice u8)
+          slice
+        <:
+        t_Slice u8)
+  in
+  out
+
+class t_UpdatingArray (#v_Self: Type) = { f_push:v_Self -> t_Slice u8 -> v_Self }
+
+type t_UpdatableArray (v_LEN: usize) = {
+  f_value:t_Array u8 v_LEN;
+  f_pointer:usize
+}
+
+let impl__new (#v_LEN: usize) (value: t_Array u8 v_LEN) : t_UpdatableArray v_LEN =
+  { f_value = value; f_pointer = sz 0 }
+
+let impl__array (#v_LEN: usize) (self: t_UpdatableArray v_LEN) : t_Array u8 v_LEN = self.f_value
+
+let impl_1 (#v_LEN: usize) : t_UpdatingArray (t_UpdatableArray v_LEN) =
+  {
+    f_push
+    =
+    fun (self: t_UpdatableArray v_LEN) (other: t_Slice u8) ->
+      let self:t_UpdatableArray v_LEN =
+        {
+          self with
+          f_value
+          =
+          Rust_primitives.Hax.update_at (f_value self <: t_UpdatableArray v_LEN)
+            ({
+                Core.Ops.Range.f_start = self.f_pointer;
+                Core.Ops.Range.f_end
+                =
+                self.f_pointer +! (Core.Slice.impl__len other <: usize) <: usize
+              })
+            (Core.Slice.impl__copy_from_slice (Core.Ops.Index.IndexMut.index_mut self.f_value
+                    ({
+                        Core.Ops.Range.f_start = self.f_pointer;
+                        Core.Ops.Range.f_end
+                        =
+                        self.f_pointer +! (Core.Slice.impl__len other <: usize) <: usize
+                      })
+                  <:
+                  t_Slice u8)
+                other
+              <:
+              t_Slice u8)
+        }
+      in
+      let self:t_UpdatableArray v_LEN =
+        { self with f_pointer = self.f_pointer +! (Core.Slice.impl__len other <: usize) }
+      in
+      self
+  }
+
+let to_unsigned_representative (fe: i32) : u16 =
+  cast (fe +! ((fe >>! 15l <: i32) &. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32)) <: u16

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fst
@@ -38,7 +38,7 @@ let v_XOFx4 (v_K: usize) (input: t_Array (t_Array u8 (sz 34)) v_K) =
             t_Array (t_Array u8 (sz 840)) v_K)
     else
       let out:t_Array (t_Array u8 (sz 840)) v_K =
-        match cast (v_K <: usize) <: u8 with
+        match cast (v_K <: usize) <: pub_u8 with
         | 2uy ->
           let d0, d1, _, _:(t_Array u8 (sz 840) & t_Array u8 (sz 840) & t_Array u8 (sz 840) &
             t_Array u8 (sz 840)) =

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fst
@@ -1,0 +1,103 @@
+module Libcrux.Kem.Kyber.Hash_functions
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_G (input: t_Slice u8) = Libcrux.Digest.sha3_512_ input
+
+let v_H (input: t_Slice u8) = Libcrux.Digest.sha3_256_ input
+
+let v_PRF (v_LEN: usize) (input: t_Slice u8) = Libcrux.Digest.shake256 v_LEN input
+
+let v_XOFx4 (v_K: usize) (input: t_Array (t_Array u8 (sz 34)) v_K) =
+  let out:t_Array (t_Array u8 (sz 840)) v_K =
+    Rust_primitives.Hax.repeat (Rust_primitives.Hax.repeat 0uy (sz 840) <: t_Array u8 (sz 840)) v_K
+  in
+  let out:t_Array (t_Array u8 (sz 840)) v_K =
+    if ~.(Libcrux_platform.simd256_support () <: bool) || ~.true
+    then
+      Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                Core.Ops.Range.f_start = sz 0;
+                Core.Ops.Range.f_end = v_K
+              }
+              <:
+              Core.Ops.Range.t_Range usize)
+          <:
+          Core.Ops.Range.t_Range usize)
+        out
+        (fun out i ->
+            let out:t_Array (t_Array u8 (sz 840)) v_K = out in
+            let i:usize = i in
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out
+              i
+              (Libcrux.Digest.shake128 (sz 840)
+                  (Rust_primitives.unsize (input.[ i ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+                <:
+                t_Array u8 (sz 840))
+            <:
+            t_Array (t_Array u8 (sz 840)) v_K)
+    else
+      let out:t_Array (t_Array u8 (sz 840)) v_K =
+        match cast (v_K <: usize) <: u8 with
+        | 2uy ->
+          let d0, d1, _, _:(t_Array u8 (sz 840) & t_Array u8 (sz 840) & t_Array u8 (sz 840) &
+            t_Array u8 (sz 840)) =
+            Libcrux.Digest.shake128x4 (sz 840)
+              (Rust_primitives.unsize (input.[ sz 0 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+              (Rust_primitives.unsize (input.[ sz 1 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+              (Rust_primitives.unsize (input.[ sz 0 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+              (Rust_primitives.unsize (input.[ sz 1 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+          in
+          let out:t_Array (t_Array u8 (sz 840)) v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out (sz 0) d0
+          in
+          let out:t_Array (t_Array u8 (sz 840)) v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out (sz 1) d1
+          in
+          out
+        | 3uy ->
+          let d0, d1, d2, _:(t_Array u8 (sz 840) & t_Array u8 (sz 840) & t_Array u8 (sz 840) &
+            t_Array u8 (sz 840)) =
+            Libcrux.Digest.shake128x4 (sz 840)
+              (Rust_primitives.unsize (input.[ sz 0 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+              (Rust_primitives.unsize (input.[ sz 1 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+              (Rust_primitives.unsize (input.[ sz 2 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+              (Rust_primitives.unsize (input.[ sz 0 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+          in
+          let out:t_Array (t_Array u8 (sz 840)) v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out (sz 0) d0
+          in
+          let out:t_Array (t_Array u8 (sz 840)) v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out (sz 1) d1
+          in
+          let out:t_Array (t_Array u8 (sz 840)) v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out (sz 2) d2
+          in
+          out
+        | 4uy ->
+          let d0, d1, d2, d3:(t_Array u8 (sz 840) & t_Array u8 (sz 840) & t_Array u8 (sz 840) &
+            t_Array u8 (sz 840)) =
+            Libcrux.Digest.shake128x4 (sz 840)
+              (Rust_primitives.unsize (input.[ sz 0 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+              (Rust_primitives.unsize (input.[ sz 1 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+              (Rust_primitives.unsize (input.[ sz 2 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+              (Rust_primitives.unsize (input.[ sz 3 ] <: t_Array u8 (sz 34)) <: t_Slice u8)
+          in
+          let out:t_Array (t_Array u8 (sz 840)) v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out (sz 0) d0
+          in
+          let out:t_Array (t_Array u8 (sz 840)) v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out (sz 1) d1
+          in
+          let out:t_Array (t_Array u8 (sz 840)) v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out (sz 2) d2
+          in
+          let out:t_Array (t_Array u8 (sz 840)) v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out (sz 3) d3
+          in
+          out
+        | _ -> out
+      in
+      out
+  in
+  out

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fsti
@@ -1,0 +1,14 @@
+module Libcrux.Kem.Kyber.Hash_functions
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val v_G (input: t_Slice u8) : Prims.Pure (t_Array u8 (sz 64)) Prims.l_True (fun _ -> Prims.l_True)
+
+val v_H (input: t_Slice u8) : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val v_PRF (v_LEN: usize) (input: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val v_XOFx4 (v_K: usize) (input: t_Array (t_Array u8 (sz 34)) v_K)
+    : Prims.Pure (t_Array (t_Array u8 (sz 840)) v_K) Prims.l_True (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Helper.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Helper.fst
@@ -1,0 +1,6 @@
+module Libcrux.Kem.Kyber.Helper
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fst
@@ -1,0 +1,563 @@
+module Libcrux.Kem.Kyber.Ind_cpa
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let into_padded_array (v_LEN: usize) (slice: t_Slice u8) =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        if ~.((Core.Slice.impl__len slice <: usize) <=. v_LEN <: bool)
+        then
+          Rust_primitives.Hax.never_to_any (Core.Panicking.panic "assertion failed: slice.len() <= LEN"
+
+              <:
+              Rust_primitives.Hax.t_Never)
+      in
+      ()
+  in
+  let out:t_Array u8 v_LEN = Rust_primitives.Hax.repeat 0uy v_LEN in
+  let out:t_Array u8 v_LEN =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+      ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = Core.Slice.impl__len slice <: usize }
+        <:
+        Core.Ops.Range.t_Range usize)
+      (Core.Slice.impl__copy_from_slice (out.[ {
+                Core.Ops.Range.f_start = sz 0;
+                Core.Ops.Range.f_end = Core.Slice.impl__len slice <: usize
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
+          slice
+        <:
+        t_Slice u8)
+  in
+  out
+
+let sample_ring_element_cbd
+      (v_K v_ETA2_RANDOMNESS_SIZE v_ETA2: usize)
+      (prf_input: t_Array u8 (sz 33))
+      (domain_separator: u8)
+     =
+  let error_1_:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
+  in
+  let domain_separator, error_1_, prf_input:(u8 &
+    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+    t_Array u8 (sz 33)) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = v_K
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      (domain_separator, error_1_, prf_input
+        <:
+        (u8 & t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K & t_Array u8 (sz 33))
+      )
+      (fun temp_0_ i ->
+          let domain_separator, error_1_, prf_input:(u8 &
+            t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+            t_Array u8 (sz 33)) =
+            temp_0_
+          in
+          let i:usize = i in
+          let prf_input:t_Array u8 (sz 33) =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize prf_input
+              (sz 32)
+              domain_separator
+          in
+          let domain_separator:u8 = domain_separator +! 1uy in
+          let (prf_output: t_Array u8 v_ETA2_RANDOMNESS_SIZE):t_Array u8 v_ETA2_RANDOMNESS_SIZE =
+            Libcrux.Kem.Kyber.Hash_functions.v_PRF v_ETA2_RANDOMNESS_SIZE
+              (Rust_primitives.unsize prf_input <: t_Slice u8)
+          in
+          let error_1_:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize error_1_
+              i
+              (Libcrux.Kem.Kyber.Sampling.sample_from_binomial_distribution v_ETA2
+                  (Rust_primitives.unsize prf_output <: t_Slice u8)
+                <:
+                Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+          in
+          domain_separator, error_1_, prf_input
+          <:
+          (u8 & t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+            t_Array u8 (sz 33)))
+  in
+  let hax_temp_output:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K = error_1_ in
+  prf_input, domain_separator, hax_temp_output
+  <:
+  (t_Array u8 (sz 33) & u8 & t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+
+let sample_vector_cbd_then_ntt
+      (v_K v_ETA v_ETA_RANDOMNESS_SIZE: usize)
+      (prf_input: t_Array u8 (sz 33))
+      (domain_separator: u8)
+     =
+  let re_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
+  in
+  let domain_separator, prf_input, re_as_ntt:(u8 & t_Array u8 (sz 33) &
+    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = v_K
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      (domain_separator, prf_input, re_as_ntt
+        <:
+        (u8 & t_Array u8 (sz 33) & t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      )
+      (fun temp_0_ i ->
+          let domain_separator, prf_input, re_as_ntt:(u8 & t_Array u8 (sz 33) &
+            t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+            temp_0_
+          in
+          let i:usize = i in
+          let prf_input:t_Array u8 (sz 33) =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize prf_input
+              (sz 32)
+              domain_separator
+          in
+          let domain_separator:u8 = domain_separator +! 1uy in
+          let (prf_output: t_Array u8 v_ETA_RANDOMNESS_SIZE):t_Array u8 v_ETA_RANDOMNESS_SIZE =
+            Libcrux.Kem.Kyber.Hash_functions.v_PRF v_ETA_RANDOMNESS_SIZE
+              (Rust_primitives.unsize prf_input <: t_Slice u8)
+          in
+          let r:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            Libcrux.Kem.Kyber.Sampling.sample_from_binomial_distribution v_ETA
+              (Rust_primitives.unsize prf_output <: t_Slice u8)
+          in
+          let re_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re_as_ntt
+              i
+              (Libcrux.Kem.Kyber.Ntt.ntt_binomially_sampled_ring_element r
+                <:
+                Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+          in
+          domain_separator, prf_input, re_as_ntt
+          <:
+          (u8 & t_Array u8 (sz 33) &
+            t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+  in
+  re_as_ntt, domain_separator
+  <:
+  (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K & u8)
+
+let compress_then_serialize_u
+      (v_K v_OUT_LEN v_COMPRESSION_FACTOR v_BLOCK_LEN: usize)
+      (input: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+     =
+  let out:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
+  let out:t_Array u8 v_OUT_LEN =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Iter.Traits.Collect.f_into_iter input
+                <:
+                Core.Array.Iter.t_IntoIter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate
+            (Core.Array.Iter.t_IntoIter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate
+        (Core.Array.Iter.t_IntoIter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+      out
+      (fun out temp_1_ ->
+          let out:t_Array u8 v_OUT_LEN = out in
+          let i, re:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) = temp_1_ in
+          Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+            ({
+                Core.Ops.Range.f_start = i *! (v_OUT_LEN /! v_K <: usize) <: usize;
+                Core.Ops.Range.f_end = (i +! sz 1 <: usize) *! (v_OUT_LEN /! v_K <: usize) <: usize
+              }
+              <:
+              Core.Ops.Range.t_Range usize)
+            (Core.Slice.impl__copy_from_slice (out.[ {
+                      Core.Ops.Range.f_start = i *! (v_OUT_LEN /! v_K <: usize) <: usize;
+                      Core.Ops.Range.f_end
+                      =
+                      (i +! sz 1 <: usize) *! (v_OUT_LEN /! v_K <: usize) <: usize
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize ]
+                  <:
+                  t_Slice u8)
+                (Rust_primitives.unsize (Libcrux.Kem.Kyber.Serialize.compress_then_serialize_ring_element_u
+                        v_COMPRESSION_FACTOR
+                        v_BLOCK_LEN
+                        re
+                      <:
+                      t_Array u8 v_BLOCK_LEN)
+                  <:
+                  t_Slice u8)
+              <:
+              t_Slice u8)
+          <:
+          t_Array u8 v_OUT_LEN)
+  in
+  out
+
+let deserialize_then_decompress_u
+      (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
+      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+     =
+  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
+  in
+  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact (Rust_primitives.unsize ciphertext <: t_Slice u8)
+                  ((Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *!
+                      v_U_COMPRESSION_FACTOR
+                      <:
+                      usize) /!
+                    sz 8
+                    <:
+                    usize)
+                <:
+                Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+      u_as_ntt
+      (fun u_as_ntt temp_1_ ->
+          let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+            u_as_ntt
+          in
+          let i, u_bytes:(usize & t_Slice u8) = temp_1_ in
+          let u:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_ring_element_u v_U_COMPRESSION_FACTOR
+              u_bytes
+          in
+          let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize u_as_ntt
+              i
+              (Libcrux.Kem.Kyber.Ntt.ntt_vector_u v_U_COMPRESSION_FACTOR u
+                <:
+                Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+          in
+          u_as_ntt)
+  in
+  u_as_ntt
+
+let deserialize_public_key (v_K: usize) (public_key: t_Slice u8) =
+  let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
+  in
+  let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact public_key
+                  Libcrux.Kem.Kyber.Constants.v_BYTES_PER_RING_ELEMENT
+                <:
+                Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+      tt_as_ntt
+      (fun tt_as_ntt temp_1_ ->
+          let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+            tt_as_ntt
+          in
+          let i, tt_as_ntt_bytes:(usize & t_Slice u8) = temp_1_ in
+          Rust_primitives.Hax.Monomorphized_update_at.update_at_usize tt_as_ntt
+            i
+            (Libcrux.Kem.Kyber.Serialize.deserialize_to_uncompressed_ring_element tt_as_ntt_bytes
+              <:
+              Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+          <:
+          t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+  in
+  tt_as_ntt
+
+let deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8) =
+  let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
+  in
+  let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact secret_key
+                  Libcrux.Kem.Kyber.Constants.v_BYTES_PER_RING_ELEMENT
+                <:
+                Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+      secret_as_ntt
+      (fun secret_as_ntt temp_1_ ->
+          let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+            secret_as_ntt
+          in
+          let i, secret_bytes:(usize & t_Slice u8) = temp_1_ in
+          Rust_primitives.Hax.Monomorphized_update_at.update_at_usize secret_as_ntt
+            i
+            (Libcrux.Kem.Kyber.Serialize.deserialize_to_uncompressed_ring_element secret_bytes
+              <:
+              Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+          <:
+          t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+  in
+  secret_as_ntt
+
+let decrypt
+      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
+          usize)
+      (secret_key: t_Slice u8)
+      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+     =
+  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    deserialize_then_decompress_u v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR ciphertext
+  in
+  let v:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_ring_element_v v_V_COMPRESSION_FACTOR
+      (ciphertext.[ { Core.Ops.Range.f_start = v_VECTOR_U_ENCODED_SIZE }
+          <:
+          Core.Ops.Range.t_RangeFrom usize ]
+        <:
+        t_Slice u8)
+  in
+  let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    deserialize_secret_key v_K secret_key
+  in
+  let message:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Matrix.compute_message v_K v secret_as_ntt u_as_ntt
+  in
+  Libcrux.Kem.Kyber.Serialize.compress_then_serialize_message message
+
+let encrypt
+      (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+          usize)
+      (public_key: t_Slice u8)
+      (message: t_Array u8 (sz 32))
+      (randomness: t_Slice u8)
+     =
+  let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    deserialize_public_key v_K public_key
+  in
+  let seed:t_Slice u8 =
+    public_key.[ { Core.Ops.Range.f_start = v_T_AS_NTT_ENCODED_SIZE }
+      <:
+      Core.Ops.Range.t_RangeFrom usize ]
+  in
+  let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+    Libcrux.Kem.Kyber.Matrix.sample_matrix_A v_K
+      (into_padded_array (sz 34) seed <: t_Array u8 (sz 34))
+      false
+  in
+  let (prf_input: t_Array u8 (sz 33)):t_Array u8 (sz 33) = into_padded_array (sz 33) randomness in
+  let r_as_ntt, domain_separator:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+    u8) =
+    sample_vector_cbd_then_ntt v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input 0uy
+  in
+  let tmp0, tmp1, out:(t_Array u8 (sz 33) & u8 &
+    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+    sample_ring_element_cbd v_K v_ETA2_RANDOMNESS_SIZE v_ETA2 prf_input domain_separator
+  in
+  let prf_input:t_Array u8 (sz 33) = tmp0 in
+  let domain_separator:u8 = tmp1 in
+  let error_1_:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K = out in
+  let prf_input:t_Array u8 (sz 33) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize prf_input (sz 32) domain_separator
+  in
+  let (prf_output: t_Array u8 v_ETA2_RANDOMNESS_SIZE):t_Array u8 v_ETA2_RANDOMNESS_SIZE =
+    Libcrux.Kem.Kyber.Hash_functions.v_PRF v_ETA2_RANDOMNESS_SIZE
+      (Rust_primitives.unsize prf_input <: t_Slice u8)
+  in
+  let error_2_:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Sampling.sample_from_binomial_distribution v_ETA2
+      (Rust_primitives.unsize prf_output <: t_Slice u8)
+  in
+  let u:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Libcrux.Kem.Kyber.Matrix.compute_vector_u v_K v_A_transpose r_as_ntt error_1_
+  in
+  let message_as_ring_element:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_message message
+  in
+  let v:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Matrix.compute_ring_element_v v_K
+      tt_as_ntt
+      r_as_ntt
+      error_2_
+      message_as_ring_element
+  in
+  let c1:t_Array u8 v_C1_LEN =
+    compress_then_serialize_u v_K v_C1_LEN v_U_COMPRESSION_FACTOR v_BLOCK_LEN u
+  in
+  let c2:t_Array u8 v_C2_LEN =
+    Libcrux.Kem.Kyber.Serialize.compress_then_serialize_ring_element_v v_V_COMPRESSION_FACTOR
+      v_C2_LEN
+      v
+  in
+  let (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE):t_Array u8 v_CIPHERTEXT_SIZE =
+    into_padded_array v_CIPHERTEXT_SIZE (Rust_primitives.unsize c1 <: t_Slice u8)
+  in
+  let ciphertext:t_Array u8 v_CIPHERTEXT_SIZE =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from ciphertext
+      ({ Core.Ops.Range.f_start = v_C1_LEN } <: Core.Ops.Range.t_RangeFrom usize)
+      (Core.Slice.impl__copy_from_slice (ciphertext.[ { Core.Ops.Range.f_start = v_C1_LEN }
+              <:
+              Core.Ops.Range.t_RangeFrom usize ]
+            <:
+            t_Slice u8)
+          (Core.Array.impl_23__as_slice v_C2_LEN c2 <: t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  ciphertext
+
+let serialize_secret_key
+      (v_K v_OUT_LEN: usize)
+      (key: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+     =
+  let out:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
+  let out:t_Array u8 v_OUT_LEN =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Iter.Traits.Collect.f_into_iter key
+                <:
+                Core.Array.Iter.t_IntoIter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate
+            (Core.Array.Iter.t_IntoIter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate
+        (Core.Array.Iter.t_IntoIter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+      out
+      (fun out temp_1_ ->
+          let out:t_Array u8 v_OUT_LEN = out in
+          let i, re:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) = temp_1_ in
+          Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+            ({
+                Core.Ops.Range.f_start
+                =
+                i *! Libcrux.Kem.Kyber.Constants.v_BYTES_PER_RING_ELEMENT <: usize;
+                Core.Ops.Range.f_end
+                =
+                (i +! sz 1 <: usize) *! Libcrux.Kem.Kyber.Constants.v_BYTES_PER_RING_ELEMENT
+                <:
+                usize
+              }
+              <:
+              Core.Ops.Range.t_Range usize)
+            (Core.Slice.impl__copy_from_slice (out.[ {
+                      Core.Ops.Range.f_start
+                      =
+                      i *! Libcrux.Kem.Kyber.Constants.v_BYTES_PER_RING_ELEMENT <: usize;
+                      Core.Ops.Range.f_end
+                      =
+                      (i +! sz 1 <: usize) *! Libcrux.Kem.Kyber.Constants.v_BYTES_PER_RING_ELEMENT
+                      <:
+                      usize
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize ]
+                  <:
+                  t_Slice u8)
+                (Rust_primitives.unsize (Libcrux.Kem.Kyber.Serialize.serialize_uncompressed_ring_element
+                        re
+                      <:
+                      t_Array u8 (sz 384))
+                  <:
+                  t_Slice u8)
+              <:
+              t_Slice u8)
+          <:
+          t_Array u8 v_OUT_LEN)
+  in
+  out
+
+let serialize_public_key
+      (v_K v_RANKED_BYTES_PER_RING_ELEMENT v_PUBLIC_KEY_SIZE: usize)
+      (tt_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      (seed_for_a: t_Slice u8)
+     =
+  let public_key_serialized:t_Array u8 v_PUBLIC_KEY_SIZE =
+    Rust_primitives.Hax.repeat 0uy v_PUBLIC_KEY_SIZE
+  in
+  let public_key_serialized:t_Array u8 v_PUBLIC_KEY_SIZE =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range public_key_serialized
+      ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = v_RANKED_BYTES_PER_RING_ELEMENT }
+        <:
+        Core.Ops.Range.t_Range usize)
+      (Core.Slice.impl__copy_from_slice (public_key_serialized.[ {
+                Core.Ops.Range.f_start = sz 0;
+                Core.Ops.Range.f_end = v_RANKED_BYTES_PER_RING_ELEMENT
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
+          (Rust_primitives.unsize (serialize_secret_key v_K
+                  v_RANKED_BYTES_PER_RING_ELEMENT
+                  tt_as_ntt
+                <:
+                t_Array u8 v_RANKED_BYTES_PER_RING_ELEMENT)
+            <:
+            t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  let public_key_serialized:t_Array u8 v_PUBLIC_KEY_SIZE =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from public_key_serialized
+      ({ Core.Ops.Range.f_start = v_RANKED_BYTES_PER_RING_ELEMENT }
+        <:
+        Core.Ops.Range.t_RangeFrom usize)
+      (Core.Slice.impl__copy_from_slice (public_key_serialized.[ {
+                Core.Ops.Range.f_start = v_RANKED_BYTES_PER_RING_ELEMENT
+              }
+              <:
+              Core.Ops.Range.t_RangeFrom usize ]
+            <:
+            t_Slice u8)
+          seed_for_a
+        <:
+        t_Slice u8)
+  in
+  public_key_serialized
+
+let generate_keypair
+      (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+          usize)
+      (key_generation_seed: t_Slice u8)
+     =
+  let hashed:t_Array u8 (sz 64) = Libcrux.Kem.Kyber.Hash_functions.v_G key_generation_seed in
+  let seed_for_A, seed_for_secret_and_error:(t_Slice u8 & t_Slice u8) =
+    Core.Slice.impl__split_at (Rust_primitives.unsize hashed <: t_Slice u8) (sz 32)
+  in
+  let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+    Libcrux.Kem.Kyber.Matrix.sample_matrix_A v_K
+      (into_padded_array (sz 34) seed_for_A <: t_Array u8 (sz 34))
+      true
+  in
+  let (prf_input: t_Array u8 (sz 33)):t_Array u8 (sz 33) =
+    into_padded_array (sz 33) seed_for_secret_and_error
+  in
+  let secret_as_ntt, domain_separator:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      v_K &
+    u8) =
+    sample_vector_cbd_then_ntt v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input 0uy
+  in
+  let error_as_ntt, _:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K & u8) =
+    sample_vector_cbd_then_ntt v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input domain_separator
+  in
+  let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Libcrux.Kem.Kyber.Matrix.compute_As_plus_e v_K v_A_transpose secret_as_ntt error_as_ntt
+  in
+  let public_key_serialized:t_Array u8 v_PUBLIC_KEY_SIZE =
+    serialize_public_key v_K v_RANKED_BYTES_PER_RING_ELEMENT v_PUBLIC_KEY_SIZE tt_as_ntt seed_for_A
+  in
+  let secret_key_serialized:t_Array u8 v_PRIVATE_KEY_SIZE =
+    serialize_secret_key v_K v_PRIVATE_KEY_SIZE secret_as_ntt
+  in
+  secret_key_serialized, public_key_serialized
+  <:
+  (t_Array u8 v_PRIVATE_KEY_SIZE & t_Array u8 v_PUBLIC_KEY_SIZE)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fsti
@@ -1,0 +1,80 @@
+module Libcrux.Kem.Kyber.Ind_cpa
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val into_padded_array (v_LEN: usize) (slice: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val sample_ring_element_cbd
+      (v_K v_ETA2_RANDOMNESS_SIZE v_ETA2: usize)
+      (prf_input: t_Array u8 (sz 33))
+      (domain_separator: u8)
+    : Prims.Pure
+      (t_Array u8 (sz 33) & u8 & t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val sample_vector_cbd_then_ntt
+      (v_K v_ETA v_ETA_RANDOMNESS_SIZE: usize)
+      (prf_input: t_Array u8 (sz 33))
+      (domain_separator: u8)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K & u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compress_then_serialize_u
+      (v_K v_OUT_LEN v_COMPRESSION_FACTOR v_BLOCK_LEN: usize)
+      (input: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_u
+      (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
+      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_public_key (v_K: usize) (public_key: t_Slice u8)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val decrypt
+      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
+          usize)
+      (secret_key: t_Slice u8)
+      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encrypt
+      (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+          usize)
+      (public_key: t_Slice u8)
+      (message: t_Array u8 (sz 32))
+      (randomness: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_CIPHERTEXT_SIZE) Prims.l_True (fun _ -> Prims.l_True)
+
+val serialize_secret_key
+      (v_K v_OUT_LEN: usize)
+      (key: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val serialize_public_key
+      (v_K v_RANKED_BYTES_PER_RING_ELEMENT v_PUBLIC_KEY_SIZE: usize)
+      (tt_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      (seed_for_a: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_PUBLIC_KEY_SIZE) Prims.l_True (fun _ -> Prims.l_True)
+
+val generate_keypair
+      (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+          usize)
+      (key_generation_seed: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_PRIVATE_KEY_SIZE & t_Array u8 v_PUBLIC_KEY_SIZE)
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fst
@@ -1,0 +1,28 @@
+module Libcrux.Kem.Kyber.Kyber1024
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let decapsulate_1024_
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 3168))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1568))
+     =
+  Libcrux.Kem.Kyber.decapsulate (sz 4) (sz 3168) (sz 1536) (sz 1568) (sz 1568) (sz 1536) (sz 1408)
+    (sz 160) (sz 11) (sz 5) (sz 352) (sz 2) (sz 128) (sz 2) (sz 128) (sz 1600) secret_key ciphertext
+
+let encapsulate_1024_
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1568))
+      (randomness: t_Array u8 (sz 32))
+     =
+  Libcrux.Kem.Kyber.encapsulate (sz 4) (sz 1568) (sz 1568) (sz 1536) (sz 1408) (sz 160) (sz 11)
+    (sz 5) (sz 352) (sz 2) (sz 128) (sz 2) (sz 128) public_key randomness
+
+let generate_key_pair_1024_ (randomness: t_Array u8 (sz 64)) =
+  Libcrux.Kem.Kyber.generate_keypair (sz 4)
+    (sz 1536)
+    (sz 3168)
+    (sz 1568)
+    (sz 1536)
+    (sz 2)
+    (sz 128)
+    randomness

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fsti
@@ -1,0 +1,89 @@
+module Libcrux.Kem.Kyber.Kyber1024
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_ETA1: usize = sz 2
+
+let v_ETA1_RANDOMNESS_SIZE: usize = v_ETA1 *! sz 64
+
+let v_ETA2: usize = sz 2
+
+let v_ETA2_RANDOMNESS_SIZE: usize = v_ETA2 *! sz 64
+
+let v_RANK_1024_: usize = sz 4
+
+let v_CPA_PKE_SECRET_KEY_SIZE_1024_: usize =
+  ((v_RANK_1024_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_RANKED_BYTES_PER_RING_ELEMENT_1024_: usize =
+  (v_RANK_1024_ *! Libcrux.Kem.Kyber.Constants.v_BITS_PER_RING_ELEMENT <: usize) /! sz 8
+
+let v_T_AS_NTT_ENCODED_SIZE_1024_: usize =
+  ((v_RANK_1024_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_PUBLIC_KEY_SIZE_1024_: usize = v_T_AS_NTT_ENCODED_SIZE_1024_ +! sz 32
+
+let v_SECRET_KEY_SIZE_1024_: usize =
+  ((v_CPA_PKE_SECRET_KEY_SIZE_1024_ +! v_CPA_PKE_PUBLIC_KEY_SIZE_1024_ <: usize) +!
+    Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
+    <:
+    usize) +!
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+
+let v_VECTOR_U_COMPRESSION_FACTOR_1024_: usize = sz 11
+
+let v_C1_BLOCK_SIZE_1024_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_U_COMPRESSION_FACTOR_1024_
+    <:
+    usize) /!
+  sz 8
+
+let v_C1_SIZE_1024_: usize = v_C1_BLOCK_SIZE_1024_ *! v_RANK_1024_
+
+let v_VECTOR_V_COMPRESSION_FACTOR_1024_: usize = sz 5
+
+let v_C2_SIZE_1024_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_V_COMPRESSION_FACTOR_1024_
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_CIPHERTEXT_SIZE_1024_: usize = v_C1_SIZE_1024_ +! v_C2_SIZE_1024_
+
+let v_IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize =
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_1024_
+
+unfold
+let t_Kyber1024Ciphertext = Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1568)
+
+unfold
+let t_Kyber1024PrivateKey = Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 3168)
+
+unfold
+let t_Kyber1024PublicKey = Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1568)
+
+val decapsulate_1024_
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 3168))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1568))
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encapsulate_1024_
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1568))
+      (randomness: t_Array u8 (sz 32))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1568) & t_Array u8 (sz 32))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_key_pair_1024_ (randomness: t_Array u8 (sz 64))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberKeyPair (sz 3168) (sz 1568))
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fst
@@ -1,0 +1,28 @@
+module Libcrux.Kem.Kyber.Kyber512
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let decapsulate_512_
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 1632))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 768))
+     =
+  Libcrux.Kem.Kyber.decapsulate (sz 2) (sz 1632) (sz 768) (sz 800) (sz 768) (sz 768) (sz 640)
+    (sz 128) (sz 10) (sz 4) (sz 320) (sz 3) (sz 192) (sz 2) (sz 128) (sz 800) secret_key ciphertext
+
+let encapsulate_512_
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 800))
+      (randomness: t_Array u8 (sz 32))
+     =
+  Libcrux.Kem.Kyber.encapsulate (sz 2) (sz 768) (sz 800) (sz 768) (sz 640) (sz 128) (sz 10) (sz 4)
+    (sz 320) (sz 3) (sz 192) (sz 2) (sz 128) public_key randomness
+
+let generate_key_pair_512_ (randomness: t_Array u8 (sz 64)) =
+  Libcrux.Kem.Kyber.generate_keypair (sz 2)
+    (sz 768)
+    (sz 1632)
+    (sz 800)
+    (sz 768)
+    (sz 3)
+    (sz 192)
+    randomness

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fsti
@@ -1,0 +1,89 @@
+module Libcrux.Kem.Kyber.Kyber512
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_ETA1: usize = sz 3
+
+let v_ETA1_RANDOMNESS_SIZE: usize = v_ETA1 *! sz 64
+
+let v_ETA2: usize = sz 2
+
+let v_ETA2_RANDOMNESS_SIZE: usize = v_ETA2 *! sz 64
+
+let v_RANK_512_: usize = sz 2
+
+let v_CPA_PKE_SECRET_KEY_SIZE_512_: usize =
+  ((v_RANK_512_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_RANKED_BYTES_PER_RING_ELEMENT_512_: usize =
+  (v_RANK_512_ *! Libcrux.Kem.Kyber.Constants.v_BITS_PER_RING_ELEMENT <: usize) /! sz 8
+
+let v_T_AS_NTT_ENCODED_SIZE_512_: usize =
+  ((v_RANK_512_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_PUBLIC_KEY_SIZE_512_: usize = v_T_AS_NTT_ENCODED_SIZE_512_ +! sz 32
+
+let v_SECRET_KEY_SIZE_512_: usize =
+  ((v_CPA_PKE_SECRET_KEY_SIZE_512_ +! v_CPA_PKE_PUBLIC_KEY_SIZE_512_ <: usize) +!
+    Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
+    <:
+    usize) +!
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+
+let v_VECTOR_U_COMPRESSION_FACTOR_512_: usize = sz 10
+
+let v_C1_BLOCK_SIZE_512_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_U_COMPRESSION_FACTOR_512_
+    <:
+    usize) /!
+  sz 8
+
+let v_C1_SIZE_512_: usize = v_C1_BLOCK_SIZE_512_ *! v_RANK_512_
+
+let v_VECTOR_V_COMPRESSION_FACTOR_512_: usize = sz 4
+
+let v_C2_SIZE_512_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_V_COMPRESSION_FACTOR_512_
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_CIPHERTEXT_SIZE_512_: usize = v_C1_SIZE_512_ +! v_C2_SIZE_512_
+
+let v_IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize =
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_512_
+
+unfold
+let t_Kyber512Ciphertext = Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 768)
+
+unfold
+let t_Kyber512PrivateKey = Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 1632)
+
+unfold
+let t_Kyber512PublicKey = Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 800)
+
+val decapsulate_512_
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 1632))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 768))
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encapsulate_512_
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 800))
+      (randomness: t_Array u8 (sz 32))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 768) & t_Array u8 (sz 32))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_key_pair_512_ (randomness: t_Array u8 (sz 64))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberKeyPair (sz 1632) (sz 800))
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fst
@@ -1,0 +1,28 @@
+module Libcrux.Kem.Kyber.Kyber768
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let decapsulate_768_
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 2400))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1088))
+     =
+  Libcrux.Kem.Kyber.decapsulate (sz 3) (sz 2400) (sz 1152) (sz 1184) (sz 1088) (sz 1152) (sz 960)
+    (sz 128) (sz 10) (sz 4) (sz 320) (sz 2) (sz 128) (sz 2) (sz 128) (sz 1120) secret_key ciphertext
+
+let encapsulate_768_
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1184))
+      (randomness: t_Array u8 (sz 32))
+     =
+  Libcrux.Kem.Kyber.encapsulate (sz 3) (sz 1088) (sz 1184) (sz 1152) (sz 960) (sz 128) (sz 10)
+    (sz 4) (sz 320) (sz 2) (sz 128) (sz 2) (sz 128) public_key randomness
+
+let generate_key_pair_768_ (randomness: t_Array u8 (sz 64)) =
+  Libcrux.Kem.Kyber.generate_keypair (sz 3)
+    (sz 1152)
+    (sz 2400)
+    (sz 1184)
+    (sz 1152)
+    (sz 2)
+    (sz 128)
+    randomness

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fsti
@@ -1,0 +1,89 @@
+module Libcrux.Kem.Kyber.Kyber768
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_ETA1: usize = sz 2
+
+let v_ETA1_RANDOMNESS_SIZE: usize = v_ETA1 *! sz 64
+
+let v_ETA2: usize = sz 2
+
+let v_ETA2_RANDOMNESS_SIZE: usize = v_ETA2 *! sz 64
+
+let v_RANK_768_: usize = sz 3
+
+let v_CPA_PKE_SECRET_KEY_SIZE_768_: usize =
+  ((v_RANK_768_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_RANKED_BYTES_PER_RING_ELEMENT_768_: usize =
+  (v_RANK_768_ *! Libcrux.Kem.Kyber.Constants.v_BITS_PER_RING_ELEMENT <: usize) /! sz 8
+
+let v_T_AS_NTT_ENCODED_SIZE_768_: usize =
+  ((v_RANK_768_ *! Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT <: usize) *!
+    Libcrux.Kem.Kyber.Constants.v_BITS_PER_COEFFICIENT
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_PUBLIC_KEY_SIZE_768_: usize = v_T_AS_NTT_ENCODED_SIZE_768_ +! sz 32
+
+let v_SECRET_KEY_SIZE_768_: usize =
+  ((v_CPA_PKE_SECRET_KEY_SIZE_768_ +! v_CPA_PKE_PUBLIC_KEY_SIZE_768_ <: usize) +!
+    Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
+    <:
+    usize) +!
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+
+let v_VECTOR_U_COMPRESSION_FACTOR_768_: usize = sz 10
+
+let v_C1_BLOCK_SIZE_768_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_U_COMPRESSION_FACTOR_768_
+    <:
+    usize) /!
+  sz 8
+
+let v_C1_SIZE_768_: usize = v_C1_BLOCK_SIZE_768_ *! v_RANK_768_
+
+let v_VECTOR_V_COMPRESSION_FACTOR_768_: usize = sz 4
+
+let v_C2_SIZE_768_: usize =
+  (Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_VECTOR_V_COMPRESSION_FACTOR_768_
+    <:
+    usize) /!
+  sz 8
+
+let v_CPA_PKE_CIPHERTEXT_SIZE_768_: usize = v_C1_SIZE_768_ +! v_C2_SIZE_768_
+
+let v_IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize =
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_768_
+
+unfold
+let t_Kyber768Ciphertext = Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1088)
+
+unfold
+let t_Kyber768PrivateKey = Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 2400)
+
+unfold
+let t_Kyber768PublicKey = Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1184)
+
+val decapsulate_768_
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 2400))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1088))
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encapsulate_768_
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey (sz 1184))
+      (randomness: t_Array u8 (sz 32))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberCiphertext (sz 1088) & t_Array u8 (sz 32))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_key_pair_768_ (randomness: t_Array u8 (sz 64))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberKeyPair (sz 2400) (sz 1184))
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fst
@@ -1,0 +1,540 @@
+module Libcrux.Kem.Kyber.Matrix
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let compute_As_plus_e
+      (v_K: usize)
+      (matrix_A: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+      (s_as_ntt error_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+     =
+  let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
+  in
+  let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__iter (Rust_primitives.unsize matrix_A
+                    <:
+                    t_Slice (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+                <:
+                Core.Slice.Iter.t_Iter
+                (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate
+            (Core.Slice.Iter.t_Iter
+              (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate
+        (Core.Slice.Iter.t_Iter (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)))
+      result
+      (fun result temp_1_ ->
+          let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K = result in
+          let i, row:(usize & t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+            temp_1_
+          in
+          let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+            Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+                      (Core.Slice.impl__iter (Rust_primitives.unsize row
+                            <:
+                            t_Slice Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                        <:
+                        Core.Slice.Iter.t_Iter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                    <:
+                    Core.Iter.Adapters.Enumerate.t_Enumerate
+                    (Core.Slice.Iter.t_Iter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement))
+                <:
+                Core.Iter.Adapters.Enumerate.t_Enumerate
+                (Core.Slice.Iter.t_Iter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement))
+              result
+              (fun result temp_1_ ->
+                  let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+                    result
+                  in
+                  let j, matrix_element:(usize &
+                    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+                    temp_1_
+                  in
+                  let product:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                    Libcrux.Kem.Kyber.Ntt.ntt_multiply matrix_element
+                      (s_as_ntt.[ j ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                  in
+                  let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
+                      i
+                      (Libcrux.Kem.Kyber.Arithmetic.add_to_ring_element v_K
+                          (result.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                          product
+                        <:
+                        Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                  in
+                  result)
+          in
+          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                    Core.Ops.Range.f_start = sz 0;
+                    Core.Ops.Range.f_end
+                    =
+                    Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+                  }
+                  <:
+                  Core.Ops.Range.t_Range usize)
+              <:
+              Core.Ops.Range.t_Range usize)
+            result
+            (fun result j ->
+                let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+                  result
+                in
+                let j:usize = j in
+                let coefficient_normal_form:i32 =
+                  Libcrux.Kem.Kyber.Arithmetic.to_standard_domain ((result.[ i ]
+                        <:
+                        Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ]
+                      <:
+                      i32)
+                in
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
+                  i
+                  ({
+                      (result.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) with
+                      Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                      =
+                      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (result.[ i ]
+                          <:
+                          Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                          .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        j
+                        (Libcrux.Kem.Kyber.Arithmetic.barrett_reduce (coefficient_normal_form +!
+                              ((error_as_ntt.[ i ]
+                                  <:
+                                  Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ]
+                                <:
+                                i32)
+                              <:
+                              i32)
+                          <:
+                          i32)
+                      <:
+                      t_Array i32 (sz 256)
+                    }
+                    <:
+                    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)))
+  in
+  result
+
+let compute_message
+      (v_K: usize)
+      (v: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (secret_as_ntt u_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+     =
+  let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = v_K
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      result
+      (fun result i ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          let i:usize = i in
+          let product:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            Libcrux.Kem.Kyber.Ntt.ntt_multiply (secret_as_ntt.[ i ]
+                <:
+                Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+              (u_as_ntt.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+          in
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            Libcrux.Kem.Kyber.Arithmetic.add_to_ring_element v_K result product
+          in
+          result)
+  in
+  let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Ntt.invert_ntt_montgomery v_K result
+  in
+  let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      result
+      (fun result i ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          let i:usize = i in
+          let coefficient_normal_form:i32 =
+            Libcrux.Kem.Kyber.Arithmetic.montgomery_reduce ((result
+                    .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                  <:
+                  i32) *!
+                1441l
+                <:
+                i32)
+          in
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              result with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                i
+                (Libcrux.Kem.Kyber.Arithmetic.barrett_reduce ((v
+                          .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                        <:
+                        i32) -!
+                      coefficient_normal_form
+                      <:
+                      i32)
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          result)
+  in
+  result
+
+let compute_ring_element_v
+      (v_K: usize)
+      (tt_as_ntt r_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      (error_2_ message: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+     =
+  let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = v_K
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      result
+      (fun result i ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          let i:usize = i in
+          let product:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            Libcrux.Kem.Kyber.Ntt.ntt_multiply (tt_as_ntt.[ i ]
+                <:
+                Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+              (r_as_ntt.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+          in
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            Libcrux.Kem.Kyber.Arithmetic.add_to_ring_element v_K result product
+          in
+          result)
+  in
+  let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Ntt.invert_ntt_montgomery v_K result
+  in
+  let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      result
+      (fun result i ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          let i:usize = i in
+          let coefficient_normal_form:i32 =
+            Libcrux.Kem.Kyber.Arithmetic.montgomery_reduce ((result
+                    .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                  <:
+                  i32) *!
+                1441l
+                <:
+                i32)
+          in
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              result with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                i
+                (Libcrux.Kem.Kyber.Arithmetic.barrett_reduce ((coefficient_normal_form +!
+                        (error_2_.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ] <: i32)
+                        <:
+                        i32) +!
+                      (message.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ] <: i32)
+                      <:
+                      i32)
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          result)
+  in
+  result
+
+let compute_vector_u
+      (v_K: usize)
+      (a_as_ntt: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+      (r_as_ntt error_1_: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+     =
+  let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
+  in
+  let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__iter (Rust_primitives.unsize a_as_ntt
+                    <:
+                    t_Slice (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+                <:
+                Core.Slice.Iter.t_Iter
+                (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate
+            (Core.Slice.Iter.t_Iter
+              (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate
+        (Core.Slice.Iter.t_Iter (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)))
+      result
+      (fun result temp_1_ ->
+          let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K = result in
+          let i, row:(usize & t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+            temp_1_
+          in
+          let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+            Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+                      (Core.Slice.impl__iter (Rust_primitives.unsize row
+                            <:
+                            t_Slice Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                        <:
+                        Core.Slice.Iter.t_Iter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                    <:
+                    Core.Iter.Adapters.Enumerate.t_Enumerate
+                    (Core.Slice.Iter.t_Iter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement))
+                <:
+                Core.Iter.Adapters.Enumerate.t_Enumerate
+                (Core.Slice.Iter.t_Iter Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement))
+              result
+              (fun result temp_1_ ->
+                  let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+                    result
+                  in
+                  let j, a_element:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+                    temp_1_
+                  in
+                  let product:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                    Libcrux.Kem.Kyber.Ntt.ntt_multiply a_element
+                      (r_as_ntt.[ j ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                  in
+                  let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
+                      i
+                      (Libcrux.Kem.Kyber.Arithmetic.add_to_ring_element v_K
+                          (result.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                          product
+                        <:
+                        Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                  in
+                  result)
+          in
+          let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
+              i
+              (Libcrux.Kem.Kyber.Ntt.invert_ntt_montgomery v_K
+                  (result.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                <:
+                Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+          in
+          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                    Core.Ops.Range.f_start = sz 0;
+                    Core.Ops.Range.f_end
+                    =
+                    Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+                  }
+                  <:
+                  Core.Ops.Range.t_Range usize)
+              <:
+              Core.Ops.Range.t_Range usize)
+            result
+            (fun result j ->
+                let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+                  result
+                in
+                let j:usize = j in
+                let coefficient_normal_form:i32 =
+                  Libcrux.Kem.Kyber.Arithmetic.montgomery_reduce (((result.[ i ]
+                          <:
+                          Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                          .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ]
+                        <:
+                        i32) *!
+                      1441l
+                      <:
+                      i32)
+                in
+                let result:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+                  Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
+                    i
+                    ({
+                        (result.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) with
+                        Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        =
+                        Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (result.[ i ]
+                            <:
+                            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          j
+                          (Libcrux.Kem.Kyber.Arithmetic.barrett_reduce (coefficient_normal_form +!
+                                ((error_1_.[ i ]
+                                    <:
+                                    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                                    .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ]
+                                  <:
+                                  i32)
+                                <:
+                                i32)
+                            <:
+                            i32)
+                        <:
+                        t_Array i32 (sz 256)
+                      }
+                      <:
+                      Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                in
+                result))
+  in
+  result
+
+let sample_matrix_A (v_K: usize) (seed: t_Array u8 (sz 34)) (transpose: bool) =
+  let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+    Rust_primitives.Hax.repeat (Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+          v_K
+        <:
+        t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      v_K
+  in
+  let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = v_K
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      v_A_transpose
+      (fun v_A_transpose i ->
+          let v_A_transpose:t_Array
+            (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+            v_A_transpose
+          in
+          let i:usize = i in
+          let seeds:t_Array (t_Array u8 (sz 34)) v_K = Rust_primitives.Hax.repeat seed v_K in
+          let seeds:t_Array (t_Array u8 (sz 34)) v_K =
+            Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                      Core.Ops.Range.f_start = sz 0;
+                      Core.Ops.Range.f_end = v_K
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize)
+                <:
+                Core.Ops.Range.t_Range usize)
+              seeds
+              (fun seeds j ->
+                  let seeds:t_Array (t_Array u8 (sz 34)) v_K = seeds in
+                  let j:usize = j in
+                  let seeds:t_Array (t_Array u8 (sz 34)) v_K =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize seeds
+                      j
+                      (Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (seeds.[ j ]
+                            <:
+                            t_Array u8 (sz 34))
+                          (sz 32)
+                          (cast (i <: usize) <: u8)
+                        <:
+                        t_Array u8 (sz 34))
+                  in
+                  let seeds:t_Array (t_Array u8 (sz 34)) v_K =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize seeds
+                      j
+                      (Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (seeds.[ j ]
+                            <:
+                            t_Array u8 (sz 34))
+                          (sz 33)
+                          (cast (j <: usize) <: u8)
+                        <:
+                        t_Array u8 (sz 34))
+                  in
+                  seeds)
+          in
+          let xof_bytes:t_Array (t_Array u8 (sz 840)) v_K =
+            Libcrux.Kem.Kyber.Hash_functions.v_XOFx4 v_K seeds
+          in
+          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                    Core.Ops.Range.f_start = sz 0;
+                    Core.Ops.Range.f_end = v_K
+                  }
+                  <:
+                  Core.Ops.Range.t_Range usize)
+              <:
+              Core.Ops.Range.t_Range usize)
+            v_A_transpose
+            (fun v_A_transpose j ->
+                let v_A_transpose:t_Array
+                  (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+                  v_A_transpose
+                in
+                let j:usize = j in
+                let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                  Libcrux.Kem.Kyber.Sampling.sample_from_uniform_distribution (xof_bytes.[ j ]
+                      <:
+                      t_Array u8 (sz 840))
+                in
+                if transpose
+                then
+                  let v_A_transpose:t_Array
+                    (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v_A_transpose
+                      j
+                      (Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (v_A_transpose.[ j
+                            ]
+                            <:
+                            t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+                          i
+                          sampled
+                        <:
+                        t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+                  in
+                  v_A_transpose
+                else
+                  let v_A_transpose:t_Array
+                    (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v_A_transpose
+                      i
+                      (Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (v_A_transpose.[ i
+                            ]
+                            <:
+                            t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+                          j
+                          sampled
+                        <:
+                        t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+                  in
+                  v_A_transpose))
+  in
+  v_A_transpose

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fst
@@ -465,7 +465,7 @@ let sample_matrix_A (v_K: usize) (seed: t_Array u8 (sz 34)) (transpose: bool) =
                             <:
                             t_Array u8 (sz 34))
                           (sz 32)
-                          (cast (i <: usize) <: u8)
+                          (classify (cast (i <: usize) <: pub_u8))
                         <:
                         t_Array u8 (sz 34))
                   in
@@ -476,7 +476,7 @@ let sample_matrix_A (v_K: usize) (seed: t_Array u8 (sz 34)) (transpose: bool) =
                             <:
                             t_Array u8 (sz 34))
                           (sz 33)
-                          (cast (j <: usize) <: u8)
+                          (classify (cast (j <: usize) <: pub_u8))
                         <:
                         t_Array u8 (sz 34))
                   in

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fsti
@@ -1,0 +1,41 @@
+module Libcrux.Kem.Kyber.Matrix
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val compute_As_plus_e
+      (v_K: usize)
+      (matrix_A: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+      (s_as_ntt error_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compute_message
+      (v_K: usize)
+      (v: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (secret_as_ntt u_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compute_ring_element_v
+      (v_K: usize)
+      (tt_as_ntt r_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      (error_2_ message: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compute_vector_u
+      (v_K: usize)
+      (a_as_ntt: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+      (r_as_ntt error_1_: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val sample_matrix_A (v_K: usize) (seed: t_Array u8 (sz 34)) (transpose: bool)
+    : Prims.Pure (t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fst
@@ -1,0 +1,606 @@
+module Libcrux.Kem.Kyber.Ntt
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let ntt_multiply_binomials (a0, a1: (i32 & i32)) (b0, b1: (i32 & i32)) (zeta: i32) =
+  Libcrux.Kem.Kyber.Arithmetic.montgomery_reduce ((a0 *! b0 <: i32) +!
+      ((Libcrux.Kem.Kyber.Arithmetic.montgomery_reduce (a1 *! b1 <: i32) <: i32) *! zeta <: i32)
+      <:
+      i32),
+  Libcrux.Kem.Kyber.Arithmetic.montgomery_reduce ((a0 *! b1 <: i32) +! (a1 *! b0 <: i32) <: i32)
+  <:
+  (i32 & i32)
+
+let invert_ntt_at_layer
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer: usize)
+     =
+  let step:usize = sz 1 <<! layer in
+  let re, zeta_i:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = sz 128 >>! layer <: usize
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      (re, zeta_i <: (Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize))
+      (fun temp_0_ round ->
+          let re, zeta_i:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize) = temp_0_ in
+          let round:usize = round in
+          let zeta_i:usize = zeta_i -! sz 1 in
+          let offset:usize = (round *! step <: usize) *! sz 2 in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                      Core.Ops.Range.f_start = offset;
+                      Core.Ops.Range.f_end = offset +! step <: usize
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize)
+                <:
+                Core.Ops.Range.t_Range usize)
+              re
+              (fun re j ->
+                  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+                  let j:usize = j in
+                  let a_minus_b:i32 =
+                    (re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j +! step <: usize ] <: i32) -!
+                    (re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ] <: i32)
+                  in
+                  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                    {
+                      re with
+                      Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                      =
+                      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                          .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        j
+                        ((re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ] <: i32) +!
+                          (re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j +! step <: usize ]
+                            <:
+                            i32)
+                          <:
+                          i32)
+                    }
+                    <:
+                    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+                  in
+                  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                    {
+                      re with
+                      Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                      =
+                      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                          .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        (j +! step <: usize)
+                        (Libcrux.Kem.Kyber.Arithmetic.montgomery_reduce (a_minus_b *!
+                              (v_ZETAS_TIMES_MONTGOMERY_R.[ zeta_i ] <: i32)
+                              <:
+                              i32)
+                          <:
+                          i32)
+                    }
+                    <:
+                    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+                  in
+                  re)
+          in
+          re, zeta_i <: (Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize))
+  in
+  let hax_temp_output:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+  zeta_i, hax_temp_output <: (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+
+let invert_ntt_montgomery (v_K: usize) (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+  let _:Prims.unit = () <: Prims.unit in
+  let zeta_i:usize = Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT /! sz 2 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    invert_ntt_at_layer zeta_i re (sz 1)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist1:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist1 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    invert_ntt_at_layer zeta_i re (sz 2)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist2:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist2 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    invert_ntt_at_layer zeta_i re (sz 3)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist3:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist3 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    invert_ntt_at_layer zeta_i re (sz 4)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist4:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist4 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    invert_ntt_at_layer zeta_i re (sz 5)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist5:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist5 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    invert_ntt_at_layer zeta_i re (sz 6)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist6:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist6 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    invert_ntt_at_layer zeta_i re (sz 7)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist7:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist7 in
+  let _:Prims.unit = () <: Prims.unit in
+  let _:Prims.unit = () <: Prims.unit in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = sz 2
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      re
+      (fun re i ->
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+          let i:usize = i in
+          {
+            re with
+            Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+            =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              i
+              (Libcrux.Kem.Kyber.Arithmetic.barrett_reduce (re
+                      .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                    <:
+                    i32)
+                <:
+                i32)
+            <:
+            t_Array i32 (sz 256)
+          }
+          <:
+          Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+  in
+  re
+
+let ntt_at_layer
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer initial_coefficient_bound: usize)
+     =
+  let step:usize = sz 1 <<! layer in
+  let re, zeta_i:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = sz 128 >>! layer <: usize
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      (re, zeta_i <: (Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize))
+      (fun temp_0_ round ->
+          let re, zeta_i:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize) = temp_0_ in
+          let round:usize = round in
+          let zeta_i:usize = zeta_i +! sz 1 in
+          let offset:usize = (round *! step <: usize) *! sz 2 in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                      Core.Ops.Range.f_start = offset;
+                      Core.Ops.Range.f_end = offset +! step <: usize
+                    }
+                    <:
+                    Core.Ops.Range.t_Range usize)
+                <:
+                Core.Ops.Range.t_Range usize)
+              re
+              (fun re j ->
+                  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+                  let j:usize = j in
+                  let t:i32 =
+                    Libcrux.Kem.Kyber.Arithmetic.montgomery_multiply_sfe_by_fer (re
+                          .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j +! step <: usize ]
+                        <:
+                        i32)
+                      (v_ZETAS_TIMES_MONTGOMERY_R.[ zeta_i ] <: i32)
+                  in
+                  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                    {
+                      re with
+                      Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                      =
+                      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                          .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        (j +! step <: usize)
+                        ((re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ] <: i32) -! t <: i32)
+                    }
+                    <:
+                    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+                  in
+                  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                    {
+                      re with
+                      Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                      =
+                      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                          .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        j
+                        ((re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ] <: i32) +! t <: i32)
+                    }
+                    <:
+                    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+                  in
+                  re)
+          in
+          re, zeta_i <: (Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize))
+  in
+  let _:Prims.unit = () <: Prims.unit in
+  let hax_temp_output:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+  zeta_i, hax_temp_output <: (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+
+let ntt_at_layer_3_
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer: usize)
+     =
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer zeta_i re layer (sz 3)
+  in
+  let zeta_i:usize = tmp0 in
+  let hax_temp_output:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  zeta_i, hax_temp_output <: (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+
+let ntt_at_layer_3328_
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer: usize)
+     =
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer zeta_i re layer (sz 3328)
+  in
+  let zeta_i:usize = tmp0 in
+  let hax_temp_output:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  zeta_i, hax_temp_output <: (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+
+let ntt_binomially_sampled_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+  let _:Prims.unit = () <: Prims.unit in
+  let zeta_i:usize = sz 1 in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = sz 128
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      re
+      (fun re j ->
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+          let j:usize = j in
+          let t:i32 =
+            (re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j +! sz 128 <: usize ] <: i32) *!
+            (-1600l)
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                (j +! sz 128 <: usize)
+                ((re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ] <: i32) -! t <: i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                j
+                ((re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ] <: i32) +! t <: i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          re)
+  in
+  let _:Prims.unit = () <: Prims.unit in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3_ zeta_i re (sz 6)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist8:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist8 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3_ zeta_i re (sz 5)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist9:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist9 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3_ zeta_i re (sz 4)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist10:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist10 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3_ zeta_i re (sz 3)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist11:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist11 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3_ zeta_i re (sz 2)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist12:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist12 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3_ zeta_i re (sz 1)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist13:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist13 in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      re
+      (fun re i ->
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+          let i:usize = i in
+          {
+            re with
+            Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+            =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              i
+              (Libcrux.Kem.Kyber.Arithmetic.barrett_reduce (re
+                      .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                    <:
+                    i32)
+                <:
+                i32)
+            <:
+            t_Array i32 (sz 256)
+          }
+          <:
+          Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+  in
+  re
+
+let ntt_multiply (lhs rhs: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+  let _:Prims.unit = () <: Prims.unit in
+  let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end
+              =
+              Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT /! sz 4 <: usize
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      out
+      (fun out i ->
+          let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+          let i:usize = i in
+          let product:(i32 & i32) =
+            ntt_multiply_binomials ((lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ sz 4 *! i
+                    <:
+                    usize ]
+                  <:
+                  i32),
+                (lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ (sz 4 *! i <: usize) +! sz 1
+                    <:
+                    usize ]
+                  <:
+                  i32)
+                <:
+                (i32 & i32))
+              ((rhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ sz 4 *! i <: usize ] <: i32),
+                (rhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ (sz 4 *! i <: usize) +! sz 1
+                    <:
+                    usize ]
+                  <:
+                  i32)
+                <:
+                (i32 & i32))
+              (v_ZETAS_TIMES_MONTGOMERY_R.[ sz 64 +! i <: usize ] <: i32)
+          in
+          let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              out with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                (sz 4 *! i <: usize)
+                product._1
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              out with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 4 *! i <: usize) +! sz 1 <: usize)
+                product._2
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let product:(i32 & i32) =
+            ntt_multiply_binomials ((lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ (sz 4 *! i
+                      <:
+                      usize) +!
+                    sz 2
+                    <:
+                    usize ]
+                  <:
+                  i32),
+                (lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ (sz 4 *! i <: usize) +! sz 3
+                    <:
+                    usize ]
+                  <:
+                  i32)
+                <:
+                (i32 & i32))
+              ((rhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ (sz 4 *! i <: usize) +! sz 2
+                    <:
+                    usize ]
+                  <:
+                  i32),
+                (rhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ (sz 4 *! i <: usize) +! sz 3
+                    <:
+                    usize ]
+                  <:
+                  i32)
+                <:
+                (i32 & i32))
+              (Core.Ops.Arith.Neg.neg (v_ZETAS_TIMES_MONTGOMERY_R.[ sz 64 +! i <: usize ] <: i32)
+                <:
+                i32)
+          in
+          let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              out with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 4 *! i <: usize) +! sz 2 <: usize)
+                product._1
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              out with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 4 *! i <: usize) +! sz 3 <: usize)
+                product._2
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          out)
+  in
+  out
+
+let ntt_vector_u
+      (v_VECTOR_U_COMPRESSION_FACTOR: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+     =
+  let _:Prims.unit = () <: Prims.unit in
+  let zeta_i:usize = sz 0 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3328_ zeta_i re (sz 7)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist14:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist14 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3328_ zeta_i re (sz 6)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist15:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist15 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3328_ zeta_i re (sz 5)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist16:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist16 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3328_ zeta_i re (sz 4)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist17:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist17 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3328_ zeta_i re (sz 3)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist18:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist18 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3328_ zeta_i re (sz 2)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist19:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist19 in
+  let tmp0, out:(usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+    ntt_at_layer_3328_ zeta_i re (sz 1)
+  in
+  let zeta_i:usize = tmp0 in
+  let hoist20:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = out in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = hoist20 in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      re
+      (fun re i ->
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+          let i:usize = i in
+          {
+            re with
+            Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+            =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              i
+              (Libcrux.Kem.Kyber.Arithmetic.barrett_reduce (re
+                      .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                    <:
+                    i32)
+                <:
+                i32)
+            <:
+            t_Array i32 (sz 256)
+          }
+          <:
+          Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+  in
+  re

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fsti
@@ -1,0 +1,224 @@
+module Libcrux.Kem.Kyber.Ntt
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_ZETAS_TIMES_MONTGOMERY_R: t_Array i32 (sz 128) =
+  let list =
+    [
+      (-1044l); (-758l); (-359l); (-1517l); 1493l; 1422l; 287l; 202l; (-171l); 622l; 1577l; 182l;
+      962l; (-1202l); (-1474l); 1468l; 573l; (-1325l); 264l; 383l; (-829l); 1458l; (-1602l); (-130l);
+      (-681l); 1017l; 732l; 608l; (-1542l); 411l; (-205l); (-1571l); 1223l; 652l; (-552l); 1015l;
+      (-1293l); 1491l; (-282l); (-1544l); 516l; (-8l); (-320l); (-666l); (-1618l); (-1162l); 126l;
+      1469l; (-853l); (-90l); (-271l); 830l; 107l; (-1421l); (-247l); (-951l); (-398l); 961l;
+      (-1508l); (-725l); 448l; (-1065l); 677l; (-1275l); (-1103l); 430l; 555l; 843l; (-1251l); 871l;
+      1550l; 105l; 422l; 587l; 177l; (-235l); (-291l); (-460l); 1574l; 1653l; (-246l); 778l; 1159l;
+      (-147l); (-777l); 1483l; (-602l); 1119l; (-1590l); 644l; (-872l); 349l; 418l; 329l; (-156l);
+      (-75l); 817l; 1097l; 603l; 610l; 1322l; (-1285l); (-1465l); 384l; (-1215l); (-136l); 1218l;
+      (-1335l); (-874l); 220l; (-1187l); (-1659l); (-1185l); (-1530l); (-1278l); 794l; (-1510l);
+      (-854l); (-870l); 478l; (-108l); (-308l); 996l; 991l; 958l; (-1460l); 1522l; 1628l
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 128);
+  Rust_primitives.Hax.array_of_list list
+
+val ntt_multiply_binomials: (i32 & i32) -> (i32 & i32) -> zeta: i32
+  -> Prims.Pure (i32 & i32) Prims.l_True (fun _ -> Prims.l_True)
+
+val invert_ntt_at_layer
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer: usize)
+    : Prims.Pure (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val invert_ntt_montgomery (v_K: usize) (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val ntt_at_layer
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer initial_coefficient_bound: usize)
+    : Prims.Pure (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val ntt_at_layer_3_
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer: usize)
+    : Prims.Pure (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val ntt_at_layer_3328_
+      (zeta_i: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      (layer: usize)
+    : Prims.Pure (usize & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val ntt_binomially_sampled_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      (requires
+        Hax_lib.v_forall (fun i ->
+              let i:usize = i in
+              Hax_lib.implies (i <.
+                  (Core.Slice.impl__len (Rust_primitives.unsize re
+                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        <:
+                        t_Slice i32)
+                    <:
+                    usize)
+                  <:
+                  bool)
+                (fun temp_0_ ->
+                    let _:Prims.unit = temp_0_ in
+                    (Core.Num.impl__i32__abs (re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                          <:
+                          i32)
+                      <:
+                      i32) <=.
+                    3l
+                    <:
+                    bool)
+              <:
+              bool))
+      (ensures
+        fun result ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result
+                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                              i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <.
+                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      <:
+                      bool)
+                <:
+                bool))
+
+val ntt_multiply (lhs rhs: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      (requires
+        Hax_lib.v_forall (fun i ->
+              let i:usize = i in
+              Hax_lib.implies (i <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+                  <:
+                  bool)
+                (fun temp_0_ ->
+                    let _:Prims.unit = temp_0_ in
+                    ((lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ] <: i32) >=. 0l <: bool) &&
+                    ((lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ] <: i32) <. 4096l <: bool
+                    ) &&
+                    ((Core.Num.impl__i32__abs (rhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <=.
+                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      <:
+                      bool))
+              <:
+              bool))
+      (ensures
+        fun result ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result
+                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                              i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <=.
+                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      <:
+                      bool)
+                <:
+                bool))
+
+val ntt_vector_u
+      (v_VECTOR_U_COMPRESSION_FACTOR: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      (requires
+        Hax_lib.v_forall (fun i ->
+              let i:usize = i in
+              Hax_lib.implies (i <.
+                  (Core.Slice.impl__len (Rust_primitives.unsize re
+                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        <:
+                        t_Slice i32)
+                    <:
+                    usize)
+                  <:
+                  bool)
+                (fun temp_0_ ->
+                    let _:Prims.unit = temp_0_ in
+                    (Core.Num.impl__i32__abs (re.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                          <:
+                          i32)
+                      <:
+                      i32) <=.
+                    3328l
+                    <:
+                    bool)
+              <:
+              bool))
+      (ensures
+        fun result ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result
+                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                              i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <.
+                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                      <:
+                      bool)
+                <:
+                bool))

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fsti
@@ -104,13 +104,13 @@ val ntt_binomially_sampled_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_Poly
                     bool)
                   (fun temp_0_ ->
                       let _:Prims.unit = temp_0_ in
-                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                      v (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
                               i ]
                             <:
                             i32)
                         <:
-                        i32) <.
-                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                        i32) <
+                      v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
                       <:
                       bool)
                 <:
@@ -129,12 +129,12 @@ val ntt_multiply (lhs rhs: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
                     ((lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ] <: i32) >=. 0l <: bool) &&
                     ((lhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ] <: i32) <. 4096l <: bool
                     ) &&
-                    ((Core.Num.impl__i32__abs (rhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
+                    (v (Core.Num.impl__i32__abs (rhs.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ i ]
                             <:
                             i32)
                         <:
-                        i32) <=.
-                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                        i32) <=
+                      v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
                       <:
                       bool))
               <:
@@ -155,13 +155,13 @@ val ntt_multiply (lhs rhs: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
                     bool)
                   (fun temp_0_ ->
                       let _:Prims.unit = temp_0_ in
-                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                      v (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
                               i ]
                             <:
                             i32)
                         <:
-                        i32) <=.
-                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                        i32) <=
+                      v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
                       <:
                       bool)
                 <:
@@ -211,13 +211,13 @@ val ntt_vector_u
                     bool)
                   (fun temp_0_ ->
                       let _:Prims.unit = temp_0_ in
-                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                      v (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
                               i ]
                             <:
                             i32)
                         <:
-                        i32) <.
-                      Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
+                        i32) <
+                      v Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS
                       <:
                       bool)
                 <:

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst
@@ -1,0 +1,271 @@
+module Libcrux.Kem.Kyber.Sampling
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let rejection_sampling_panic_with_diagnostic (_: Prims.unit) =
+  Rust_primitives.Hax.never_to_any (Core.Panicking.panic "explicit panic"
+      <:
+      Rust_primitives.Hax.t_Never)
+
+let sample_from_binomial_distribution_2_ (randomness: t_Slice u8) =
+  let (sampled: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement):Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+  =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact randomness (sz 4) <: Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+      sampled
+      (fun sampled temp_1_ ->
+          let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = sampled in
+          let chunk_number, byte_chunk:(usize & t_Slice u8) = temp_1_ in
+          let (random_bits_as_u32: u32):u32 =
+            (((cast (byte_chunk.[ sz 0 ] <: u8) <: u32) |.
+                ((cast (byte_chunk.[ sz 1 ] <: u8) <: u32) <<! 8l <: u32)
+                <:
+                u32) |.
+              ((cast (byte_chunk.[ sz 2 ] <: u8) <: u32) <<! 16l <: u32)
+              <:
+              u32) |.
+            ((cast (byte_chunk.[ sz 3 ] <: u8) <: u32) <<! 24l <: u32)
+          in
+          let even_bits:u32 = random_bits_as_u32 &. 1431655765ul in
+          let odd_bits:u32 = (random_bits_as_u32 >>! 1l <: u32) &. 1431655765ul in
+          let coin_toss_outcomes:u32 = even_bits +! odd_bits in
+          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_step_by
+                    ({
+                        Core.Ops.Range.f_start = 0ul;
+                        Core.Ops.Range.f_end = Core.Num.impl__u32__BITS
+                      }
+                      <:
+                      Core.Ops.Range.t_Range u32)
+                    (sz 4)
+                  <:
+                  Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range u32))
+              <:
+              Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range u32))
+            sampled
+            (fun sampled outcome_set ->
+                let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = sampled in
+                let outcome_set:u32 = outcome_set in
+                let outcome_1_:i32 =
+                  cast ((coin_toss_outcomes >>! outcome_set <: u32) &. 3ul <: u32) <: i32
+                in
+                let outcome_2_:i32 =
+                  cast ((coin_toss_outcomes >>! (outcome_set +! 2ul <: u32) <: u32) &. 3ul <: u32)
+                  <:
+                  i32
+                in
+                let offset:usize = cast (outcome_set >>! 2l <: u32) <: usize in
+                let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                  {
+                    sampled with
+                    Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize sampled
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                      ((sz 8 *! chunk_number <: usize) +! offset <: usize)
+                      (outcome_1_ -! outcome_2_ <: i32)
+                  }
+                  <:
+                  Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+                in
+                sampled))
+  in
+  let _:Prims.unit = () <: Prims.unit in
+  sampled
+
+let sample_from_binomial_distribution_3_ (randomness: t_Slice u8) =
+  let (sampled: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement):Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+  =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact randomness (sz 3) <: Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+      sampled
+      (fun sampled temp_1_ ->
+          let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = sampled in
+          let chunk_number, byte_chunk:(usize & t_Slice u8) = temp_1_ in
+          let (random_bits_as_u24: u32):u32 =
+            ((cast (byte_chunk.[ sz 0 ] <: u8) <: u32) |.
+              ((cast (byte_chunk.[ sz 1 ] <: u8) <: u32) <<! 8l <: u32)
+              <:
+              u32) |.
+            ((cast (byte_chunk.[ sz 2 ] <: u8) <: u32) <<! 16l <: u32)
+          in
+          let first_bits:u32 = random_bits_as_u24 &. 2396745ul in
+          let second_bits:u32 = (random_bits_as_u24 >>! 1l <: u32) &. 2396745ul in
+          let third_bits:u32 = (random_bits_as_u24 >>! 2l <: u32) &. 2396745ul in
+          let coin_toss_outcomes:u32 = (first_bits +! second_bits <: u32) +! third_bits in
+          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_step_by
+                    ({ Core.Ops.Range.f_start = 0l; Core.Ops.Range.f_end = 24l }
+                      <:
+                      Core.Ops.Range.t_Range i32)
+                    (sz 6)
+                  <:
+                  Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range i32))
+              <:
+              Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range i32))
+            sampled
+            (fun sampled outcome_set ->
+                let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = sampled in
+                let outcome_set:i32 = outcome_set in
+                let outcome_1_:i32 =
+                  cast ((coin_toss_outcomes >>! outcome_set <: u32) &. 7ul <: u32) <: i32
+                in
+                let outcome_2_:i32 =
+                  cast ((coin_toss_outcomes >>! (outcome_set +! 3l <: i32) <: u32) &. 7ul <: u32)
+                  <:
+                  i32
+                in
+                let offset:usize = cast (outcome_set /! 6l <: i32) <: usize in
+                let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                  {
+                    sampled with
+                    Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize sampled
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                      ((sz 4 *! chunk_number <: usize) +! offset <: usize)
+                      (outcome_1_ -! outcome_2_ <: i32)
+                  }
+                  <:
+                  Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+                in
+                sampled))
+  in
+  let _:Prims.unit = () <: Prims.unit in
+  sampled
+
+let sample_from_binomial_distribution (v_ETA: usize) (randomness: t_Slice u8) =
+  let _:Prims.unit = () <: Prims.unit in
+  match cast (v_ETA <: usize) <: u32 with
+  | 2ul -> sample_from_binomial_distribution_2_ randomness
+  | 3ul -> sample_from_binomial_distribution_3_ randomness
+  | _ ->
+    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+
+        <:
+        Rust_primitives.Hax.t_Never)
+
+let sample_from_uniform_distribution (randomness: t_Array u8 (sz 840)) =
+  let (sampled_coefficients: usize):usize = sz 0 in
+  let (out: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement):Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+  =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let done:bool = false in
+  let done, out, sampled_coefficients:(bool & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement &
+    usize) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Slice.impl__chunks (
+                Rust_primitives.unsize randomness <: t_Slice u8)
+              (sz 3)
+            <:
+            Core.Slice.Iter.t_Chunks u8)
+        <:
+        Core.Slice.Iter.t_Chunks u8)
+      (done, out, sampled_coefficients
+        <:
+        (bool & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize))
+      (fun temp_0_ bytes ->
+          let done, out, sampled_coefficients:(bool &
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement &
+            usize) =
+            temp_0_
+          in
+          let bytes:t_Slice u8 = bytes in
+          if ~.done <: bool
+          then
+            let b1:i32 = cast (bytes.[ sz 0 ] <: u8) <: i32 in
+            let b2:i32 = cast (bytes.[ sz 1 ] <: u8) <: i32 in
+            let b3:i32 = cast (bytes.[ sz 2 ] <: u8) <: i32 in
+            let d1:i32 = ((b2 &. 15l <: i32) <<! 8l <: i32) |. b1 in
+            let d2:i32 = (b3 <<! 4l <: i32) |. (b2 >>! 4l <: i32) in
+            let out, sampled_coefficients:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement &
+              usize) =
+              if
+                d1 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &&
+                sampled_coefficients <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+              then
+                let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                  {
+                    out with
+                    Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                      sampled_coefficients
+                      d1
+                  }
+                  <:
+                  Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+                in
+                out, sampled_coefficients +! sz 1
+                <:
+                (Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize)
+              else
+                out, sampled_coefficients
+                <:
+                (Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize)
+            in
+            let out, sampled_coefficients:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement &
+              usize) =
+              if
+                d2 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &&
+                sampled_coefficients <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+              then
+                let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                  {
+                    out with
+                    Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                      sampled_coefficients
+                      d2
+                  }
+                  <:
+                  Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+                in
+                let sampled_coefficients:usize = sampled_coefficients +! sz 1 in
+                out, sampled_coefficients
+                <:
+                (Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize)
+              else
+                out, sampled_coefficients
+                <:
+                (Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize)
+            in
+            if sampled_coefficients =. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+            then
+              let done:bool = true in
+              done, out, sampled_coefficients
+              <:
+              (bool & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize)
+            else
+              done, out, sampled_coefficients
+              <:
+              (bool & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize)
+          else
+            done, out, sampled_coefficients
+            <:
+            (bool & Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement & usize))
+  in
+  let _:Prims.unit =
+    if ~.done
+    then
+      let _:Prims.unit = rejection_sampling_panic_with_diagnostic () in
+      ()
+  in
+  let _:Prims.unit = () <: Prims.unit in
+  out

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst
@@ -194,6 +194,12 @@ let sample_from_uniform_distribution (randomness: t_Array u8 (sz 840)) =
             let out, sampled_coefficients:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement &
               usize) =
               if
+                // NOTE: We declassify d1 here, and this should be carefully reviewed.
+                //       We believe this is safe because d1 is derived from b1 and b2, 
+                //       both of which are fresh random inputs, not used anywhere else.
+                //       The comparison between d1 and 3329 tells the adversary whether d1
+                //       is in the field. This is not secret information, since the
+                //       failure of this comparison leads to d1 being discarded,
                 declassify d1 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &&
                 sampled_coefficients <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
               then
@@ -221,6 +227,12 @@ let sample_from_uniform_distribution (randomness: t_Array u8 (sz 840)) =
             let out, sampled_coefficients:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement &
               usize) =
               if
+                // NOTE: We declassify d2 here, and this should be carefully reviewed.
+                //       We believe this is safe because d2 is derived from b2 and b3, 
+                //       both of which are fresh random inputs, not used anywhere else.
+                //       The comparison between d2 and 3329 tells the adversary whether d2
+                //       is in the field. This is not secret information, since the
+                //       failure of this comparison leads to d2 being discarded,
                 declassify d2 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &&
                 sampled_coefficients <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
               then

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst
@@ -43,25 +43,25 @@ let sample_from_binomial_distribution_2_ (randomness: t_Slice u8) =
                         Core.Ops.Range.f_end = Core.Num.impl__u32__BITS
                       }
                       <:
-                      Core.Ops.Range.t_Range u32)
+                      Core.Ops.Range.t_Range pub_u32)
                     (sz 4)
                   <:
-                  Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range u32))
+                  Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range pub_u32))
               <:
-              Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range u32))
+              Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range pub_u32))
             sampled
             (fun sampled outcome_set ->
                 let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = sampled in
-                let outcome_set:u32 = outcome_set in
+                let outcome_set:pub_u32 = outcome_set in
                 let outcome_1_:i32 =
                   cast ((coin_toss_outcomes >>! outcome_set <: u32) &. 3ul <: u32) <: i32
                 in
                 let outcome_2_:i32 =
-                  cast ((coin_toss_outcomes >>! (outcome_set +! 2ul <: u32) <: u32) &. 3ul <: u32)
+                  cast ((coin_toss_outcomes >>! (outcome_set +! 2ul <: pub_u32) <: u32) &. 3ul <: u32)
                   <:
                   i32
                 in
-                let offset:usize = cast (outcome_set >>! 2l <: u32) <: usize in
+                let offset:usize = cast (outcome_set >>! 2l <: pub_u32) <: usize in
                 let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
                   {
                     sampled with
@@ -110,25 +110,25 @@ let sample_from_binomial_distribution_3_ (randomness: t_Slice u8) =
           Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_step_by
                     ({ Core.Ops.Range.f_start = 0l; Core.Ops.Range.f_end = 24l }
                       <:
-                      Core.Ops.Range.t_Range i32)
+                      Core.Ops.Range.t_Range pub_i32)
                     (sz 6)
                   <:
-                  Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range i32))
+                  Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range pub_i32))
               <:
-              Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range i32))
+              Core.Iter.Adapters.Step_by.t_StepBy (Core.Ops.Range.t_Range pub_i32))
             sampled
             (fun sampled outcome_set ->
                 let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = sampled in
-                let outcome_set:i32 = outcome_set in
+                let outcome_set:pub_i32 = outcome_set in
                 let outcome_1_:i32 =
-                  cast ((coin_toss_outcomes >>! outcome_set <: u32) &. 7ul <: u32) <: i32
+                  cast ((coin_toss_outcomes >>! outcome_set <: pub_u32) &. 7ul <: u32) <: i32
                 in
                 let outcome_2_:i32 =
-                  cast ((coin_toss_outcomes >>! (outcome_set +! 3l <: i32) <: u32) &. 7ul <: u32)
+                  cast ((coin_toss_outcomes >>! (outcome_set +! 3l <: pub_i32) <: u32) &. 7ul <: u32)
                   <:
                   i32
                 in
-                let offset:usize = cast (outcome_set /! 6l <: i32) <: usize in
+                let offset:usize = cast (outcome_set /! 6l <: pub_i32) <: usize in
                 let sampled:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
                   {
                     sampled with
@@ -149,7 +149,7 @@ let sample_from_binomial_distribution_3_ (randomness: t_Slice u8) =
 
 let sample_from_binomial_distribution (v_ETA: usize) (randomness: t_Slice u8) =
   let _:Prims.unit = () <: Prims.unit in
-  match cast (v_ETA <: usize) <: u32 with
+  match cast (v_ETA <: usize) <: pub_u32 with
   | 2ul -> sample_from_binomial_distribution_2_ randomness
   | 3ul -> sample_from_binomial_distribution_3_ randomness
   | _ ->
@@ -194,7 +194,7 @@ let sample_from_uniform_distribution (randomness: t_Array u8 (sz 840)) =
             let out, sampled_coefficients:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement &
               usize) =
               if
-                d1 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &&
+                declassify d1 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &&
                 sampled_coefficients <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
               then
                 let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
@@ -221,7 +221,7 @@ let sample_from_uniform_distribution (randomness: t_Array u8 (sz 840)) =
             let out, sampled_coefficients:(Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement &
               usize) =
               if
-                d2 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &&
+                declassify d2 <. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS &&
                 sampled_coefficients <. Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
               then
                 let out:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fsti
@@ -1,0 +1,79 @@
+module Libcrux.Kem.Kyber.Sampling
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val rejection_sampling_panic_with_diagnostic: Prims.unit
+  -> Prims.Pure Prims.unit Prims.l_True (fun _ -> Prims.l_True)
+
+val sample_from_binomial_distribution_2_ (randomness: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      (requires (Core.Slice.impl__len randomness <: usize) =. (sz 2 *! sz 64 <: usize))
+      (ensures
+        fun result ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result
+                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                              i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <=.
+                      2l
+                      <:
+                      bool)
+                <:
+                bool))
+
+val sample_from_binomial_distribution_3_ (randomness: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      (requires (Core.Slice.impl__len randomness <: usize) =. (sz 3 *! sz 64 <: usize))
+      (ensures
+        fun result ->
+          let result:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = result in
+          Hax_lib.v_forall (fun i ->
+                let i:usize = i in
+                Hax_lib.implies (i <.
+                    (Core.Slice.impl__len (Rust_primitives.unsize result
+                              .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          <:
+                          t_Slice i32)
+                      <:
+                      usize)
+                    <:
+                    bool)
+                  (fun temp_0_ ->
+                      let _:Prims.unit = temp_0_ in
+                      (Core.Num.impl__i32__abs (result.Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[
+                              i ]
+                            <:
+                            i32)
+                        <:
+                        i32) <=.
+                      3l
+                      <:
+                      bool)
+                <:
+                bool))
+
+val sample_from_binomial_distribution (v_ETA: usize) (randomness: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val sample_from_uniform_distribution (randomness: t_Array u8 (sz 840))
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fst
@@ -643,7 +643,7 @@ let compress_then_serialize_ring_element_u
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
      =
   let _:Prims.unit = () <: Prims.unit in
-  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  match cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32 with
   | 10ul -> compress_then_serialize_10_ v_OUT_LEN re
   | 11ul -> compress_then_serialize_11_ v_OUT_LEN re
   | _ ->
@@ -657,7 +657,7 @@ let compress_then_serialize_ring_element_v
       (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
      =
   let _:Prims.unit = () <: Prims.unit in
-  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  match cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32 with
   | 4ul -> compress_then_serialize_4_ v_OUT_LEN re
   | 5ul -> compress_then_serialize_5_ v_OUT_LEN re
   | _ ->
@@ -1181,7 +1181,7 @@ let deserialize_then_decompress_ring_element_u
       (serialized: t_Slice u8)
      =
   let _:Prims.unit = () <: Prims.unit in
-  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  match cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32 with
   | 10ul -> deserialize_then_decompress_10_ serialized
   | 11ul -> deserialize_then_decompress_11_ serialized
   | _ ->
@@ -1195,7 +1195,7 @@ let deserialize_then_decompress_ring_element_v
       (serialized: t_Slice u8)
      =
   let _:Prims.unit = () <: Prims.unit in
-  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  match cast (v_COMPRESSION_FACTOR <: usize) <: pub_u32 with
   | 4ul -> deserialize_then_decompress_4_ serialized
   | 5ul -> deserialize_then_decompress_5_ serialized
   | _ ->

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fst
@@ -1,0 +1,1301 @@
+module Libcrux.Kem.Kyber.Serialize
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let compress_coefficients_10_ (coefficient1 coefficient2 coefficient3 coefficient4: i32) =
+  let coef1:u8 = cast (coefficient1 &. 255l <: i32) <: u8 in
+  let coef2:u8 =
+    ((cast (coefficient2 &. 63l <: i32) <: u8) <<! 2l <: u8) |.
+    (cast ((coefficient1 >>! 8l <: i32) &. 3l <: i32) <: u8)
+  in
+  let coef3:u8 =
+    ((cast (coefficient3 &. 15l <: i32) <: u8) <<! 4l <: u8) |.
+    (cast ((coefficient2 >>! 6l <: i32) &. 15l <: i32) <: u8)
+  in
+  let coef4:u8 =
+    ((cast (coefficient4 &. 3l <: i32) <: u8) <<! 6l <: u8) |.
+    (cast ((coefficient3 >>! 4l <: i32) &. 63l <: i32) <: u8)
+  in
+  let coef5:u8 = cast ((coefficient4 >>! 2l <: i32) &. 255l <: i32) <: u8 in
+  coef1, coef2, coef3, coef4, coef5 <: (u8 & u8 & u8 & u8 & u8)
+
+let compress_coefficients_11_
+      (coefficient1 coefficient2 coefficient3 coefficient4 coefficient5 coefficient6 coefficient7 coefficient8:
+          i32)
+     =
+  let coef1:u8 = cast (coefficient1 <: i32) <: u8 in
+  let coef2:u8 =
+    ((cast (coefficient2 &. 31l <: i32) <: u8) <<! 3l <: u8) |.
+    (cast (coefficient1 >>! 8l <: i32) <: u8)
+  in
+  let coef3:u8 =
+    ((cast (coefficient3 &. 3l <: i32) <: u8) <<! 6l <: u8) |.
+    (cast (coefficient2 >>! 5l <: i32) <: u8)
+  in
+  let coef4:u8 = cast ((coefficient3 >>! 2l <: i32) &. 255l <: i32) <: u8 in
+  let coef5:u8 =
+    ((cast (coefficient4 &. 127l <: i32) <: u8) <<! 1l <: u8) |.
+    (cast (coefficient3 >>! 10l <: i32) <: u8)
+  in
+  let coef6:u8 =
+    ((cast (coefficient5 &. 15l <: i32) <: u8) <<! 4l <: u8) |.
+    (cast (coefficient4 >>! 7l <: i32) <: u8)
+  in
+  let coef7:u8 =
+    ((cast (coefficient6 &. 1l <: i32) <: u8) <<! 7l <: u8) |.
+    (cast (coefficient5 >>! 4l <: i32) <: u8)
+  in
+  let coef8:u8 = cast ((coefficient6 >>! 1l <: i32) &. 255l <: i32) <: u8 in
+  let coef9:u8 =
+    ((cast (coefficient7 &. 63l <: i32) <: u8) <<! 2l <: u8) |.
+    (cast (coefficient6 >>! 9l <: i32) <: u8)
+  in
+  let coef10:u8 =
+    ((cast (coefficient8 &. 7l <: i32) <: u8) <<! 5l <: u8) |.
+    (cast (coefficient7 >>! 6l <: i32) <: u8)
+  in
+  let coef11:u8 = cast (coefficient8 >>! 3l <: i32) <: u8 in
+  coef1, coef2, coef3, coef4, coef5, coef6, coef7, coef8, coef9, coef10, coef11
+  <:
+  (u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8)
+
+let compress_coefficients_3_ (coefficient1 coefficient2: u16) =
+  let coef1:u8 = cast (coefficient1 &. 255us <: u16) <: u8 in
+  let coef2:u8 =
+    cast ((coefficient1 >>! 8l <: u16) |. ((coefficient2 &. 15us <: u16) <<! 4l <: u16) <: u16)
+    <:
+    u8
+  in
+  let coef3:u8 = cast ((coefficient2 >>! 4l <: u16) &. 255us <: u16) <: u8 in
+  coef1, coef2, coef3 <: (u8 & u8 & u8)
+
+let compress_coefficients_5_
+      (coefficient2 coefficient1 coefficient4 coefficient3 coefficient5 coefficient7 coefficient6 coefficient8:
+          u8)
+     =
+  let coef1:u8 = ((coefficient2 &. 7uy <: u8) <<! 5l <: u8) |. coefficient1 in
+  let coef2:u8 =
+    (((coefficient4 &. 1uy <: u8) <<! 7l <: u8) |. (coefficient3 <<! 2l <: u8) <: u8) |.
+    (coefficient2 >>! 3l <: u8)
+  in
+  let coef3:u8 = ((coefficient5 &. 15uy <: u8) <<! 4l <: u8) |. (coefficient4 >>! 1l <: u8) in
+  let coef4:u8 =
+    (((coefficient7 &. 3uy <: u8) <<! 6l <: u8) |. (coefficient6 <<! 1l <: u8) <: u8) |.
+    (coefficient5 >>! 4l <: u8)
+  in
+  let coef5:u8 = (coefficient8 <<! 3l <: u8) |. (coefficient7 >>! 2l <: u8) in
+  coef1, coef2, coef3, coef4, coef5 <: (u8 & u8 & u8 & u8 & u8)
+
+let decompress_coefficients_10_ (byte2 byte1 byte3 byte4 byte5: i32) =
+  let coefficient1:i32 = ((byte2 &. 3l <: i32) <<! 8l <: i32) |. (byte1 &. 255l <: i32) in
+  let coefficient2:i32 = ((byte3 &. 15l <: i32) <<! 6l <: i32) |. (byte2 >>! 2l <: i32) in
+  let coefficient3:i32 = ((byte4 &. 63l <: i32) <<! 4l <: i32) |. (byte3 >>! 4l <: i32) in
+  let coefficient4:i32 = (byte5 <<! 2l <: i32) |. (byte4 >>! 6l <: i32) in
+  coefficient1, coefficient2, coefficient3, coefficient4 <: (i32 & i32 & i32 & i32)
+
+let decompress_coefficients_11_
+      (byte2 byte1 byte3 byte5 byte4 byte6 byte7 byte9 byte8 byte10 byte11: i32)
+     =
+  let coefficient1:i32 = ((byte2 &. 7l <: i32) <<! 8l <: i32) |. byte1 in
+  let coefficient2:i32 = ((byte3 &. 63l <: i32) <<! 5l <: i32) |. (byte2 >>! 3l <: i32) in
+  let coefficient3:i32 =
+    (((byte5 &. 1l <: i32) <<! 10l <: i32) |. (byte4 <<! 2l <: i32) <: i32) |. (byte3 >>! 6l <: i32)
+  in
+  let coefficient4:i32 = ((byte6 &. 15l <: i32) <<! 7l <: i32) |. (byte5 >>! 1l <: i32) in
+  let coefficient5:i32 = ((byte7 &. 127l <: i32) <<! 4l <: i32) |. (byte6 >>! 4l <: i32) in
+  let coefficient6:i32 =
+    (((byte9 &. 3l <: i32) <<! 9l <: i32) |. (byte8 <<! 1l <: i32) <: i32) |. (byte7 >>! 7l <: i32)
+  in
+  let coefficient7:i32 = ((byte10 &. 31l <: i32) <<! 6l <: i32) |. (byte9 >>! 2l <: i32) in
+  let coefficient8:i32 = (byte11 <<! 3l <: i32) |. (byte10 >>! 5l <: i32) in
+  coefficient1,
+  coefficient2,
+  coefficient3,
+  coefficient4,
+  coefficient5,
+  coefficient6,
+  coefficient7,
+  coefficient8
+  <:
+  (i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32)
+
+let decompress_coefficients_4_ (byte: u8) =
+  let coefficient1:i32 = cast (byte &. 15uy <: u8) <: i32 in
+  let coefficient2:i32 = cast ((byte >>! 4l <: u8) &. 15uy <: u8) <: i32 in
+  coefficient1, coefficient2 <: (i32 & i32)
+
+let decompress_coefficients_5_ (byte1 byte2 byte3 byte4 byte5: i32) =
+  let coefficient1:i32 = byte1 &. 31l in
+  let coefficient2:i32 = ((byte2 &. 3l <: i32) <<! 3l <: i32) |. (byte1 >>! 5l <: i32) in
+  let coefficient3:i32 = (byte2 >>! 2l <: i32) &. 31l in
+  let coefficient4:i32 = ((byte3 &. 15l <: i32) <<! 1l <: i32) |. (byte2 >>! 7l <: i32) in
+  let coefficient5:i32 = ((byte4 &. 1l <: i32) <<! 4l <: i32) |. (byte3 >>! 4l <: i32) in
+  let coefficient6:i32 = (byte4 >>! 1l <: i32) &. 31l in
+  let coefficient7:i32 = ((byte5 &. 7l <: i32) <<! 2l <: i32) |. (byte4 >>! 6l <: i32) in
+  let coefficient8:i32 = byte5 >>! 3l in
+  coefficient1,
+  coefficient2,
+  coefficient3,
+  coefficient4,
+  coefficient5,
+  coefficient6,
+  coefficient7,
+  coefficient8
+  <:
+  (i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32)
+
+let compress_then_serialize_10_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+     =
+  let serialized:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
+  let serialized:t_Array u8 v_OUT_LEN =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact (Rust_primitives.unsize re
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    <:
+                    t_Slice i32)
+                  (sz 4)
+                <:
+                Core.Slice.Iter.t_ChunksExact i32)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+      serialized
+      (fun serialized temp_1_ ->
+          let serialized:t_Array u8 v_OUT_LEN = serialized in
+          let i, coefficients:(usize & t_Slice i32) = temp_1_ in
+          let coefficient1:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 10uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 0 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coefficient2:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 10uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 1 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coefficient3:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 10uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 2 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coefficient4:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 10uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 3 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coef1, coef2, coef3, coef4, coef5:(u8 & u8 & u8 & u8 & u8) =
+            compress_coefficients_10_ coefficient1 coefficient2 coefficient3 coefficient4
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              (sz 5 *! i <: usize)
+              coef1
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 5 *! i <: usize) +! sz 1 <: usize)
+              coef2
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 5 *! i <: usize) +! sz 2 <: usize)
+              coef3
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 5 *! i <: usize) +! sz 3 <: usize)
+              coef4
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 5 *! i <: usize) +! sz 4 <: usize)
+              coef5
+          in
+          serialized)
+  in
+  serialized
+
+let compress_then_serialize_11_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+     =
+  let serialized:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
+  let serialized:t_Array u8 v_OUT_LEN =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact (Rust_primitives.unsize re
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    <:
+                    t_Slice i32)
+                  (sz 8)
+                <:
+                Core.Slice.Iter.t_ChunksExact i32)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+      serialized
+      (fun serialized temp_1_ ->
+          let serialized:t_Array u8 v_OUT_LEN = serialized in
+          let i, coefficients:(usize & t_Slice i32) = temp_1_ in
+          let coefficient1:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 11uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 0 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coefficient2:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 11uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 1 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coefficient3:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 11uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 2 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coefficient4:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 11uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 3 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coefficient5:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 11uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 4 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coefficient6:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 11uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 5 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coefficient7:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 11uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 6 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coefficient8:i32 =
+            Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 11uy
+              (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 7 ] <: i32
+                  )
+                <:
+                u16)
+          in
+          let coef1, coef2, coef3, coef4, coef5, coef6, coef7, coef8, coef9, coef10, coef11:(u8 & u8 &
+            u8 &
+            u8 &
+            u8 &
+            u8 &
+            u8 &
+            u8 &
+            u8 &
+            u8 &
+            u8) =
+            compress_coefficients_11_ coefficient1
+              coefficient2
+              coefficient3
+              coefficient4
+              coefficient5
+              coefficient6
+              coefficient7
+              coefficient8
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              (sz 11 *! i <: usize)
+              coef1
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 11 *! i <: usize) +! sz 1 <: usize)
+              coef2
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 11 *! i <: usize) +! sz 2 <: usize)
+              coef3
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 11 *! i <: usize) +! sz 3 <: usize)
+              coef4
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 11 *! i <: usize) +! sz 4 <: usize)
+              coef5
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 11 *! i <: usize) +! sz 5 <: usize)
+              coef6
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 11 *! i <: usize) +! sz 6 <: usize)
+              coef7
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 11 *! i <: usize) +! sz 7 <: usize)
+              coef8
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 11 *! i <: usize) +! sz 8 <: usize)
+              coef9
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 11 *! i <: usize) +! sz 9 <: usize)
+              coef10
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 11 *! i <: usize) +! sz 10 <: usize)
+              coef11
+          in
+          serialized)
+  in
+  serialized
+
+let compress_then_serialize_4_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+     =
+  let serialized:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
+  let serialized:t_Array u8 v_OUT_LEN =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact (Rust_primitives.unsize re
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    <:
+                    t_Slice i32)
+                  (sz 2)
+                <:
+                Core.Slice.Iter.t_ChunksExact i32)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+      serialized
+      (fun serialized temp_1_ ->
+          let serialized:t_Array u8 v_OUT_LEN = serialized in
+          let i, coefficients:(usize & t_Slice i32) = temp_1_ in
+          let coefficient1:u8 =
+            cast (Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 4uy
+                  (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 0 ]
+                        <:
+                        i32)
+                    <:
+                    u16)
+                <:
+                i32)
+            <:
+            u8
+          in
+          let coefficient2:u8 =
+            cast (Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 4uy
+                  (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 1 ]
+                        <:
+                        i32)
+                    <:
+                    u16)
+                <:
+                i32)
+            <:
+            u8
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              i
+              ((coefficient2 <<! 4l <: u8) |. coefficient1 <: u8)
+          in
+          serialized)
+  in
+  serialized
+
+let compress_then_serialize_5_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+     =
+  let serialized:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat 0uy v_OUT_LEN in
+  let serialized:t_Array u8 v_OUT_LEN =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact (Rust_primitives.unsize re
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    <:
+                    t_Slice i32)
+                  (sz 8)
+                <:
+                Core.Slice.Iter.t_ChunksExact i32)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+      serialized
+      (fun serialized temp_1_ ->
+          let serialized:t_Array u8 v_OUT_LEN = serialized in
+          let i, coefficients:(usize & t_Slice i32) = temp_1_ in
+          let coefficient1:u8 =
+            cast (Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 5uy
+                  (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 0 ]
+                        <:
+                        i32)
+                    <:
+                    u16)
+                <:
+                i32)
+            <:
+            u8
+          in
+          let coefficient2:u8 =
+            cast (Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 5uy
+                  (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 1 ]
+                        <:
+                        i32)
+                    <:
+                    u16)
+                <:
+                i32)
+            <:
+            u8
+          in
+          let coefficient3:u8 =
+            cast (Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 5uy
+                  (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 2 ]
+                        <:
+                        i32)
+                    <:
+                    u16)
+                <:
+                i32)
+            <:
+            u8
+          in
+          let coefficient4:u8 =
+            cast (Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 5uy
+                  (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 3 ]
+                        <:
+                        i32)
+                    <:
+                    u16)
+                <:
+                i32)
+            <:
+            u8
+          in
+          let coefficient5:u8 =
+            cast (Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 5uy
+                  (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 4 ]
+                        <:
+                        i32)
+                    <:
+                    u16)
+                <:
+                i32)
+            <:
+            u8
+          in
+          let coefficient6:u8 =
+            cast (Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 5uy
+                  (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 5 ]
+                        <:
+                        i32)
+                    <:
+                    u16)
+                <:
+                i32)
+            <:
+            u8
+          in
+          let coefficient7:u8 =
+            cast (Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 5uy
+                  (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 6 ]
+                        <:
+                        i32)
+                    <:
+                    u16)
+                <:
+                i32)
+            <:
+            u8
+          in
+          let coefficient8:u8 =
+            cast (Libcrux.Kem.Kyber.Compress.compress_ciphertext_coefficient 5uy
+                  (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 7 ]
+                        <:
+                        i32)
+                    <:
+                    u16)
+                <:
+                i32)
+            <:
+            u8
+          in
+          let coef1, coef2, coef3, coef4, coef5:(u8 & u8 & u8 & u8 & u8) =
+            compress_coefficients_5_ coefficient2
+              coefficient1
+              coefficient4
+              coefficient3
+              coefficient5
+              coefficient7
+              coefficient6
+              coefficient8
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              (sz 5 *! i <: usize)
+              coef1
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 5 *! i <: usize) +! sz 1 <: usize)
+              coef2
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 5 *! i <: usize) +! sz 2 <: usize)
+              coef3
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 5 *! i <: usize) +! sz 3 <: usize)
+              coef4
+          in
+          let serialized:t_Array u8 v_OUT_LEN =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 5 *! i <: usize) +! sz 4 <: usize)
+              coef5
+          in
+          serialized)
+  in
+  serialized
+
+let compress_then_serialize_message (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+  let serialized:t_Array u8 (sz 32) = Rust_primitives.Hax.repeat 0uy (sz 32) in
+  let serialized:t_Array u8 (sz 32) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact (Rust_primitives.unsize re
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    <:
+                    t_Slice i32)
+                  (sz 8)
+                <:
+                Core.Slice.Iter.t_ChunksExact i32)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+      serialized
+      (fun serialized temp_1_ ->
+          let serialized:t_Array u8 (sz 32) = serialized in
+          let i, coefficients:(usize & t_Slice i32) = temp_1_ in
+          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+                    (Core.Slice.impl__iter coefficients <: Core.Slice.Iter.t_Iter i32)
+                  <:
+                  Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_Iter i32))
+              <:
+              Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_Iter i32))
+            serialized
+            (fun serialized temp_1_ ->
+                let serialized:t_Array u8 (sz 32) = serialized in
+                let j, coefficient:(usize & i32) = temp_1_ in
+                let coefficient:u16 =
+                  Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative coefficient
+                in
+                let coefficient_compressed:u8 =
+                  Libcrux.Kem.Kyber.Compress.compress_message_coefficient coefficient
+                in
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+                  i
+                  ((serialized.[ i ] <: u8) |. (coefficient_compressed <<! j <: u8) <: u8))
+          <:
+          t_Array u8 (sz 32))
+  in
+  serialized
+
+let compress_then_serialize_ring_element_u
+      (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+     =
+  let _:Prims.unit = () <: Prims.unit in
+  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  | 10ul -> compress_then_serialize_10_ v_OUT_LEN re
+  | 11ul -> compress_then_serialize_11_ v_OUT_LEN re
+  | _ ->
+    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+
+        <:
+        Rust_primitives.Hax.t_Never)
+
+let compress_then_serialize_ring_element_v
+      (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+     =
+  let _:Prims.unit = () <: Prims.unit in
+  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  | 4ul -> compress_then_serialize_4_ v_OUT_LEN re
+  | 5ul -> compress_then_serialize_5_ v_OUT_LEN re
+  | _ ->
+    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+
+        <:
+        Rust_primitives.Hax.t_Never)
+
+let deserialize_then_decompress_10_ (serialized: t_Slice u8) =
+  let _:Prims.unit = () <: Prims.unit in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact serialized (sz 5) <: Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+      re
+      (fun re temp_1_ ->
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+          let i, bytes:(usize & t_Slice u8) = temp_1_ in
+          let byte1:i32 = cast (bytes.[ sz 0 ] <: u8) <: i32 in
+          let byte2:i32 = cast (bytes.[ sz 1 ] <: u8) <: i32 in
+          let byte3:i32 = cast (bytes.[ sz 2 ] <: u8) <: i32 in
+          let byte4:i32 = cast (bytes.[ sz 3 ] <: u8) <: i32 in
+          let byte5:i32 = cast (bytes.[ sz 4 ] <: u8) <: i32 in
+          let coefficient1, coefficient2, coefficient3, coefficient4:(i32 & i32 & i32 & i32) =
+            decompress_coefficients_10_ byte2 byte1 byte3 byte4 byte5
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                (sz 4 *! i <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 10uy coefficient1
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 4 *! i <: usize) +! sz 1 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 10uy coefficient2
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 4 *! i <: usize) +! sz 2 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 10uy coefficient3
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 4 *! i <: usize) +! sz 3 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 10uy coefficient4
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          re)
+  in
+  re
+
+let deserialize_then_decompress_11_ (serialized: t_Slice u8) =
+  let _:Prims.unit = () <: Prims.unit in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact serialized (sz 11) <: Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+      re
+      (fun re temp_1_ ->
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+          let i, bytes:(usize & t_Slice u8) = temp_1_ in
+          let byte1:i32 = cast (bytes.[ sz 0 ] <: u8) <: i32 in
+          let byte2:i32 = cast (bytes.[ sz 1 ] <: u8) <: i32 in
+          let byte3:i32 = cast (bytes.[ sz 2 ] <: u8) <: i32 in
+          let byte4:i32 = cast (bytes.[ sz 3 ] <: u8) <: i32 in
+          let byte5:i32 = cast (bytes.[ sz 4 ] <: u8) <: i32 in
+          let byte6:i32 = cast (bytes.[ sz 5 ] <: u8) <: i32 in
+          let byte7:i32 = cast (bytes.[ sz 6 ] <: u8) <: i32 in
+          let byte8:i32 = cast (bytes.[ sz 7 ] <: u8) <: i32 in
+          let byte9:i32 = cast (bytes.[ sz 8 ] <: u8) <: i32 in
+          let byte10:i32 = cast (bytes.[ sz 9 ] <: u8) <: i32 in
+          let byte11:i32 = cast (bytes.[ sz 10 ] <: u8) <: i32 in
+          let
+          coefficient1,
+          coefficient2,
+          coefficient3,
+          coefficient4,
+          coefficient5,
+          coefficient6,
+          coefficient7,
+          coefficient8:(i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32) =
+            decompress_coefficients_11_ byte2 byte1 byte3 byte5 byte4 byte6 byte7 byte9 byte8 byte10
+              byte11
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                (sz 8 *! i <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 11uy coefficient1
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 1 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 11uy coefficient2
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 2 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 11uy coefficient3
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 3 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 11uy coefficient4
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 4 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 11uy coefficient5
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 5 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 11uy coefficient6
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 6 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 11uy coefficient7
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 7 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 11uy coefficient8
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          re)
+  in
+  re
+
+let deserialize_then_decompress_4_ (serialized: t_Slice u8) =
+  let _:Prims.unit = () <: Prims.unit in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__iter serialized <: Core.Slice.Iter.t_Iter u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_Iter u8))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_Iter u8))
+      re
+      (fun re temp_1_ ->
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+          let i, byte:(usize & u8) = temp_1_ in
+          let coefficient1, coefficient2:(i32 & i32) = decompress_coefficients_4_ byte in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                (sz 2 *! i <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 4uy coefficient1
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 2 *! i <: usize) +! sz 1 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 4uy coefficient2
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          re)
+  in
+  re
+
+let deserialize_then_decompress_5_ (serialized: t_Slice u8) =
+  let _:Prims.unit = () <: Prims.unit in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact serialized (sz 5) <: Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+      re
+      (fun re temp_1_ ->
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+          let i, bytes:(usize & t_Slice u8) = temp_1_ in
+          let byte1:i32 = cast (bytes.[ sz 0 ] <: u8) <: i32 in
+          let byte2:i32 = cast (bytes.[ sz 1 ] <: u8) <: i32 in
+          let byte3:i32 = cast (bytes.[ sz 2 ] <: u8) <: i32 in
+          let byte4:i32 = cast (bytes.[ sz 3 ] <: u8) <: i32 in
+          let byte5:i32 = cast (bytes.[ sz 4 ] <: u8) <: i32 in
+          let
+          coefficient1,
+          coefficient2,
+          coefficient3,
+          coefficient4,
+          coefficient5,
+          coefficient6,
+          coefficient7,
+          coefficient8:(i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32) =
+            decompress_coefficients_5_ byte1 byte2 byte3 byte4 byte5
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                (sz 8 *! i <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 5uy coefficient1
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 1 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 5uy coefficient2
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 2 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 5uy coefficient3
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 3 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 5uy coefficient4
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 4 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 5uy coefficient5
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 5 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 5uy coefficient6
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 6 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 5uy coefficient7
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 8 *! i <: usize) +! sz 7 <: usize)
+                (Libcrux.Kem.Kyber.Compress.decompress_ciphertext_coefficient 5uy coefficient8
+                  <:
+                  i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          re)
+  in
+  re
+
+let deserialize_then_decompress_message (serialized: t_Array u8 (sz 32)) =
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Iter.Traits.Collect.f_into_iter serialized
+                <:
+                Core.Array.Iter.t_IntoIter u8 (sz 32))
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Array.Iter.t_IntoIter u8 (sz 32)))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Array.Iter.t_IntoIter u8 (sz 32)))
+      re
+      (fun re temp_1_ ->
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+          let i, byte:(usize & u8) = temp_1_ in
+          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                    Core.Ops.Range.f_start = sz 0;
+                    Core.Ops.Range.f_end = sz 8
+                  }
+                  <:
+                  Core.Ops.Range.t_Range usize)
+              <:
+              Core.Ops.Range.t_Range usize)
+            re
+            (fun re j ->
+                let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+                let j:usize = j in
+                let coefficient_compressed:i32 = cast ((byte >>! j <: u8) &. 1uy <: u8) <: i32 in
+                let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+                  {
+                    re with
+                    Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    =
+                    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                      ((sz 8 *! i <: usize) +! j <: usize)
+                      (Libcrux.Kem.Kyber.Compress.decompress_message_coefficient coefficient_compressed
+
+                        <:
+                        i32)
+                  }
+                  <:
+                  Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+                in
+                re)
+          <:
+          Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+  in
+  re
+
+let deserialize_then_decompress_ring_element_u
+      (v_COMPRESSION_FACTOR: usize)
+      (serialized: t_Slice u8)
+     =
+  let _:Prims.unit = () <: Prims.unit in
+  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  | 10ul -> deserialize_then_decompress_10_ serialized
+  | 11ul -> deserialize_then_decompress_11_ serialized
+  | _ ->
+    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+
+        <:
+        Rust_primitives.Hax.t_Never)
+
+let deserialize_then_decompress_ring_element_v
+      (v_COMPRESSION_FACTOR: usize)
+      (serialized: t_Slice u8)
+     =
+  let _:Prims.unit = () <: Prims.unit in
+  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+  | 4ul -> deserialize_then_decompress_4_ serialized
+  | 5ul -> deserialize_then_decompress_5_ serialized
+  | _ ->
+    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+
+        <:
+        Rust_primitives.Hax.t_Never)
+
+let deserialize_to_uncompressed_ring_element (serialized: t_Slice u8) =
+  let _:Prims.unit = () <: Prims.unit in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO
+  in
+  let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact serialized (sz 3) <: Core.Slice.Iter.t_ChunksExact u8)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
+      re
+      (fun re temp_1_ ->
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement = re in
+          let i, bytes:(usize & t_Slice u8) = temp_1_ in
+          let byte1:i32 = cast (bytes.[ sz 0 ] <: u8) <: i32 in
+          let byte2:i32 = cast (bytes.[ sz 1 ] <: u8) <: i32 in
+          let byte3:i32 = cast (bytes.[ sz 2 ] <: u8) <: i32 in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                (sz 2 *! i <: usize)
+                (((byte2 &. 15l <: i32) <<! 8l <: i32) |. (byte1 &. 255l <: i32) <: i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          let re:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+            {
+              re with
+              Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                ((sz 2 *! i <: usize) +! sz 1 <: usize)
+                ((byte3 <<! 4l <: i32) |. ((byte2 >>! 4l <: i32) &. 15l <: i32) <: i32)
+            }
+            <:
+            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+          in
+          re)
+  in
+  re
+
+let serialize_uncompressed_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) =
+  let serialized:t_Array u8 (sz 384) = Rust_primitives.Hax.repeat 0uy (sz 384) in
+  let serialized:t_Array u8 (sz 384) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
+              (Core.Slice.impl__chunks_exact (Rust_primitives.unsize re
+                        .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                    <:
+                    t_Slice i32)
+                  (sz 2)
+                <:
+                Core.Slice.Iter.t_ChunksExact i32)
+            <:
+            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+        <:
+        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact i32))
+      serialized
+      (fun serialized temp_1_ ->
+          let serialized:t_Array u8 (sz 384) = serialized in
+          let i, coefficients:(usize & t_Slice i32) = temp_1_ in
+          let coefficient1:u16 =
+            Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 0 ] <: i32)
+          in
+          let coefficient2:u16 =
+            Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative (coefficients.[ sz 1 ] <: i32)
+          in
+          let coef1, coef2, coef3:(u8 & u8 & u8) =
+            compress_coefficients_3_ coefficient1 coefficient2
+          in
+          let serialized:t_Array u8 (sz 384) =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              (sz 3 *! i <: usize)
+              coef1
+          in
+          let serialized:t_Array u8 (sz 384) =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 3 *! i <: usize) +! sz 1 <: usize)
+              coef2
+          in
+          let serialized:t_Array u8 (sz 384) =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize serialized
+              ((sz 3 *! i <: usize) +! sz 2 <: usize)
+              coef3
+          in
+          serialized)
+  in
+  serialized

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fsti
@@ -1,0 +1,119 @@
+module Libcrux.Kem.Kyber.Serialize
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val compress_coefficients_10_ (coefficient1 coefficient2 coefficient3 coefficient4: i32)
+    : Prims.Pure (u8 & u8 & u8 & u8 & u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_coefficients_11_
+      (coefficient1 coefficient2 coefficient3 coefficient4 coefficient5 coefficient6 coefficient7 coefficient8:
+          i32)
+    : Prims.Pure (u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compress_coefficients_3_ (coefficient1 coefficient2: u16)
+    : Prims.Pure (u8 & u8 & u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_coefficients_5_
+      (coefficient2 coefficient1 coefficient4 coefficient3 coefficient5 coefficient7 coefficient6 coefficient8:
+          u8)
+    : Prims.Pure (u8 & u8 & u8 & u8 & u8) Prims.l_True (fun _ -> Prims.l_True)
+
+val decompress_coefficients_10_ (byte2 byte1 byte3 byte4 byte5: i32)
+    : Prims.Pure (i32 & i32 & i32 & i32) Prims.l_True (fun _ -> Prims.l_True)
+
+val decompress_coefficients_11_
+      (byte2 byte1 byte3 byte5 byte4 byte6 byte7 byte9 byte8 byte10 byte11: i32)
+    : Prims.Pure (i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val decompress_coefficients_4_ (byte: u8)
+    : Prims.Pure (i32 & i32) Prims.l_True (fun _ -> Prims.l_True)
+
+val decompress_coefficients_5_ (byte1 byte2 byte3 byte4 byte5: i32)
+    : Prims.Pure (i32 & i32 & i32 & i32 & i32 & i32 & i32 & i32)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val compress_then_serialize_10_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_11_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_4_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_5_
+      (v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_message (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_ring_element_u
+      (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val compress_then_serialize_ring_element_v
+      (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
+      (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_10_ (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_11_ (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_4_ (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_5_ (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_message (serialized: t_Array u8 (sz 32))
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_ring_element_u
+      (v_COMPRESSION_FACTOR: usize)
+      (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_then_decompress_ring_element_v
+      (v_COMPRESSION_FACTOR: usize)
+      (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val deserialize_to_uncompressed_ring_element (serialized: t_Slice u8)
+    : Prims.Pure Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val serialize_uncompressed_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+    : Prims.Pure (t_Array u8 (sz 384)) Prims.l_True (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Types.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.Types.fst
@@ -1,0 +1,195 @@
+module Libcrux.Kem.Kyber.Types
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+type t_KyberCiphertext (v_SIZE: usize) = { f_value:t_Array u8 v_SIZE }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1 (v_SIZE: usize) : Core.Convert.t_AsRef (t_KyberCiphertext v_SIZE) (t_Slice u8) =
+  { f_as_ref = fun (self: t_KyberCiphertext v_SIZE) -> Rust_primitives.unsize self.f_value }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_2 (v_SIZE: usize) : Core.Convert.t_From (t_KyberCiphertext v_SIZE) (t_Array u8 v_SIZE) =
+  { f_from = fun (value: t_Array u8 v_SIZE) -> { f_value = value } <: t_KyberCiphertext v_SIZE }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_3 (v_SIZE: usize) : Core.Convert.t_From (t_KyberCiphertext v_SIZE) (t_Array u8 v_SIZE) =
+  {
+    f_from
+    =
+    fun (value: t_Array u8 v_SIZE) ->
+      { f_value = Core.Clone.f_clone value } <: t_KyberCiphertext v_SIZE
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_4 (v_SIZE: usize) : Core.Convert.t_From (t_Array u8 v_SIZE) (t_KyberCiphertext v_SIZE) =
+  { f_from = fun (value: t_KyberCiphertext v_SIZE) -> value.f_value }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_5 (v_SIZE: usize) : Core.Convert.t_TryFrom (t_KyberCiphertext v_SIZE) (t_Slice u8) =
+  {
+    f_Error = Core.Array.t_TryFromSliceError;
+    f_try_from
+    =
+    fun (value: t_Slice u8) ->
+      match Core.Convert.f_try_into value with
+      | Core.Result.Result_Ok value ->
+        Core.Result.Result_Ok ({ f_value = value } <: t_KyberCiphertext v_SIZE)
+        <:
+        Core.Result.t_Result (t_KyberCiphertext v_SIZE) Core.Array.t_TryFromSliceError
+      | Core.Result.Result_Err e ->
+        Core.Result.Result_Err e
+        <:
+        Core.Result.t_Result (t_KyberCiphertext v_SIZE) Core.Array.t_TryFromSliceError
+  }
+
+let impl_6__as_slice (v_SIZE: usize) (self: t_KyberCiphertext v_SIZE) : t_Array u8 v_SIZE =
+  self.f_value
+
+let impl_6__len (v_SIZE: usize) (self: t_KyberCiphertext v_SIZE) : usize = v_SIZE
+
+let impl_6__split_at (v_SIZE: usize) (self: t_KyberCiphertext v_SIZE) (mid: usize)
+    : (t_Slice u8 & t_Slice u8) =
+  Core.Slice.impl__split_at (Rust_primitives.unsize self.f_value <: t_Slice u8) mid
+
+type t_KyberPrivateKey (v_SIZE: usize) = { f_value:t_Array u8 v_SIZE }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_7 (v_SIZE: usize) : Core.Convert.t_AsRef (t_KyberPrivateKey v_SIZE) (t_Slice u8) =
+  { f_as_ref = fun (self: t_KyberPrivateKey v_SIZE) -> Rust_primitives.unsize self.f_value }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_8 (v_SIZE: usize) : Core.Convert.t_From (t_KyberPrivateKey v_SIZE) (t_Array u8 v_SIZE) =
+  { f_from = fun (value: t_Array u8 v_SIZE) -> { f_value = value } <: t_KyberPrivateKey v_SIZE }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_9 (v_SIZE: usize) : Core.Convert.t_From (t_KyberPrivateKey v_SIZE) (t_Array u8 v_SIZE) =
+  {
+    f_from
+    =
+    fun (value: t_Array u8 v_SIZE) ->
+      { f_value = Core.Clone.f_clone value } <: t_KyberPrivateKey v_SIZE
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_10 (v_SIZE: usize) : Core.Convert.t_From (t_Array u8 v_SIZE) (t_KyberPrivateKey v_SIZE) =
+  { f_from = fun (value: t_KyberPrivateKey v_SIZE) -> value.f_value }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_11 (v_SIZE: usize) : Core.Convert.t_TryFrom (t_KyberPrivateKey v_SIZE) (t_Slice u8) =
+  {
+    f_Error = Core.Array.t_TryFromSliceError;
+    f_try_from
+    =
+    fun (value: t_Slice u8) ->
+      match Core.Convert.f_try_into value with
+      | Core.Result.Result_Ok value ->
+        Core.Result.Result_Ok ({ f_value = value } <: t_KyberPrivateKey v_SIZE)
+        <:
+        Core.Result.t_Result (t_KyberPrivateKey v_SIZE) Core.Array.t_TryFromSliceError
+      | Core.Result.Result_Err e ->
+        Core.Result.Result_Err e
+        <:
+        Core.Result.t_Result (t_KyberPrivateKey v_SIZE) Core.Array.t_TryFromSliceError
+  }
+
+let impl_12__as_slice (v_SIZE: usize) (self: t_KyberPrivateKey v_SIZE) : t_Array u8 v_SIZE =
+  self.f_value
+
+let impl_12__len (v_SIZE: usize) (self: t_KyberPrivateKey v_SIZE) : usize = v_SIZE
+
+let impl_12__split_at (v_SIZE: usize) (self: t_KyberPrivateKey v_SIZE) (mid: usize)
+    : (t_Slice u8 & t_Slice u8) =
+  Core.Slice.impl__split_at (Rust_primitives.unsize self.f_value <: t_Slice u8) mid
+
+type t_KyberPublicKey (v_SIZE: usize) = { f_value:t_Array u8 v_SIZE }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_13 (v_SIZE: usize) : Core.Convert.t_AsRef (t_KyberPublicKey v_SIZE) (t_Slice u8) =
+  { f_as_ref = fun (self: t_KyberPublicKey v_SIZE) -> Rust_primitives.unsize self.f_value }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_14 (v_SIZE: usize) : Core.Convert.t_From (t_KyberPublicKey v_SIZE) (t_Array u8 v_SIZE) =
+  { f_from = fun (value: t_Array u8 v_SIZE) -> { f_value = value } <: t_KyberPublicKey v_SIZE }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_15 (v_SIZE: usize) : Core.Convert.t_From (t_KyberPublicKey v_SIZE) (t_Array u8 v_SIZE) =
+  {
+    f_from
+    =
+    fun (value: t_Array u8 v_SIZE) ->
+      { f_value = Core.Clone.f_clone value } <: t_KyberPublicKey v_SIZE
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_16 (v_SIZE: usize) : Core.Convert.t_From (t_Array u8 v_SIZE) (t_KyberPublicKey v_SIZE) =
+  { f_from = fun (value: t_KyberPublicKey v_SIZE) -> value.f_value }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_17 (v_SIZE: usize) : Core.Convert.t_TryFrom (t_KyberPublicKey v_SIZE) (t_Slice u8) =
+  {
+    f_Error = Core.Array.t_TryFromSliceError;
+    f_try_from
+    =
+    fun (value: t_Slice u8) ->
+      match Core.Convert.f_try_into value with
+      | Core.Result.Result_Ok value ->
+        Core.Result.Result_Ok ({ f_value = value } <: t_KyberPublicKey v_SIZE)
+        <:
+        Core.Result.t_Result (t_KyberPublicKey v_SIZE) Core.Array.t_TryFromSliceError
+      | Core.Result.Result_Err e ->
+        Core.Result.Result_Err e
+        <:
+        Core.Result.t_Result (t_KyberPublicKey v_SIZE) Core.Array.t_TryFromSliceError
+  }
+
+let impl_18__as_slice (v_SIZE: usize) (self: t_KyberPublicKey v_SIZE) : t_Array u8 v_SIZE =
+  self.f_value
+
+let impl_18__len (v_SIZE: usize) (self: t_KyberPublicKey v_SIZE) : usize = v_SIZE
+
+let impl_18__split_at (v_SIZE: usize) (self: t_KyberPublicKey v_SIZE) (mid: usize)
+    : (t_Slice u8 & t_Slice u8) =
+  Core.Slice.impl__split_at (Rust_primitives.unsize self.f_value <: t_Slice u8) mid
+
+type t_KyberKeyPair (v_PRIVATE_KEY_SIZE: usize) (v_PUBLIC_KEY_SIZE: usize) = {
+  f_sk:t_KyberPrivateKey v_PRIVATE_KEY_SIZE;
+  f_pk:t_KyberPublicKey v_PUBLIC_KEY_SIZE
+}
+
+let impl__from
+      (v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE: usize)
+      (sk: t_KyberPrivateKey v_PRIVATE_KEY_SIZE)
+      (pk: t_KyberPublicKey v_PUBLIC_KEY_SIZE)
+    : t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE =
+  { f_sk = sk; f_pk = pk } <: t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE
+
+let impl__new
+      (v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE: usize)
+      (sk: t_Array u8 v_PRIVATE_KEY_SIZE)
+      (pk: t_Array u8 v_PUBLIC_KEY_SIZE)
+    : t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE =
+  { f_sk = Core.Convert.f_into sk; f_pk = Core.Convert.f_into pk }
+  <:
+  t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE
+
+let impl__pk
+      (v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE: usize)
+      (self: t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
+    : t_Array u8 v_PUBLIC_KEY_SIZE = impl_18__as_slice v_PUBLIC_KEY_SIZE self.f_pk
+
+let impl__private_key
+      (v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE: usize)
+      (self: t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
+    : t_KyberPrivateKey v_PRIVATE_KEY_SIZE = self.f_sk
+
+let impl__public_key
+      (v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE: usize)
+      (self: t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
+    : t_KyberPublicKey v_PUBLIC_KEY_SIZE = self.f_pk
+
+let impl__sk
+      (v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE: usize)
+      (self: t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
+    : t_Array u8 v_PRIVATE_KEY_SIZE = impl_12__as_slice v_PRIVATE_KEY_SIZE self.f_sk

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.fst
@@ -1,0 +1,310 @@
+module Libcrux.Kem.Kyber
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let serialize_kem_secret_key
+      (v_SERIALIZED_KEY_LEN: usize)
+      (private_key public_key implicit_rejection_value: t_Slice u8)
+     =
+  let out:t_Array u8 v_SERIALIZED_KEY_LEN = Rust_primitives.Hax.repeat 0uy v_SERIALIZED_KEY_LEN in
+  let pointer:usize = sz 0 in
+  let out:t_Array u8 v_SERIALIZED_KEY_LEN =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+      ({
+          Core.Ops.Range.f_start = pointer;
+          Core.Ops.Range.f_end = pointer +! (Core.Slice.impl__len private_key <: usize) <: usize
+        }
+        <:
+        Core.Ops.Range.t_Range usize)
+      (Core.Slice.impl__copy_from_slice (out.[ {
+                Core.Ops.Range.f_start = pointer;
+                Core.Ops.Range.f_end
+                =
+                pointer +! (Core.Slice.impl__len private_key <: usize) <: usize
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
+          private_key
+        <:
+        t_Slice u8)
+  in
+  let pointer:usize = pointer +! (Core.Slice.impl__len private_key <: usize) in
+  let out:t_Array u8 v_SERIALIZED_KEY_LEN =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+      ({
+          Core.Ops.Range.f_start = pointer;
+          Core.Ops.Range.f_end = pointer +! (Core.Slice.impl__len public_key <: usize) <: usize
+        }
+        <:
+        Core.Ops.Range.t_Range usize)
+      (Core.Slice.impl__copy_from_slice (out.[ {
+                Core.Ops.Range.f_start = pointer;
+                Core.Ops.Range.f_end
+                =
+                pointer +! (Core.Slice.impl__len public_key <: usize) <: usize
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
+          public_key
+        <:
+        t_Slice u8)
+  in
+  let pointer:usize = pointer +! (Core.Slice.impl__len public_key <: usize) in
+  let out:t_Array u8 v_SERIALIZED_KEY_LEN =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+      ({
+          Core.Ops.Range.f_start = pointer;
+          Core.Ops.Range.f_end = pointer +! Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE <: usize
+        }
+        <:
+        Core.Ops.Range.t_Range usize)
+      (Core.Slice.impl__copy_from_slice (out.[ {
+                Core.Ops.Range.f_start = pointer;
+                Core.Ops.Range.f_end
+                =
+                pointer +! Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE <: usize
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
+          (Rust_primitives.unsize (Libcrux.Kem.Kyber.Hash_functions.v_H public_key
+                <:
+                t_Array u8 (sz 32))
+            <:
+            t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  let pointer:usize = pointer +! Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE in
+  let out:t_Array u8 v_SERIALIZED_KEY_LEN =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+      ({
+          Core.Ops.Range.f_start = pointer;
+          Core.Ops.Range.f_end
+          =
+          pointer +! (Core.Slice.impl__len implicit_rejection_value <: usize) <: usize
+        }
+        <:
+        Core.Ops.Range.t_Range usize)
+      (Core.Slice.impl__copy_from_slice (out.[ {
+                Core.Ops.Range.f_start = pointer;
+                Core.Ops.Range.f_end
+                =
+                pointer +! (Core.Slice.impl__len implicit_rejection_value <: usize) <: usize
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
+          implicit_rejection_value
+        <:
+        t_Slice u8)
+  in
+  out
+
+let decapsulate
+      (v_K v_SECRET_KEY_SIZE v_CPA_SECRET_KEY_SIZE v_PUBLIC_KEY_SIZE v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_C1_BLOCK_SIZE v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE v_IMPLICIT_REJECTION_HASH_INPUT_SIZE:
+          usize)
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey v_SECRET_KEY_SIZE)
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext v_CIPHERTEXT_SIZE)
+     =
+  let ind_cpa_secret_key, secret_key:(t_Slice u8 & t_Slice u8) =
+    Libcrux.Kem.Kyber.Types.impl_12__split_at v_SECRET_KEY_SIZE secret_key v_CPA_SECRET_KEY_SIZE
+  in
+  let ind_cpa_public_key, secret_key:(t_Slice u8 & t_Slice u8) =
+    Core.Slice.impl__split_at secret_key v_PUBLIC_KEY_SIZE
+  in
+  let ind_cpa_public_key_hash, implicit_rejection_value:(t_Slice u8 & t_Slice u8) =
+    Core.Slice.impl__split_at secret_key Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
+  in
+  let decrypted:t_Array u8 (sz 32) =
+    Libcrux.Kem.Kyber.Ind_cpa.decrypt v_K
+      v_CIPHERTEXT_SIZE
+      v_C1_SIZE
+      v_VECTOR_U_COMPRESSION_FACTOR
+      v_VECTOR_V_COMPRESSION_FACTOR
+      ind_cpa_secret_key
+      ciphertext.Libcrux.Kem.Kyber.Types.f_value
+  in
+  let (to_hash: t_Array u8 (sz 64)):t_Array u8 (sz 64) =
+    Libcrux.Kem.Kyber.Ind_cpa.into_padded_array (sz 64)
+      (Rust_primitives.unsize decrypted <: t_Slice u8)
+  in
+  let to_hash:t_Array u8 (sz 64) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from to_hash
+      ({ Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE }
+        <:
+        Core.Ops.Range.t_RangeFrom usize)
+      (Core.Slice.impl__copy_from_slice (to_hash.[ {
+                Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+              }
+              <:
+              Core.Ops.Range.t_RangeFrom usize ]
+            <:
+            t_Slice u8)
+          ind_cpa_public_key_hash
+        <:
+        t_Slice u8)
+  in
+  let hashed:t_Array u8 (sz 64) =
+    Libcrux.Kem.Kyber.Hash_functions.v_G (Rust_primitives.unsize to_hash <: t_Slice u8)
+  in
+  let shared_secret, pseudorandomness:(t_Slice u8 & t_Slice u8) =
+    Core.Slice.impl__split_at (Rust_primitives.unsize hashed <: t_Slice u8)
+      Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+  in
+  let (to_hash: t_Array u8 v_IMPLICIT_REJECTION_HASH_INPUT_SIZE):t_Array u8
+    v_IMPLICIT_REJECTION_HASH_INPUT_SIZE =
+    Libcrux.Kem.Kyber.Ind_cpa.into_padded_array v_IMPLICIT_REJECTION_HASH_INPUT_SIZE
+      implicit_rejection_value
+  in
+  let to_hash:t_Array u8 v_IMPLICIT_REJECTION_HASH_INPUT_SIZE =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from to_hash
+      ({ Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE }
+        <:
+        Core.Ops.Range.t_RangeFrom usize)
+      (Core.Slice.impl__copy_from_slice (to_hash.[ {
+                Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+              }
+              <:
+              Core.Ops.Range.t_RangeFrom usize ]
+            <:
+            t_Slice u8)
+          (Core.Convert.f_as_ref ciphertext <: t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  let (implicit_rejection_shared_secret: t_Array u8 (sz 32)):t_Array u8 (sz 32) =
+    Libcrux.Kem.Kyber.Hash_functions.v_PRF (sz 32) (Rust_primitives.unsize to_hash <: t_Slice u8)
+  in
+  let expected_ciphertext:t_Array u8 v_CIPHERTEXT_SIZE =
+    Libcrux.Kem.Kyber.Ind_cpa.encrypt v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE
+      v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_C1_BLOCK_SIZE v_ETA1
+      v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE ind_cpa_public_key decrypted
+      pseudorandomness
+  in
+  let selector:u8 =
+    Libcrux.Kem.Kyber.Constant_time_ops.compare_ciphertexts_in_constant_time v_CIPHERTEXT_SIZE
+      (Core.Convert.f_as_ref ciphertext <: t_Slice u8)
+      (Rust_primitives.unsize expected_ciphertext <: t_Slice u8)
+  in
+  Libcrux.Kem.Kyber.Constant_time_ops.select_shared_secret_in_constant_time shared_secret
+    (Rust_primitives.unsize implicit_rejection_shared_secret <: t_Slice u8)
+    selector
+
+let encapsulate
+      (v_K v_CIPHERTEXT_SIZE v_PUBLIC_KEY_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_VECTOR_U_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+          usize)
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey v_PUBLIC_KEY_SIZE)
+      (randomness: t_Array u8 (sz 32))
+     =
+  let (to_hash: t_Array u8 (sz 64)):t_Array u8 (sz 64) =
+    Libcrux.Kem.Kyber.Ind_cpa.into_padded_array (sz 64)
+      (Rust_primitives.unsize randomness <: t_Slice u8)
+  in
+  let to_hash:t_Array u8 (sz 64) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from to_hash
+      ({ Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE }
+        <:
+        Core.Ops.Range.t_RangeFrom usize)
+      (Core.Slice.impl__copy_from_slice (to_hash.[ {
+                Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_H_DIGEST_SIZE
+              }
+              <:
+              Core.Ops.Range.t_RangeFrom usize ]
+            <:
+            t_Slice u8)
+          (Rust_primitives.unsize (Libcrux.Kem.Kyber.Hash_functions.v_H (Rust_primitives.unsize (Libcrux.Kem.Kyber.Types.impl_18__as_slice
+                          v_PUBLIC_KEY_SIZE
+                          public_key
+                        <:
+                        t_Array u8 v_PUBLIC_KEY_SIZE)
+                    <:
+                    t_Slice u8)
+                <:
+                t_Array u8 (sz 32))
+            <:
+            t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  let hashed:t_Array u8 (sz 64) =
+    Libcrux.Kem.Kyber.Hash_functions.v_G (Rust_primitives.unsize to_hash <: t_Slice u8)
+  in
+  let shared_secret, pseudorandomness:(t_Slice u8 & t_Slice u8) =
+    Core.Slice.impl__split_at (Rust_primitives.unsize hashed <: t_Slice u8)
+      Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+  in
+  let ciphertext:t_Array u8 v_CIPHERTEXT_SIZE =
+    Libcrux.Kem.Kyber.Ind_cpa.encrypt v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE
+      v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_VECTOR_U_BLOCK_LEN
+      v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE
+      (Rust_primitives.unsize (Libcrux.Kem.Kyber.Types.impl_18__as_slice v_PUBLIC_KEY_SIZE
+              public_key
+            <:
+            t_Array u8 v_PUBLIC_KEY_SIZE)
+        <:
+        t_Slice u8) randomness pseudorandomness
+  in
+  let shared_secret:t_Array u8 (sz 32) =
+    match Core.Convert.f_try_into shared_secret with
+    | Core.Result.Result_Ok shared_secret -> shared_secret
+    | Core.Result.Result_Err _ ->
+      Rust_primitives.Hax.never_to_any (Core.Panicking.panic "explicit panic"
+          <:
+          Rust_primitives.Hax.t_Never)
+  in
+  Core.Convert.f_into ciphertext, shared_secret
+  <:
+  (Libcrux.Kem.Kyber.Types.t_KyberCiphertext v_CIPHERTEXT_SIZE & t_Array u8 (sz 32))
+
+let generate_keypair
+      (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+          usize)
+      (randomness: t_Array u8 (sz 64))
+     =
+  let ind_cpa_keypair_randomness:t_Slice u8 =
+    randomness.[ {
+        Core.Ops.Range.f_start = sz 0;
+        Core.Ops.Range.f_end = Libcrux.Kem.Kyber.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE
+      }
+      <:
+      Core.Ops.Range.t_Range usize ]
+  in
+  let implicit_rejection_value:t_Slice u8 =
+    randomness.[ {
+        Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE
+      }
+      <:
+      Core.Ops.Range.t_RangeFrom usize ]
+  in
+  let ind_cpa_private_key, public_key:(t_Array u8 v_CPA_PRIVATE_KEY_SIZE &
+    t_Array u8 v_PUBLIC_KEY_SIZE) =
+    Libcrux.Kem.Kyber.Ind_cpa.generate_keypair v_K
+      v_CPA_PRIVATE_KEY_SIZE
+      v_PUBLIC_KEY_SIZE
+      v_BYTES_PER_RING_ELEMENT
+      v_ETA1
+      v_ETA1_RANDOMNESS_SIZE
+      ind_cpa_keypair_randomness
+  in
+  let secret_key_serialized:t_Array u8 v_PRIVATE_KEY_SIZE =
+    serialize_kem_secret_key v_PRIVATE_KEY_SIZE
+      (Rust_primitives.unsize ind_cpa_private_key <: t_Slice u8)
+      (Rust_primitives.unsize public_key <: t_Slice u8)
+      implicit_rejection_value
+  in
+  let (private_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey v_PRIVATE_KEY_SIZE):Libcrux.Kem.Kyber.Types.t_KyberPrivateKey
+  v_PRIVATE_KEY_SIZE =
+    Core.Convert.f_from secret_key_serialized
+  in
+  Libcrux.Kem.Kyber.Types.impl__from v_PRIVATE_KEY_SIZE
+    v_PUBLIC_KEY_SIZE
+    private_key
+    (Core.Convert.f_into public_key <: Libcrux.Kem.Kyber.Types.t_KyberPublicKey v_PUBLIC_KEY_SIZE)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.Kyber.fsti
@@ -1,0 +1,40 @@
+module Libcrux.Kem.Kyber
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+unfold
+let t_KyberSharedSecret = t_Array u8 (sz 32)
+
+let v_KEY_GENERATION_SEED_SIZE: usize =
+  Libcrux.Kem.Kyber.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE +!
+  Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+
+val serialize_kem_secret_key
+      (v_SERIALIZED_KEY_LEN: usize)
+      (private_key public_key implicit_rejection_value: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_SERIALIZED_KEY_LEN) Prims.l_True (fun _ -> Prims.l_True)
+
+val decapsulate
+      (v_K v_SECRET_KEY_SIZE v_CPA_SECRET_KEY_SIZE v_PUBLIC_KEY_SIZE v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_C1_BLOCK_SIZE v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE v_IMPLICIT_REJECTION_HASH_INPUT_SIZE:
+          usize)
+      (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey v_SECRET_KEY_SIZE)
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_KyberCiphertext v_CIPHERTEXT_SIZE)
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encapsulate
+      (v_K v_CIPHERTEXT_SIZE v_PUBLIC_KEY_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_VECTOR_U_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+          usize)
+      (public_key: Libcrux.Kem.Kyber.Types.t_KyberPublicKey v_PUBLIC_KEY_SIZE)
+      (randomness: t_Array u8 (sz 32))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberCiphertext v_CIPHERTEXT_SIZE & t_Array u8 (sz 32))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_keypair
+      (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+          usize)
+      (randomness: t_Array u8 (sz 64))
+    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
+      Prims.l_True
+      (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction-secret-independent/Libcrux.Kem.fst
+++ b/proofs/fstar/extraction-secret-independent/Libcrux.Kem.fst
@@ -1,0 +1,6 @@
+module Libcrux.Kem
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+

--- a/proofs/fstar/extraction-secret-independent/Libcrux_platform.fsti
+++ b/proofs/fstar/extraction-secret-independent/Libcrux_platform.fsti
@@ -1,0 +1,4 @@
+module Libcrux_platform
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+
+val simd256_support : unit -> bool

--- a/proofs/fstar/extraction-secret-independent/Makefile
+++ b/proofs/fstar/extraction-secret-independent/Makefile
@@ -1,0 +1,137 @@
+# This is a generically useful Makefile for F* that is self-contained
+#
+# It is tempting to factor this out into multiple Makefiles but that
+# makes it less portable, so resist temptation, or move to a more
+# sophisticated build system.
+#
+# We expect FSTAR_HOME to be set to your FSTAR repo/install directory
+# We expect HACL_HOME to be set to your HACL* repo location
+# We expect HAX_LIBS_HOME to be set to the folder containing core, rust_primitives etc.
+#
+# ROOTS contains all the top-level F* files you wish to verify
+# The default target `verify` verified ROOTS and its dependencies
+# To lax-check instead, set `OTHERFLAGS="--lax"` on the command-line
+#
+#
+# To make F* emacs mode use the settings in this file, you need to
+# add the following lines to your .emacs
+#
+# (setq-default fstar-executable "<YOUR_FSTAR_HOME>/bin/fstar.exe")
+# (setq-default fstar-smt-executable "<YOUR_Z3_HOME>/bin/z3")
+#
+# (defun my-fstar-compute-prover-args-using-make ()
+#   "Construct arguments to pass to F* by calling make."
+#   (with-demoted-errors "Error when constructing arg string: %S"
+#     (let* ((fname (file-name-nondirectory buffer-file-name))
+# 	   (target (concat fname "-in"))
+# 	   (argstr (car (process-lines "make" "--quiet" target))))
+#       (split-string argstr))))
+# (setq fstar-subp-prover-args #'my-fstar-compute-prover-args-using-make)
+#
+
+WORKSPACE_ROOT ?= $(shell git rev-parse --show-toplevel)/..
+
+HAX_HOME ?= $(WORKSPACE_ROOT)/hax
+HAX_PROOF_LIBS_HOME ?= $(HAX_HOME)/proof-libs/fstar-secret-integers
+HAX_LIBS_HOME ?= $(HAX_HOME)/hax-lib/proofs/fstar/extraction
+FSTAR_HOME    ?= $(WORKSPACE_ROOT)/FStar
+HACL_HOME     ?= $(WORKSPACE_ROOT)/hacl-star
+FSTAR_BIN     ?= $(shell command -v fstar.exe 1>&2 2> /dev/null && echo "fstar.exe" || echo "$(FSTAR_HOME)/bin/fstar.exe")
+
+CACHE_DIR     ?= cache
+HINT_DIR      ?= hints
+
+.PHONY: all verify verify-lax clean
+
+all:
+	rm -f .depend && $(MAKE) .depend
+	$(MAKE) verify
+
+
+SECRET_INDEPENDENT = \
+	Libcrux.Kem.Kyber.Constants.fsti \
+	Libcrux.Digest.fsti \
+	Libcrux.Kem.Kyber.Hash_functions.fsti \
+	Libcrux.Kem.Kyber.Hash_functions.fst \
+	Libcrux.Kem.Kyber.Kyber768.fsti \
+	Libcrux.Kem.Kyber.Kyber768.fst \
+	Libcrux.Kem.Kyber.Kyber1024.fsti \
+	Libcrux.Kem.Kyber.Kyber1024.fst \
+	Libcrux.Kem.Kyber.Kyber512.fsti \
+	Libcrux.Kem.Kyber.Kyber512.fst \
+	Libcrux.Kem.Kyber.Types.fst \
+	Libcrux.Kem.Kyber.fsti \
+	Libcrux.Kem.Kyber.fst \
+	Libcrux.Kem.Kyber.Ind_cpa.fsti \
+	Libcrux.Kem.Kyber.Ind_cpa.fst \
+	Libcrux.Kem.Kyber.Arithmetic.fsti \
+	Libcrux.Kem.Kyber.Arithmetic.fst \
+	Libcrux.Kem.Kyber.Compress.fsti \
+	Libcrux.Kem.Kyber.Compress.fst \
+	Libcrux.Kem.Kyber.Constant_time_ops.fsti \
+	Libcrux.Kem.Kyber.Constant_time_ops.fst \
+	Libcrux.Kem.Kyber.Matrix.fsti \
+	Libcrux.Kem.Kyber.Matrix.fst \
+	Libcrux.Kem.Kyber.Ntt.fsti \
+	Libcrux.Kem.Kyber.Ntt.fst \
+	Libcrux.Kem.Kyber.Sampling.fst \
+	Libcrux.Kem.Kyber.Serialize.PartA.fsti \
+	Libcrux.Kem.Kyber.Serialize.PartA.fst \
+	Libcrux.Kem.Kyber.Serialize.PartB.fsti \
+	Libcrux.Kem.Kyber.Serialize.PartB.fst \
+	Libcrux.Kem.Kyber.Serialize.fst
+
+SECRET_INDEPENDENT_CHECKED = $(addsuffix .checked, $(addprefix $(CACHE_DIR)/,$(SECRET_INDEPENDENT)))
+
+# By default, we process all the files in the current directory. Here, we
+# *extend* the set of relevant files with the tests.
+ROOTS = $(SECRET_INDEPENDENT)
+
+FSTAR_INCLUDE_DIRS = $(HACL_HOME)/lib $(HAX_PROOF_LIBS_HOME)/rust_primitives $(HAX_PROOF_LIBS_HOME)/core $(HAX_LIBS_HOME)
+
+FSTAR_FLAGS = --cmi \
+  --warn_error -331 \
+  --admit_smt_queries true \
+  --cache_checked_modules --cache_dir $(CACHE_DIR) \
+  --already_cached "+Prims+FStar+LowStar+C+Spec.Loops+TestLib" \
+  $(addprefix --include ,$(FSTAR_INCLUDE_DIRS))
+
+FSTAR = $(FSTAR_BIN) $(FSTAR_FLAGS)
+
+
+.depend: $(HINT_DIR) $(CACHE_DIR) $(ROOTS)
+	$(info $(ROOTS))
+	$(FSTAR) --cmi --dep full $(ROOTS) --extract '* -Prims -LowStar -FStar' > $@
+
+include .depend
+
+$(HINT_DIR):
+	mkdir -p $@
+
+$(CACHE_DIR):
+	mkdir -p $@
+
+$(SECRET_INDEPENDENT_CHECKED): OTHERFLAGS=--admit_smt_queries true
+$(CACHE_DIR)/%.checked: | .depend $(HINT_DIR) $(CACHE_DIR)
+	$(FSTAR) $(OTHERFLAGS) $< $(ENABLE_HINTS) --hint_file $(HINT_DIR)/$(notdir $*).hints
+
+verify: $(SECRET_INDEPENDENT_CHECKED)
+
+# Targets for interactive mode
+
+%.fst-in:
+	$(info $(FSTAR_FLAGS) \
+	  $(ENABLE_HINTS) --hint_file $(HINT_DIR)/$(basename $@).fst.hints)
+
+%.fsti-in:
+	$(info $(FSTAR_FLAGS) \
+	  $(ENABLE_HINTS) --hint_file $(HINT_DIR)/$(basename $@).fsti.hints)
+
+
+# Clean targets
+
+SHELL=/usr/bin/env bash
+
+clean:
+	rm -rf $(CACHE_DIR)/*
+	rm *.fst

--- a/proofs/fstar/extraction-secret-independent/Makefile
+++ b/proofs/fstar/extraction-secret-independent/Makefile
@@ -38,8 +38,8 @@ FSTAR_HOME    ?= $(WORKSPACE_ROOT)/FStar
 HACL_HOME     ?= $(WORKSPACE_ROOT)/hacl-star
 FSTAR_BIN     ?= $(shell command -v fstar.exe 1>&2 2> /dev/null && echo "fstar.exe" || echo "$(FSTAR_HOME)/bin/fstar.exe")
 
-CACHE_DIR     ?= cache
-HINT_DIR      ?= hints
+CACHE_DIR     ?= .cache
+HINT_DIR      ?= .hints
 
 .PHONY: all verify verify-lax clean
 
@@ -75,10 +75,7 @@ SECRET_INDEPENDENT = \
 	Libcrux.Kem.Kyber.Ntt.fsti \
 	Libcrux.Kem.Kyber.Ntt.fst \
 	Libcrux.Kem.Kyber.Sampling.fst \
-	Libcrux.Kem.Kyber.Serialize.PartA.fsti \
-	Libcrux.Kem.Kyber.Serialize.PartA.fst \
-	Libcrux.Kem.Kyber.Serialize.PartB.fsti \
-	Libcrux.Kem.Kyber.Serialize.PartB.fst \
+	Libcrux.Kem.Kyber.Serialize.fsti \
 	Libcrux.Kem.Kyber.Serialize.fst
 
 SECRET_INDEPENDENT_CHECKED = $(addsuffix .checked, $(addprefix $(CACHE_DIR)/,$(SECRET_INDEPENDENT)))
@@ -90,7 +87,7 @@ ROOTS = $(SECRET_INDEPENDENT)
 FSTAR_INCLUDE_DIRS = $(HACL_HOME)/lib $(HAX_PROOF_LIBS_HOME)/rust_primitives $(HAX_PROOF_LIBS_HOME)/core $(HAX_LIBS_HOME)
 
 FSTAR_FLAGS = --cmi \
-  --warn_error -331 \
+  --warn_error -331-321-274 \
   --admit_smt_queries true \
   --cache_checked_modules --cache_dir $(CACHE_DIR) \
   --already_cached "+Prims+FStar+LowStar+C+Spec.Loops+TestLib" \


### PR DESCRIPTION
This PR adds secret independence proofs on top of the existing proofs for Kyber.

It correctly flags the timing leak in this older version of our code:
https://github.com/cryspen/libcrux/blob/2a3cd5d4b09de1fb214c0ae9c6ee915877794bbc/src/kem/kyber/compress.rs#L59

This leak has now been fixed and our analysis verifies that the leak no longer exits.

The analysis also flags potential leaks in these lines:
https://github.com/cryspen/libcrux/blob/ea52806f4961c53f71e819740370f05895ac16e7/src/kem/kyber/sampling.rs#L33

https://github.com/cryspen/libcrux/blob/ea52806f4961c53f71e819740370f05895ac16e7/src/kem/kyber/sampling.rs#L37

For these instances, we add declassification operations to allow them.

The PR adds a new directory that annotates the extracted F* code with type annotations needed for secret independence (classifications or public/secret declarations.) In a future PR, we would like to backport these changes to Rust so that the new directory becomes unnecessary.