### PR TITLE
Fix hax cfg issues

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -65,6 +65,8 @@ jobs:
       - name: 🏃 Make sure the extracted Kyber snapshot is up-to-date
         run: |
           eval $(opam env)
+          (cd proofs/fstar/extraction/ && ./clean.sh)
+          rm -f sys/platform/proofs/fstar/extraction/*.fst*
           ./hax-driver.py --kyber-reference
           git diff --exit-code
 

--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -35,11 +35,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
-      - name: 🔨 OCaml Setup
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: 4.14.1
-
       - name: ⤵ Install FStar
         run: nix profile install github:FStarLang/FStar/v2024.01.13
 
@@ -55,12 +50,14 @@ jobs:
           repository: hacspec/hacspec-v2
           path: hax
 
-      - name: 🔨 Setup hax
-        working-directory: hax
+      - name: ⤵ Install & confiure Cachix
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes nodejs
-          ./setup.sh
+          nix profile install nixpkgs#cachix
+          cachix use hax
+
+      - name: ⤵ Install hax
+        run: |
+          nix profile install ./hax
 
       - name: 🏃 Extract the Kyber reference code
         run: |

--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -62,24 +62,26 @@ jobs:
           sudo apt-get install --yes nodejs
           ./setup.sh
 
-      - name: 🏃 Make sure the extracted Kyber snapshot is up-to-date
+      - name: 🏃 Extract the Kyber reference code
         run: |
           eval $(opam env)
           (cd proofs/fstar/extraction/ && ./clean.sh)
           rm -f sys/platform/proofs/fstar/extraction/*.fst*
           ./hax-driver.py --kyber-reference
-          git diff --exit-code
 
-      - name: 🏃 Extract and verify the Kyber reference code
+      - name: 🏃 Regenerate `extraction-*` folders
+        run: ./proofs/fstar/patches.sh apply
+
+      - name: 🏃 Make sure snapshots are up-to-date
+        run: git diff --exit-code
+
+      - name: 🏃 Verify the Kyber reference code
         run: |
           env FSTAR_HOME=${{ github.workspace }}/fstar \
               HACL_HOME=${{ github.workspace }}/hacl-star \
               HAX_HOME=${{ github.workspace }}/hax \
               PATH="${PATH}:${{ github.workspace }}/fstar/bin" \
               ./hax-driver.py --verify-extraction
-
-      - name: 🏃 Regenerate `extraction-*` folders
-        run: ./proofs/fstar/patches.sh apply
 
       - name: 🏃 Verify Kyber `extraction-edited` F* code
         run: |

--- a/hax-driver.py
+++ b/hax-driver.py
@@ -124,7 +124,7 @@ elif options.kyber_reference:
             "-C", "-p", "libcrux", "-p", "libcrux-platform", ";",
             "into",
             "-i",
-            f"-** +libcrux::kem::kyber::** +!libcrux_platform::* {exclude_sha3_implementations} -libcrux::**::types::index_impls::**",
+            f"-** +libcrux::kem::kyber::** +!libcrux_platform::platform::* {exclude_sha3_implementations} -libcrux::**::types::index_impls::**",
             "fstar",
             "--interfaces",
             "+* -libcrux::kem::kyber::types +!libcrux_platform::**",

--- a/proofs/fstar/extraction-edited.patch
+++ b/proofs/fstar/extraction-edited.patch
@@ -1,14 +1,11 @@
 diff -ruN extraction/Libcrux.Digest.fst extraction-edited/Libcrux.Digest.fst
---- extraction/Libcrux.Digest.fst	2024-02-01 11:03:26.797761034 +0100
+--- extraction/Libcrux.Digest.fst	2024-02-05 15:27:11.362357768 +0100
 +++ extraction-edited/Libcrux.Digest.fst	1970-01-01 01:00:00.000000000 +0100
 @@ -1,48 +0,0 @@
 -module Libcrux.Digest
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
 -open Core
 -open FStar.Mul
--
--let shake128x4_256_ (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8) =
--  Libcrux.Hacl.Sha3.X4.shake128 v_LEN data0 data1 data2 data3
 -
 -let sha3_256_ (payload: t_Slice u8) = Libcrux.Hacl.Sha3.sha256 payload
 -
@@ -46,13 +43,16 @@ diff -ruN extraction/Libcrux.Digest.fst extraction-edited/Libcrux.Digest.fst
 -  <:
 -  (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
 -
+-let shake128x4_256_ (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8) =
+-  shake128x4_portable v_LEN data0 data1 data2 data3
+-
 -let shake128x4 (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8) =
--  if Libcrux_platform.simd256_support ()
+-  if Libcrux_platform.Platform.simd256_support ()
 -  then shake128x4_256_ v_LEN data0 data1 data2 data3
 -  else shake128x4_portable v_LEN data0 data1 data2 data3
 diff -ruN extraction/Libcrux.Digest.fsti extraction-edited/Libcrux.Digest.fsti
---- extraction/Libcrux.Digest.fsti	2024-02-01 11:03:26.785761386 +0100
-+++ extraction-edited/Libcrux.Digest.fsti	2024-02-01 11:03:26.852759421 +0100
+--- extraction/Libcrux.Digest.fsti	2024-02-05 15:27:11.360357813 +0100
++++ extraction-edited/Libcrux.Digest.fsti	2024-02-05 15:27:11.409356697 +0100
 @@ -1,31 +1,41 @@
  module Libcrux.Digest
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -60,32 +60,8 @@ diff -ruN extraction/Libcrux.Digest.fsti extraction-edited/Libcrux.Digest.fsti
  open Core
 -open FStar.Mul
  
--val shake128x4_256_ (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8)
--    : Prims.Pure (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
--      Prims.l_True
--      (fun _ -> Prims.l_True)
--
 -val sha3_256_ (payload: t_Slice u8)
 -    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
--
--val sha3_512_ (payload: t_Slice u8)
--    : Prims.Pure (t_Array u8 (sz 64)) Prims.l_True (fun _ -> Prims.l_True)
--
--val shake128 (v_LEN: usize) (data: t_Slice u8)
--    : Prims.Pure (t_Array u8 v_LEN) Prims.l_True (fun _ -> Prims.l_True)
--
--val shake256 (v_LEN: usize) (data: t_Slice u8)
--    : Prims.Pure (t_Array u8 v_LEN) Prims.l_True (fun _ -> Prims.l_True)
--
--val shake128x4_portable (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8)
--    : Prims.Pure (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
--      Prims.l_True
--      (fun _ -> Prims.l_True)
--
--val shake128x4 (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8)
--    : Prims.Pure (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
--      Prims.l_True
--      (fun _ -> Prims.l_True)
 +type t_Algorithm =
 +  | Algorithm_Sha1 : t_Algorithm
 +  | Algorithm_Sha224 : t_Algorithm
@@ -114,9 +90,31 @@ diff -ruN extraction/Libcrux.Digest.fsti extraction-edited/Libcrux.Digest.fsti
 +  | Algorithm_Sha3_512_  -> sz 64
 +
 +val sha3_256_ (payload: t_Slice u8) : t_Array u8 (sz 32)
-+
+ 
+-val sha3_512_ (payload: t_Slice u8)
+-    : Prims.Pure (t_Array u8 (sz 64)) Prims.l_True (fun _ -> Prims.l_True)
 +val sha3_512_ (payload: t_Slice u8) : t_Array u8 (sz 64)
-+
+ 
+-val shake128 (v_LEN: usize) (data: t_Slice u8)
+-    : Prims.Pure (t_Array u8 v_LEN) Prims.l_True (fun _ -> Prims.l_True)
+-
+-val shake256 (v_LEN: usize) (data: t_Slice u8)
+-    : Prims.Pure (t_Array u8 v_LEN) Prims.l_True (fun _ -> Prims.l_True)
+-
+-val shake128x4_portable (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8)
+-    : Prims.Pure (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
+-      Prims.l_True
+-      (fun _ -> Prims.l_True)
+-
+-val shake128x4_256_ (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8)
+-    : Prims.Pure (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
+-      Prims.l_True
+-      (fun _ -> Prims.l_True)
+-
+-val shake128x4 (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8)
+-    : Prims.Pure (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
+-      Prims.l_True
+-      (fun _ -> Prims.l_True)
 +val shake128 (v_LEN: usize) (data: t_Slice u8) : t_Array u8 v_LEN
 +
 +val shake128x4 (v_LEN: usize) (data0: t_Slice u8) (data1: t_Slice u8) (data2: t_Slice u8) (data3: t_Slice u8): (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
@@ -124,7 +122,7 @@ diff -ruN extraction/Libcrux.Digest.fsti extraction-edited/Libcrux.Digest.fsti
 +val shake256 (v_LEN: usize) (data: t_Slice u8) : t_Array u8 v_LEN
 diff -ruN extraction/Libcrux.Kem.fst extraction-edited/Libcrux.Kem.fst
 --- extraction/Libcrux.Kem.fst	1970-01-01 01:00:00.000000000 +0100
-+++ extraction-edited/Libcrux.Kem.fst	2024-02-01 11:03:26.840759773 +0100
++++ extraction-edited/Libcrux.Kem.fst	2024-02-05 15:27:11.403356834 +0100
 @@ -0,0 +1,6 @@
 +module Libcrux.Kem
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -133,8 +131,8 @@ diff -ruN extraction/Libcrux.Kem.fst extraction-edited/Libcrux.Kem.fst
 +
 +
 diff -ruN extraction/Libcrux.Kem.Kyber.Arithmetic.fst extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst
---- extraction/Libcrux.Kem.Kyber.Arithmetic.fst	2024-02-01 11:03:26.800760946 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst	2024-02-01 11:03:26.836759890 +0100
+--- extraction/Libcrux.Kem.Kyber.Arithmetic.fst	2024-02-05 15:27:11.356357905 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst	2024-02-05 15:27:11.434356128 +0100
 @@ -1,81 +1,356 @@
  module Libcrux.Kem.Kyber.Arithmetic
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -532,8 +530,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Arithmetic.fst extraction-edited/Libcrux.
 +  
 + 
 diff -ruN extraction/Libcrux.Kem.Kyber.Arithmetic.fsti extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti
---- extraction/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-02-01 11:03:26.775761679 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-02-01 11:03:26.829760095 +0100
+--- extraction/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-02-05 15:27:11.370357586 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-02-05 15:27:11.406356766 +0100
 @@ -3,10 +3,32 @@
  open Core
  open FStar.Mul
@@ -873,8 +871,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Arithmetic.fsti extraction-edited/Libcrux
 -                <:
 -                bool))
 diff -ruN extraction/Libcrux.Kem.Kyber.Compress.fst extraction-edited/Libcrux.Kem.Kyber.Compress.fst
---- extraction/Libcrux.Kem.Kyber.Compress.fst	2024-02-01 11:03:26.780761533 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Compress.fst	2024-02-01 11:03:26.819760389 +0100
+--- extraction/Libcrux.Kem.Kyber.Compress.fst	2024-02-05 15:27:11.397356971 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Compress.fst	2024-02-05 15:27:11.428356265 +0100
 @@ -1,39 +1,79 @@
  module Libcrux.Kem.Kyber.Compress
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -978,8 +976,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Compress.fst extraction-edited/Libcrux.Ke
 +  res <: Libcrux.Kem.Kyber.Arithmetic.i32_b 3328
 +#pop-options
 diff -ruN extraction/Libcrux.Kem.Kyber.Compress.fsti extraction-edited/Libcrux.Kem.Kyber.Compress.fsti
---- extraction/Libcrux.Kem.Kyber.Compress.fsti	2024-02-01 11:03:26.762762061 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Compress.fsti	2024-02-01 11:03:26.847759568 +0100
+--- extraction/Libcrux.Kem.Kyber.Compress.fsti	2024-02-05 15:27:11.393357062 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Compress.fsti	2024-02-05 15:27:11.422356401 +0100
 @@ -3,8 +3,19 @@
  open Core
  open FStar.Mul
@@ -1045,8 +1043,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Compress.fsti extraction-edited/Libcrux.K
 +      (requires fe =. 0l || fe =. 1l) 
 +      (fun result -> v result >= 0 /\ v result < 3329)
 diff -ruN extraction/Libcrux.Kem.Kyber.Constants.fsti extraction-edited/Libcrux.Kem.Kyber.Constants.fsti
---- extraction/Libcrux.Kem.Kyber.Constants.fsti	2024-02-01 11:03:26.795761093 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Constants.fsti	2024-02-01 11:03:26.821760330 +0100
+--- extraction/Libcrux.Kem.Kyber.Constants.fsti	2024-02-05 15:27:11.369357609 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Constants.fsti	2024-02-05 15:27:11.427356287 +0100
 @@ -15,7 +15,8 @@
  
  let v_FIELD_MODULUS: i32 = 3329l
@@ -1058,8 +1056,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Constants.fsti extraction-edited/Libcrux.
  let v_REJECTION_SAMPLING_SEED_SIZE: usize = sz 168 *! sz 5
  
 diff -ruN extraction/Libcrux.Kem.Kyber.Constant_time_ops.fst extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst
---- extraction/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-02-01 11:03:26.802760887 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-02-01 11:03:26.832760008 +0100
+--- extraction/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-02-05 15:27:11.359357836 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-02-05 15:27:11.442355946 +0100
 @@ -4,56 +4,163 @@
  open FStar.Mul
  
@@ -1245,8 +1243,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Constant_time_ops.fst extraction-edited/L
 +  )
 +#pop-options
 diff -ruN extraction/Libcrux.Kem.Kyber.Constant_time_ops.fsti extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti
---- extraction/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-02-01 11:03:26.798761005 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-02-01 11:03:26.837759861 +0100
+--- extraction/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-02-05 15:27:11.355357927 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-02-05 15:27:11.424356356 +0100
 @@ -20,7 +20,8 @@
  
  val compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_Slice u8)
@@ -1278,8 +1276,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Constant_time_ops.fsti extraction-edited/
 +          Hax_lib.implies (selector =. 0uy <: bool) (fun _ -> result =. lhs <: bool) &&
 +          Hax_lib.implies (selector <>. 0uy <: bool) (fun _ -> result =. rhs <: bool))
 diff -ruN extraction/Libcrux.Kem.Kyber.fst extraction-edited/Libcrux.Kem.Kyber.fst
---- extraction/Libcrux.Kem.Kyber.fst	2024-02-01 11:03:26.764762002 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.fst	2024-02-01 11:03:26.824760242 +0100
+--- extraction/Libcrux.Kem.Kyber.fst	2024-02-05 15:27:11.394357039 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.fst	2024-02-05 15:27:11.451355741 +0100
 @@ -1,12 +1,29 @@
  module Libcrux.Kem.Kyber
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -1554,8 +1552,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.fst extraction-edited/Libcrux.Kem.Kyber.f
 +    (Core.Convert.f_into public_key <: Libcrux.Kem.Kyber.Types.t_KyberPublicKey v_PUBLIC_KEY_SIZE)
 +
 diff -ruN extraction/Libcrux.Kem.Kyber.fsti extraction-edited/Libcrux.Kem.Kyber.fsti
---- extraction/Libcrux.Kem.Kyber.fsti	2024-02-01 11:03:26.791761210 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.fsti	2024-02-01 11:03:26.850759480 +0100
+--- extraction/Libcrux.Kem.Kyber.fsti	2024-02-05 15:27:11.374357495 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.fsti	2024-02-05 15:27:11.436356082 +0100
 @@ -4,42 +4,81 @@
  open FStar.Mul
  
@@ -1660,8 +1658,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.fsti extraction-edited/Libcrux.Kem.Kyber.
 +      (ensures (fun kp -> 
 +                (kp.f_sk.f_value,kp.f_pk.f_value) == Spec.Kyber.ind_cca_generate_keypair p randomness))
 diff -ruN extraction/Libcrux.Kem.Kyber.Hash_functions.fst extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst
---- extraction/Libcrux.Kem.Kyber.Hash_functions.fst	2024-02-01 11:03:26.803760858 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst	2024-02-01 11:03:26.830760066 +0100
+--- extraction/Libcrux.Kem.Kyber.Hash_functions.fst	2024-02-05 15:27:11.378357404 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst	2024-02-05 15:27:11.407356743 +0100
 @@ -3,18 +3,27 @@
  open Core
  open FStar.Mul
@@ -1689,7 +1687,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Hash_functions.fst extraction-edited/Libc
      Rust_primitives.Hax.repeat (Rust_primitives.Hax.repeat 0uy (sz 840) <: t_Array u8 (sz 840)) v_K
    in
    let out:t_Array (t_Array u8 (sz 840)) v_K =
--    if ~.(Libcrux_platform.simd256_support () <: bool) || ~.true
+-    if ~.(Libcrux_platform.Platform.simd256_support () <: bool)
 +    if ~.(Libcrux_platform.simd256_support <: bool) || ~.false
      then
        Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
@@ -1701,8 +1699,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Hash_functions.fst extraction-edited/Libc
 +  admit(); //P-F
    out
 diff -ruN extraction/Libcrux.Kem.Kyber.Hash_functions.fsti extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti
---- extraction/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-02-01 11:03:26.758762178 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-02-01 11:03:26.855759333 +0100
+--- extraction/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-02-05 15:27:11.358357859 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-02-05 15:27:11.431356196 +0100
 @@ -3,12 +3,24 @@
  open Core
  open FStar.Mul
@@ -1733,8 +1731,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Hash_functions.fsti extraction-edited/Lib
 +            (forall i. i < v v_K ==> Seq.index res i == Spec.Kyber.v_XOF (sz 840) (Seq.index input i))))
 +          
 diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst
---- extraction/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-02-01 11:03:26.765761973 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-02-01 11:03:26.853759392 +0100
+--- extraction/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-02-05 15:27:11.386357221 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-02-05 15:27:11.419356470 +0100
 @@ -1,5 +1,5 @@
  module Libcrux.Kem.Kyber.Ind_cpa
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -2445,8 +2443,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
 +  res
 + 
 diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti
---- extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-02-01 11:03:26.806760770 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-02-01 11:03:26.843759685 +0100
+--- extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-02-05 15:27:11.380357358 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-02-05 15:27:11.410356675 +0100
 @@ -1,80 +1,152 @@
  module Libcrux.Kem.Kyber.Ind_cpa
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -2649,8 +2647,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-edited/Libcrux.Ke
 + 
 +    
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber1024.fst extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst
---- extraction/Libcrux.Kem.Kyber.Kyber1024.fst	2024-02-01 11:03:26.792761181 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst	2024-02-01 11:03:26.815760506 +0100
+--- extraction/Libcrux.Kem.Kyber.Kyber1024.fst	2024-02-05 15:27:11.375357472 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst	2024-02-05 15:27:11.444355900 +0100
 @@ -3,37 +3,23 @@
  open Core
  open FStar.Mul
@@ -2703,8 +2701,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber1024.fst extraction-edited/Libcrux.K
      (sz 3168)
      (sz 1568)
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber1024.fsti extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fsti
---- extraction/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-02-01 11:03:26.787761327 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-02-01 11:03:26.816760477 +0100
+--- extraction/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-02-05 15:27:11.377357426 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-02-05 15:27:11.429356242 +0100
 @@ -63,32 +63,27 @@
    Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_1024_
  
@@ -2750,8 +2748,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber1024.fsti extraction-edited/Libcrux.
        Prims.l_True
        (fun _ -> Prims.l_True)
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber512.fst extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst
---- extraction/Libcrux.Kem.Kyber.Kyber512.fst	2024-02-01 11:03:26.756762236 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst	2024-02-01 11:03:26.835759920 +0100
+--- extraction/Libcrux.Kem.Kyber.Kyber512.fst	2024-02-05 15:27:11.389357153 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst	2024-02-05 15:27:11.439356014 +0100
 @@ -3,37 +3,23 @@
  open Core
  open FStar.Mul
@@ -2804,8 +2802,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber512.fst extraction-edited/Libcrux.Ke
      (sz 1632)
      (sz 800)
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber512.fsti extraction-edited/Libcrux.Kem.Kyber.Kyber512.fsti
---- extraction/Libcrux.Kem.Kyber.Kyber512.fsti	2024-02-01 11:03:26.794761122 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber512.fsti	2024-02-01 11:03:26.812760594 +0100
+--- extraction/Libcrux.Kem.Kyber.Kyber512.fsti	2024-02-05 15:27:11.372357540 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber512.fsti	2024-02-05 15:27:11.441355968 +0100
 @@ -63,32 +63,27 @@
    Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_512_
  
@@ -2851,8 +2849,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber512.fsti extraction-edited/Libcrux.K
        Prims.l_True
        (fun _ -> Prims.l_True)
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber768.fst extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst
---- extraction/Libcrux.Kem.Kyber.Kyber768.fst	2024-02-01 11:03:26.760762119 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst	2024-02-01 11:03:26.833759978 +0100
+--- extraction/Libcrux.Kem.Kyber.Kyber768.fst	2024-02-05 15:27:11.390357130 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst	2024-02-05 15:27:11.438356037 +0100
 @@ -3,37 +3,24 @@
  open Core
  open FStar.Mul
@@ -2906,8 +2904,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber768.fst extraction-edited/Libcrux.Ke
      (sz 2400)
      (sz 1184)
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber768.fsti extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti
---- extraction/Libcrux.Kem.Kyber.Kyber768.fsti	2024-02-01 11:03:26.784761415 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti	2024-02-01 11:03:26.822760301 +0100
+--- extraction/Libcrux.Kem.Kyber.Kyber768.fsti	2024-02-05 15:27:11.364357722 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti	2024-02-05 15:27:11.449355786 +0100
 @@ -63,32 +63,30 @@
    Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_768_
  
@@ -2962,8 +2960,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber768.fsti extraction-edited/Libcrux.K
 +      (ensures (fun kp -> (kp.f_sk.f_value,kp.f_pk.f_value) == Spec.Kyber.kyber768_generate_keypair randomness))
 +
 diff -ruN extraction/Libcrux.Kem.Kyber.Matrix.fst extraction-edited/Libcrux.Kem.Kyber.Matrix.fst
---- extraction/Libcrux.Kem.Kyber.Matrix.fst	2024-02-01 11:03:26.770761826 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Matrix.fst	2024-02-01 11:03:26.858759245 +0100
+--- extraction/Libcrux.Kem.Kyber.Matrix.fst	2024-02-05 15:27:11.353357973 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Matrix.fst	2024-02-05 15:27:11.421356424 +0100
 @@ -3,192 +3,188 @@
  open Core
  open FStar.Mul
@@ -3754,8 +3752,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Matrix.fst extraction-edited/Libcrux.Kem.
 +  admit(); //P-F
    v_A_transpose
 diff -ruN extraction/Libcrux.Kem.Kyber.Matrix.fsti extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti
---- extraction/Libcrux.Kem.Kyber.Matrix.fsti	2024-02-01 11:03:26.777761621 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti	2024-02-01 11:03:26.842759714 +0100
+--- extraction/Libcrux.Kem.Kyber.Matrix.fsti	2024-02-05 15:27:11.396356993 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti	2024-02-05 15:27:11.414356583 +0100
 @@ -3,39 +3,71 @@
  open Core
  open FStar.Mul
@@ -3858,8 +3856,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Matrix.fsti extraction-edited/Libcrux.Kem
 +        if transpose then Libcrux.Kem.Kyber.Arithmetic.to_spec_matrix_b #p res == matrix_A
 +        else Libcrux.Kem.Kyber.Arithmetic.to_spec_matrix_b #p res == Spec.Kyber.matrix_transpose matrix_A)
 diff -ruN extraction/Libcrux.Kem.Kyber.Ntt.fst extraction-edited/Libcrux.Kem.Kyber.Ntt.fst
---- extraction/Libcrux.Kem.Kyber.Ntt.fst	2024-02-01 11:03:26.779761562 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Ntt.fst	2024-02-01 11:03:26.827760154 +0100
+--- extraction/Libcrux.Kem.Kyber.Ntt.fst	2024-02-05 15:27:11.384357267 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Ntt.fst	2024-02-05 15:27:11.432356173 +0100
 @@ -1,56 +1,130 @@
  module Libcrux.Kem.Kyber.Ntt
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -4790,8 +4788,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ntt.fst extraction-edited/Libcrux.Kem.Kyb
 +  down_cast_poly_b #(8*3328) #3328 re 
 +#pop-options
 diff -ruN extraction/Libcrux.Kem.Kyber.Ntt.fsti extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti
---- extraction/Libcrux.Kem.Kyber.Ntt.fsti	2024-02-01 11:03:26.782761474 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti	2024-02-01 11:03:26.811760624 +0100
+--- extraction/Libcrux.Kem.Kyber.Ntt.fsti	2024-02-05 15:27:11.382357312 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti	2024-02-05 15:27:11.404356811 +0100
 @@ -2,223 +2,80 @@
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
  open Core
@@ -5084,8 +5082,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ntt.fsti extraction-edited/Libcrux.Kem.Ky
 +      (ensures fun _ -> True)
 +
 diff -ruN extraction/Libcrux.Kem.Kyber.Sampling.fst extraction-edited/Libcrux.Kem.Kyber.Sampling.fst
---- extraction/Libcrux.Kem.Kyber.Sampling.fst	2024-02-01 11:03:26.805760800 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Sampling.fst	2024-02-01 11:03:26.849759509 +0100
+--- extraction/Libcrux.Kem.Kyber.Sampling.fst	2024-02-05 15:27:11.383357290 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Sampling.fst	2024-02-05 15:27:11.416356538 +0100
 @@ -3,27 +3,34 @@
  open Core
  open FStar.Mul
@@ -5498,8 +5496,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Sampling.fst extraction-edited/Libcrux.Ke
 +  out 
 +#pop-options
 diff -ruN extraction/Libcrux.Kem.Kyber.Sampling.fsti extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti
---- extraction/Libcrux.Kem.Kyber.Sampling.fsti	2024-02-01 11:03:26.774761709 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti	2024-02-01 11:03:26.856759304 +0100
+--- extraction/Libcrux.Kem.Kyber.Sampling.fsti	2024-02-05 15:27:11.387357198 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti	2024-02-05 15:27:11.418356492 +0100
 @@ -3,77 +3,37 @@
  open Core
  open FStar.Mul
@@ -5600,8 +5598,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Sampling.fsti extraction-edited/Libcrux.K
 +//      (ensures fun result -> (forall i. v (result.f_coefficients.[i]) >= 0))
 +      
 diff -ruN extraction/Libcrux.Kem.Kyber.Serialize.fst extraction-edited/Libcrux.Kem.Kyber.Serialize.fst
---- extraction/Libcrux.Kem.Kyber.Serialize.fst	2024-02-01 11:03:26.789761269 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Serialize.fst	2024-02-01 11:03:26.818760418 +0100
+--- extraction/Libcrux.Kem.Kyber.Serialize.fst	2024-02-05 15:27:11.367357654 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Serialize.fst	2024-02-05 15:27:11.446355855 +0100
 @@ -1,8 +1,14 @@
  module Libcrux.Kem.Kyber.Serialize
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -6988,8 +6986,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Serialize.fst extraction-edited/Libcrux.K
    serialized
 +#pop-options
 diff -ruN extraction/Libcrux.Kem.Kyber.Serialize.fsti extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti
---- extraction/Libcrux.Kem.Kyber.Serialize.fsti	2024-02-01 11:03:26.769761855 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti	2024-02-01 11:03:26.845759626 +0100
+--- extraction/Libcrux.Kem.Kyber.Serialize.fsti	2024-02-05 15:27:11.391357107 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti	2024-02-05 15:27:11.402356857 +0100
 @@ -2,118 +2,193 @@
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
  open Core
@@ -7252,8 +7250,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Serialize.fsti extraction-edited/Libcrux.
 +      (requires True)
 +      (ensures (fun res -> True))
 diff -ruN extraction/Libcrux.Kem.Kyber.Types.fst extraction-edited/Libcrux.Kem.Kyber.Types.fst
---- extraction/Libcrux.Kem.Kyber.Types.fst	2024-02-01 11:03:26.772761767 +0100
-+++ extraction-edited/Libcrux.Kem.Kyber.Types.fst	2024-02-01 11:03:26.839759802 +0100
+--- extraction/Libcrux.Kem.Kyber.Types.fst	2024-02-05 15:27:11.365357700 +0100
++++ extraction-edited/Libcrux.Kem.Kyber.Types.fst	2024-02-05 15:27:11.425356333 +0100
 @@ -3,31 +3,33 @@
  open Core
  open FStar.Mul
@@ -7524,33 +7522,16 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Types.fst extraction-edited/Libcrux.Kem.K
 +      (self: t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
      : t_Array u8 v_PRIVATE_KEY_SIZE = impl_12__as_slice v_PRIVATE_KEY_SIZE self.f_sk
 diff -ruN extraction/Libcrux_platform.fsti extraction-edited/Libcrux_platform.fsti
---- extraction/Libcrux_platform.fsti	2024-02-01 11:03:26.767761914 +0100
-+++ extraction-edited/Libcrux_platform.fsti	2024-02-01 11:03:26.826760184 +0100
-@@ -1,20 +1,4 @@
- module Libcrux_platform
- #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
--open Core
--open FStar.Mul
- 
--val bmi2_adx_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
--
--val simd256_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
--
--val x25519_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
--
--val adv_simd_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
--
--val aes_ni_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
--
--val pmull_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
--
--val sha256_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
--
--val simd128_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+--- extraction/Libcrux_platform.fsti	1970-01-01 01:00:00.000000000 +0100
++++ extraction-edited/Libcrux_platform.fsti	2024-02-05 15:27:11.447355832 +0100
+@@ -0,0 +1,4 @@
++module Libcrux_platform
++#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
++
 +val simd256_support: bool
 diff -ruN extraction/MkSeq.fst extraction-edited/MkSeq.fst
 --- extraction/MkSeq.fst	1970-01-01 01:00:00.000000000 +0100
-+++ extraction-edited/MkSeq.fst	2024-02-01 11:03:26.814760535 +0100
++++ extraction-edited/MkSeq.fst	2024-02-05 15:27:11.413356606 +0100
 @@ -0,0 +1,91 @@
 +module MkSeq
 +open Core
@@ -7645,7 +7626,7 @@ diff -ruN extraction/MkSeq.fst extraction-edited/MkSeq.fst
 +%splice[] (init 13 (fun i -> create_gen_tac (i + 1)))
 diff -ruN extraction/Spec.Kyber.fst extraction-edited/Spec.Kyber.fst
 --- extraction/Spec.Kyber.fst	1970-01-01 01:00:00.000000000 +0100
-+++ extraction-edited/Spec.Kyber.fst	2024-02-01 11:03:26.846759597 +0100
++++ extraction-edited/Spec.Kyber.fst	2024-02-05 15:27:11.411356652 +0100
 @@ -0,0 +1,433 @@
 +module Spec.Kyber
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"

--- a/proofs/fstar/extraction-secret-independent.patch
+++ b/proofs/fstar/extraction-secret-independent.patch
@@ -1,6 +1,6 @@
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fst
---- extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst	2024-02-01 11:03:26.836759890 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fst	2024-02-01 11:03:26.911757691 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst	2024-02-05 15:27:11.434356128 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fst	2024-02-05 15:27:11.506354488 +0100
 @@ -1,356 +1,81 @@
  module Libcrux.Kem.Kyber.Arithmetic
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -397,8 +397,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst extraction-secret-i
 -  
 - 
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-02-01 11:03:26.829760095 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-02-01 11:03:26.901757984 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-02-05 15:27:11.406356766 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-02-05 15:27:11.465355422 +0100
 @@ -3,32 +3,10 @@
  open Core
  open FStar.Mul
@@ -744,8 +744,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti extraction-secret-
 +                <:
 +                bool))
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Compress.fst extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fst
---- extraction-edited/Libcrux.Kem.Kyber.Compress.fst	2024-02-01 11:03:26.819760389 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fst	2024-02-01 11:03:26.888758365 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Compress.fst	2024-02-05 15:27:11.428356265 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fst	2024-02-05 15:27:11.461355513 +0100
 @@ -1,79 +1,39 @@
  module Libcrux.Kem.Kyber.Compress
 -#set-options "--fuel 0 --ifuel 0 --z3rlimit 200"
@@ -850,8 +850,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Compress.fst extraction-secret-ind
 +  (Core.Ops.Arith.Neg.neg fe <: i32) &.
 +  ((Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS +! 1l <: i32) /! 2l <: i32)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Compress.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Compress.fsti	2024-02-01 11:03:26.847759568 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fsti	2024-02-01 11:03:26.913757632 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Compress.fsti	2024-02-05 15:27:11.422356401 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fsti	2024-02-05 15:27:11.471355285 +0100
 @@ -3,42 +3,44 @@
  open Core
  open FStar.Mul
@@ -923,8 +923,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Compress.fsti extraction-secret-in
 -      (fun result -> v result >= 0 /\ v result < 3329)
 +    : Prims.Pure i32 (requires fe =. 0l || fe =. 1l) (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Constants.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Constants.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Constants.fsti	2024-02-01 11:03:26.821760330 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Constants.fsti	2024-02-01 11:03:26.896758131 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Constants.fsti	2024-02-05 15:27:11.427356287 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Constants.fsti	2024-02-05 15:27:11.484354989 +0100
 @@ -15,8 +15,7 @@
  
  let v_FIELD_MODULUS: i32 = 3329l
@@ -936,8 +936,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Constants.fsti extraction-secret-i
  let v_REJECTION_SAMPLING_SEED_SIZE: usize = sz 168 *! sz 5
  
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fst
---- extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-02-01 11:03:26.832760008 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-02-01 11:03:26.869758923 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-02-05 15:27:11.442355946 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-02-05 15:27:11.469355331 +0100
 @@ -4,163 +4,61 @@
  open FStar.Mul
  
@@ -1126,8 +1126,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst extraction-s
 -#pop-options
 +  out
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-02-01 11:03:26.837759861 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-02-01 11:03:26.905757867 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-02-05 15:27:11.424356356 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-02-05 15:27:11.496354716 +0100
 @@ -20,26 +20,30 @@
  
  val compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_Slice u8)
@@ -1171,7 +1171,7 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti extraction-
 +                result = rhs <: bool))
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Conversions.fst extraction-secret-independent/Libcrux.Kem.Kyber.Conversions.fst
 --- extraction-edited/Libcrux.Kem.Kyber.Conversions.fst	1970-01-01 01:00:00.000000000 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Conversions.fst	2024-02-01 11:03:26.865759040 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Conversions.fst	2024-02-05 15:27:11.479355103 +0100
 @@ -0,0 +1,87 @@
 +module Libcrux.Kem.Kyber.Conversions
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -1262,8 +1262,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Conversions.fst extraction-secret-
 +  cast (fe +! ((fe >>! 15l <: i32) &. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32)) <: u16
 \ Pas de fin de ligne à la fin du fichier
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.fst extraction-secret-independent/Libcrux.Kem.Kyber.fst
---- extraction-edited/Libcrux.Kem.Kyber.fst	2024-02-01 11:03:26.824760242 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.fst	2024-02-01 11:03:26.885758453 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.fst	2024-02-05 15:27:11.451355741 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.fst	2024-02-05 15:27:11.458355581 +0100
 @@ -1,29 +1,12 @@
  module Libcrux.Kem.Kyber
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -1507,8 +1507,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.fst extraction-secret-independent/
      (Core.Convert.f_into public_key <: Libcrux.Kem.Kyber.Types.t_KyberPublicKey v_PUBLIC_KEY_SIZE)
 -
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.fsti extraction-secret-independent/Libcrux.Kem.Kyber.fsti
---- extraction-edited/Libcrux.Kem.Kyber.fsti	2024-02-01 11:03:26.850759480 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.fsti	2024-02-01 11:03:26.895758160 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.fsti	2024-02-05 15:27:11.436356082 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.fsti	2024-02-05 15:27:11.501354602 +0100
 @@ -10,75 +10,31 @@
    Libcrux.Kem.Kyber.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE +!
    Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
@@ -1598,8 +1598,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.fsti extraction-secret-independent
 +      Prims.l_True
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fst
---- extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst	2024-02-01 11:03:26.830760066 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fst	2024-02-01 11:03:26.893758219 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst	2024-02-05 15:27:11.407356743 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fst	2024-02-05 15:27:11.482355034 +0100
 @@ -3,27 +3,18 @@
  open Core
  open FStar.Mul
@@ -1648,8 +1648,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst extraction-secr
 -  admit(); //P-F
    out
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-02-01 11:03:26.855759333 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-02-01 11:03:26.867758981 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-02-05 15:27:11.431356196 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-02-05 15:27:11.497354693 +0100
 @@ -3,24 +3,12 @@
  open Core
  open FStar.Mul
@@ -1681,7 +1681,7 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti extraction-sec
 +    : Prims.Pure (t_Array (t_Array u8 (sz 840)) v_K) Prims.l_True (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Helper.fst extraction-secret-independent/Libcrux.Kem.Kyber.Helper.fst
 --- extraction-edited/Libcrux.Kem.Kyber.Helper.fst	1970-01-01 01:00:00.000000000 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Helper.fst	2024-02-01 11:03:26.903757925 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Helper.fst	2024-02-05 15:27:11.474355217 +0100
 @@ -0,0 +1,6 @@
 +module Libcrux.Kem.Kyber.Helper
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -1690,8 +1690,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Helper.fst extraction-secret-indep
 +
 +
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fst
---- extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-02-01 11:03:26.853759392 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-02-01 11:03:26.898758072 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-02-05 15:27:11.419356470 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-02-05 15:27:11.493354784 +0100
 @@ -1,5 +1,5 @@
  module Libcrux.Kem.Kyber.Ind_cpa
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -2402,8 +2402,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-secret-inde
 -  res
 - 
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-02-01 11:03:26.843759685 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-02-01 11:03:26.864759069 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-02-05 15:27:11.410356675 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-02-05 15:27:11.490354852 +0100
 @@ -1,152 +1,80 @@
  module Libcrux.Kem.Kyber.Ind_cpa
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -2606,8 +2606,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-secret-ind
 +      Prims.l_True
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fst
---- extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst	2024-02-01 11:03:26.815760506 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fst	2024-02-01 11:03:26.874758776 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst	2024-02-05 15:27:11.444355900 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fst	2024-02-05 15:27:11.499354647 +0100
 @@ -3,23 +3,22 @@
  open Core
  open FStar.Mul
@@ -2641,8 +2641,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst extraction-secret-in
      (sz 3168)
      (sz 1568)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fst
---- extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst	2024-02-01 11:03:26.835759920 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fst	2024-02-01 11:03:26.917757515 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst	2024-02-05 15:27:11.439356014 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fst	2024-02-05 15:27:11.468355354 +0100
 @@ -5,21 +5,20 @@
  
  let decapsulate_512_
@@ -2673,8 +2673,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst extraction-secret-ind
      (sz 1632)
      (sz 800)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fst
---- extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst	2024-02-01 11:03:26.833759978 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fst	2024-02-01 11:03:26.910757720 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst	2024-02-05 15:27:11.438356037 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fst	2024-02-05 15:27:11.473355240 +0100
 @@ -3,24 +3,22 @@
  open Core
  open FStar.Mul
@@ -2708,8 +2708,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst extraction-secret-ind
      (sz 2400)
      (sz 1184)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti	2024-02-01 11:03:26.822760301 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fsti	2024-02-01 11:03:26.879758629 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti	2024-02-05 15:27:11.449355786 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fsti	2024-02-05 15:27:11.491354829 +0100
 @@ -74,19 +74,16 @@
  val decapsulate_768_
        (secret_key: Libcrux.Kem.Kyber.Types.t_KyberPrivateKey (sz 2400))
@@ -2738,8 +2738,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti extraction-secret-in
 +      Prims.l_True
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Matrix.fst extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fst
---- extraction-edited/Libcrux.Kem.Kyber.Matrix.fst	2024-02-01 11:03:26.858759245 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fst	2024-02-01 11:03:26.883758512 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Matrix.fst	2024-02-05 15:27:11.421356424 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fst	2024-02-05 15:27:11.466355399 +0100
 @@ -3,418 +3,432 @@
  open Core
  open FStar.Mul
@@ -3548,8 +3548,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Matrix.fst extraction-secret-indep
 -  admit(); //P-F
    v_A_transpose
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti	2024-02-01 11:03:26.842759714 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fsti	2024-02-01 11:03:26.906757837 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti	2024-02-05 15:27:11.414356583 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fsti	2024-02-05 15:27:11.485354966 +0100
 @@ -3,71 +3,39 @@
  open Core
  open FStar.Mul
@@ -3652,8 +3652,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti extraction-secret-inde
 +      Prims.l_True
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ntt.fst extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fst
---- extraction-edited/Libcrux.Kem.Kyber.Ntt.fst	2024-02-01 11:03:26.827760154 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fst	2024-02-01 11:03:26.892758248 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Ntt.fst	2024-02-05 15:27:11.432356173 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fst	2024-02-05 15:27:11.503354556 +0100
 @@ -1,130 +1,56 @@
  module Libcrux.Kem.Kyber.Ntt
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -4584,8 +4584,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ntt.fst extraction-secret-independ
 -#pop-options
 +  re
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti	2024-02-01 11:03:26.811760624 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fsti	2024-02-01 11:03:26.915757574 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti	2024-02-05 15:27:11.404356811 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fsti	2024-02-05 15:27:11.487354921 +0100
 @@ -2,80 +2,224 @@
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
  open Core
@@ -4879,8 +4879,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti extraction-secret-indepen
 +                <:
 +                bool))
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Sampling.fst extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst
---- extraction-edited/Libcrux.Kem.Kyber.Sampling.fst	2024-02-01 11:03:26.849759509 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst	2024-02-01 11:03:26.862759128 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Sampling.fst	2024-02-05 15:27:11.416356538 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst	2024-02-05 15:27:11.488354898 +0100
 @@ -3,34 +3,27 @@
  open Core
  open FStar.Mul
@@ -5317,8 +5317,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Sampling.fst extraction-secret-ind
 -#pop-options
 +  out
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti	2024-02-01 11:03:26.856759304 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fsti	2024-02-01 11:03:26.899758043 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti	2024-02-05 15:27:11.418356492 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fsti	2024-02-05 15:27:11.455355650 +0100
 @@ -3,37 +3,77 @@
  open Core
  open FStar.Mul
@@ -5419,8 +5419,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti extraction-secret-in
 +      Prims.l_True
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Serialize.fst extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fst
---- extraction-edited/Libcrux.Kem.Kyber.Serialize.fst	2024-02-01 11:03:26.818760418 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fst	2024-02-01 11:03:26.881758571 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Serialize.fst	2024-02-05 15:27:11.446355855 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fst	2024-02-05 15:27:11.494354761 +0100
 @@ -1,14 +1,8 @@
  module Libcrux.Kem.Kyber.Serialize
 -#set-options "--fuel 0 --ifuel 0 --z3rlimit 50 --retry 3"
@@ -6814,8 +6814,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Serialize.fst extraction-secret-in
    serialized
 -#pop-options
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti	2024-02-01 11:03:26.845759626 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fsti	2024-02-01 11:03:26.870758893 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti	2024-02-05 15:27:11.402356857 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fsti	2024-02-05 15:27:11.460355536 +0100
 @@ -2,193 +2,118 @@
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
  open Core
@@ -7078,8 +7078,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti extraction-secret-i
 +val serialize_uncompressed_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
 +    : Prims.Pure (t_Array u8 (sz 384)) Prims.l_True (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Types.fst extraction-secret-independent/Libcrux.Kem.Kyber.Types.fst
---- extraction-edited/Libcrux.Kem.Kyber.Types.fst	2024-02-01 11:03:26.839759802 +0100
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Types.fst	2024-02-01 11:03:26.875758746 +0100
+--- extraction-edited/Libcrux.Kem.Kyber.Types.fst	2024-02-05 15:27:11.425356333 +0100
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Types.fst	2024-02-05 15:27:11.463355467 +0100
 @@ -3,8 +3,6 @@
  open Core
  open FStar.Mul
@@ -7126,8 +7126,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Types.fst extraction-secret-indepe
  
  type t_KyberKeyPair (v_PRIVATE_KEY_SIZE: usize) (v_PUBLIC_KEY_SIZE: usize) = {
 diff -ruN extraction-edited/Libcrux_platform.fsti extraction-secret-independent/Libcrux_platform.fsti
---- extraction-edited/Libcrux_platform.fsti	2024-02-01 11:03:26.826760184 +0100
-+++ extraction-secret-independent/Libcrux_platform.fsti	2024-02-01 11:03:26.887758395 +0100
+--- extraction-edited/Libcrux_platform.fsti	2024-02-05 15:27:11.447355832 +0100
++++ extraction-secret-independent/Libcrux_platform.fsti	2024-02-05 15:27:11.457355604 +0100
 @@ -1,4 +1,4 @@
  module Libcrux_platform
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -7135,7 +7135,7 @@ diff -ruN extraction-edited/Libcrux_platform.fsti extraction-secret-independent/
 -val simd256_support: bool
 +val simd256_support : unit -> bool
 diff -ruN extraction-edited/MkSeq.fst extraction-secret-independent/MkSeq.fst
---- extraction-edited/MkSeq.fst	2024-02-01 11:03:26.814760535 +0100
+--- extraction-edited/MkSeq.fst	2024-02-05 15:27:11.413356606 +0100
 +++ extraction-secret-independent/MkSeq.fst	1970-01-01 01:00:00.000000000 +0100
 @@ -1,91 +0,0 @@
 -module MkSeq
@@ -7230,7 +7230,7 @@ diff -ruN extraction-edited/MkSeq.fst extraction-secret-independent/MkSeq.fst
 -
 -%splice[] (init 13 (fun i -> create_gen_tac (i + 1)))
 diff -ruN extraction-edited/Spec.Kyber.fst extraction-secret-independent/Spec.Kyber.fst
---- extraction-edited/Spec.Kyber.fst	2024-02-01 11:03:26.846759597 +0100
+--- extraction-edited/Spec.Kyber.fst	2024-02-05 15:27:11.411356652 +0100
 +++ extraction-secret-independent/Spec.Kyber.fst	1970-01-01 01:00:00.000000000 +0100
 @@ -1,433 +0,0 @@
 -module Spec.Kyber

--- a/proofs/fstar/extraction/Libcrux.Digest.fst
+++ b/proofs/fstar/extraction/Libcrux.Digest.fst
@@ -43,6 +43,6 @@ let shake128x4_256_ (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8) =
   shake128x4_portable v_LEN data0 data1 data2 data3
 
 let shake128x4 (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8) =
-  if Libcrux_platform.simd256_support ()
+  if Libcrux_platform.Platform.simd256_support ()
   then shake128x4_256_ v_LEN data0 data1 data2 data3
   else shake128x4_portable v_LEN data0 data1 data2 data3

--- a/proofs/fstar/extraction/Libcrux.Digest.fst
+++ b/proofs/fstar/extraction/Libcrux.Digest.fst
@@ -3,9 +3,6 @@ module Libcrux.Digest
 open Core
 open FStar.Mul
 
-let shake128x4_256_ (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8) =
-  Libcrux.Hacl.Sha3.X4.shake128 v_LEN data0 data1 data2 data3
-
 let sha3_256_ (payload: t_Slice u8) = Libcrux.Hacl.Sha3.sha256 payload
 
 let sha3_512_ (payload: t_Slice u8) = Libcrux.Hacl.Sha3.sha512 payload
@@ -41,6 +38,9 @@ let shake128x4_portable (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8) =
   digest0, digest1, digest2, digest3
   <:
   (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
+
+let shake128x4_256_ (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8) =
+  shake128x4_portable v_LEN data0 data1 data2 data3
 
 let shake128x4 (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8) =
   if Libcrux_platform.simd256_support ()

--- a/proofs/fstar/extraction/Libcrux.Digest.fsti
+++ b/proofs/fstar/extraction/Libcrux.Digest.fsti
@@ -3,11 +3,6 @@ module Libcrux.Digest
 open Core
 open FStar.Mul
 
-val shake128x4_256_ (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8)
-    : Prims.Pure (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
 val sha3_256_ (payload: t_Slice u8)
     : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
 
@@ -21,6 +16,11 @@ val shake256 (v_LEN: usize) (data: t_Slice u8)
     : Prims.Pure (t_Array u8 v_LEN) Prims.l_True (fun _ -> Prims.l_True)
 
 val shake128x4_portable (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val shake128x4_256_ (v_LEN: usize) (data0 data1 data2 data3: t_Slice u8)
     : Prims.Pure (t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN & t_Array u8 v_LEN)
       Prims.l_True
       (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Hash_functions.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Hash_functions.fst
@@ -14,7 +14,7 @@ let v_XOFx4 (v_K: usize) (input: t_Array (t_Array u8 (sz 34)) v_K) =
     Rust_primitives.Hax.repeat (Rust_primitives.Hax.repeat 0uy (sz 840) <: t_Array u8 (sz 840)) v_K
   in
   let out:t_Array (t_Array u8 (sz 840)) v_K =
-    if ~.(Libcrux_platform.simd256_support () <: bool) || ~.false
+    if ~.(Libcrux_platform.Platform.simd256_support () <: bool)
     then
       Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
                 Core.Ops.Range.f_start = sz 0;

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Hash_functions.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Hash_functions.fst
@@ -14,7 +14,7 @@ let v_XOFx4 (v_K: usize) (input: t_Array (t_Array u8 (sz 34)) v_K) =
     Rust_primitives.Hax.repeat (Rust_primitives.Hax.repeat 0uy (sz 840) <: t_Array u8 (sz 840)) v_K
   in
   let out:t_Array (t_Array u8 (sz 840)) v_K =
-    if ~.(Libcrux_platform.simd256_support () <: bool) || ~.true
+    if ~.(Libcrux_platform.simd256_support () <: bool) || ~.false
     then
       Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
                 Core.Ops.Range.f_start = sz 0;

--- a/proofs/fstar/extraction/Makefile
+++ b/proofs/fstar/extraction/Makefile
@@ -49,7 +49,6 @@ all:
 
 
 VERIFIED = \
-	Libcrux_platform.fsti \
 	Libcrux.Kem.Kyber.Constants.fsti \
 	Libcrux.Kem.Kyber.Kyber768.fst \
 	Libcrux.Kem.Kyber.Kyber1024.fst \

--- a/proofs/fstar/extraction/clean.sh
+++ b/proofs/fstar/extraction/clean.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# This should really be part of the Makefile
+
+rm -f *.fst
+rm -f *.fsti

--- a/src/kem/kyber/hash_functions.rs
+++ b/src/kem/kyber/hash_functions.rs
@@ -24,7 +24,7 @@ pub(crate) fn XOFx4<const K: usize>(
 ) -> [[u8; REJECTION_SAMPLING_SEED_SIZE]; K] {
     let mut out = [[0u8; REJECTION_SAMPLING_SEED_SIZE]; K];
 
-    if !simd256_support() || !cfg!(simd256) {
+    if !simd256_support() {
         // Without SIMD256 support we fake it and call shak128 4 times.
         // While shak128x4 does this too, this is faster because we only do the
         // required number of invocations (K).

--- a/sys/platform/proofs/fstar/extraction/Libcrux_platform.Platform.fsti
+++ b/sys/platform/proofs/fstar/extraction/Libcrux_platform.Platform.fsti
@@ -1,0 +1,20 @@
+module Libcrux_platform.Platform
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val adv_simd_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val aes_ni_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val bmi2_adx_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val pmull_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val sha256_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val simd128_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val simd256_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val x25519_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)

--- a/sys/platform/proofs/fstar/extraction/Libcrux_platform.fsti
+++ b/sys/platform/proofs/fstar/extraction/Libcrux_platform.fsti
@@ -3,18 +3,4 @@ module Libcrux_platform
 open Core
 open FStar.Mul
 
-val adv_simd_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
-val aes_ni_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
-val bmi2_adx_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
-val pmull_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
-val sha256_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
 val simd128_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
-val simd256_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
-val x25519_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)

--- a/sys/platform/proofs/fstar/extraction/Libcrux_platform.fsti
+++ b/sys/platform/proofs/fstar/extraction/Libcrux_platform.fsti
@@ -3,18 +3,18 @@ module Libcrux_platform
 open Core
 open FStar.Mul
 
-val bmi2_adx_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
-val simd256_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
-val x25519_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
-
 val adv_simd_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
 val aes_ni_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val bmi2_adx_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
 val pmull_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
 val sha256_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
 val simd128_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val simd256_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val x25519_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)

--- a/sys/platform/proofs/fstar/extraction/Libcrux_platform.fsti
+++ b/sys/platform/proofs/fstar/extraction/Libcrux_platform.fsti
@@ -1,6 +1,0 @@
-module Libcrux_platform
-#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
-open Core
-open FStar.Mul
-
-val simd128_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)

--- a/sys/platform/src/lib.rs
+++ b/sys/platform/src/lib.rs
@@ -25,169 +25,204 @@ mod macos_arm;
 #[cfg(test)]
 mod test;
 
-// TODO: Check for z14 or z15
-pub fn simd128_support() -> bool {
-    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-    {
-        use macos_arm::*;
-        adv_simd()
-    }
+pub use platform::*;
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    {
-        cpu_id::supported(Feature::sse2)
-            && cpu_id::supported(Feature::sse3)
-            && cpu_id::supported(Feature::sse4_1)
-            && cpu_id::supported(Feature::avx)
+#[cfg(hax)]
+mod platform {
+    pub fn simd128_support() -> bool {
+        false
     }
-
-    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-    {
-        use linux_arm::*;
-        adv_simd()
+    pub fn simd256_support() -> bool {
+        false
     }
-
-    #[cfg(not(any(
-        all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
-        target_arch = "x86",
-        target_arch = "x86_64"
-    )))]
-    {
+    pub fn x25519_support() -> bool {
+        false
+    }
+    pub fn bmi2_adx_support() -> bool {
+        false
+    }
+    pub fn pmull_support() -> bool {
+        false
+    }
+    pub fn adv_simd_support() -> bool {
+        false
+    }
+    pub fn aes_ni_support() -> bool {
+        false
+    }
+    pub fn sha256_support() -> bool {
         false
     }
 }
 
-pub fn simd256_support() -> bool {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    return cpu_id::supported(Feature::avx2);
+#[cfg(not(hax))]
+mod platform {
+    use super::*;
 
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-    false
-}
+    // TODO: Check for z14 or z15
+    pub fn simd128_support() -> bool {
+        #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+        {
+            use macos_arm::*;
+            adv_simd()
+        }
 
-pub fn x25519_support() -> bool {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    return cpu_id::supported(Feature::bmi2) && cpu_id::supported(Feature::adx);
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            cpu_id::supported(Feature::sse2)
+                && cpu_id::supported(Feature::sse3)
+                && cpu_id::supported(Feature::sse4_1)
+                && cpu_id::supported(Feature::avx)
+        }
 
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-    false
-}
+        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+        {
+            use linux_arm::*;
+            adv_simd()
+        }
 
-pub fn bmi2_adx_support() -> bool {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    return cpu_id::supported(Feature::bmi2) && cpu_id::supported(Feature::adx);
-
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-    false
-}
-
-/// Check whether p(cl)mull is supported
-pub fn pmull_support() -> bool {
-    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-    {
-        use crate::macos_arm::*;
-        pmull()
+        #[cfg(not(any(
+            all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
+            target_arch = "x86",
+            target_arch = "x86_64"
+        )))]
+        {
+            false
+        }
     }
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    {
-        cpu_id::supported(Feature::pclmulqdq)
-    }
+    pub fn simd256_support() -> bool {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        return cpu_id::supported(Feature::avx2);
 
-    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-    {
-        use crate::linux_arm::*;
-        pmull()
-    }
-
-    #[cfg(not(any(
-        all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
-        target_arch = "x86",
-        target_arch = "x86_64"
-    )))]
-    {
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
         false
     }
-}
 
-/// Check whether advanced SIMD features are supported
-pub fn adv_simd_support() -> bool {
-    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-    {
-        use macos_arm::*;
-        adv_simd()
-    }
+    pub fn x25519_support() -> bool {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        return cpu_id::supported(Feature::bmi2) && cpu_id::supported(Feature::adx);
 
-    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-    {
-        use linux_arm::*;
-        adv_simd()
-    }
-
-    #[cfg(not(all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos"))))]
-    {
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
         false
     }
-}
 
-/// Check whether AES is supported
-pub fn aes_ni_support() -> bool {
-    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-    {
-        use crate::macos_arm::*;
-        aes()
-    }
+    pub fn bmi2_adx_support() -> bool {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        return cpu_id::supported(Feature::bmi2) && cpu_id::supported(Feature::adx);
 
-    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-    {
-        use crate::linux_arm::*;
-        aes()
-    }
-
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    {
-        cpu_id::supported(Feature::avx)
-            && cpu_id::supported(Feature::sse)
-            && cpu_id::supported(Feature::aes)
-            && cpu_id::supported(Feature::pclmulqdq)
-            && cpu_id::supported(Feature::movbe)
-    }
-
-    #[cfg(not(any(
-        all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
-        target_arch = "x86",
-        target_arch = "x86_64"
-    )))]
-    {
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
         false
     }
-}
 
-/// Check whether SHA256 is supported
-pub fn sha256_support() -> bool {
-    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-    {
-        use crate::macos_arm::*;
-        sha256()
+    /// Check whether p(cl)mull is supported
+    pub fn pmull_support() -> bool {
+        #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+        {
+            use crate::macos_arm::*;
+            pmull()
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            cpu_id::supported(Feature::pclmulqdq)
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+        {
+            use crate::linux_arm::*;
+            pmull()
+        }
+
+        #[cfg(not(any(
+            all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
+            target_arch = "x86",
+            target_arch = "x86_64"
+        )))]
+        {
+            false
+        }
     }
 
-    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-    {
-        use crate::linux_arm::*;
-        sha256()
+    /// Check whether advanced SIMD features are supported
+    pub fn adv_simd_support() -> bool {
+        #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+        {
+            use macos_arm::*;
+            adv_simd()
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+        {
+            use linux_arm::*;
+            adv_simd()
+        }
+
+        #[cfg(not(all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos"))))]
+        {
+            false
+        }
     }
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    {
-        cpu_id::supported(Feature::sha)
+    /// Check whether AES is supported
+    pub fn aes_ni_support() -> bool {
+        #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+        {
+            use crate::macos_arm::*;
+            aes()
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+        {
+            use crate::linux_arm::*;
+            aes()
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            cpu_id::supported(Feature::avx)
+                && cpu_id::supported(Feature::sse)
+                && cpu_id::supported(Feature::aes)
+                && cpu_id::supported(Feature::pclmulqdq)
+                && cpu_id::supported(Feature::movbe)
+        }
+
+        #[cfg(not(any(
+            all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
+            target_arch = "x86",
+            target_arch = "x86_64"
+        )))]
+        {
+            false
+        }
     }
 
-    #[cfg(not(any(
-        all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
-        target_arch = "x86",
-        target_arch = "x86_64"
-    )))]
-    {
-        false
+    /// Check whether SHA256 is supported
+    pub fn sha256_support() -> bool {
+        #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+        {
+            use crate::macos_arm::*;
+            sha256()
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+        {
+            use crate::linux_arm::*;
+            sha256()
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            cpu_id::supported(Feature::sha)
+        }
+
+        #[cfg(not(any(
+            all(target_arch = "aarch64", any(target_os = "linux", target_os = "macos")),
+            target_arch = "x86",
+            target_arch = "x86_64"
+        )))]
+        {
+            false
+        }
     }
 }


### PR DESCRIPTION
This PR:
 - update F*;
 - makes F* extraction stable across hardware (well, I hope, I cannot try);
 - fixes the Makefiles in `proofs/extraction/fstar` so that they use the correct folder for Libcrux_platform;
 - makes CI check snapshots are up to date;
 - cut CI time for the `hax` job in two by installing Hax from Nix (going from ~12 minutes to ~1 minute)