### PR TITLE
Drop simd256 cfg from SHA3 crate

### DIFF
--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -21,7 +21,7 @@ hax-lib = { git = "https://github.com/hacspec/hax/" }
 
 [features]
 default = []
-simd128 = ["libcrux-sha3/simd256"]
+simd128 = ["libcrux-sha3/simd128"]
 simd256 = ["libcrux-sha3/simd256"]
 
 [dev-dependencies]

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -21,8 +21,8 @@ hax-lib = { git = "https://github.com/hacspec/hax/" }
 
 [features]
 default = []
-simd128 = []
-simd256 = []
+simd128 = ["libcrux-sha3/simd256"]
+simd256 = ["libcrux-sha3/simd256"]
 
 [dev-dependencies]
 rand = { version = "0.8" }


### PR DESCRIPTION
Only use the `simd256` feature, not the config.