### PR TITLE
impl Send for Drbg

### DIFF
--- a/src/hacl/drbg.rs
+++ b/src/hacl/drbg.rs
@@ -106,3 +106,5 @@ impl Drop for Drbg {
         unsafe { Hacl_HMAC_DRBG_free(self.alg as u8, self.state) };
     }
 }
+
+unsafe impl Send for Drbg {}


### PR DESCRIPTION
This is needed for achieving `Sync` using a Mutex. Since there is no uncoordinated shared state with other threads, it is safe to impl `Send`. 