### PR TITLE
Libcrux optimize decap

### DIFF
--- a/benchmarks/benches/kyber768.rs
+++ b/benchmarks/benches/kyber768.rs
@@ -22,12 +22,12 @@ pub fn comparisons_key_generation(c: &mut Criterion) {
         })
     });
 
-    group.bench_function("libcrux portable deserialized (external random)", |b| {
+    group.bench_function("libcrux portable unpacked (external random)", |b| {
         b.iter(|| {
             let mut seed = [0; 64];
             rng.fill_bytes(&mut seed);
             let _tuple =
-                libcrux::kem::kyber::kyber768::generate_key_pair_deserialized(seed);
+                libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed);
         })
     });
 
@@ -161,13 +161,13 @@ pub fn comparisons_decapsulation(c: &mut Criterion) {
         )
     });
 
-    group.bench_function("libcrux portable deserialized", |b| {
+    group.bench_function("libcrux portable unpacked", |b| {
         b.iter_batched(
             || {
                 let mut seed = [0; 64];
                 OsRng.fill_bytes(&mut seed);
                 let ((sk,pk,a,rej,pkh),_pk) =
-                     libcrux::kem::kyber::kyber768::generate_key_pair_deserialized(seed);
+                     libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed);
                 
                 let mut rand = [0; 32];
                 let mut seed2 = [0; 64];
@@ -181,7 +181,7 @@ pub fn comparisons_decapsulation(c: &mut Criterion) {
             },
             |((sk,pk,a,rej,pkh),ciphertext)| {
                 let _shared_secret = 
-                    libcrux::kem::kyber::kyber768::decapsulate_deserialized(&sk,&pk,&a,&rej,&pkh,&ciphertext);
+                    libcrux::kem::kyber::kyber768::decapsulate_unpacked(&sk,&pk,&a,&rej,&pkh,&ciphertext);
             },
             BatchSize::SmallInput,
         )

--- a/benchmarks/benches/kyber768.rs
+++ b/benchmarks/benches/kyber768.rs
@@ -166,17 +166,12 @@ pub fn comparisons_decapsulation(c: &mut Criterion) {
             || {
                 let mut seed = [0; 64];
                 OsRng.fill_bytes(&mut seed);
-                let ((sk,pk,a,rej,pkh),_pk) =
+                let ((sk,pk,a,rej,pkh),pubkey) =
                      libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed);
                 
                 let mut rand = [0; 32];
-                let mut seed2 = [0; 64];
                 OsRng.fill_bytes(&mut rand);
-                OsRng.fill_bytes(&mut seed2);
-                let kp =
-                    libcrux::kem::kyber::kyber768::generate_key_pair(seed2);
-                let (ciphertext,_) = libcrux::kem::kyber::kyber768::encapsulate(&kp.public_key(),rand);
-                
+                let (ciphertext,_) = libcrux::kem::kyber::kyber768::encapsulate(&pubkey,rand);
                 ((sk,pk,a,rej,pkh),ciphertext)
             },
             |((sk,pk,a,rej,pkh),ciphertext)| {

--- a/benchmarks/benches/kyber768.rs
+++ b/benchmarks/benches/kyber768.rs
@@ -26,8 +26,7 @@ pub fn comparisons_key_generation(c: &mut Criterion) {
         b.iter(|| {
             let mut seed = [0; 64];
             rng.fill_bytes(&mut seed);
-            let _tuple =
-                libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed);
+            let _tuple = libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed);
         })
     });
 
@@ -44,7 +43,6 @@ pub fn comparisons_key_generation(c: &mut Criterion) {
                 libcrux::kem::key_gen(Algorithm::MlKem768, &mut rng).unwrap();
         })
     });
-
 
     group.bench_function("pqclean reference implementation", |b| {
         b.iter(|| {
@@ -166,17 +164,17 @@ pub fn comparisons_decapsulation(c: &mut Criterion) {
             || {
                 let mut seed = [0; 64];
                 OsRng.fill_bytes(&mut seed);
-                let ((sk,pk,a,rej,pkh),pubkey) =
-                     libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed);
-                
+                let (sk_state, pubkey) =
+                    libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed);
+
                 let mut rand = [0; 32];
                 OsRng.fill_bytes(&mut rand);
-                let (ciphertext,_) = libcrux::kem::kyber::kyber768::encapsulate(&pubkey,rand);
-                ((sk,pk,a,rej,pkh),ciphertext)
+                let (ciphertext, _) = libcrux::kem::kyber::kyber768::encapsulate(&pubkey, rand);
+                (sk_state, ciphertext)
             },
-            |((sk,pk,a,rej,pkh),ciphertext)| {
-                let _shared_secret = 
-                    libcrux::kem::kyber::kyber768::decapsulate_unpacked(&sk,&pk,&a,&rej,&pkh,&ciphertext);
+            |(sk_state, ciphertext)| {
+                let _shared_secret =
+                    libcrux::kem::kyber::kyber768::decapsulate_unpacked(&sk_state, &ciphertext);
             },
             BatchSize::SmallInput,
         )

--- a/kyber-c.yaml
+++ b/kyber-c.yaml
@@ -9,7 +9,9 @@ files:
       - [libcrux_platform]
   - name: libcrux_kyber
     api:
+      - [libcrux_kyber, kyber512]
       - [libcrux_kyber, kyber768]
+      - [libcrux_kyber, kyber1024]
     private:
       - [libcrux_kyber, "*"]
     include_in_c:
@@ -17,3 +19,13 @@ files:
   - name: core
     private:
       - [core, "*"]
+    # NOTE: putting Eurydice in core prevent eurydice from detecting spurious calls
+    # across C translation units from Eurydice to core (notably related to the
+    # result type), and thus prevents eurydice from flipping some result types
+    # being public, which pollutes the header.
+    # NOTE: putting Eurydice as public (api) is required, since some compilation
+    # passes produce calls to Eurydice.slice_to_array2 *after* reachability
+    # analysis, meaning that we cannot let reachability analysis eliminate
+    # Eurydice definitions on an as-needed basis
+    api:
+      - [Eurydice, "*"]

--- a/kyber-c.yaml
+++ b/kyber-c.yaml
@@ -2,20 +2,38 @@ files:
   - name: libcrux_digest
     api:
       - [libcrux, digest]
+      - [libcrux, digest, "*"]
     include_in_h:
       - '"libcrux_hacl_glue.h"'
+
   - name: libcrux_platform
     api:
       - [libcrux_platform]
-  - name: libcrux_kyber
+
+  - name: libcrux_kyber512
     api:
       - [libcrux_kyber, kyber512]
+    include_in_c:
+      - '"libcrux_hacl_glue.h"'
+
+  - name: libcrux_kyber768
+    api:
       - [libcrux_kyber, kyber768]
+    include_in_c:
+      - '"libcrux_hacl_glue.h"'
+
+  - name: libcrux_kyber1024
+    api:
       - [libcrux_kyber, kyber1024]
+    include_in_c:
+      - '"libcrux_hacl_glue.h"'
+
+  - name: libcrux_kyber_common
     private:
       - [libcrux_kyber, "*"]
     include_in_c:
       - '"libcrux_hacl_glue.h"'
+
   - name: core
     private:
       - [core, "*"]

--- a/kyber-c.yaml
+++ b/kyber-c.yaml
@@ -31,8 +31,9 @@ files:
   - name: libcrux_kyber_common
     private:
       - [libcrux_kyber, "*"]
-    include_in_c:
+    include_in_h:
       - '"libcrux_hacl_glue.h"'
+    inline_static: true
 
   - name: core
     private:

--- a/proofs/fstar/extraction-edited.patch
+++ b/proofs/fstar/extraction-edited.patch
@@ -1,6 +1,6 @@
 diff -ruN extraction/BitVecEq.fst extraction-edited/BitVecEq.fst
 --- extraction/BitVecEq.fst	1970-01-01 01:00:00
-+++ extraction-edited/BitVecEq.fst	2024-04-26 12:03:43
++++ extraction-edited/BitVecEq.fst	2024-05-07 18:38:45
 @@ -0,0 +1,12 @@
 +module BitVecEq
 +
@@ -16,7 +16,7 @@ diff -ruN extraction/BitVecEq.fst extraction-edited/BitVecEq.fst
 +
 diff -ruN extraction/BitVecEq.fsti extraction-edited/BitVecEq.fsti
 --- extraction/BitVecEq.fsti	1970-01-01 01:00:00
-+++ extraction-edited/BitVecEq.fsti	2024-04-26 12:03:44
++++ extraction-edited/BitVecEq.fsti	2024-05-07 18:38:45
 @@ -0,0 +1,294 @@
 +module BitVecEq
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -313,7 +313,7 @@ diff -ruN extraction/BitVecEq.fsti extraction-edited/BitVecEq.fsti
 + = admit ()
 +*)
 diff -ruN extraction/Libcrux.Digest.Incremental_x4.fsti extraction-edited/Libcrux.Digest.Incremental_x4.fsti
---- extraction/Libcrux.Digest.Incremental_x4.fsti	2024-04-26 12:03:34
+--- extraction/Libcrux.Digest.Incremental_x4.fsti	2024-05-07 18:38:45
 +++ extraction-edited/Libcrux.Digest.Incremental_x4.fsti	1970-01-01 01:00:00
 @@ -1,31 +0,0 @@
 -module Libcrux.Digest.Incremental_x4
@@ -348,8 +348,8 @@ diff -ruN extraction/Libcrux.Digest.Incremental_x4.fsti extraction-edited/Libcru
 -      Prims.l_True
 -      (fun _ -> Prims.l_True)
 diff -ruN extraction/Libcrux.Digest.fsti extraction-edited/Libcrux.Digest.fsti
---- extraction/Libcrux.Digest.fsti	2024-04-26 12:03:35
-+++ extraction-edited/Libcrux.Digest.fsti	2024-04-26 12:03:43
+--- extraction/Libcrux.Digest.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Digest.fsti	2024-05-07 18:38:45
 @@ -3,13 +3,29 @@
  open Core
  open FStar.Mul
@@ -383,8 +383,8 @@ diff -ruN extraction/Libcrux.Digest.fsti extraction-edited/Libcrux.Digest.fsti
 +      Prims.l_True
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction/Libcrux.Kem.Kyber.Arithmetic.fst extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst
---- extraction/Libcrux.Kem.Kyber.Arithmetic.fst	2024-04-26 12:03:35
-+++ extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst	2024-04-26 12:03:44
+--- extraction/Libcrux.Kem.Kyber.Arithmetic.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst	2024-05-07 18:38:45
 @@ -1,81 +1,364 @@
  module Libcrux.Kem.Kyber.Arithmetic
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -790,8 +790,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Arithmetic.fst extraction-edited/Libcrux.
 +  
 + 
 diff -ruN extraction/Libcrux.Kem.Kyber.Arithmetic.fsti extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti
---- extraction/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-04-26 12:03:38
+--- extraction/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-05-07 18:38:45
 @@ -3,175 +3,257 @@
  open Core
  open FStar.Mul
@@ -1184,8 +1184,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Arithmetic.fsti extraction-edited/Libcrux
 +
 +
 diff -ruN extraction/Libcrux.Kem.Kyber.Compress.fst extraction-edited/Libcrux.Kem.Kyber.Compress.fst
---- extraction/Libcrux.Kem.Kyber.Compress.fst	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.Compress.fst	2024-04-26 12:03:39
+--- extraction/Libcrux.Kem.Kyber.Compress.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Compress.fst	2024-05-07 18:38:45
 @@ -1,39 +1,79 @@
  module Libcrux.Kem.Kyber.Compress
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -1289,8 +1289,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Compress.fst extraction-edited/Libcrux.Ke
 +  res <: Libcrux.Kem.Kyber.Arithmetic.i32_b 3328
 +#pop-options
 diff -ruN extraction/Libcrux.Kem.Kyber.Compress.fsti extraction-edited/Libcrux.Kem.Kyber.Compress.fsti
---- extraction/Libcrux.Kem.Kyber.Compress.fsti	2024-04-26 12:03:34
-+++ extraction-edited/Libcrux.Kem.Kyber.Compress.fsti	2024-04-26 12:03:43
+--- extraction/Libcrux.Kem.Kyber.Compress.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Compress.fsti	2024-05-07 18:38:45
 @@ -3,8 +3,19 @@
  open Core
  open FStar.Mul
@@ -1386,8 +1386,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Compress.fsti extraction-edited/Libcrux.K
 +      (requires fe =. 0l || fe =. 1l) 
 +      (fun result -> v result >= 0 /\ v result < 3329)
 diff -ruN extraction/Libcrux.Kem.Kyber.Constant_time_ops.fst extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst
---- extraction/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-04-26 12:03:36
+--- extraction/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-05-07 18:38:45
 @@ -4,56 +4,163 @@
  open FStar.Mul
  
@@ -1573,8 +1573,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Constant_time_ops.fst extraction-edited/L
 +  )
 +#pop-options
 diff -ruN extraction/Libcrux.Kem.Kyber.Constant_time_ops.fsti extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti
---- extraction/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-04-26 12:03:36
-+++ extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-04-26 12:03:44
+--- extraction/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-05-07 18:38:45
 @@ -3,7 +3,6 @@
  open Core
  open FStar.Mul
@@ -1622,8 +1622,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Constant_time_ops.fsti extraction-edited/
 +          Hax_lib.implies (selector =. 0uy <: bool) (fun _ -> result =. lhs <: bool) &&
 +          Hax_lib.implies (selector <>. 0uy <: bool) (fun _ -> result =. rhs <: bool))
 diff -ruN extraction/Libcrux.Kem.Kyber.Constants.fsti extraction-edited/Libcrux.Kem.Kyber.Constants.fsti
---- extraction/Libcrux.Kem.Kyber.Constants.fsti	2024-04-26 12:03:35
-+++ extraction-edited/Libcrux.Kem.Kyber.Constants.fsti	2024-04-26 12:03:43
+--- extraction/Libcrux.Kem.Kyber.Constants.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Constants.fsti	2024-05-07 18:38:45
 @@ -3,24 +3,20 @@
  open Core
  open FStar.Mul
@@ -1652,8 +1652,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Constants.fsti extraction-edited/Libcrux.
 +
  let v_SHARED_SECRET_SIZE: usize = sz 32
 diff -ruN extraction/Libcrux.Kem.Kyber.Hash_functions.fst extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst
---- extraction/Libcrux.Kem.Kyber.Hash_functions.fst	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst	2024-04-26 12:03:42
+--- extraction/Libcrux.Kem.Kyber.Hash_functions.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst	2024-05-07 18:38:45
 @@ -3,129 +3,114 @@
  open Core
  open FStar.Mul
@@ -1887,8 +1887,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Hash_functions.fst extraction-edited/Libc
 +  admit(); // We assume that shake128x4 correctly implements XOFx4
 +  out 
 diff -ruN extraction/Libcrux.Kem.Kyber.Hash_functions.fsti extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti
---- extraction/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-04-26 12:03:34
-+++ extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-04-26 12:03:42
+--- extraction/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-05-07 18:38:45
 @@ -3,35 +3,17 @@
  open Core
  open FStar.Mul
@@ -1937,8 +1937,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Hash_functions.fsti extraction-edited/Lib
 +          (ensures (fun res ->
 +            (forall i. i < v v_K ==> Seq.index res i == Spec.Kyber.v_XOF (sz 840) (Seq.index input i))))
 diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst
---- extraction/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-04-26 12:03:34
-+++ extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-04-26 12:03:43
+--- extraction/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-05-07 18:38:45
 @@ -1,5 +1,5 @@
  module Libcrux.Kem.Kyber.Ind_cpa
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -2183,19 +2183,25 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
                          v_COMPRESSION_FACTOR
                          v_BLOCK_LEN
                          re
-@@ -203,62 +214,168 @@
+@@ -203,153 +214,168 @@
            <:
            t_Array u8 v_OUT_LEN)
    in
 +  admit();//P-F
    out
  
--let deserialize_then_decompress_u
--      (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
--      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+-let encrypt_unpacked
+-      (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+-          usize)
+-      (tt_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+-      (a_transpose: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+-      (message: t_Array u8 (sz 32))
+-      (randomness: t_Slice u8)
 -     =
--  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
--    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
+-  let (prf_input: t_Array u8 (sz 33)):t_Array u8 (sz 33) = into_padded_array (sz 33) randomness in
+-  let r_as_ntt, domain_separator:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-    u8) =
+-    sample_vector_cbd_then_ntt v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input 0uy
 +#push-options "--split_queries always"
 +let deserialize_then_decompress_u (#p:Spec.Kyber.params)
 +      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR: usize)
@@ -2203,6 +2209,69 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
 +  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K =
 +    Rust_primitives.Hax.repeat wfZero v_K
    in
+-  let tmp0, tmp1, out:(t_Array u8 (sz 33) & u8 &
+-    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+-    sample_ring_element_cbd v_K v_ETA2_RANDOMNESS_SIZE v_ETA2 prf_input domain_separator
+-  in
+-  let prf_input:t_Array u8 (sz 33) = tmp0 in
+-  let domain_separator:u8 = tmp1 in
+-  let error_1_:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K = out in
+-  let prf_input:t_Array u8 (sz 33) =
+-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize prf_input (sz 32) domain_separator
+-  in
+-  let (prf_output: t_Array u8 v_ETA2_RANDOMNESS_SIZE):t_Array u8 v_ETA2_RANDOMNESS_SIZE =
+-    Libcrux.Kem.Kyber.Hash_functions.v_PRF v_ETA2_RANDOMNESS_SIZE
+-      (Rust_primitives.unsize prf_input <: t_Slice u8)
+-  in
+-  let error_2_:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+-    Libcrux.Kem.Kyber.Sampling.sample_from_binomial_distribution v_ETA2
+-      (Rust_primitives.unsize prf_output <: t_Slice u8)
+-  in
+-  let u:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+-    Libcrux.Kem.Kyber.Matrix.compute_vector_u v_K a_transpose r_as_ntt error_1_
+-  in
+-  let message_as_ring_element:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+-    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_message message
+-  in
+-  let v:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+-    Libcrux.Kem.Kyber.Matrix.compute_ring_element_v v_K
+-      tt_as_ntt
+-      r_as_ntt
+-      error_2_
+-      message_as_ring_element
+-  in
+-  let c1:t_Array u8 v_C1_LEN =
+-    compress_then_serialize_u v_K v_C1_LEN v_U_COMPRESSION_FACTOR v_BLOCK_LEN u
+-  in
+-  let c2:t_Array u8 v_C2_LEN =
+-    Libcrux.Kem.Kyber.Serialize.compress_then_serialize_ring_element_v v_V_COMPRESSION_FACTOR
+-      v_C2_LEN
+-      v
+-  in
+-  let (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE):t_Array u8 v_CIPHERTEXT_SIZE =
+-    into_padded_array v_CIPHERTEXT_SIZE (Rust_primitives.unsize c1 <: t_Slice u8)
+-  in
+-  let ciphertext:t_Array u8 v_CIPHERTEXT_SIZE =
+-    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from ciphertext
+-      ({ Core.Ops.Range.f_start = v_C1_LEN } <: Core.Ops.Range.t_RangeFrom usize)
+-      (Core.Slice.impl__copy_from_slice (ciphertext.[ { Core.Ops.Range.f_start = v_C1_LEN }
+-              <:
+-              Core.Ops.Range.t_RangeFrom usize ]
+-            <:
+-            t_Slice u8)
+-          (Core.Array.impl_23__as_slice v_C2_LEN c2 <: t_Slice u8)
+-        <:
+-        t_Slice u8)
+-  in
+-  ciphertext
+-
+-let deserialize_then_decompress_u
+-      (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
+-      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+-     =
+-  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+-    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
+-  in
 -  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
 -    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
 -              (Core.Slice.impl__chunks_exact (Rust_primitives.unsize ciphertext <: t_Slice u8)
@@ -2265,8 +2334,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
    u_as_ntt
 +#pop-options
  
--let encrypt
--      (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+-let decrypt_unpacked
 +#push-options "--z3rlimit 200"
 +let deserialize_public_key (#p:Spec.Kyber.params) 
 +    (v_K: usize) (public_key: t_Slice u8) =
@@ -2336,9 +2404,13 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
 +
 +#push-options "--z3rlimit 400 --split_queries no"
 +let decrypt #p
-+      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
+       (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
            usize)
--      (public_key: t_Slice u8)
+-      (secret_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+-      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+-     =
+-  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+-    deserialize_then_decompress_u v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR ciphertext
 +      (secret_key: t_Slice u8)
 +      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE) = 
 +  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K =
@@ -2347,25 +2419,34 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
 +      v_VECTOR_U_ENCODED_SIZE
 +      v_U_COMPRESSION_FACTOR
 +      ciphertext
-+  in
+   in
+-  let v:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+-    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_ring_element_v v_V_COMPRESSION_FACTOR
 +  let v:Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement =
 +    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_ring_element_v #p v_V_COMPRESSION_FACTOR
-+      (ciphertext.[ { Core.Ops.Range.f_start = v_VECTOR_U_ENCODED_SIZE }
-+          <:
-+          Core.Ops.Range.t_RangeFrom usize ]
-+        <:
-+        t_Slice u8)
-+  in
+       (ciphertext.[ { Core.Ops.Range.f_start = v_VECTOR_U_ENCODED_SIZE }
+           <:
+           Core.Ops.Range.t_RangeFrom usize ]
+         <:
+         t_Slice u8)
+   in
+-  let message:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+-    Libcrux.Kem.Kyber.Matrix.compute_message v_K v secret_as_ntt u_as_ntt
 +  let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K =
 +    deserialize_secret_key #p v_K secret_key
-+  in
+   in
+-  Libcrux.Kem.Kyber.Serialize.compress_then_serialize_message message
 +  let message:Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement =
 +    Libcrux.Kem.Kyber.Matrix.compute_message #p v_K v secret_as_ntt u_as_ntt
 +  in
 +  let res = Libcrux.Kem.Kyber.Serialize.compress_then_serialize_message message in
 +  res
 +#pop-options
-+
+ 
+-let encrypt
+-      (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+-          usize)
+-      (public_key: t_Slice u8)
 +#push-options "--z3rlimit 200"
 +let encrypt #p
 +      v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE
@@ -2382,108 +2463,97 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
        (public_key.[ { Core.Ops.Range.f_end = v_T_AS_NTT_ENCODED_SIZE }
            <:
            Core.Ops.Range.t_RangeTo usize ]
-@@ -270,55 +387,64 @@
+@@ -361,82 +387,98 @@
        <:
        Core.Ops.Range.t_RangeFrom usize ]
    in
--  let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+-  let a_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
 -    Libcrux.Kem.Kyber.Matrix.sample_matrix_A v_K
 +  let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K) v_K =
 +    Libcrux.Kem.Kyber.Matrix.sample_matrix_A #p v_K
        (into_padded_array (sz 34) seed <: t_Array u8 (sz 34))
        false
    in
-   let (prf_input: t_Array u8 (sz 33)):t_Array u8 (sz 33) = into_padded_array (sz 33) randomness in
--  let r_as_ntt, domain_separator:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
-+  let r_as_ntt, domain_separator:(t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K &
-     u8) =
--    sample_vector_cbd_then_ntt v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input 0uy
-+    sample_vector_cbd_then_ntt #p v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input 0uy
-   in
-+  assert (v domain_separator == v v_K);
-   let tmp0, tmp1, out:(t_Array u8 (sz 33) & u8 &
--    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
--    sample_ring_element_cbd v_K v_ETA2_RANDOMNESS_SIZE v_ETA2 prf_input domain_separator
-+    t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K) =
-+    sample_vector_cbd #p v_K v_ETA2_RANDOMNESS_SIZE v_ETA2 prf_input domain_separator
-   in
-   let prf_input:t_Array u8 (sz 33) = tmp0 in
-   let domain_separator:u8 = tmp1 in
--  let error_1_:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K = out in
-+  let error_1_:t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K = out in
-   let prf_input:t_Array u8 (sz 33) =
-     Rust_primitives.Hax.Monomorphized_update_at.update_at_usize prf_input (sz 32) domain_separator
-   in
-+  assert (Seq.equal prf_input (Seq.append randomness (Seq.create 1 domain_separator)));
-+  assert (prf_input == Seq.append randomness (Seq.create 1 domain_separator));
-   let (prf_output: t_Array u8 v_ETA2_RANDOMNESS_SIZE):t_Array u8 v_ETA2_RANDOMNESS_SIZE =
-     Libcrux.Kem.Kyber.Hash_functions.v_PRF v_ETA2_RANDOMNESS_SIZE
-       (Rust_primitives.unsize prf_input <: t_Slice u8)
-   in
--  let error_2_:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
--    Libcrux.Kem.Kyber.Sampling.sample_from_binomial_distribution v_ETA2
-+  let error_2_:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement_b (pow2 (v v_ETA2) - 1) =
-+    Libcrux.Kem.Kyber.Sampling.sample_from_binomial_distribution #p v_ETA2
-       (Rust_primitives.unsize prf_output <: t_Slice u8)
-   in
--  let u:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
--    Libcrux.Kem.Kyber.Matrix.compute_vector_u v_K v_A_transpose r_as_ntt error_1_
-+  let error_2_:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement_b 7 =
-+    Libcrux.Kem.Kyber.Arithmetic.cast_poly_b error_2_ in
-+  let u:t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K =
-+    Libcrux.Kem.Kyber.Matrix.compute_vector_u #p v_K v_A_transpose r_as_ntt error_1_
-   in
--  let message_as_ring_element:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
-+  let message_as_ring_element:Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement =
-     Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_message message
-   in
--  let v:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
--    Libcrux.Kem.Kyber.Matrix.compute_ring_element_v v_K
-+  let v:Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement =
-+    Libcrux.Kem.Kyber.Matrix.compute_ring_element_v #p v_K
-       tt_as_ntt
-       r_as_ntt
-       error_2_
-       message_as_ring_element
-   in
-   let c1:t_Array u8 v_C1_LEN =
--    compress_then_serialize_u v_K v_C1_LEN v_U_COMPRESSION_FACTOR v_BLOCK_LEN u
-+    compress_then_serialize_u #p v_K v_C1_LEN v_U_COMPRESSION_FACTOR v_BLOCK_LEN u
-   in
-   let c2:t_Array u8 v_C2_LEN =
--    Libcrux.Kem.Kyber.Serialize.compress_then_serialize_ring_element_v v_V_COMPRESSION_FACTOR
-+    Libcrux.Kem.Kyber.Serialize.compress_then_serialize_ring_element_v #p v_V_COMPRESSION_FACTOR
-       v_C2_LEN
-       v
-   in
-+  assert (v_C1_LEN = Spec.Kyber.v_C1_SIZE p);
-+  assert (v_C2_LEN = Spec.Kyber.v_C2_SIZE p);
-+  assert (v_CIPHERTEXT_SIZE == v_C1_LEN +! v_C2_LEN);
-+  assert (v_C1_LEN <=. v_CIPHERTEXT_SIZE);
-   let (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE):t_Array u8 v_CIPHERTEXT_SIZE =
-     into_padded_array v_CIPHERTEXT_SIZE (Rust_primitives.unsize c1 <: t_Slice u8)
-   in
-@@ -334,83 +460,25 @@
-         <:
-         t_Slice u8)
-   in
-+  lemma_slice_append ciphertext c1 c2;
-   ciphertext
-+#pop-options
- 
+-  encrypt_unpacked v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN
+-    v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2
+-    v_ETA2_RANDOMNESS_SIZE tt_as_ntt a_transpose message randomness
+-
 -let deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8) =
 -  let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
 -    Rust_primitives.Hax.repeat Libcrux.Kem.Kyber.Arithmetic.impl__PolynomialRingElement__ZERO v_K
--  in
++  let (prf_input: t_Array u8 (sz 33)):t_Array u8 (sz 33) = into_padded_array (sz 33) randomness in
++  let r_as_ntt, domain_separator:(t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K &
++    u8) =
++    sample_vector_cbd_then_ntt #p v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input 0uy
+   in
 -  let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
 -    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter (Core.Iter.Traits.Iterator.f_enumerate
 -              (Core.Slice.impl__chunks_exact secret_key
 -                  Libcrux.Kem.Kyber.Constants.v_BYTES_PER_RING_ELEMENT
 -                <:
 -                Core.Slice.Iter.t_ChunksExact u8)
--            <:
++  assert (v domain_separator == v v_K);
++  let tmp0, tmp1, out:(t_Array u8 (sz 33) & u8 &
++    t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K) =
++    sample_vector_cbd #p v_K v_ETA2_RANDOMNESS_SIZE v_ETA2 prf_input domain_separator
++  in
++  let prf_input:t_Array u8 (sz 33) = tmp0 in
++  let domain_separator:u8 = tmp1 in
++  let error_1_:t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K = out in
++  let prf_input:t_Array u8 (sz 33) =
++    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize prf_input (sz 32) domain_separator
++  in
++  assert (Seq.equal prf_input (Seq.append randomness (Seq.create 1 domain_separator)));
++  assert (prf_input == Seq.append randomness (Seq.create 1 domain_separator));
++  let (prf_output: t_Array u8 v_ETA2_RANDOMNESS_SIZE):t_Array u8 v_ETA2_RANDOMNESS_SIZE =
++    Libcrux.Kem.Kyber.Hash_functions.v_PRF v_ETA2_RANDOMNESS_SIZE
++      (Rust_primitives.unsize prf_input <: t_Slice u8)
++  in
++  let error_2_:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement_b (pow2 (v v_ETA2) - 1) =
++    Libcrux.Kem.Kyber.Sampling.sample_from_binomial_distribution #p v_ETA2
++      (Rust_primitives.unsize prf_output <: t_Slice u8)
++  in
++  let error_2_:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement_b 7 =
++    Libcrux.Kem.Kyber.Arithmetic.cast_poly_b error_2_ in
++  let u:t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K =
++    Libcrux.Kem.Kyber.Matrix.compute_vector_u #p v_K v_A_transpose r_as_ntt error_1_
++  in
++  let message_as_ring_element:Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement =
++    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_message message
++  in
++  let v:Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement =
++    Libcrux.Kem.Kyber.Matrix.compute_ring_element_v #p v_K
++      tt_as_ntt
++      r_as_ntt
++      error_2_
++      message_as_ring_element
++  in
++  let c1:t_Array u8 v_C1_LEN =
++    compress_then_serialize_u #p v_K v_C1_LEN v_U_COMPRESSION_FACTOR v_BLOCK_LEN u
++  in
++  let c2:t_Array u8 v_C2_LEN =
++    Libcrux.Kem.Kyber.Serialize.compress_then_serialize_ring_element_v #p v_V_COMPRESSION_FACTOR
++      v_C2_LEN
++      v
++  in
++  assert (v_C1_LEN = Spec.Kyber.v_C1_SIZE p);
++  assert (v_C2_LEN = Spec.Kyber.v_C2_SIZE p);
++  assert (v_CIPHERTEXT_SIZE == v_C1_LEN +! v_C2_LEN);
++  assert (v_C1_LEN <=. v_CIPHERTEXT_SIZE);
++  let (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE):t_Array u8 v_CIPHERTEXT_SIZE =
++    into_padded_array v_CIPHERTEXT_SIZE (Rust_primitives.unsize c1 <: t_Slice u8)
++  in
++  let ciphertext:t_Array u8 v_CIPHERTEXT_SIZE =
++    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from ciphertext
++      ({ Core.Ops.Range.f_start = v_C1_LEN } <: Core.Ops.Range.t_RangeFrom usize)
++      (Core.Slice.impl__copy_from_slice (ciphertext.[ { Core.Ops.Range.f_start = v_C1_LEN }
++              <:
++              Core.Ops.Range.t_RangeFrom usize ]
+             <:
 -            Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
--        <:
++            t_Slice u8)
++          (Core.Array.impl_23__as_slice v_C2_LEN c2 <: t_Slice u8)
+         <:
 -        Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_ChunksExact u8))
 -      secret_as_ntt
 -      (fun secret_as_ntt temp_1_ ->
@@ -2498,33 +2568,29 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
 -              Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
 -          <:
 -          t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
--  in
++        t_Slice u8)
+   in
 -  secret_as_ntt
--
++  lemma_slice_append ciphertext c1 c2;
++  ciphertext
++#pop-options
+ 
 -let decrypt
 -      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
 -          usize)
 -      (secret_key: t_Slice u8)
 -      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
 -     =
--  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
--    deserialize_then_decompress_u v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR ciphertext
--  in
--  let v:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
--    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_ring_element_v v_V_COMPRESSION_FACTOR
--      (ciphertext.[ { Core.Ops.Range.f_start = v_VECTOR_U_ENCODED_SIZE }
--          <:
--          Core.Ops.Range.t_RangeFrom usize ]
--        <:
--        t_Slice u8)
--  in
 -  let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
 -    deserialize_secret_key v_K secret_key
 -  in
--  let message:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
--    Libcrux.Kem.Kyber.Matrix.compute_message v_K v secret_as_ntt u_as_ntt
--  in
--  Libcrux.Kem.Kyber.Serialize.compress_then_serialize_message message
+-  decrypt_unpacked v_K
+-    v_CIPHERTEXT_SIZE
+-    v_VECTOR_U_ENCODED_SIZE
+-    v_U_COMPRESSION_FACTOR
+-    v_V_COMPRESSION_FACTOR
+-    secret_as_ntt
+-    ciphertext
 -
 -let serialize_secret_key
 +let serialize_secret_key (#p:Spec.Kyber.params)
@@ -2558,7 +2624,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
            Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
              ({
                  Core.Ops.Range.f_start
-@@ -449,13 +517,14 @@
+@@ -475,13 +517,14 @@
            <:
            t_Array u8 v_OUT_LEN)
    in
@@ -2577,7 +2643,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
    let public_key_serialized:t_Array u8 v_PUBLIC_KEY_SIZE =
      Rust_primitives.Hax.repeat 0uy v_PUBLIC_KEY_SIZE
    in
-@@ -472,7 +541,7 @@
+@@ -498,7 +541,7 @@
                Core.Ops.Range.t_Range usize ]
              <:
              t_Slice u8)
@@ -2586,7 +2652,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
                    v_RANKED_BYTES_PER_RING_ELEMENT
                    tt_as_ntt
                  <:
-@@ -498,42 +567,49 @@
+@@ -524,232 +567,49 @@
          <:
          t_Slice u8)
    in
@@ -2595,19 +2661,20 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
 +    seed_for_a;
    public_key_serialized
  
--let generate_keypair
-+
-+let generate_keypair #p
-       (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
-           usize)
+-let generate_keypair_unpacked
+-      (v_K v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE: usize)
 -      (key_generation_seed: t_Slice u8)
 -     =
++
++let generate_keypair #p
++      (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
++          usize)
 +      (key_generation_seed: t_Slice u8) =
    let hashed:t_Array u8 (sz 64) = Libcrux.Kem.Kyber.Hash_functions.v_G key_generation_seed in
    let seed_for_A, seed_for_secret_and_error:(t_Slice u8 & t_Slice u8) =
      Core.Slice.impl__split_at (Rust_primitives.unsize hashed <: t_Slice u8) (sz 32)
    in
--  let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+-  let a_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
 -    Libcrux.Kem.Kyber.Matrix.sample_matrix_A v_K
 +  let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K) v_K =
 +    Libcrux.Kem.Kyber.Matrix.sample_matrix_A #p v_K
@@ -2630,7 +2697,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
 +    sample_vector_cbd_then_ntt #p v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input domain_separator
    in
 -  let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
--    Libcrux.Kem.Kyber.Matrix.compute_As_plus_e v_K v_A_transpose secret_as_ntt error_as_ntt
+-    Libcrux.Kem.Kyber.Matrix.compute_As_plus_e v_K a_transpose secret_as_ntt error_as_ntt
 +  let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K =
 +    Libcrux.Kem.Kyber.Matrix.compute_As_plus_e #p v_K v_A_transpose secret_as_ntt error_as_ntt
    in
@@ -2638,6 +2705,197 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
 -    serialize_public_key v_K v_RANKED_BYTES_PER_RING_ELEMENT v_PUBLIC_KEY_SIZE tt_as_ntt seed_for_A
 +    serialize_public_key #p v_K v_RANKED_BYTES_PER_RING_ELEMENT v_PUBLIC_KEY_SIZE tt_as_ntt seed_for_A
    in
+-  let secret_as_ntt, tt_as_ntt:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+-              Core.Ops.Range.f_start = sz 0;
+-              Core.Ops.Range.f_end = v_K
+-            }
+-            <:
+-            Core.Ops.Range.t_Range usize)
+-        <:
+-        Core.Ops.Range.t_Range usize)
+-      (secret_as_ntt, tt_as_ntt
+-        <:
+-        (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-          t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+-      (fun temp_0_ i ->
+-          let secret_as_ntt, tt_as_ntt:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+-              v_K &
+-            t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+-            temp_0_
+-          in
+-          let i:usize = i in
+-          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+-                    Core.Ops.Range.f_start = sz 0;
+-                    Core.Ops.Range.f_end
+-                    =
+-                    Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+-                  }
+-                  <:
+-                  Core.Ops.Range.t_Range usize)
+-              <:
+-              Core.Ops.Range.t_Range usize)
+-            (secret_as_ntt, tt_as_ntt
+-              <:
+-              (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-                t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+-            (fun temp_0_ j ->
+-                let secret_as_ntt, tt_as_ntt:(t_Array
+-                    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-                  t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+-                  temp_0_
+-                in
+-                let j:usize = j in
+-                let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+-                  Rust_primitives.Hax.Monomorphized_update_at.update_at_usize secret_as_ntt
+-                    i
+-                    ({
+-                        (secret_as_ntt.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+-                        ) with
+-                        Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+-                        =
+-                        Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (secret_as_ntt.[
+-                              i ]
+-                            <:
+-                            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+-                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+-                          j
+-                          (cast (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative ((secret_as_ntt.[
+-                                        i ]
+-                                      <:
+-                                      Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+-                                      .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ]
+-                                    <:
+-                                    i32)
+-                                <:
+-                                u16)
+-                            <:
+-                            i32)
+-                        <:
+-                        t_Array i32 (sz 256)
+-                      }
+-                      <:
+-                      Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+-                in
+-                let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+-                  Rust_primitives.Hax.Monomorphized_update_at.update_at_usize tt_as_ntt
+-                    i
+-                    ({
+-                        (tt_as_ntt.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) with
+-                        Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+-                        =
+-                        Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (tt_as_ntt.[ i ]
+-                            <:
+-                            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+-                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+-                          j
+-                          (cast (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative ((tt_as_ntt.[
+-                                        i ]
+-                                      <:
+-                                      Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+-                                      .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ]
+-                                    <:
+-                                    i32)
+-                                <:
+-                                u16)
+-                            <:
+-                            i32)
+-                        <:
+-                        t_Array i32 (sz 256)
+-                      }
+-                      <:
+-                      Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+-                in
+-                secret_as_ntt, tt_as_ntt
+-                <:
+-                (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-                  t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+-          <:
+-          (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-            t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+-  in
+-  let a_matrix:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+-    a_transpose
+-  in
+-  let a_matrix:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+-              Core.Ops.Range.f_start = sz 0;
+-              Core.Ops.Range.f_end = v_K
+-            }
+-            <:
+-            Core.Ops.Range.t_Range usize)
+-        <:
+-        Core.Ops.Range.t_Range usize)
+-      a_matrix
+-      (fun a_matrix i ->
+-          let a_matrix:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+-            v_K =
+-            a_matrix
+-          in
+-          let i:usize = i in
+-          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+-                    Core.Ops.Range.f_start = sz 0;
+-                    Core.Ops.Range.f_end = v_K
+-                  }
+-                  <:
+-                  Core.Ops.Range.t_Range usize)
+-              <:
+-              Core.Ops.Range.t_Range usize)
+-            a_matrix
+-            (fun a_matrix j ->
+-                let a_matrix:t_Array
+-                  (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+-                  a_matrix
+-                in
+-                let j:usize = j in
+-                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize a_matrix
+-                  i
+-                  (Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (a_matrix.[ i ]
+-                        <:
+-                        t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+-                      j
+-                      ((a_transpose.[ j ]
+-                          <:
+-                          t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K).[ i ]
+-                        <:
+-                        Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+-                    <:
+-                    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+-                <:
+-                t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+-          <:
+-          t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+-  in
+-  (secret_as_ntt, tt_as_ntt, a_matrix
+-    <:
+-    (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-      t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-      t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)),
+-  public_key_serialized
+-  <:
+-  ((t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-      t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-      t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K) &
+-    t_Array u8 v_PUBLIC_KEY_SIZE)
+-
+-let generate_keypair
+-      (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+-          usize)
+-      (key_generation_seed: t_Slice u8)
+-     =
+-  let (secret_as_ntt, v__t_as_ntt, v__a_transpose), public_key_serialized:((t_Array
+-        Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-      t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-      t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K) &
+-    t_Array u8 v_PUBLIC_KEY_SIZE) =
+-    generate_keypair_unpacked v_K
+-      v_PUBLIC_KEY_SIZE
+-      v_RANKED_BYTES_PER_RING_ELEMENT
+-      v_ETA1
+-      v_ETA1_RANDOMNESS_SIZE
+-      key_generation_seed
+-  in
    let secret_key_serialized:t_Array u8 v_PRIVATE_KEY_SIZE =
 -    serialize_secret_key v_K v_PRIVATE_KEY_SIZE secret_as_ntt
 +    serialize_secret_key #p v_K v_PRIVATE_KEY_SIZE secret_as_ntt
@@ -2650,9 +2908,9 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-edited/Libcrux.Kem
 +  res
 + 
 diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti
---- extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-04-26 12:03:35
-+++ extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-04-26 12:03:43
-@@ -1,171 +1,151 @@
+--- extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-05-07 18:38:45
+@@ -1,196 +1,151 @@
  module Libcrux.Kem.Kyber.Ind_cpa
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -2719,25 +2977,6 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-edited/Libcrux.Ke
 +        res == Spec.Kyber.compress_then_encode_u p 
 +               (Libcrux.Kem.Kyber.Arithmetic.to_spec_vector_b #p input)))
  
--/// Call [`deserialize_then_decompress_ring_element_u`] on each ring element
--/// in the `ciphertext`.
--val deserialize_then_decompress_u
--      (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
-+val deserialize_then_decompress_u (#p:Spec.Kyber.params)
-+      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR: usize)
-       (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
--    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
--      Prims.l_True
--      (fun _ -> Prims.l_True)
-+    : Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K) 
-+      (requires v_K == p.v_RANK /\
-+                v_CIPHERTEXT_SIZE == Spec.Kyber.v_CPA_PKE_CIPHERTEXT_SIZE p /\
-+                v_VECTOR_U_ENCODED_SIZE == Spec.Kyber.v_C1_SIZE p /\
-+                v_U_COMPRESSION_FACTOR == p.v_VECTOR_U_COMPRESSION_FACTOR)
-+      (ensures fun res ->
-+        Libcrux.Kem.Kyber.Arithmetic.to_spec_vector_b #p res ==
-+        Spec.Kyber.(vector_ntt (decode_then_decompress_u p (Seq.slice ciphertext 0 (v (Spec.Kyber.v_C1_SIZE p))))))
- 
 -/// This function implements <strong>Algorithm 13</strong> of the
 -/// NIST FIPS 203 specification; this is the Kyber CPA-PKE encryption algorithm.
 -/// Algorithm 13 is reproduced below:
@@ -2773,37 +3012,34 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-edited/Libcrux.Ke
 -/// ```
 -/// The NIST FIPS 203 standard can be found at
 -/// <https://csrc.nist.gov/pubs/fips/203/ipd>.
--val encrypt
+-val encrypt_unpacked
 -      (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
 -          usize)
--      (public_key: t_Slice u8)
+-      (tt_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+-      (a_transpose: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
 -      (message: t_Array u8 (sz 32))
 -      (randomness: t_Slice u8)
 -    : Prims.Pure (t_Array u8 v_CIPHERTEXT_SIZE) Prims.l_True (fun _ -> Prims.l_True)
-+val deserialize_public_key (#p:Spec.Kyber.params) 
-+    (v_K: usize) (public_key: t_Array u8 (Spec.Kyber.v_T_AS_NTT_ENCODED_SIZE p))
-+    : Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K)
-+      (requires v_K == p.v_RANK /\
-+                length public_key == Spec.Kyber.v_RANKED_BYTES_PER_RING_ELEMENT p)
-+      (ensures fun res -> 
-+        Libcrux.Kem.Kyber.Arithmetic.to_spec_vector_b res ==
-+        Spec.Kyber.vector_decode_12 #p public_key)
-+   
-+val deserialize_secret_key (#p:Spec.Kyber.params) (v_K: usize) (secret_key: t_Slice u8)
-+    : Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K)
-+      (requires v_K == p.v_RANK /\
-+                length secret_key == Spec.Kyber.v_CPA_PKE_SECRET_KEY_SIZE p)
-+      (ensures fun res ->
-+         Libcrux.Kem.Kyber.Arithmetic.to_spec_vector_b #p res ==
-+         Spec.Kyber.vector_decode_12 #p secret_key)
-+    
- 
--/// Call [`deserialize_to_uncompressed_ring_element`] for each ring element.
--val deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8)
+-
+-/// Call [`deserialize_then_decompress_ring_element_u`] on each ring element
+-/// in the `ciphertext`.
+-val deserialize_then_decompress_u
+-      (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
++val deserialize_then_decompress_u (#p:Spec.Kyber.params)
++      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR: usize)
+       (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
 -    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
 -      Prims.l_True
 -      (fun _ -> Prims.l_True)
--
++    : Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K) 
++      (requires v_K == p.v_RANK /\
++                v_CIPHERTEXT_SIZE == Spec.Kyber.v_CPA_PKE_CIPHERTEXT_SIZE p /\
++                v_VECTOR_U_ENCODED_SIZE == Spec.Kyber.v_C1_SIZE p /\
++                v_U_COMPRESSION_FACTOR == p.v_VECTOR_U_COMPRESSION_FACTOR)
++      (ensures fun res ->
++        Libcrux.Kem.Kyber.Arithmetic.to_spec_vector_b #p res ==
++        Spec.Kyber.(vector_ntt (decode_then_decompress_u p (Seq.slice ciphertext 0 (v (Spec.Kyber.v_C1_SIZE p))))))
+ 
 -/// This function implements <strong>Algorithm 14</strong> of the
 -/// NIST FIPS 203 specification; this is the Kyber CPA-PKE decryption algorithm.
 -/// Algorithm 14 is reproduced below:
@@ -2822,11 +3058,30 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-edited/Libcrux.Ke
 -/// ```
 -/// The NIST FIPS 203 standard can be found at
 -/// <https://csrc.nist.gov/pubs/fips/203/ipd>.
--val decrypt
+-val decrypt_unpacked
++val deserialize_public_key (#p:Spec.Kyber.params) 
++    (v_K: usize) (public_key: t_Array u8 (Spec.Kyber.v_T_AS_NTT_ENCODED_SIZE p))
++    : Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K)
++      (requires v_K == p.v_RANK /\
++                length public_key == Spec.Kyber.v_RANKED_BYTES_PER_RING_ELEMENT p)
++      (ensures fun res -> 
++        Libcrux.Kem.Kyber.Arithmetic.to_spec_vector_b res ==
++        Spec.Kyber.vector_decode_12 #p public_key)
++   
++val deserialize_secret_key (#p:Spec.Kyber.params) (v_K: usize) (secret_key: t_Slice u8)
++    : Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K)
++      (requires v_K == p.v_RANK /\
++                length secret_key == Spec.Kyber.v_CPA_PKE_SECRET_KEY_SIZE p)
++      (ensures fun res ->
++         Libcrux.Kem.Kyber.Arithmetic.to_spec_vector_b #p res ==
++         Spec.Kyber.vector_decode_12 #p secret_key)
++    
++
 +val decrypt (#p:Spec.Kyber.params)
        (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
            usize)
-       (secret_key: t_Slice u8)
+-      (secret_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
++      (secret_key: t_Slice u8)
        (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
 -    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
 +    : Pure (t_Array u8 (sz 32))
@@ -2839,19 +3094,31 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-edited/Libcrux.Ke
 +      (ensures (fun res ->
 +                res == Spec.Kyber.ind_cpa_decrypt p secret_key ciphertext))
  
+-val encrypt
++
++val encrypt (#p:Spec.Kyber.params)
+       (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+           usize)
+       (public_key: t_Slice u8)
+       (message: t_Array u8 (sz 32))
+-      (randomness: t_Slice u8)
+-    : Prims.Pure (t_Array u8 v_CIPHERTEXT_SIZE) Prims.l_True (fun _ -> Prims.l_True)
+-
+-/// Call [`deserialize_to_uncompressed_ring_element`] for each ring element.
+-val deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8)
+-    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+-      Prims.l_True
+-      (fun _ -> Prims.l_True)
+-
+-val decrypt
+-      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
+-          usize)
+-      (secret_key: t_Slice u8)
+-      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+-    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+-
 -/// Call [`serialize_uncompressed_ring_element`] for each ring element.
 -val serialize_secret_key
--      (v_K v_OUT_LEN: usize)
--      (key: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
--    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
- 
--/// Concatenate `t` and `ρ` into the public key.
--val serialize_public_key
-+val encrypt (#p:Spec.Kyber.params)
-+      (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
-+          usize)
-+      (public_key: t_Slice u8)
-+      (message: t_Array u8 (sz 32))
 +      (randomness: t_Slice u8{length randomness <. sz 33})
 +    : Pure (t_Array u8 v_CIPHERTEXT_SIZE)
 +      (requires (v_K == p.v_RANK /\
@@ -2871,7 +3138,12 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-edited/Libcrux.Ke
 +      (ensures (fun ct -> ct == Spec.Kyber.ind_cpa_encrypt p public_key message randomness))
 +               
 +val serialize_secret_key (#p:Spec.Kyber.params)
-+      (v_K v_OUT_LEN: usize)
+       (v_K v_OUT_LEN: usize)
+-      (key: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+-    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+-
+-/// Concatenate `t` and `ρ` into the public key.
+-val serialize_public_key
 +      (key: t_Array Libcrux.Kem.Kyber.Arithmetic.wfPolynomialRingElement v_K)
 +    : Pure (t_Array u8 v_OUT_LEN)
 +      (requires (v_K == p.v_RANK /\ v_OUT_LEN == Spec.Kyber.v_CPA_PKE_SECRET_KEY_SIZE p))
@@ -2927,6 +3199,15 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-edited/Libcrux.Ke
 -/// ```
 -/// The NIST FIPS 203 standard can be found at
 -/// <https://csrc.nist.gov/pubs/fips/203/ipd>.
+-val generate_keypair_unpacked
+-      (v_K v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE: usize)
+-      (key_generation_seed: t_Slice u8)
+-    : Prims.Pure
+-      ((t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-          t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-          t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K) &
+-        t_Array u8 v_PUBLIC_KEY_SIZE) Prims.l_True (fun _ -> Prims.l_True)
+-
 -val generate_keypair
 +val generate_keypair (#p:Spec.Kyber.params)
        (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
@@ -2947,8 +3228,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-edited/Libcrux.Ke
 + 
 +    
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber1024.fst extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst
---- extraction/Libcrux.Kem.Kyber.Kyber1024.fst	2024-04-26 12:03:34
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst	2024-04-26 12:03:42
+--- extraction/Libcrux.Kem.Kyber.Kyber1024.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst	2024-05-07 18:38:45
 @@ -7,19 +7,19 @@
        (secret_key: Libcrux.Kem.Kyber.Types.t_MlKemPrivateKey (sz 3168))
        (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 1568))
@@ -2972,18 +3253,37 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber1024.fst extraction-edited/Libcrux.K
        (sz 1536)
        (sz 1568)
        public_key.Libcrux.Kem.Kyber.Types.f_value
-@@ -33,7 +33,7 @@
+@@ -32,26 +32,8 @@
+     <:
      Core.Option.t_Option (Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1568))
  
+-let decapsulate_unpacked
+-      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 4))
+-      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 1568))
+-     =
+-  Libcrux.Kem.Kyber.decapsulate_unpacked (sz 4) (sz 3168) (sz 1536) (sz 1568) (sz 1568) (sz 1536)
+-    (sz 1408) (sz 160) (sz 11) (sz 5) (sz 352) (sz 2) (sz 128) (sz 2) (sz 128) (sz 1600) state
+-    ciphertext
+-
  let generate_key_pair (randomness: t_Array u8 (sz 64)) =
 -  Libcrux.Kem.Kyber.generate_keypair (sz 4)
+-    (sz 1536)
+-    (sz 3168)
+-    (sz 1568)
+-    (sz 1536)
+-    (sz 2)
+-    (sz 128)
+-    randomness
+-
+-let generate_key_pair_unpacked (randomness: t_Array u8 (sz 64)) =
+-  Libcrux.Kem.Kyber.generate_keypair_unpacked (sz 4)
 +  Libcrux.Kem.Kyber.generate_keypair #Spec.Kyber.kyber1024_params (sz 4)
      (sz 1536)
      (sz 3168)
      (sz 1568)
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber1024.fsti extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fsti
---- extraction/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-04-26 12:03:35
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-04-26 12:03:43
+--- extraction/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-05-07 18:38:45
 @@ -71,13 +71,11 @@
  unfold
  let t_MlKem1024PublicKey = Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1568)
@@ -2998,7 +3298,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber1024.fsti extraction-edited/Libcrux.
  val encapsulate
        (public_key: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1568))
        (randomness: t_Array u8 (sz 32))
-@@ -85,14 +83,11 @@
+@@ -85,29 +83,12 @@
        Prims.l_True
        (fun _ -> Prims.l_True)
  
@@ -3009,13 +3309,28 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber1024.fsti extraction-edited/Libcrux.
        Prims.l_True
        (fun _ -> Prims.l_True)
  
+-unfold
+-let t_MlKem1024State = Libcrux.Kem.Kyber.t_MlKemState (sz 4)
+-
+-val decapsulate_unpacked
+-      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 4))
+-      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 1568))
+-    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+-
 -/// Generate ML-KEM 1024 Key Pair
  val generate_key_pair (randomness: t_Array u8 (sz 64))
      : Prims.Pure (Libcrux.Kem.Kyber.Types.t_MlKemKeyPair (sz 3168) (sz 1568))
+-      Prims.l_True
+-      (fun _ -> Prims.l_True)
+-
+-val generate_key_pair_unpacked (randomness: t_Array u8 (sz 64))
+-    : Prims.Pure
+-      (Libcrux.Kem.Kyber.t_MlKemState (sz 4) & Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1568))
        Prims.l_True
+       (fun _ -> Prims.l_True)
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber512.fst extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst
---- extraction/Libcrux.Kem.Kyber.Kyber512.fst	2024-04-26 12:03:35
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst	2024-04-26 12:03:43
+--- extraction/Libcrux.Kem.Kyber.Kyber512.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst	2024-05-07 18:38:45
 @@ -7,19 +7,19 @@
        (secret_key: Libcrux.Kem.Kyber.Types.t_MlKemPrivateKey (sz 1632))
        (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 768))
@@ -3039,18 +3354,37 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber512.fst extraction-edited/Libcrux.Ke
        (sz 768)
        (sz 800)
        public_key.Libcrux.Kem.Kyber.Types.f_value
-@@ -33,7 +33,7 @@
+@@ -32,26 +32,8 @@
+     <:
      Core.Option.t_Option (Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 800))
  
+-let decapsulate_unpacked
+-      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 2))
+-      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 768))
+-     =
+-  Libcrux.Kem.Kyber.decapsulate_unpacked (sz 2) (sz 1632) (sz 768) (sz 800) (sz 768) (sz 768)
+-    (sz 640) (sz 128) (sz 10) (sz 4) (sz 320) (sz 3) (sz 192) (sz 2) (sz 128) (sz 800) state
+-    ciphertext
+-
  let generate_key_pair (randomness: t_Array u8 (sz 64)) =
 -  Libcrux.Kem.Kyber.generate_keypair (sz 2)
+-    (sz 768)
+-    (sz 1632)
+-    (sz 800)
+-    (sz 768)
+-    (sz 3)
+-    (sz 192)
+-    randomness
+-
+-let generate_key_pair_unpacked (randomness: t_Array u8 (sz 64)) =
+-  Libcrux.Kem.Kyber.generate_keypair_unpacked (sz 2)
 +  Libcrux.Kem.Kyber.generate_keypair #Spec.Kyber.kyber512_params (sz 2)
      (sz 768)
      (sz 1632)
      (sz 800)
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber512.fsti extraction-edited/Libcrux.Kem.Kyber.Kyber512.fsti
---- extraction/Libcrux.Kem.Kyber.Kyber512.fsti	2024-04-26 12:03:34
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber512.fsti	2024-04-26 12:03:42
+--- extraction/Libcrux.Kem.Kyber.Kyber512.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber512.fsti	2024-05-07 18:38:45
 @@ -71,13 +71,11 @@
  unfold
  let t_MlKem512PublicKey = Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 800)
@@ -3065,7 +3399,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber512.fsti extraction-edited/Libcrux.K
  val encapsulate
        (public_key: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 800))
        (randomness: t_Array u8 (sz 32))
-@@ -85,14 +83,11 @@
+@@ -85,29 +83,12 @@
        Prims.l_True
        (fun _ -> Prims.l_True)
  
@@ -3076,13 +3410,28 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber512.fsti extraction-edited/Libcrux.K
        Prims.l_True
        (fun _ -> Prims.l_True)
  
+-unfold
+-let t_MlKem512State = Libcrux.Kem.Kyber.t_MlKemState (sz 2)
+-
+-val decapsulate_unpacked
+-      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 2))
+-      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 768))
+-    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+-
 -/// Generate ML-KEM 512 Key Pair
  val generate_key_pair (randomness: t_Array u8 (sz 64))
      : Prims.Pure (Libcrux.Kem.Kyber.Types.t_MlKemKeyPair (sz 1632) (sz 800))
+-      Prims.l_True
+-      (fun _ -> Prims.l_True)
+-
+-val generate_key_pair_unpacked (randomness: t_Array u8 (sz 64))
+-    : Prims.Pure
+-      (Libcrux.Kem.Kyber.t_MlKemState (sz 2) & Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 800))
        Prims.l_True
+       (fun _ -> Prims.l_True)
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber768.fst extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst
---- extraction/Libcrux.Kem.Kyber.Kyber768.fst	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst	2024-04-26 12:03:37
+--- extraction/Libcrux.Kem.Kyber.Kyber768.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst	2024-05-07 18:38:45
 @@ -7,19 +7,19 @@
        (secret_key: Libcrux.Kem.Kyber.Types.t_MlKemPrivateKey (sz 2400))
        (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 1088))
@@ -3106,19 +3455,38 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber768.fst extraction-edited/Libcrux.Ke
        (sz 1152)
        (sz 1184)
        public_key.Libcrux.Kem.Kyber.Types.f_value
-@@ -33,7 +33,7 @@
+@@ -32,26 +32,8 @@
+     <:
      Core.Option.t_Option (Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1184))
  
+-let decapsulate_unpacked
+-      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 3))
+-      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 1088))
+-     =
+-  Libcrux.Kem.Kyber.decapsulate_unpacked (sz 3) (sz 2400) (sz 1152) (sz 1184) (sz 1088) (sz 1152)
+-    (sz 960) (sz 128) (sz 10) (sz 4) (sz 320) (sz 2) (sz 128) (sz 2) (sz 128) (sz 1120) state
+-    ciphertext
+-
  let generate_key_pair (randomness: t_Array u8 (sz 64)) =
 -  Libcrux.Kem.Kyber.generate_keypair (sz 3)
+-    (sz 1152)
+-    (sz 2400)
+-    (sz 1184)
+-    (sz 1152)
+-    (sz 2)
+-    (sz 128)
+-    randomness
+-
+-let generate_key_pair_unpacked (randomness: t_Array u8 (sz 64)) =
+-  Libcrux.Kem.Kyber.generate_keypair_unpacked (sz 3)
 +  Libcrux.Kem.Kyber.generate_keypair #Spec.Kyber.kyber768_params (sz 3)
      (sz 1152)
      (sz 2400)
      (sz 1184)
 diff -ruN extraction/Libcrux.Kem.Kyber.Kyber768.fsti extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti
---- extraction/Libcrux.Kem.Kyber.Kyber768.fsti	2024-04-26 12:03:34
-+++ extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti	2024-04-26 12:03:42
-@@ -71,29 +71,25 @@
+--- extraction/Libcrux.Kem.Kyber.Kyber768.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti	2024-05-07 18:38:45
+@@ -71,43 +71,25 @@
  unfold
  let t_MlKem768PublicKey = Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1184)
  
@@ -3146,15 +3514,29 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Kyber768.fsti extraction-edited/Libcrux.K
        Prims.l_True
        (fun _ -> Prims.l_True)
  
+-unfold
+-let t_MlKem768State = Libcrux.Kem.Kyber.t_MlKemState (sz 3)
+-
+-val decapsulate_unpacked
+-      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 3))
+-      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 1088))
+-    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+-
 -/// Generate ML-KEM 768 Key Pair
  val generate_key_pair (randomness: t_Array u8 (sz 64))
      : Prims.Pure (Libcrux.Kem.Kyber.Types.t_MlKemKeyPair (sz 2400) (sz 1184))
        Prims.l_True
 -      (fun _ -> Prims.l_True)
+-
+-val generate_key_pair_unpacked (randomness: t_Array u8 (sz 64))
+-    : Prims.Pure
+-      (Libcrux.Kem.Kyber.t_MlKemState (sz 3) & Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1184))
+-      Prims.l_True
+-      (fun _ -> Prims.l_True)
 +      (ensures (fun kp -> (kp.f_sk.f_value,kp.f_pk.f_value) == Spec.Kyber.kyber768_generate_keypair randomness))
 diff -ruN extraction/Libcrux.Kem.Kyber.Matrix.fst extraction-edited/Libcrux.Kem.Kyber.Matrix.fst
---- extraction/Libcrux.Kem.Kyber.Matrix.fst	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.Matrix.fst	2024-04-26 12:03:39
+--- extraction/Libcrux.Kem.Kyber.Matrix.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Matrix.fst	2024-05-07 18:38:45
 @@ -3,192 +3,188 @@
  open Core
  open FStar.Mul
@@ -3952,8 +4334,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Matrix.fst extraction-edited/Libcrux.Kem.
 +  admit(); //P-F
    v_A_transpose
 diff -ruN extraction/Libcrux.Kem.Kyber.Matrix.fsti extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti
---- extraction/Libcrux.Kem.Kyber.Matrix.fsti	2024-04-26 12:03:35
-+++ extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti	2024-04-26 12:03:43
+--- extraction/Libcrux.Kem.Kyber.Matrix.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti	2024-05-07 18:38:45
 @@ -3,46 +3,71 @@
  open Core
  open FStar.Mul
@@ -4062,8 +4444,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Matrix.fsti extraction-edited/Libcrux.Kem
 +        if transpose then Libcrux.Kem.Kyber.Arithmetic.to_spec_matrix_b #p res == matrix_A
 +        else Libcrux.Kem.Kyber.Arithmetic.to_spec_matrix_b #p res == Spec.Kyber.matrix_transpose matrix_A)
 diff -ruN extraction/Libcrux.Kem.Kyber.Ntt.fst extraction-edited/Libcrux.Kem.Kyber.Ntt.fst
---- extraction/Libcrux.Kem.Kyber.Ntt.fst	2024-04-26 12:03:34
-+++ extraction-edited/Libcrux.Kem.Kyber.Ntt.fst	2024-04-26 12:03:42
+--- extraction/Libcrux.Kem.Kyber.Ntt.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Ntt.fst	2024-05-07 18:38:45
 @@ -1,56 +1,130 @@
  module Libcrux.Kem.Kyber.Ntt
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -4973,8 +5355,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ntt.fst extraction-edited/Libcrux.Kem.Kyb
 +  down_cast_poly_b #(8*3328) #3328 re 
 +#pop-options
 diff -ruN extraction/Libcrux.Kem.Kyber.Ntt.fsti extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti
---- extraction/Libcrux.Kem.Kyber.Ntt.fsti	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti	2024-04-26 12:03:40
+--- extraction/Libcrux.Kem.Kyber.Ntt.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti	2024-05-07 18:38:45
 @@ -2,276 +2,80 @@
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
  open Core
@@ -5316,8 +5698,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Ntt.fsti extraction-edited/Libcrux.Kem.Ky
 +      (ensures fun _ -> True)
 +
 diff -ruN extraction/Libcrux.Kem.Kyber.Sampling.fst extraction-edited/Libcrux.Kem.Kyber.Sampling.fst
---- extraction/Libcrux.Kem.Kyber.Sampling.fst	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.Sampling.fst	2024-04-26 12:03:40
+--- extraction/Libcrux.Kem.Kyber.Sampling.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Sampling.fst	2024-05-07 18:38:45
 @@ -3,22 +3,34 @@
  open Core
  open FStar.Mul
@@ -5920,8 +6302,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Sampling.fst extraction-edited/Libcrux.Ke
 +  out 
 +#pop-options
 diff -ruN extraction/Libcrux.Kem.Kyber.Sampling.fsti extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti
---- extraction/Libcrux.Kem.Kyber.Sampling.fsti	2024-04-26 12:03:34
-+++ extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti	2024-04-26 12:03:42
+--- extraction/Libcrux.Kem.Kyber.Sampling.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti	2024-05-07 18:38:45
 @@ -3,155 +3,37 @@
  open Core
  open FStar.Mul
@@ -6102,8 +6484,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Sampling.fsti extraction-edited/Libcrux.K
 +//      (ensures fun result -> (forall i. v (result.f_coefficients.[i]) >= 0))
 +      
 diff -ruN extraction/Libcrux.Kem.Kyber.Serialize.fst extraction-edited/Libcrux.Kem.Kyber.Serialize.fst
---- extraction/Libcrux.Kem.Kyber.Serialize.fst	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.Serialize.fst	2024-04-26 12:03:38
+--- extraction/Libcrux.Kem.Kyber.Serialize.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Serialize.fst	2024-05-07 18:38:45
 @@ -1,8 +1,15 @@
  module Libcrux.Kem.Kyber.Serialize
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -7693,8 +8075,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Serialize.fst extraction-edited/Libcrux.K
 +#pop-options
 +
 diff -ruN extraction/Libcrux.Kem.Kyber.Serialize.fsti extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti
---- extraction/Libcrux.Kem.Kyber.Serialize.fsti	2024-04-26 12:03:35
-+++ extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti	2024-04-26 12:03:43
+--- extraction/Libcrux.Kem.Kyber.Serialize.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti	2024-05-07 18:38:45
 @@ -2,133 +2,188 @@
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
  open Core
@@ -7963,8 +8345,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Serialize.fsti extraction-edited/Libcrux.
 +        int_t_array_bitwise_eq res 8 coefficients 12
 +      ))
 diff -ruN extraction/Libcrux.Kem.Kyber.Types.fst extraction-edited/Libcrux.Kem.Kyber.Types.fst
---- extraction/Libcrux.Kem.Kyber.Types.fst	2024-04-26 12:03:34
-+++ extraction-edited/Libcrux.Kem.Kyber.Types.fst	2024-04-26 12:03:43
+--- extraction/Libcrux.Kem.Kyber.Types.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.Types.fst	2024-05-07 18:38:45
 @@ -40,13 +40,41 @@
      f_from = fun (value: t_MlKemCiphertext v_SIZE) -> value.f_value
    }
@@ -8160,8 +8542,8 @@ diff -ruN extraction/Libcrux.Kem.Kyber.Types.fst extraction-edited/Libcrux.Kem.K
        (v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE: usize)
        (sk: t_Array u8 v_PRIVATE_KEY_SIZE)
 diff -ruN extraction/Libcrux.Kem.Kyber.fst extraction-edited/Libcrux.Kem.Kyber.fst
---- extraction/Libcrux.Kem.Kyber.fst	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.fst	2024-04-26 12:03:38
+--- extraction/Libcrux.Kem.Kyber.fst	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.fst	2024-05-07 18:38:45
 @@ -1,12 +1,29 @@
  module Libcrux.Kem.Kyber
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -8396,12 +8778,109 @@ diff -ruN extraction/Libcrux.Kem.Kyber.fst extraction-edited/Libcrux.Kem.Kyber.f
        (public_key.[ { Core.Ops.Range.f_start = v_RANKED_BYTES_PER_RING_ELEMENT }
            <:
            Core.Ops.Range.t_RangeFrom usize ]
-@@ -285,12 +330,12 @@
+@@ -285,109 +330,12 @@
          t_Slice u8)
    in
    public_key =. public_key_serialized
 +#pop-options
  
+-let decapsulate_unpacked
+-      (v_K v_SECRET_KEY_SIZE v_CPA_SECRET_KEY_SIZE v_PUBLIC_KEY_SIZE v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_C1_BLOCK_SIZE v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE v_IMPLICIT_REJECTION_HASH_INPUT_SIZE:
+-          usize)
+-      (state: t_MlKemState v_K)
+-      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext v_CIPHERTEXT_SIZE)
+-     =
+-  let (secret_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K):t_Array
+-    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+-    state.f_secret_as_ntt
+-  in
+-  let (tt_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K):t_Array
+-    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+-    state.f_t_as_ntt
+-  in
+-  let (a_transpose: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K):t_Array
+-    (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+-    state.f_a_transpose
+-  in
+-  let (implicit_rejection_value: t_Slice u8):t_Slice u8 = Rust_primitives.unsize state.f_rej in
+-  let (ind_cpa_public_key_hash: t_Slice u8):t_Slice u8 =
+-    Rust_primitives.unsize state.f_ind_cpa_public_key_hash
+-  in
+-  let decrypted:t_Array u8 (sz 32) =
+-    Libcrux.Kem.Kyber.Ind_cpa.decrypt_unpacked v_K
+-      v_CIPHERTEXT_SIZE
+-      v_C1_SIZE
+-      v_VECTOR_U_COMPRESSION_FACTOR
+-      v_VECTOR_V_COMPRESSION_FACTOR
+-      secret_as_ntt
+-      ciphertext.Libcrux.Kem.Kyber.Types.f_value
+-  in
+-  let (to_hash: t_Array u8 (sz 64)):t_Array u8 (sz 64) =
+-    Libcrux.Kem.Kyber.Ind_cpa.into_padded_array (sz 64)
+-      (Rust_primitives.unsize decrypted <: t_Slice u8)
+-  in
+-  let to_hash:t_Array u8 (sz 64) =
+-    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from to_hash
+-      ({ Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE }
+-        <:
+-        Core.Ops.Range.t_RangeFrom usize)
+-      (Core.Slice.impl__copy_from_slice (to_hash.[ {
+-                Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+-              }
+-              <:
+-              Core.Ops.Range.t_RangeFrom usize ]
+-            <:
+-            t_Slice u8)
+-          ind_cpa_public_key_hash
+-        <:
+-        t_Slice u8)
+-  in
+-  let hashed:t_Array u8 (sz 64) =
+-    Libcrux.Kem.Kyber.Hash_functions.v_G (Rust_primitives.unsize to_hash <: t_Slice u8)
+-  in
+-  let shared_secret, pseudorandomness:(t_Slice u8 & t_Slice u8) =
+-    Core.Slice.impl__split_at (Rust_primitives.unsize hashed <: t_Slice u8)
+-      Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+-  in
+-  let (to_hash: t_Array u8 v_IMPLICIT_REJECTION_HASH_INPUT_SIZE):t_Array u8
+-    v_IMPLICIT_REJECTION_HASH_INPUT_SIZE =
+-    Libcrux.Kem.Kyber.Ind_cpa.into_padded_array v_IMPLICIT_REJECTION_HASH_INPUT_SIZE
+-      implicit_rejection_value
+-  in
+-  let to_hash:t_Array u8 v_IMPLICIT_REJECTION_HASH_INPUT_SIZE =
+-    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from to_hash
+-      ({ Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE }
+-        <:
+-        Core.Ops.Range.t_RangeFrom usize)
+-      (Core.Slice.impl__copy_from_slice (to_hash.[ {
+-                Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+-              }
+-              <:
+-              Core.Ops.Range.t_RangeFrom usize ]
+-            <:
+-            t_Slice u8)
+-          (Core.Convert.f_as_ref ciphertext <: t_Slice u8)
+-        <:
+-        t_Slice u8)
+-  in
+-  let (implicit_rejection_shared_secret: t_Array u8 (sz 32)):t_Array u8 (sz 32) =
+-    Libcrux.Kem.Kyber.Hash_functions.v_PRF (sz 32) (Rust_primitives.unsize to_hash <: t_Slice u8)
+-  in
+-  let expected_ciphertext:t_Array u8 v_CIPHERTEXT_SIZE =
+-    Libcrux.Kem.Kyber.Ind_cpa.encrypt_unpacked v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE
+-      v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR
+-      v_C1_BLOCK_SIZE v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE tt_as_ntt
+-      a_transpose decrypted pseudorandomness
+-  in
+-  let selector:u8 =
+-    Libcrux.Kem.Kyber.Constant_time_ops.compare_ciphertexts_in_constant_time v_CIPHERTEXT_SIZE
+-      (Core.Convert.f_as_ref ciphertext <: t_Slice u8)
+-      (Rust_primitives.unsize expected_ciphertext <: t_Slice u8)
+-  in
+-  Libcrux.Kem.Kyber.Constant_time_ops.select_shared_secret_in_constant_time shared_secret
+-    (Rust_primitives.unsize implicit_rejection_shared_secret <: t_Slice u8)
+-    selector
+-
 -let generate_keypair
 +let generate_keypair #p
        (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
@@ -8412,7 +8891,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.fst extraction-edited/Libcrux.Kem.Kyber.f
    let ind_cpa_keypair_randomness:t_Slice u8 =
      randomness.[ {
          Core.Ops.Range.f_start = sz 0;
-@@ -308,7 +353,7 @@
+@@ -405,7 +353,7 @@
    in
    let ind_cpa_private_key, public_key:(t_Array u8 v_CPA_PRIVATE_KEY_SIZE &
      t_Array u8 v_PUBLIC_KEY_SIZE) =
@@ -8421,7 +8900,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.fst extraction-edited/Libcrux.Kem.Kyber.f
        v_CPA_PRIVATE_KEY_SIZE
        v_PUBLIC_KEY_SIZE
        v_BYTES_PER_RING_ELEMENT
-@@ -317,7 +362,7 @@
+@@ -414,7 +362,7 @@
        ind_cpa_keypair_randomness
    in
    let secret_key_serialized:t_Array u8 v_PRIVATE_KEY_SIZE =
@@ -8430,15 +8909,70 @@ diff -ruN extraction/Libcrux.Kem.Kyber.fst extraction-edited/Libcrux.Kem.Kyber.f
        (Rust_primitives.unsize ind_cpa_private_key <: t_Slice u8)
        (Rust_primitives.unsize public_key <: t_Slice u8)
        implicit_rejection_value
-@@ -330,3 +375,4 @@
-     v_PUBLIC_KEY_SIZE
+@@ -428,59 +376,3 @@
      private_key
      (Core.Convert.f_into public_key <: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey v_PUBLIC_KEY_SIZE)
-+
+ 
+-let generate_keypair_unpacked
+-      (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+-          usize)
+-      (randomness: t_Array u8 (sz 64))
+-     =
+-  let ind_cpa_keypair_randomness:t_Slice u8 =
+-    randomness.[ {
+-        Core.Ops.Range.f_start = sz 0;
+-        Core.Ops.Range.f_end = Libcrux.Kem.Kyber.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE
+-      }
+-      <:
+-      Core.Ops.Range.t_Range usize ]
+-  in
+-  let implicit_rejection_value:t_Slice u8 =
+-    randomness.[ {
+-        Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE
+-      }
+-      <:
+-      Core.Ops.Range.t_RangeFrom usize ]
+-  in
+-  let (secret_as_ntt, tt_as_ntt, a_transpose), ind_cpa_public_key:((t_Array
+-        Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-      t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+-      t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K) &
+-    t_Array u8 v_PUBLIC_KEY_SIZE) =
+-    Libcrux.Kem.Kyber.Ind_cpa.generate_keypair_unpacked v_K
+-      v_PUBLIC_KEY_SIZE
+-      v_BYTES_PER_RING_ELEMENT
+-      v_ETA1
+-      v_ETA1_RANDOMNESS_SIZE
+-      ind_cpa_keypair_randomness
+-  in
+-  let ind_cpa_public_key_hash:t_Array u8 (sz 32) =
+-    Libcrux.Kem.Kyber.Hash_functions.v_H (Rust_primitives.unsize ind_cpa_public_key <: t_Slice u8)
+-  in
+-  let (rej: t_Array u8 (sz 32)):t_Array u8 (sz 32) =
+-    Core.Result.impl__unwrap (Core.Convert.f_try_into implicit_rejection_value
+-        <:
+-        Core.Result.t_Result (t_Array u8 (sz 32)) Core.Array.t_TryFromSliceError)
+-  in
+-  let (pubkey: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey v_PUBLIC_KEY_SIZE):Libcrux.Kem.Kyber.Types.t_MlKemPublicKey
+-  v_PUBLIC_KEY_SIZE =
+-    Core.Convert.f_from ind_cpa_public_key
+-  in
+-  ({
+-      f_secret_as_ntt = secret_as_ntt;
+-      f_t_as_ntt = tt_as_ntt;
+-      f_a_transpose = a_transpose;
+-      f_rej = rej;
+-      f_ind_cpa_public_key_hash = ind_cpa_public_key_hash
+-    }
+-    <:
+-    t_MlKemState v_K),
+-  pubkey
+-  <:
+-  (t_MlKemState v_K & Libcrux.Kem.Kyber.Types.t_MlKemPublicKey v_PUBLIC_KEY_SIZE)
 diff -ruN extraction/Libcrux.Kem.Kyber.fsti extraction-edited/Libcrux.Kem.Kyber.fsti
---- extraction/Libcrux.Kem.Kyber.fsti	2024-04-26 12:03:33
-+++ extraction-edited/Libcrux.Kem.Kyber.fsti	2024-04-26 12:03:41
-@@ -6,42 +6,88 @@
+--- extraction/Libcrux.Kem.Kyber.fsti	2024-05-07 18:38:45
++++ extraction-edited/Libcrux.Kem.Kyber.fsti	2024-05-07 18:38:45
+@@ -6,65 +6,88 @@
  unfold
  let t_MlKemSharedSecret = t_Array u8 (sz 32)
  
@@ -8525,12 +9059,35 @@ diff -ruN extraction/Libcrux.Kem.Kyber.fsti extraction-edited/Libcrux.Kem.Kyber.
 +                 ))
 +      (ensures (fun _ -> Prims.l_True))
  
+-type t_MlKemState (v_K: usize) = {
+-  f_secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K;
+-  f_t_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K;
+-  f_a_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K;
+-  f_rej:t_Array u8 (sz 32);
+-  f_ind_cpa_public_key_hash:t_Array u8 (sz 32)
+-}
+-
+-val decapsulate_unpacked
+-      (v_K v_SECRET_KEY_SIZE v_CPA_SECRET_KEY_SIZE v_PUBLIC_KEY_SIZE v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_C1_BLOCK_SIZE v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE v_IMPLICIT_REJECTION_HASH_INPUT_SIZE:
+-          usize)
+-      (state: t_MlKemState v_K)
+-      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext v_CIPHERTEXT_SIZE)
+-    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+-
 -val generate_keypair
 +val generate_keypair (#p:Spec.Kyber.params)
        (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
            usize)
        (randomness: t_Array u8 (sz 64))
 -    : Prims.Pure (Libcrux.Kem.Kyber.Types.t_MlKemKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
+-      Prims.l_True
+-      (fun _ -> Prims.l_True)
+-
+-val generate_keypair_unpacked
+-      (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+-          usize)
+-      (randomness: t_Array u8 (sz 64))
+-    : Prims.Pure (t_MlKemState v_K & Libcrux.Kem.Kyber.Types.t_MlKemPublicKey v_PUBLIC_KEY_SIZE)
 -      Prims.l_True
 -      (fun _ -> Prims.l_True)
 +    : Pure (Libcrux.Kem.Kyber.Types.t_MlKemKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
@@ -8545,7 +9102,7 @@ diff -ruN extraction/Libcrux.Kem.Kyber.fsti extraction-edited/Libcrux.Kem.Kyber.
 +                (kp.f_sk.f_value,kp.f_pk.f_value) == Spec.Kyber.ind_cca_generate_keypair p randomness))
 diff -ruN extraction/Libcrux.Kem.fst extraction-edited/Libcrux.Kem.fst
 --- extraction/Libcrux.Kem.fst	1970-01-01 01:00:00
-+++ extraction-edited/Libcrux.Kem.fst	2024-04-26 12:03:44
++++ extraction-edited/Libcrux.Kem.fst	2024-05-07 18:38:45
 @@ -0,0 +1,6 @@
 +module Libcrux.Kem
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -8555,7 +9112,7 @@ diff -ruN extraction/Libcrux.Kem.fst extraction-edited/Libcrux.Kem.fst
 +
 diff -ruN extraction/Libcrux_platform.Platform.fsti extraction-edited/Libcrux_platform.Platform.fsti
 --- extraction/Libcrux_platform.Platform.fsti	1970-01-01 01:00:00
-+++ extraction-edited/Libcrux_platform.Platform.fsti	2024-04-26 12:03:37
++++ extraction-edited/Libcrux_platform.Platform.fsti	2024-05-07 18:38:45
 @@ -0,0 +1,20 @@
 +module Libcrux_platform.Platform
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -8579,7 +9136,7 @@ diff -ruN extraction/Libcrux_platform.Platform.fsti extraction-edited/Libcrux_pl
 +val simd128_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 diff -ruN extraction/MkSeq.fst extraction-edited/MkSeq.fst
 --- extraction/MkSeq.fst	1970-01-01 01:00:00
-+++ extraction-edited/MkSeq.fst	2024-04-26 12:03:43
++++ extraction-edited/MkSeq.fst	2024-05-07 18:38:45
 @@ -0,0 +1,91 @@
 +module MkSeq
 +open Core
@@ -8674,7 +9231,7 @@ diff -ruN extraction/MkSeq.fst extraction-edited/MkSeq.fst
 +%splice[] (init 13 (fun i -> create_gen_tac (i + 1)))
 diff -ruN extraction/Spec.Kyber.fst extraction-edited/Spec.Kyber.fst
 --- extraction/Spec.Kyber.fst	1970-01-01 01:00:00
-+++ extraction-edited/Spec.Kyber.fst	2024-04-26 12:03:42
++++ extraction-edited/Spec.Kyber.fst	2024-05-07 18:38:45
 @@ -0,0 +1,435 @@
 +module Spec.Kyber
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"

--- a/proofs/fstar/extraction-secret-independent.patch
+++ b/proofs/fstar/extraction-secret-independent.patch
@@ -1,5 +1,5 @@
 diff -ruN extraction-edited/BitVecEq.fst extraction-secret-independent/BitVecEq.fst
---- extraction-edited/BitVecEq.fst	2024-04-26 12:03:43
+--- extraction-edited/BitVecEq.fst	2024-05-07 18:38:45
 +++ extraction-secret-independent/BitVecEq.fst	1970-01-01 01:00:00
 @@ -1,12 +0,0 @@
 -module BitVecEq
@@ -15,7 +15,7 @@ diff -ruN extraction-edited/BitVecEq.fst extraction-secret-independent/BitVecEq.
 -
 -
 diff -ruN extraction-edited/BitVecEq.fsti extraction-secret-independent/BitVecEq.fsti
---- extraction-edited/BitVecEq.fsti	2024-04-26 12:03:44
+--- extraction-edited/BitVecEq.fsti	2024-05-07 18:38:45
 +++ extraction-secret-independent/BitVecEq.fsti	1970-01-01 01:00:00
 @@ -1,294 +0,0 @@
 -module BitVecEq
@@ -313,8 +313,8 @@ diff -ruN extraction-edited/BitVecEq.fsti extraction-secret-independent/BitVecEq
 - = admit ()
 -*)
 diff -ruN extraction-edited/Libcrux.Digest.fsti extraction-secret-independent/Libcrux.Digest.fsti
---- extraction-edited/Libcrux.Digest.fsti	2024-04-26 12:03:43
-+++ extraction-secret-independent/Libcrux.Digest.fsti	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Digest.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Digest.fsti	2024-05-07 18:38:46
 @@ -1,31 +1,41 @@
  module Libcrux.Digest
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -379,8 +379,8 @@ diff -ruN extraction-edited/Libcrux.Digest.fsti extraction-secret-independent/Li
 -      (fun _ -> Prims.l_True)
 +val shake256 (v_LEN: usize) (data: t_Slice u8) : t_Array u8 v_LEN
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fst
---- extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst	2024-04-26 12:03:44
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fst	2024-04-26 12:03:47
+--- extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fst	2024-05-07 18:38:46
 @@ -1,364 +1,81 @@
  module Libcrux.Kem.Kyber.Arithmetic
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -785,8 +785,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fst extraction-secret-i
 -  
 - 
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-04-26 12:03:38
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-04-26 12:03:44
+--- extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Arithmetic.fsti	2024-05-07 18:38:45
 @@ -3,32 +3,10 @@
  open Core
  open FStar.Mul
@@ -1140,8 +1140,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Arithmetic.fsti extraction-secret-
 +                <:
 +                bool))
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Compress.fst extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fst
---- extraction-edited/Libcrux.Kem.Kyber.Compress.fst	2024-04-26 12:03:39
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fst	2024-04-26 12:03:45
+--- extraction-edited/Libcrux.Kem.Kyber.Compress.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fst	2024-05-07 18:38:45
 @@ -1,79 +1,39 @@
  module Libcrux.Kem.Kyber.Compress
 -#set-options "--fuel 0 --ifuel 0 --z3rlimit 200"
@@ -1246,8 +1246,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Compress.fst extraction-secret-ind
 +  (Core.Ops.Arith.Neg.neg fe <: i32) &.
 +  ((Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS +! 1l <: i32) /! 2l <: i32)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Compress.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Compress.fsti	2024-04-26 12:03:43
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fsti	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Kem.Kyber.Compress.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Compress.fsti	2024-05-07 18:38:46
 @@ -3,42 +3,44 @@
  open Core
  open FStar.Mul
@@ -1319,8 +1319,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Compress.fsti extraction-secret-in
 -      (fun result -> v result >= 0 /\ v result < 3329)
 +    : Prims.Pure i32 (requires fe =. 0l || fe =. 1l) (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fst
---- extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-04-26 12:03:36
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-04-26 12:03:44
+--- extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fst	2024-05-07 18:38:45
 @@ -4,163 +4,61 @@
  open FStar.Mul
  
@@ -1509,8 +1509,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fst extraction-s
 -#pop-options
 +  out
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-04-26 12:03:44
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-04-26 12:03:48
+--- extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Constant_time_ops.fsti	2024-05-07 18:38:46
 @@ -20,26 +20,30 @@
  
  val compare_ciphertexts_in_constant_time (v_CIPHERTEXT_SIZE: usize) (lhs rhs: t_Slice u8)
@@ -1554,7 +1554,7 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Constant_time_ops.fsti extraction-
 +                result = rhs <: bool))
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Conversions.fst extraction-secret-independent/Libcrux.Kem.Kyber.Conversions.fst
 --- extraction-edited/Libcrux.Kem.Kyber.Conversions.fst	1970-01-01 01:00:00
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Conversions.fst	2024-04-26 12:03:44
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Conversions.fst	2024-05-07 18:38:45
 @@ -0,0 +1,87 @@
 +module Libcrux.Kem.Kyber.Conversions
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -1645,8 +1645,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Conversions.fst extraction-secret-
 +  cast (fe +! ((fe >>! 15l <: i32) &. Libcrux.Kem.Kyber.Constants.v_FIELD_MODULUS <: i32)) <: u16
 \ No newline at end of file
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fst
---- extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst	2024-04-26 12:03:42
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fst	2024-04-26 12:03:45
+--- extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fst	2024-05-07 18:38:45
 @@ -3,28 +3,18 @@
  open Core
  open FStar.Mul
@@ -1714,8 +1714,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fst extraction-secr
 -  out 
 +  out
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-04-26 12:03:42
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Hash_functions.fsti	2024-05-07 18:38:45
 @@ -3,17 +3,12 @@
  open Core
  open FStar.Mul
@@ -1742,7 +1742,7 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Hash_functions.fsti extraction-sec
 +    : Prims.Pure (t_Array (t_Array u8 (sz 840)) v_K) Prims.l_True (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Helper.fst extraction-secret-independent/Libcrux.Kem.Kyber.Helper.fst
 --- extraction-edited/Libcrux.Kem.Kyber.Helper.fst	1970-01-01 01:00:00
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Helper.fst	2024-04-26 12:03:47
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Helper.fst	2024-05-07 18:38:46
 @@ -0,0 +1,6 @@
 +module Libcrux.Kem.Kyber.Helper
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
@@ -1751,8 +1751,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Helper.fst extraction-secret-indep
 +
 +
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fst
---- extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-04-26 12:03:43
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fst	2024-05-07 18:38:46
 @@ -1,5 +1,5 @@
  module Libcrux.Kem.Kyber.Ind_cpa
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -2460,8 +2460,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fst extraction-secret-inde
 -  res
 - 
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-04-26 12:03:43
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-04-26 12:03:47
+--- extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Ind_cpa.fsti	2024-05-07 18:38:46
 @@ -1,151 +1,80 @@
  module Libcrux.Kem.Kyber.Ind_cpa
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -2662,8 +2662,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ind_cpa.fsti extraction-secret-ind
 +      Prims.l_True
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fst
---- extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst	2024-04-26 12:03:42
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fst	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fst	2024-05-07 18:38:45
 @@ -3,37 +3,22 @@
  open Core
  open FStar.Mul
@@ -2712,8 +2712,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fst extraction-secret-in
      (sz 3168)
      (sz 1568)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-04-26 12:03:43
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber1024.fsti	2024-05-07 18:38:46
 @@ -63,32 +63,27 @@
    Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_1024_
  
@@ -2759,8 +2759,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber1024.fsti extraction-secret-i
        Prims.l_True
        (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fst
---- extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst	2024-04-26 12:03:43
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fst	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fst	2024-05-07 18:38:46
 @@ -3,37 +3,22 @@
  open Core
  open FStar.Mul
@@ -2809,8 +2809,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber512.fst extraction-secret-ind
      (sz 1632)
      (sz 800)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber512.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Kyber512.fsti	2024-04-26 12:03:42
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fsti	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Kem.Kyber.Kyber512.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber512.fsti	2024-05-07 18:38:45
 @@ -63,32 +63,27 @@
    Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_512_
  
@@ -2856,8 +2856,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber512.fsti extraction-secret-in
        Prims.l_True
        (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fst
---- extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst	2024-04-26 12:03:37
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fst	2024-04-26 12:03:44
+--- extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fst	2024-05-07 18:38:45
 @@ -3,37 +3,22 @@
  open Core
  open FStar.Mul
@@ -2906,8 +2906,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber768.fst extraction-secret-ind
      (sz 2400)
      (sz 1184)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti	2024-04-26 12:03:42
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fsti	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Kyber768.fsti	2024-05-07 18:38:45
 @@ -63,33 +63,27 @@
    Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE +! v_CPA_PKE_CIPHERTEXT_SIZE_768_
  
@@ -2956,8 +2956,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Kyber768.fsti extraction-secret-in
 -      (ensures (fun kp -> (kp.f_sk.f_value,kp.f_pk.f_value) == Spec.Kyber.kyber768_generate_keypair randomness))
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Matrix.fst extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fst
---- extraction-edited/Libcrux.Kem.Kyber.Matrix.fst	2024-04-26 12:03:39
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fst	2024-04-26 12:03:45
+--- extraction-edited/Libcrux.Kem.Kyber.Matrix.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fst	2024-05-07 18:38:45
 @@ -3,418 +3,432 @@
  open Core
  open FStar.Mul
@@ -3761,8 +3761,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Matrix.fst extraction-secret-indep
 -  admit(); //P-F
    v_A_transpose
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti	2024-04-26 12:03:43
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fsti	2024-04-26 12:03:47
+--- extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Matrix.fsti	2024-05-07 18:38:46
 @@ -3,71 +3,39 @@
  open Core
  open FStar.Mul
@@ -3864,8 +3864,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Matrix.fsti extraction-secret-inde
 +      Prims.l_True
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ntt.fst extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fst
---- extraction-edited/Libcrux.Kem.Kyber.Ntt.fst	2024-04-26 12:03:42
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fst	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Kem.Kyber.Ntt.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fst	2024-05-07 18:38:45
 @@ -1,130 +1,56 @@
  module Libcrux.Kem.Kyber.Ntt
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -4795,8 +4795,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ntt.fst extraction-secret-independ
 -#pop-options
 +  re
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti	2024-04-26 12:03:40
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fsti	2024-04-26 12:03:45
+--- extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Ntt.fsti	2024-05-07 18:38:45
 @@ -2,80 +2,224 @@
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
  open Core
@@ -5086,8 +5086,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Ntt.fsti extraction-secret-indepen
 +                <:
 +                bool))
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Sampling.fst extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst
---- extraction-edited/Libcrux.Kem.Kyber.Sampling.fst	2024-04-26 12:03:40
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst	2024-04-26 12:03:45
+--- extraction-edited/Libcrux.Kem.Kyber.Sampling.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fst	2024-05-07 18:38:45
 @@ -3,34 +3,27 @@
  open Core
  open FStar.Mul
@@ -5524,8 +5524,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Sampling.fst extraction-secret-ind
 -#pop-options
 +  out
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti	2024-04-26 12:03:42
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fsti	2024-04-26 12:03:45
+--- extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Sampling.fsti	2024-05-07 18:38:45
 @@ -3,37 +3,77 @@
  open Core
  open FStar.Mul
@@ -5626,8 +5626,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Sampling.fsti extraction-secret-in
 +      Prims.l_True
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Serialize.fst extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fst
---- extraction-edited/Libcrux.Kem.Kyber.Serialize.fst	2024-04-26 12:03:38
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fst	2024-04-26 12:03:44
+--- extraction-edited/Libcrux.Kem.Kyber.Serialize.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fst	2024-05-07 18:38:45
 @@ -1,15 +1,8 @@
  module Libcrux.Kem.Kyber.Serialize
 -#set-options "--fuel 0 --ifuel 0 --z3rlimit 50 --retry 3"
@@ -7110,8 +7110,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Serialize.fst extraction-secret-in
 -#pop-options
 -
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fsti
---- extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti	2024-04-26 12:03:43
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fsti	2024-04-26 12:03:47
+--- extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Serialize.fsti	2024-05-07 18:38:46
 @@ -2,188 +2,118 @@
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
  open Core
@@ -7365,8 +7365,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Serialize.fsti extraction-secret-i
 +val serialize_uncompressed_ring_element (re: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
 +    : Prims.Pure (t_Array u8 (sz 384)) Prims.l_True (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.Types.fst extraction-secret-independent/Libcrux.Kem.Kyber.Types.fst
---- extraction-edited/Libcrux.Kem.Kyber.Types.fst	2024-04-26 12:03:43
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.Types.fst	2024-04-26 12:03:46
+--- extraction-edited/Libcrux.Kem.Kyber.Types.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.Types.fst	2024-05-07 18:38:45
 @@ -3,275 +3,193 @@
  open Core
  open FStar.Mul
@@ -7710,8 +7710,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.Types.fst extraction-secret-indepe
 +      (self: t_KyberKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
      : t_Array u8 v_PRIVATE_KEY_SIZE = impl_12__as_slice v_PRIVATE_KEY_SIZE self.f_sk
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.fst extraction-secret-independent/Libcrux.Kem.Kyber.fst
---- extraction-edited/Libcrux.Kem.Kyber.fst	2024-04-26 12:03:38
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.fst	2024-04-26 12:03:44
+--- extraction-edited/Libcrux.Kem.Kyber.fst	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.fst	2024-05-07 18:38:45
 @@ -1,29 +1,12 @@
  module Libcrux.Kem.Kyber
 -#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
@@ -7990,8 +7990,8 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.fst extraction-secret-independent/
 -
 +    (Core.Convert.f_into public_key <: Libcrux.Kem.Kyber.Types.t_KyberPublicKey v_PUBLIC_KEY_SIZE)
 diff -ruN extraction-edited/Libcrux.Kem.Kyber.fsti extraction-secret-independent/Libcrux.Kem.Kyber.fsti
---- extraction-edited/Libcrux.Kem.Kyber.fsti	2024-04-26 12:03:41
-+++ extraction-secret-independent/Libcrux.Kem.Kyber.fsti	2024-04-26 12:03:45
+--- extraction-edited/Libcrux.Kem.Kyber.fsti	2024-05-07 18:38:45
++++ extraction-secret-independent/Libcrux.Kem.Kyber.fsti	2024-05-07 18:38:45
 @@ -4,90 +4,37 @@
  open FStar.Mul
  
@@ -8100,7 +8100,7 @@ diff -ruN extraction-edited/Libcrux.Kem.Kyber.fsti extraction-secret-independent
 +      Prims.l_True
 +      (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux_platform.Platform.fsti extraction-secret-independent/Libcrux_platform.Platform.fsti
---- extraction-edited/Libcrux_platform.Platform.fsti	2024-04-26 12:03:37
+--- extraction-edited/Libcrux_platform.Platform.fsti	2024-05-07 18:38:45
 +++ extraction-secret-independent/Libcrux_platform.Platform.fsti	1970-01-01 01:00:00
 @@ -1,20 +0,0 @@
 -module Libcrux_platform.Platform
@@ -8125,14 +8125,14 @@ diff -ruN extraction-edited/Libcrux_platform.Platform.fsti extraction-secret-ind
 -val simd128_support: Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 diff -ruN extraction-edited/Libcrux_platform.fsti extraction-secret-independent/Libcrux_platform.fsti
 --- extraction-edited/Libcrux_platform.fsti	1970-01-01 01:00:00
-+++ extraction-secret-independent/Libcrux_platform.fsti	2024-04-26 12:03:47
++++ extraction-secret-independent/Libcrux_platform.fsti	2024-05-07 18:38:46
 @@ -0,0 +1,4 @@
 +module Libcrux_platform
 +#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
 +
 +val simd256_support : unit -> bool
 diff -ruN extraction-edited/MkSeq.fst extraction-secret-independent/MkSeq.fst
---- extraction-edited/MkSeq.fst	2024-04-26 12:03:43
+--- extraction-edited/MkSeq.fst	2024-05-07 18:38:45
 +++ extraction-secret-independent/MkSeq.fst	1970-01-01 01:00:00
 @@ -1,91 +0,0 @@
 -module MkSeq
@@ -8227,7 +8227,7 @@ diff -ruN extraction-edited/MkSeq.fst extraction-secret-independent/MkSeq.fst
 -
 -%splice[] (init 13 (fun i -> create_gen_tac (i + 1)))
 diff -ruN extraction-edited/Spec.Kyber.fst extraction-secret-independent/Spec.Kyber.fst
---- extraction-edited/Spec.Kyber.fst	2024-04-26 12:03:42
+--- extraction-edited/Spec.Kyber.fst	2024-05-07 18:38:45
 +++ extraction-secret-independent/Spec.Kyber.fst	1970-01-01 01:00:00
 @@ -1,435 +0,0 @@
 -module Spec.Kyber

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ind_cpa.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ind_cpa.fst
@@ -205,6 +205,75 @@ let compress_then_serialize_u
   in
   out
 
+let encrypt_unpacked
+      (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+          usize)
+      (tt_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      (a_transpose: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+      (message: t_Array u8 (sz 32))
+      (randomness: t_Slice u8)
+     =
+  let (prf_input: t_Array u8 (sz 33)):t_Array u8 (sz 33) = into_padded_array (sz 33) randomness in
+  let r_as_ntt, domain_separator:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+    u8) =
+    sample_vector_cbd_then_ntt v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input 0uy
+  in
+  let tmp0, tmp1, out:(t_Array u8 (sz 33) & u8 &
+    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+    sample_ring_element_cbd v_K v_ETA2_RANDOMNESS_SIZE v_ETA2 prf_input domain_separator
+  in
+  let prf_input:t_Array u8 (sz 33) = tmp0 in
+  let domain_separator:u8 = tmp1 in
+  let error_1_:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K = out in
+  let prf_input:t_Array u8 (sz 33) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize prf_input (sz 32) domain_separator
+  in
+  let (prf_output: t_Array u8 v_ETA2_RANDOMNESS_SIZE):t_Array u8 v_ETA2_RANDOMNESS_SIZE =
+    Libcrux.Kem.Kyber.Hash_functions.v_PRF v_ETA2_RANDOMNESS_SIZE
+      (Rust_primitives.unsize prf_input <: t_Slice u8)
+  in
+  let error_2_:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Sampling.sample_from_binomial_distribution v_ETA2
+      (Rust_primitives.unsize prf_output <: t_Slice u8)
+  in
+  let u:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    Libcrux.Kem.Kyber.Matrix.compute_vector_u v_K a_transpose r_as_ntt error_1_
+  in
+  let message_as_ring_element:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_message message
+  in
+  let v:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Matrix.compute_ring_element_v v_K
+      tt_as_ntt
+      r_as_ntt
+      error_2_
+      message_as_ring_element
+  in
+  let c1:t_Array u8 v_C1_LEN =
+    compress_then_serialize_u v_K v_C1_LEN v_U_COMPRESSION_FACTOR v_BLOCK_LEN u
+  in
+  let c2:t_Array u8 v_C2_LEN =
+    Libcrux.Kem.Kyber.Serialize.compress_then_serialize_ring_element_v v_V_COMPRESSION_FACTOR
+      v_C2_LEN
+      v
+  in
+  let (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE):t_Array u8 v_CIPHERTEXT_SIZE =
+    into_padded_array v_CIPHERTEXT_SIZE (Rust_primitives.unsize c1 <: t_Slice u8)
+  in
+  let ciphertext:t_Array u8 v_CIPHERTEXT_SIZE =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from ciphertext
+      ({ Core.Ops.Range.f_start = v_C1_LEN } <: Core.Ops.Range.t_RangeFrom usize)
+      (Core.Slice.impl__copy_from_slice (ciphertext.[ { Core.Ops.Range.f_start = v_C1_LEN }
+              <:
+              Core.Ops.Range.t_RangeFrom usize ]
+            <:
+            t_Slice u8)
+          (Core.Array.impl_23__as_slice v_C2_LEN c2 <: t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  ciphertext
+
 let deserialize_then_decompress_u
       (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
       (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
@@ -249,6 +318,28 @@ let deserialize_then_decompress_u
   in
   u_as_ntt
 
+let decrypt_unpacked
+      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
+          usize)
+      (secret_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+     =
+  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    deserialize_then_decompress_u v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR ciphertext
+  in
+  let v:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_ring_element_v v_V_COMPRESSION_FACTOR
+      (ciphertext.[ { Core.Ops.Range.f_start = v_VECTOR_U_ENCODED_SIZE }
+          <:
+          Core.Ops.Range.t_RangeFrom usize ]
+        <:
+        t_Slice u8)
+  in
+  let message:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
+    Libcrux.Kem.Kyber.Matrix.compute_message v_K v secret_as_ntt u_as_ntt
+  in
+  Libcrux.Kem.Kyber.Serialize.compress_then_serialize_message message
+
 let encrypt
       (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
           usize)
@@ -270,71 +361,14 @@ let encrypt
       <:
       Core.Ops.Range.t_RangeFrom usize ]
   in
-  let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+  let a_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
     Libcrux.Kem.Kyber.Matrix.sample_matrix_A v_K
       (into_padded_array (sz 34) seed <: t_Array u8 (sz 34))
       false
   in
-  let (prf_input: t_Array u8 (sz 33)):t_Array u8 (sz 33) = into_padded_array (sz 33) randomness in
-  let r_as_ntt, domain_separator:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
-    u8) =
-    sample_vector_cbd_then_ntt v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input 0uy
-  in
-  let tmp0, tmp1, out:(t_Array u8 (sz 33) & u8 &
-    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
-    sample_ring_element_cbd v_K v_ETA2_RANDOMNESS_SIZE v_ETA2 prf_input domain_separator
-  in
-  let prf_input:t_Array u8 (sz 33) = tmp0 in
-  let domain_separator:u8 = tmp1 in
-  let error_1_:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K = out in
-  let prf_input:t_Array u8 (sz 33) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize prf_input (sz 32) domain_separator
-  in
-  let (prf_output: t_Array u8 v_ETA2_RANDOMNESS_SIZE):t_Array u8 v_ETA2_RANDOMNESS_SIZE =
-    Libcrux.Kem.Kyber.Hash_functions.v_PRF v_ETA2_RANDOMNESS_SIZE
-      (Rust_primitives.unsize prf_input <: t_Slice u8)
-  in
-  let error_2_:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
-    Libcrux.Kem.Kyber.Sampling.sample_from_binomial_distribution v_ETA2
-      (Rust_primitives.unsize prf_output <: t_Slice u8)
-  in
-  let u:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
-    Libcrux.Kem.Kyber.Matrix.compute_vector_u v_K v_A_transpose r_as_ntt error_1_
-  in
-  let message_as_ring_element:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
-    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_message message
-  in
-  let v:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
-    Libcrux.Kem.Kyber.Matrix.compute_ring_element_v v_K
-      tt_as_ntt
-      r_as_ntt
-      error_2_
-      message_as_ring_element
-  in
-  let c1:t_Array u8 v_C1_LEN =
-    compress_then_serialize_u v_K v_C1_LEN v_U_COMPRESSION_FACTOR v_BLOCK_LEN u
-  in
-  let c2:t_Array u8 v_C2_LEN =
-    Libcrux.Kem.Kyber.Serialize.compress_then_serialize_ring_element_v v_V_COMPRESSION_FACTOR
-      v_C2_LEN
-      v
-  in
-  let (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE):t_Array u8 v_CIPHERTEXT_SIZE =
-    into_padded_array v_CIPHERTEXT_SIZE (Rust_primitives.unsize c1 <: t_Slice u8)
-  in
-  let ciphertext:t_Array u8 v_CIPHERTEXT_SIZE =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from ciphertext
-      ({ Core.Ops.Range.f_start = v_C1_LEN } <: Core.Ops.Range.t_RangeFrom usize)
-      (Core.Slice.impl__copy_from_slice (ciphertext.[ { Core.Ops.Range.f_start = v_C1_LEN }
-              <:
-              Core.Ops.Range.t_RangeFrom usize ]
-            <:
-            t_Slice u8)
-          (Core.Array.impl_23__as_slice v_C2_LEN c2 <: t_Slice u8)
-        <:
-        t_Slice u8)
-  in
-  ciphertext
+  encrypt_unpacked v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN
+    v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2
+    v_ETA2_RANDOMNESS_SIZE tt_as_ntt a_transpose message randomness
 
 let deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8) =
   let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
@@ -372,24 +406,16 @@ let decrypt
       (secret_key: t_Slice u8)
       (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
      =
-  let u_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
-    deserialize_then_decompress_u v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR ciphertext
-  in
-  let v:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
-    Libcrux.Kem.Kyber.Serialize.deserialize_then_decompress_ring_element_v v_V_COMPRESSION_FACTOR
-      (ciphertext.[ { Core.Ops.Range.f_start = v_VECTOR_U_ENCODED_SIZE }
-          <:
-          Core.Ops.Range.t_RangeFrom usize ]
-        <:
-        t_Slice u8)
-  in
   let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
     deserialize_secret_key v_K secret_key
   in
-  let message:Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement =
-    Libcrux.Kem.Kyber.Matrix.compute_message v_K v secret_as_ntt u_as_ntt
-  in
-  Libcrux.Kem.Kyber.Serialize.compress_then_serialize_message message
+  decrypt_unpacked v_K
+    v_CIPHERTEXT_SIZE
+    v_VECTOR_U_ENCODED_SIZE
+    v_U_COMPRESSION_FACTOR
+    v_V_COMPRESSION_FACTOR
+    secret_as_ntt
+    ciphertext
 
 let serialize_secret_key
       (v_K v_OUT_LEN: usize)
@@ -500,16 +526,15 @@ let serialize_public_key
   in
   public_key_serialized
 
-let generate_keypair
-      (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
-          usize)
+let generate_keypair_unpacked
+      (v_K v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE: usize)
       (key_generation_seed: t_Slice u8)
      =
   let hashed:t_Array u8 (sz 64) = Libcrux.Kem.Kyber.Hash_functions.v_G key_generation_seed in
   let seed_for_A, seed_for_secret_and_error:(t_Slice u8 & t_Slice u8) =
     Core.Slice.impl__split_at (Rust_primitives.unsize hashed <: t_Slice u8) (sz 32)
   in
-  let v_A_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+  let a_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
     Libcrux.Kem.Kyber.Matrix.sample_matrix_A v_K
       (into_padded_array (sz 34) seed_for_A <: t_Array u8 (sz 34))
       true
@@ -526,10 +551,201 @@ let generate_keypair
     sample_vector_cbd_then_ntt v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE prf_input domain_separator
   in
   let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
-    Libcrux.Kem.Kyber.Matrix.compute_As_plus_e v_K v_A_transpose secret_as_ntt error_as_ntt
+    Libcrux.Kem.Kyber.Matrix.compute_As_plus_e v_K a_transpose secret_as_ntt error_as_ntt
   in
   let public_key_serialized:t_Array u8 v_PUBLIC_KEY_SIZE =
     serialize_public_key v_K v_RANKED_BYTES_PER_RING_ELEMENT v_PUBLIC_KEY_SIZE tt_as_ntt seed_for_A
+  in
+  let secret_as_ntt, tt_as_ntt:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = v_K
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      (secret_as_ntt, tt_as_ntt
+        <:
+        (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+          t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+      (fun temp_0_ i ->
+          let secret_as_ntt, tt_as_ntt:(t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+              v_K &
+            t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+            temp_0_
+          in
+          let i:usize = i in
+          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                    Core.Ops.Range.f_start = sz 0;
+                    Core.Ops.Range.f_end
+                    =
+                    Libcrux.Kem.Kyber.Constants.v_COEFFICIENTS_IN_RING_ELEMENT
+                  }
+                  <:
+                  Core.Ops.Range.t_Range usize)
+              <:
+              Core.Ops.Range.t_Range usize)
+            (secret_as_ntt, tt_as_ntt
+              <:
+              (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+                t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+            (fun temp_0_ j ->
+                let secret_as_ntt, tt_as_ntt:(t_Array
+                    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+                  t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) =
+                  temp_0_
+                in
+                let j:usize = j in
+                let secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+                  Rust_primitives.Hax.Monomorphized_update_at.update_at_usize secret_as_ntt
+                    i
+                    ({
+                        (secret_as_ntt.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement
+                        ) with
+                        Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        =
+                        Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (secret_as_ntt.[
+                              i ]
+                            <:
+                            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          j
+                          (cast (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative ((secret_as_ntt.[
+                                        i ]
+                                      <:
+                                      Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                                      .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ]
+                                    <:
+                                    i32)
+                                <:
+                                u16)
+                            <:
+                            i32)
+                        <:
+                        t_Array i32 (sz 256)
+                      }
+                      <:
+                      Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                in
+                let tt_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+                  Rust_primitives.Hax.Monomorphized_update_at.update_at_usize tt_as_ntt
+                    i
+                    ({
+                        (tt_as_ntt.[ i ] <: Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement) with
+                        Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                        =
+                        Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (tt_as_ntt.[ i ]
+                            <:
+                            Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                            .Libcrux.Kem.Kyber.Arithmetic.f_coefficients
+                          j
+                          (cast (Libcrux.Kem.Kyber.Arithmetic.to_unsigned_representative ((tt_as_ntt.[
+                                        i ]
+                                      <:
+                                      Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                                      .Libcrux.Kem.Kyber.Arithmetic.f_coefficients.[ j ]
+                                    <:
+                                    i32)
+                                <:
+                                u16)
+                            <:
+                            i32)
+                        <:
+                        t_Array i32 (sz 256)
+                      }
+                      <:
+                      Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                in
+                secret_as_ntt, tt_as_ntt
+                <:
+                (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+                  t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+          <:
+          (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+            t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K))
+  in
+  let a_matrix:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+    a_transpose
+  in
+  let a_matrix:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = v_K
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      a_matrix
+      (fun a_matrix i ->
+          let a_matrix:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+            v_K =
+            a_matrix
+          in
+          let i:usize = i in
+          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                    Core.Ops.Range.f_start = sz 0;
+                    Core.Ops.Range.f_end = v_K
+                  }
+                  <:
+                  Core.Ops.Range.t_Range usize)
+              <:
+              Core.Ops.Range.t_Range usize)
+            a_matrix
+            (fun a_matrix j ->
+                let a_matrix:t_Array
+                  (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+                  a_matrix
+                in
+                let j:usize = j in
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize a_matrix
+                  i
+                  (Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (a_matrix.[ i ]
+                        <:
+                        t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+                      j
+                      ((a_transpose.[ j ]
+                          <:
+                          t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K).[ i ]
+                        <:
+                        Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement)
+                    <:
+                    t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+                <:
+                t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+          <:
+          t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
+  in
+  (secret_as_ntt, tt_as_ntt, a_matrix
+    <:
+    (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+      t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+      t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)),
+  public_key_serialized
+  <:
+  ((t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+      t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+      t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K) &
+    t_Array u8 v_PUBLIC_KEY_SIZE)
+
+let generate_keypair
+      (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+          usize)
+      (key_generation_seed: t_Slice u8)
+     =
+  let (secret_as_ntt, v__t_as_ntt, v__a_transpose), public_key_serialized:((t_Array
+        Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+      t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+      t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K) &
+    t_Array u8 v_PUBLIC_KEY_SIZE) =
+    generate_keypair_unpacked v_K
+      v_PUBLIC_KEY_SIZE
+      v_RANKED_BYTES_PER_RING_ELEMENT
+      v_ETA1
+      v_ETA1_RANDOMNESS_SIZE
+      key_generation_seed
   in
   let secret_key_serialized:t_Array u8 v_PRIVATE_KEY_SIZE =
     serialize_secret_key v_K v_PRIVATE_KEY_SIZE secret_as_ntt

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Ind_cpa.fsti
@@ -33,15 +33,6 @@ val compress_then_serialize_u
       (input: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
     : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
 
-/// Call [`deserialize_then_decompress_ring_element_u`] on each ring element
-/// in the `ciphertext`.
-val deserialize_then_decompress_u
-      (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
-      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
-    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
 /// This function implements <strong>Algorithm 13</strong> of the
 /// NIST FIPS 203 specification; this is the Kyber CPA-PKE encryption algorithm.
 /// Algorithm 13 is reproduced below:
@@ -77,16 +68,20 @@ val deserialize_then_decompress_u
 /// ```
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
-val encrypt
+val encrypt_unpacked
       (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
           usize)
-      (public_key: t_Slice u8)
+      (tt_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      (a_transpose: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K)
       (message: t_Array u8 (sz 32))
       (randomness: t_Slice u8)
     : Prims.Pure (t_Array u8 v_CIPHERTEXT_SIZE) Prims.l_True (fun _ -> Prims.l_True)
 
-/// Call [`deserialize_to_uncompressed_ring_element`] for each ring element.
-val deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8)
+/// Call [`deserialize_then_decompress_ring_element_u`] on each ring element
+/// in the `ciphertext`.
+val deserialize_then_decompress_u
+      (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
+      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
     : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
       Prims.l_True
       (fun _ -> Prims.l_True)
@@ -109,6 +104,27 @@ val deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8)
 /// ```
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
+val decrypt_unpacked
+      (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
+          usize)
+      (secret_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
+val encrypt
+      (v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE:
+          usize)
+      (public_key: t_Slice u8)
+      (message: t_Array u8 (sz 32))
+      (randomness: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_CIPHERTEXT_SIZE) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Call [`deserialize_to_uncompressed_ring_element`] for each ring element.
+val deserialize_secret_key (v_K: usize) (secret_key: t_Slice u8)
+    : Prims.Pure (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
 val decrypt
       (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
           usize)
@@ -162,6 +178,15 @@ val serialize_public_key
 /// ```
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
+val generate_keypair_unpacked
+      (v_K v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE: usize)
+      (key_generation_seed: t_Slice u8)
+    : Prims.Pure
+      ((t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+          t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+          t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K) &
+        t_Array u8 v_PUBLIC_KEY_SIZE) Prims.l_True (fun _ -> Prims.l_True)
+
 val generate_keypair
       (v_K v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_RANKED_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
           usize)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber1024.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber1024.fst
@@ -32,8 +32,26 @@ let validate_public_key (public_key: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (s
     <:
     Core.Option.t_Option (Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1568))
 
+let decapsulate_unpacked
+      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 4))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 1568))
+     =
+  Libcrux.Kem.Kyber.decapsulate_unpacked (sz 4) (sz 3168) (sz 1536) (sz 1568) (sz 1568) (sz 1536)
+    (sz 1408) (sz 160) (sz 11) (sz 5) (sz 352) (sz 2) (sz 128) (sz 2) (sz 128) (sz 1600) state
+    ciphertext
+
 let generate_key_pair (randomness: t_Array u8 (sz 64)) =
   Libcrux.Kem.Kyber.generate_keypair (sz 4)
+    (sz 1536)
+    (sz 3168)
+    (sz 1568)
+    (sz 1536)
+    (sz 2)
+    (sz 128)
+    randomness
+
+let generate_key_pair_unpacked (randomness: t_Array u8 (sz 64)) =
+  Libcrux.Kem.Kyber.generate_keypair_unpacked (sz 4)
     (sz 1536)
     (sz 3168)
     (sz 1568)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber1024.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber1024.fsti
@@ -92,8 +92,22 @@ val validate_public_key (public_key: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (s
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+unfold
+let t_MlKem1024State = Libcrux.Kem.Kyber.t_MlKemState (sz 4)
+
+val decapsulate_unpacked
+      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 4))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 1568))
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
 /// Generate ML-KEM 1024 Key Pair
 val generate_key_pair (randomness: t_Array u8 (sz 64))
     : Prims.Pure (Libcrux.Kem.Kyber.Types.t_MlKemKeyPair (sz 3168) (sz 1568))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_key_pair_unpacked (randomness: t_Array u8 (sz 64))
+    : Prims.Pure
+      (Libcrux.Kem.Kyber.t_MlKemState (sz 4) & Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1568))
       Prims.l_True
       (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber512.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber512.fst
@@ -32,8 +32,26 @@ let validate_public_key (public_key: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (s
     <:
     Core.Option.t_Option (Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 800))
 
+let decapsulate_unpacked
+      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 2))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 768))
+     =
+  Libcrux.Kem.Kyber.decapsulate_unpacked (sz 2) (sz 1632) (sz 768) (sz 800) (sz 768) (sz 768)
+    (sz 640) (sz 128) (sz 10) (sz 4) (sz 320) (sz 3) (sz 192) (sz 2) (sz 128) (sz 800) state
+    ciphertext
+
 let generate_key_pair (randomness: t_Array u8 (sz 64)) =
   Libcrux.Kem.Kyber.generate_keypair (sz 2)
+    (sz 768)
+    (sz 1632)
+    (sz 800)
+    (sz 768)
+    (sz 3)
+    (sz 192)
+    randomness
+
+let generate_key_pair_unpacked (randomness: t_Array u8 (sz 64)) =
+  Libcrux.Kem.Kyber.generate_keypair_unpacked (sz 2)
     (sz 768)
     (sz 1632)
     (sz 800)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber512.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber512.fsti
@@ -92,8 +92,22 @@ val validate_public_key (public_key: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (s
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+unfold
+let t_MlKem512State = Libcrux.Kem.Kyber.t_MlKemState (sz 2)
+
+val decapsulate_unpacked
+      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 2))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 768))
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
 /// Generate ML-KEM 512 Key Pair
 val generate_key_pair (randomness: t_Array u8 (sz 64))
     : Prims.Pure (Libcrux.Kem.Kyber.Types.t_MlKemKeyPair (sz 1632) (sz 800))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_key_pair_unpacked (randomness: t_Array u8 (sz 64))
+    : Prims.Pure
+      (Libcrux.Kem.Kyber.t_MlKemState (sz 2) & Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 800))
       Prims.l_True
       (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber768.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber768.fst
@@ -32,8 +32,26 @@ let validate_public_key (public_key: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (s
     <:
     Core.Option.t_Option (Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1184))
 
+let decapsulate_unpacked
+      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 3))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 1088))
+     =
+  Libcrux.Kem.Kyber.decapsulate_unpacked (sz 3) (sz 2400) (sz 1152) (sz 1184) (sz 1088) (sz 1152)
+    (sz 960) (sz 128) (sz 10) (sz 4) (sz 320) (sz 2) (sz 128) (sz 2) (sz 128) (sz 1120) state
+    ciphertext
+
 let generate_key_pair (randomness: t_Array u8 (sz 64)) =
   Libcrux.Kem.Kyber.generate_keypair (sz 3)
+    (sz 1152)
+    (sz 2400)
+    (sz 1184)
+    (sz 1152)
+    (sz 2)
+    (sz 128)
+    randomness
+
+let generate_key_pair_unpacked (randomness: t_Array u8 (sz 64)) =
+  Libcrux.Kem.Kyber.generate_keypair_unpacked (sz 3)
     (sz 1152)
     (sz 2400)
     (sz 1184)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber768.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.Kyber768.fsti
@@ -92,8 +92,22 @@ val validate_public_key (public_key: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (s
       Prims.l_True
       (fun _ -> Prims.l_True)
 
+unfold
+let t_MlKem768State = Libcrux.Kem.Kyber.t_MlKemState (sz 3)
+
+val decapsulate_unpacked
+      (state: Libcrux.Kem.Kyber.t_MlKemState (sz 3))
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext (sz 1088))
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
 /// Generate ML-KEM 768 Key Pair
 val generate_key_pair (randomness: t_Array u8 (sz 64))
     : Prims.Pure (Libcrux.Kem.Kyber.Types.t_MlKemKeyPair (sz 2400) (sz 1184))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_key_pair_unpacked (randomness: t_Array u8 (sz 64))
+    : Prims.Pure
+      (Libcrux.Kem.Kyber.t_MlKemState (sz 3) & Libcrux.Kem.Kyber.Types.t_MlKemPublicKey (sz 1184))
       Prims.l_True
       (fun _ -> Prims.l_True)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.fst
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.fst
@@ -286,6 +286,103 @@ let validate_public_key
   in
   public_key =. public_key_serialized
 
+let decapsulate_unpacked
+      (v_K v_SECRET_KEY_SIZE v_CPA_SECRET_KEY_SIZE v_PUBLIC_KEY_SIZE v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_C1_BLOCK_SIZE v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE v_IMPLICIT_REJECTION_HASH_INPUT_SIZE:
+          usize)
+      (state: t_MlKemState v_K)
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext v_CIPHERTEXT_SIZE)
+     =
+  let (secret_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K):t_Array
+    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    state.f_secret_as_ntt
+  in
+  let (tt_as_ntt: t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K):t_Array
+    Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K =
+    state.f_t_as_ntt
+  in
+  let (a_transpose: t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K):t_Array
+    (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K =
+    state.f_a_transpose
+  in
+  let (implicit_rejection_value: t_Slice u8):t_Slice u8 = Rust_primitives.unsize state.f_rej in
+  let (ind_cpa_public_key_hash: t_Slice u8):t_Slice u8 =
+    Rust_primitives.unsize state.f_ind_cpa_public_key_hash
+  in
+  let decrypted:t_Array u8 (sz 32) =
+    Libcrux.Kem.Kyber.Ind_cpa.decrypt_unpacked v_K
+      v_CIPHERTEXT_SIZE
+      v_C1_SIZE
+      v_VECTOR_U_COMPRESSION_FACTOR
+      v_VECTOR_V_COMPRESSION_FACTOR
+      secret_as_ntt
+      ciphertext.Libcrux.Kem.Kyber.Types.f_value
+  in
+  let (to_hash: t_Array u8 (sz 64)):t_Array u8 (sz 64) =
+    Libcrux.Kem.Kyber.Ind_cpa.into_padded_array (sz 64)
+      (Rust_primitives.unsize decrypted <: t_Slice u8)
+  in
+  let to_hash:t_Array u8 (sz 64) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from to_hash
+      ({ Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE }
+        <:
+        Core.Ops.Range.t_RangeFrom usize)
+      (Core.Slice.impl__copy_from_slice (to_hash.[ {
+                Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+              }
+              <:
+              Core.Ops.Range.t_RangeFrom usize ]
+            <:
+            t_Slice u8)
+          ind_cpa_public_key_hash
+        <:
+        t_Slice u8)
+  in
+  let hashed:t_Array u8 (sz 64) =
+    Libcrux.Kem.Kyber.Hash_functions.v_G (Rust_primitives.unsize to_hash <: t_Slice u8)
+  in
+  let shared_secret, pseudorandomness:(t_Slice u8 & t_Slice u8) =
+    Core.Slice.impl__split_at (Rust_primitives.unsize hashed <: t_Slice u8)
+      Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+  in
+  let (to_hash: t_Array u8 v_IMPLICIT_REJECTION_HASH_INPUT_SIZE):t_Array u8
+    v_IMPLICIT_REJECTION_HASH_INPUT_SIZE =
+    Libcrux.Kem.Kyber.Ind_cpa.into_padded_array v_IMPLICIT_REJECTION_HASH_INPUT_SIZE
+      implicit_rejection_value
+  in
+  let to_hash:t_Array u8 v_IMPLICIT_REJECTION_HASH_INPUT_SIZE =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from to_hash
+      ({ Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE }
+        <:
+        Core.Ops.Range.t_RangeFrom usize)
+      (Core.Slice.impl__copy_from_slice (to_hash.[ {
+                Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_SHARED_SECRET_SIZE
+              }
+              <:
+              Core.Ops.Range.t_RangeFrom usize ]
+            <:
+            t_Slice u8)
+          (Core.Convert.f_as_ref ciphertext <: t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  let (implicit_rejection_shared_secret: t_Array u8 (sz 32)):t_Array u8 (sz 32) =
+    Libcrux.Kem.Kyber.Hash_functions.v_PRF (sz 32) (Rust_primitives.unsize to_hash <: t_Slice u8)
+  in
+  let expected_ciphertext:t_Array u8 v_CIPHERTEXT_SIZE =
+    Libcrux.Kem.Kyber.Ind_cpa.encrypt_unpacked v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE
+      v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR
+      v_C1_BLOCK_SIZE v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE tt_as_ntt
+      a_transpose decrypted pseudorandomness
+  in
+  let selector:u8 =
+    Libcrux.Kem.Kyber.Constant_time_ops.compare_ciphertexts_in_constant_time v_CIPHERTEXT_SIZE
+      (Core.Convert.f_as_ref ciphertext <: t_Slice u8)
+      (Rust_primitives.unsize expected_ciphertext <: t_Slice u8)
+  in
+  Libcrux.Kem.Kyber.Constant_time_ops.select_shared_secret_in_constant_time shared_secret
+    (Rust_primitives.unsize implicit_rejection_shared_secret <: t_Slice u8)
+    selector
+
 let generate_keypair
       (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
           usize)
@@ -330,3 +427,60 @@ let generate_keypair
     v_PUBLIC_KEY_SIZE
     private_key
     (Core.Convert.f_into public_key <: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey v_PUBLIC_KEY_SIZE)
+
+let generate_keypair_unpacked
+      (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+          usize)
+      (randomness: t_Array u8 (sz 64))
+     =
+  let ind_cpa_keypair_randomness:t_Slice u8 =
+    randomness.[ {
+        Core.Ops.Range.f_start = sz 0;
+        Core.Ops.Range.f_end = Libcrux.Kem.Kyber.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE
+      }
+      <:
+      Core.Ops.Range.t_Range usize ]
+  in
+  let implicit_rejection_value:t_Slice u8 =
+    randomness.[ {
+        Core.Ops.Range.f_start = Libcrux.Kem.Kyber.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE
+      }
+      <:
+      Core.Ops.Range.t_RangeFrom usize ]
+  in
+  let (secret_as_ntt, tt_as_ntt, a_transpose), ind_cpa_public_key:((t_Array
+        Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+      t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K &
+      t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K) &
+    t_Array u8 v_PUBLIC_KEY_SIZE) =
+    Libcrux.Kem.Kyber.Ind_cpa.generate_keypair_unpacked v_K
+      v_PUBLIC_KEY_SIZE
+      v_BYTES_PER_RING_ELEMENT
+      v_ETA1
+      v_ETA1_RANDOMNESS_SIZE
+      ind_cpa_keypair_randomness
+  in
+  let ind_cpa_public_key_hash:t_Array u8 (sz 32) =
+    Libcrux.Kem.Kyber.Hash_functions.v_H (Rust_primitives.unsize ind_cpa_public_key <: t_Slice u8)
+  in
+  let (rej: t_Array u8 (sz 32)):t_Array u8 (sz 32) =
+    Core.Result.impl__unwrap (Core.Convert.f_try_into implicit_rejection_value
+        <:
+        Core.Result.t_Result (t_Array u8 (sz 32)) Core.Array.t_TryFromSliceError)
+  in
+  let (pubkey: Libcrux.Kem.Kyber.Types.t_MlKemPublicKey v_PUBLIC_KEY_SIZE):Libcrux.Kem.Kyber.Types.t_MlKemPublicKey
+  v_PUBLIC_KEY_SIZE =
+    Core.Convert.f_from ind_cpa_public_key
+  in
+  ({
+      f_secret_as_ntt = secret_as_ntt;
+      f_t_as_ntt = tt_as_ntt;
+      f_a_transpose = a_transpose;
+      f_rej = rej;
+      f_ind_cpa_public_key_hash = ind_cpa_public_key_hash
+    }
+    <:
+    t_MlKemState v_K),
+  pubkey
+  <:
+  (t_MlKemState v_K & Libcrux.Kem.Kyber.Types.t_MlKemPublicKey v_PUBLIC_KEY_SIZE)

--- a/proofs/fstar/extraction/Libcrux.Kem.Kyber.fsti
+++ b/proofs/fstar/extraction/Libcrux.Kem.Kyber.fsti
@@ -38,10 +38,33 @@ val validate_public_key
       (public_key: t_Array u8 v_PUBLIC_KEY_SIZE)
     : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
+type t_MlKemState (v_K: usize) = {
+  f_secret_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K;
+  f_t_as_ntt:t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K;
+  f_a_transpose:t_Array (t_Array Libcrux.Kem.Kyber.Arithmetic.t_PolynomialRingElement v_K) v_K;
+  f_rej:t_Array u8 (sz 32);
+  f_ind_cpa_public_key_hash:t_Array u8 (sz 32)
+}
+
+val decapsulate_unpacked
+      (v_K v_SECRET_KEY_SIZE v_CPA_SECRET_KEY_SIZE v_PUBLIC_KEY_SIZE v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_SIZE v_C2_SIZE v_VECTOR_U_COMPRESSION_FACTOR v_VECTOR_V_COMPRESSION_FACTOR v_C1_BLOCK_SIZE v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2 v_ETA2_RANDOMNESS_SIZE v_IMPLICIT_REJECTION_HASH_INPUT_SIZE:
+          usize)
+      (state: t_MlKemState v_K)
+      (ciphertext: Libcrux.Kem.Kyber.Types.t_MlKemCiphertext v_CIPHERTEXT_SIZE)
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+
 val generate_keypair
       (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
           usize)
       (randomness: t_Array u8 (sz 64))
     : Prims.Pure (Libcrux.Kem.Kyber.Types.t_MlKemKeyPair v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val generate_keypair_unpacked
+      (v_K v_CPA_PRIVATE_KEY_SIZE v_PRIVATE_KEY_SIZE v_PUBLIC_KEY_SIZE v_BYTES_PER_RING_ELEMENT v_ETA1 v_ETA1_RANDOMNESS_SIZE:
+          usize)
+      (randomness: t_Array u8 (sz 64))
+    : Prims.Pure (t_MlKemState v_K & Libcrux.Kem.Kyber.Types.t_MlKemPublicKey v_PUBLIC_KEY_SIZE)
       Prims.l_True
       (fun _ -> Prims.l_True)

--- a/src/kem.rs
+++ b/src/kem.rs
@@ -40,7 +40,7 @@ use crate::{
 
 // hacspec code: don't let clippy touch it.
 #[allow(clippy::all)]
-pub(crate) mod kyber;
+pub mod kyber;
 
 // TODO: These functions are currently exposed simply in order to make NIST KAT
 // testing possible without an implementation of the NIST AES-CTR DRBG. Remove them

--- a/src/kem/kyber.rs
+++ b/src/kem/kyber.rs
@@ -83,7 +83,7 @@ pub(super) fn validate_public_key<
     *public_key == public_key_serialized
 }
 
-pub(super) fn generate_keypair_deserialized<
+pub(super) fn generate_keypair_unpacked<
     const K: usize,
     const CPA_PRIVATE_KEY_SIZE: usize,
     const PRIVATE_KEY_SIZE: usize,
@@ -98,7 +98,7 @@ pub(super) fn generate_keypair_deserialized<
     let ind_cpa_keypair_randomness = &randomness[0..CPA_PKE_KEY_GENERATION_SEED_SIZE];
     let implicit_rejection_value = &randomness[CPA_PKE_KEY_GENERATION_SEED_SIZE..];
 
-    let ((s_as_ntt,t_as_ntt,A_transpose),ind_cpa_public_key) = ind_cpa::generate_keypair_deserialized::<
+    let ((s_as_ntt,t_as_ntt,A_transpose),ind_cpa_public_key) = ind_cpa::generate_keypair_unpacked::<
         K,
         PUBLIC_KEY_SIZE,
         BYTES_PER_RING_ELEMENT,
@@ -188,7 +188,7 @@ pub(super) fn encapsulate<
     (ciphertext.into(), shared_secret_array)
 }
 
-pub(super) fn decapsulate_deserialized<
+pub(super) fn decapsulate_unpacked<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
     const CPA_SECRET_KEY_SIZE: usize,
@@ -214,7 +214,7 @@ pub(super) fn decapsulate_deserialized<
     ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
 ) -> MlKemSharedSecret {
 
-    let decrypted = ind_cpa::decrypt_deserialized::<
+    let decrypted = ind_cpa::decrypt_unpacked::<
         K,
         CIPHERTEXT_SIZE,
         C1_SIZE,
@@ -233,7 +233,7 @@ pub(super) fn decapsulate_deserialized<
     to_hash[SHARED_SECRET_SIZE..].copy_from_slice(ciphertext.as_ref());
     let implicit_rejection_shared_secret: [u8; SHARED_SECRET_SIZE] = PRF(&to_hash);
 
-    let expected_ciphertext = ind_cpa::encrypt_deserialized::<
+    let expected_ciphertext = ind_cpa::encrypt_unpacked::<
         K,
         CIPHERTEXT_SIZE,
         T_AS_NTT_ENCODED_SIZE,

--- a/src/kem/kyber.rs
+++ b/src/kem/kyber.rs
@@ -98,7 +98,7 @@ pub(super) fn generate_keypair_unpacked<
     let ind_cpa_keypair_randomness = &randomness[0..CPA_PKE_KEY_GENERATION_SEED_SIZE];
     let implicit_rejection_value = &randomness[CPA_PKE_KEY_GENERATION_SEED_SIZE..];
 
-    let ((s_as_ntt,t_as_ntt,A_transpose),ind_cpa_public_key) = ind_cpa::generate_keypair_unpacked::<
+    let ((s_as_ntt,t_as_ntt,a_transpose),ind_cpa_public_key) = ind_cpa::generate_keypair_unpacked::<
         K,
         PUBLIC_KEY_SIZE,
         BYTES_PER_RING_ELEMENT,
@@ -110,7 +110,7 @@ pub(super) fn generate_keypair_unpacked<
 
     let rej:[u8;32] = implicit_rejection_value.try_into().unwrap();
     let pubkey : MlKemPublicKey<PUBLIC_KEY_SIZE> = MlKemPublicKey::from(ind_cpa_public_key);
-    ((s_as_ntt,t_as_ntt,A_transpose,rej,public_key_hash),pubkey)
+    ((s_as_ntt,t_as_ntt,a_transpose,rej,public_key_hash),pubkey)
 }
 
 pub(super) fn generate_keypair<
@@ -208,7 +208,7 @@ pub(super) fn decapsulate_unpacked<
 >(
     secret_as_ntt: &[PolynomialRingElement;K],
     t_as_ntt: &[PolynomialRingElement;K],
-    A_transpose: &[[PolynomialRingElement;K];K],
+    a_transpose: &[[PolynomialRingElement;K];K],
     implicit_rejection_value: &[u8],
     ind_cpa_public_key_hash: &[u8],
     ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
@@ -246,7 +246,7 @@ pub(super) fn decapsulate_unpacked<
         ETA1_RANDOMNESS_SIZE,
         ETA2,
         ETA2_RANDOMNESS_SIZE,
-    >(t_as_ntt, A_transpose, decrypted, pseudorandomness);
+    >(t_as_ntt, a_transpose, decrypted, pseudorandomness);
 
     let selector = compare_ciphertexts_in_constant_time::<CIPHERTEXT_SIZE>(
         ciphertext.as_ref(),

--- a/src/kem/kyber/ind_cpa.rs
+++ b/src/kem/kyber/ind_cpa.rs
@@ -141,7 +141,7 @@ fn sample_vector_cbd_then_ntt<
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
-pub(super) fn generate_keypair_deserialized<
+pub(super) fn generate_keypair_unpacked<
     const K: usize,
     const PUBLIC_KEY_SIZE: usize,
     const RANKED_BYTES_PER_RING_ELEMENT: usize,
@@ -186,7 +186,7 @@ pub(super) fn generate_keypair<
     key_generation_seed: &[u8],
 ) -> ([u8; PRIVATE_KEY_SIZE], [u8; PUBLIC_KEY_SIZE]) {
     let ((secret_as_ntt,_t_as_ntt,_A_transpose),public_key_serialized) = 
-        generate_keypair_deserialized::<K,PUBLIC_KEY_SIZE,RANKED_BYTES_PER_RING_ELEMENT,ETA1,ETA1_RANDOMNESS_SIZE>(key_generation_seed);
+        generate_keypair_unpacked::<K,PUBLIC_KEY_SIZE,RANKED_BYTES_PER_RING_ELEMENT,ETA1,ETA1_RANDOMNESS_SIZE>(key_generation_seed);
     
     // sk := Encode_12(sˆ mod^{+}q)
     let secret_key_serialized = serialize_secret_key(secret_as_ntt);
@@ -257,7 +257,7 @@ fn compress_then_serialize_u<
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
-pub(crate) fn encrypt_deserialized<
+pub(crate) fn encrypt_unpacked<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
     const T_AS_NTT_ENCODED_SIZE: usize,
@@ -358,7 +358,7 @@ pub(crate) fn encrypt<
     // end for
     let A_transpose = sample_matrix_A(into_padded_array(seed), false);
     
-    encrypt_deserialized::<K,CIPHERTEXT_SIZE,T_AS_NTT_ENCODED_SIZE,C1_LEN,C2_LEN,U_COMPRESSION_FACTOR,V_COMPRESSION_FACTOR,BLOCK_LEN,ETA1,ETA1_RANDOMNESS_SIZE,ETA2,ETA2_RANDOMNESS_SIZE>(&t_as_ntt, &A_transpose, message, randomness)
+    encrypt_unpacked::<K,CIPHERTEXT_SIZE,T_AS_NTT_ENCODED_SIZE,C1_LEN,C2_LEN,U_COMPRESSION_FACTOR,V_COMPRESSION_FACTOR,BLOCK_LEN,ETA1,ETA1_RANDOMNESS_SIZE,ETA2,ETA2_RANDOMNESS_SIZE>(&t_as_ntt, &A_transpose, message, randomness)
 }
 
 /// Call [`deserialize_then_decompress_ring_element_u`] on each ring element
@@ -419,7 +419,7 @@ fn deserialize_secret_key<const K: usize>(secret_key: &[u8]) -> [PolynomialRingE
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
-pub(super) fn decrypt_deserialized<
+pub(super) fn decrypt_unpacked<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
     const VECTOR_U_ENCODED_SIZE: usize,
@@ -457,5 +457,5 @@ pub(super) fn decrypt<
     // sˆ := Decode_12(sk)
     let secret_as_ntt = deserialize_secret_key::<K>(secret_key);
 
-    decrypt_deserialized::<K,CIPHERTEXT_SIZE,VECTOR_U_ENCODED_SIZE,U_COMPRESSION_FACTOR,V_COMPRESSION_FACTOR>(&secret_as_ntt, ciphertext)
+ decrypt_unpacked::<K,CIPHERTEXT_SIZE,VECTOR_U_ENCODED_SIZE,U_COMPRESSION_FACTOR,V_COMPRESSION_FACTOR>(&secret_as_ntt, ciphertext)
 }

--- a/src/kem/kyber/ind_cpa.rs
+++ b/src/kem/kyber/ind_cpa.rs
@@ -179,8 +179,16 @@ pub(super) fn generate_keypair_unpacked<
             t_as_ntt[i].coefficients[j] = to_unsigned_representative(t_as_ntt[i].coefficients[j]) as i32;
         }
     }
+
+    // KB: We also need to transpose the A array.
+    let mut a_matrix = a_transpose;
+    for i in 0..K {
+        for j in 0..K {
+            a_matrix[i][j] = a_transpose[j][i];
+        }
+    }
     
-    ((secret_as_ntt,t_as_ntt,a_transpose),public_key_serialized)
+    ((secret_as_ntt,t_as_ntt,a_matrix),public_key_serialized)
 }
 
 #[allow(non_snake_case)]
@@ -365,9 +373,9 @@ pub(crate) fn encrypt<
     //         AˆT[i][j] := Parse(XOF(ρ, i, j))
     //     end for
     // end for
-    let A_transpose = sample_matrix_A(into_padded_array(seed), false);
+    let a_transpose = sample_matrix_A(into_padded_array(seed), false);
     
-    encrypt_unpacked::<K,CIPHERTEXT_SIZE,T_AS_NTT_ENCODED_SIZE,C1_LEN,C2_LEN,U_COMPRESSION_FACTOR,V_COMPRESSION_FACTOR,BLOCK_LEN,ETA1,ETA1_RANDOMNESS_SIZE,ETA2,ETA2_RANDOMNESS_SIZE>(&t_as_ntt, &A_transpose, message, randomness)
+    encrypt_unpacked::<K,CIPHERTEXT_SIZE,T_AS_NTT_ENCODED_SIZE,C1_LEN,C2_LEN,U_COMPRESSION_FACTOR,V_COMPRESSION_FACTOR,BLOCK_LEN,ETA1,ETA1_RANDOMNESS_SIZE,ETA2,ETA2_RANDOMNESS_SIZE>(&t_as_ntt, &a_transpose, message, randomness)
 }
 
 /// Call [`deserialize_then_decompress_ring_element_u`] on each ring element

--- a/src/kem/kyber/kyber1024.rs
+++ b/src/kem/kyber/kyber1024.rs
@@ -73,7 +73,7 @@ pub type MlKem1024State = MlKemState<RANK_1024>;
 
 pub fn generate_key_pair_unpacked(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
-) -> (MlKem1024State, MlKem1024PublicKey)  {
+) -> (MlKem1024State, MlKem1024PublicKey) {
     generate_keypair_unpacked::<
         RANK_1024,
         CPA_PKE_SECRET_KEY_SIZE_1024,
@@ -156,6 +156,5 @@ pub fn decapsulate_unpacked(
         ETA2,
         ETA2_RANDOMNESS_SIZE,
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-    >(state,ciphertext)
+    >(state, ciphertext)
 }
-

--- a/src/kem/kyber/kyber1024.rs
+++ b/src/kem/kyber/kyber1024.rs
@@ -69,6 +69,22 @@ pub fn generate_key_pair(
     >(randomness)
 }
 
+pub type MlKem1024State = MlKemState<RANK_1024>;
+
+pub fn generate_key_pair_unpacked(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+) -> (MlKem1024State, MlKem1024PublicKey)  {
+    generate_keypair_unpacked::<
+        RANK_1024,
+        CPA_PKE_SECRET_KEY_SIZE_1024,
+        SECRET_KEY_SIZE_1024,
+        CPA_PKE_PUBLIC_KEY_SIZE_1024,
+        RANKED_BYTES_PER_RING_ELEMENT_1024,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+    >(randomness)
+}
+
 /// Encapsulate ML-KEM 1024
 pub fn encapsulate(
     public_key: &MlKemPublicKey<CPA_PKE_PUBLIC_KEY_SIZE_1024>,
@@ -118,3 +134,28 @@ pub fn decapsulate(
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
     >(secret_key, ciphertext)
 }
+
+pub fn decapsulate_unpacked(
+    state: &MlKem1024State,
+    ciphertext: &MlKemCiphertext<CPA_PKE_CIPHERTEXT_SIZE_1024>,
+) -> [u8; SHARED_SECRET_SIZE] {
+    super::decapsulate_unpacked::<
+        RANK_1024,
+        SECRET_KEY_SIZE_1024,
+        CPA_PKE_SECRET_KEY_SIZE_1024,
+        CPA_PKE_PUBLIC_KEY_SIZE_1024,
+        CPA_PKE_CIPHERTEXT_SIZE_1024,
+        T_AS_NTT_ENCODED_SIZE_1024,
+        C1_SIZE_1024,
+        C2_SIZE_1024,
+        VECTOR_U_COMPRESSION_FACTOR_1024,
+        VECTOR_V_COMPRESSION_FACTOR_1024,
+        C1_BLOCK_SIZE_1024,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+    >(state,ciphertext)
+}
+

--- a/src/kem/kyber/kyber512.rs
+++ b/src/kem/kyber/kyber512.rs
@@ -67,6 +67,22 @@ pub fn generate_key_pair(
     >(randomness)
 }
 
+pub type MlKem512State = MlKemState<RANK_512>;
+
+pub fn generate_key_pair_unpacked(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+) -> (MlKem512State, MlKem512PublicKey)  {
+    generate_keypair_unpacked::<
+        RANK_512,
+        CPA_PKE_SECRET_KEY_SIZE_512,
+        SECRET_KEY_SIZE_512,
+        CPA_PKE_PUBLIC_KEY_SIZE_512,
+        RANKED_BYTES_PER_RING_ELEMENT_512,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+    >(randomness)
+}
+
 /// Encapsulate ML-KEM 512
 pub fn encapsulate(
     public_key: &MlKemPublicKey<CPA_PKE_PUBLIC_KEY_SIZE_512>,
@@ -116,3 +132,28 @@ pub fn decapsulate(
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
     >(secret_key, ciphertext)
 }
+
+pub fn decapsulate_unpacked(
+    state: &MlKem512State,
+    ciphertext: &MlKemCiphertext<CPA_PKE_CIPHERTEXT_SIZE_512>,
+) -> [u8; SHARED_SECRET_SIZE] {
+    super::decapsulate_unpacked::<
+        RANK_512,
+        SECRET_KEY_SIZE_512,
+        CPA_PKE_SECRET_KEY_SIZE_512,
+        CPA_PKE_PUBLIC_KEY_SIZE_512,
+        CPA_PKE_CIPHERTEXT_SIZE_512,
+        T_AS_NTT_ENCODED_SIZE_512,
+        C1_SIZE_512,
+        C2_SIZE_512,
+        VECTOR_U_COMPRESSION_FACTOR_512,
+        VECTOR_V_COMPRESSION_FACTOR_512,
+        C1_BLOCK_SIZE_512,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+    >(state,ciphertext)
+}
+

--- a/src/kem/kyber/kyber512.rs
+++ b/src/kem/kyber/kyber512.rs
@@ -71,7 +71,7 @@ pub type MlKem512State = MlKemState<RANK_512>;
 
 pub fn generate_key_pair_unpacked(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
-) -> (MlKem512State, MlKem512PublicKey)  {
+) -> (MlKem512State, MlKem512PublicKey) {
     generate_keypair_unpacked::<
         RANK_512,
         CPA_PKE_SECRET_KEY_SIZE_512,
@@ -154,6 +154,5 @@ pub fn decapsulate_unpacked(
         ETA2,
         ETA2_RANDOMNESS_SIZE,
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-    >(state,ciphertext)
+    >(state, ciphertext)
 }
-

--- a/src/kem/kyber/kyber768.rs
+++ b/src/kem/kyber/kyber768.rs
@@ -68,10 +68,10 @@ pub fn generate_key_pair(
     >(randomness)
 }
 
-pub fn generate_key_pair_deserialized(
+pub fn generate_key_pair_unpacked(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> (([PolynomialRingElement;3],[PolynomialRingElement;3],[[PolynomialRingElement;3];3],[u8;32],[u8;32]),MlKemPublicKey<CPA_PKE_PUBLIC_KEY_SIZE_768>)  {
-    generate_keypair_deserialized::<
+    generate_keypair_unpacked::<
         RANK_768,
         CPA_PKE_SECRET_KEY_SIZE_768,
         SECRET_KEY_SIZE_768,
@@ -132,7 +132,7 @@ pub fn decapsulate(
     >(secret_key, ciphertext)
 }
 
-pub fn decapsulate_deserialized(
+pub fn decapsulate_unpacked(
     secret_as_ntt: &[PolynomialRingElement;3],
     t_as_ntt: &[PolynomialRingElement;3],
     A_transpose: &[[PolynomialRingElement;3];3],
@@ -140,7 +140,7 @@ pub fn decapsulate_deserialized(
     ind_cpa_public_key_hash: &[u8],
     ciphertext: &MlKemCiphertext<CPA_PKE_CIPHERTEXT_SIZE_768>,
 ) -> [u8; SHARED_SECRET_SIZE] {
-    super::decapsulate_deserialized::<
+    super::decapsulate_unpacked::<
         RANK_768,
         SECRET_KEY_SIZE_768,
         CPA_PKE_SECRET_KEY_SIZE_768,

--- a/src/kem/kyber/kyber768.rs
+++ b/src/kem/kyber/kyber768.rs
@@ -68,9 +68,11 @@ pub fn generate_key_pair(
     >(randomness)
 }
 
+pub type MlKem768State = MlKemState<RANK_768>;
+
 pub fn generate_key_pair_unpacked(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
-) -> (([PolynomialRingElement;3],[PolynomialRingElement;3],[[PolynomialRingElement;3];3],[u8;32],[u8;32]),MlKemPublicKey<CPA_PKE_PUBLIC_KEY_SIZE_768>)  {
+) -> (MlKem768State, MlKem768PublicKey)  {
     generate_keypair_unpacked::<
         RANK_768,
         CPA_PKE_SECRET_KEY_SIZE_768,
@@ -133,11 +135,7 @@ pub fn decapsulate(
 }
 
 pub fn decapsulate_unpacked(
-    secret_as_ntt: &[PolynomialRingElement;3],
-    t_as_ntt: &[PolynomialRingElement;3],
-    a_transpose: &[[PolynomialRingElement;3];3],
-    implicit_rejection_value: &[u8],
-    ind_cpa_public_key_hash: &[u8],
+    state: &MlKem768State,
     ciphertext: &MlKemCiphertext<CPA_PKE_CIPHERTEXT_SIZE_768>,
 ) -> [u8; SHARED_SECRET_SIZE] {
     super::decapsulate_unpacked::<
@@ -157,7 +155,7 @@ pub fn decapsulate_unpacked(
         ETA2,
         ETA2_RANDOMNESS_SIZE,
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-    >(secret_as_ntt,t_as_ntt,a_transpose,implicit_rejection_value,ind_cpa_public_key_hash,ciphertext)
+    >(state,ciphertext)
 }
 
 #[cfg(test)]

--- a/src/kem/kyber/kyber768.rs
+++ b/src/kem/kyber/kyber768.rs
@@ -135,7 +135,7 @@ pub fn decapsulate(
 pub fn decapsulate_unpacked(
     secret_as_ntt: &[PolynomialRingElement;3],
     t_as_ntt: &[PolynomialRingElement;3],
-    A_transpose: &[[PolynomialRingElement;3];3],
+    a_transpose: &[[PolynomialRingElement;3];3],
     implicit_rejection_value: &[u8],
     ind_cpa_public_key_hash: &[u8],
     ciphertext: &MlKemCiphertext<CPA_PKE_CIPHERTEXT_SIZE_768>,
@@ -157,7 +157,7 @@ pub fn decapsulate_unpacked(
         ETA2,
         ETA2_RANDOMNESS_SIZE,
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-    >(secret_as_ntt,t_as_ntt,A_transpose,implicit_rejection_value,ind_cpa_public_key_hash,ciphertext)
+    >(secret_as_ntt,t_as_ntt,a_transpose,implicit_rejection_value,ind_cpa_public_key_hash,ciphertext)
 }
 
 #[cfg(test)]

--- a/src/kem/kyber/kyber768.rs
+++ b/src/kem/kyber/kyber768.rs
@@ -72,7 +72,7 @@ pub type MlKem768State = MlKemState<RANK_768>;
 
 pub fn generate_key_pair_unpacked(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
-) -> (MlKem768State, MlKem768PublicKey)  {
+) -> (MlKem768State, MlKem768PublicKey) {
     generate_keypair_unpacked::<
         RANK_768,
         CPA_PKE_SECRET_KEY_SIZE_768,
@@ -155,7 +155,7 @@ pub fn decapsulate_unpacked(
         ETA2,
         ETA2_RANDOMNESS_SIZE,
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-    >(state,ciphertext)
+    >(state, ciphertext)
 }
 
 #[cfg(test)]

--- a/src/kem/kyber/kyber768.rs
+++ b/src/kem/kyber/kyber768.rs
@@ -68,6 +68,20 @@ pub fn generate_key_pair(
     >(randomness)
 }
 
+pub fn generate_key_pair_deserialized(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+) -> (([PolynomialRingElement;3],[PolynomialRingElement;3],[[PolynomialRingElement;3];3],[u8;32],[u8;32]),MlKemPublicKey<CPA_PKE_PUBLIC_KEY_SIZE_768>)  {
+    generate_keypair_deserialized::<
+        RANK_768,
+        CPA_PKE_SECRET_KEY_SIZE_768,
+        SECRET_KEY_SIZE_768,
+        CPA_PKE_PUBLIC_KEY_SIZE_768,
+        RANKED_BYTES_PER_RING_ELEMENT_768,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+    >(randomness)
+}
+
 /// Encapsulate ML-KEM 768
 pub fn encapsulate(
     public_key: &MlKemPublicKey<CPA_PKE_PUBLIC_KEY_SIZE_768>,
@@ -116,6 +130,34 @@ pub fn decapsulate(
         ETA2_RANDOMNESS_SIZE,
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
     >(secret_key, ciphertext)
+}
+
+pub fn decapsulate_deserialized(
+    secret_as_ntt: &[PolynomialRingElement;3],
+    t_as_ntt: &[PolynomialRingElement;3],
+    A_transpose: &[[PolynomialRingElement;3];3],
+    implicit_rejection_value: &[u8],
+    ind_cpa_public_key_hash: &[u8],
+    ciphertext: &MlKemCiphertext<CPA_PKE_CIPHERTEXT_SIZE_768>,
+) -> [u8; SHARED_SECRET_SIZE] {
+    super::decapsulate_deserialized::<
+        RANK_768,
+        SECRET_KEY_SIZE_768,
+        CPA_PKE_SECRET_KEY_SIZE_768,
+        CPA_PKE_PUBLIC_KEY_SIZE_768,
+        CPA_PKE_CIPHERTEXT_SIZE_768,
+        T_AS_NTT_ENCODED_SIZE_768,
+        C1_SIZE_768,
+        C2_SIZE_768,
+        VECTOR_U_COMPRESSION_FACTOR_768,
+        VECTOR_V_COMPRESSION_FACTOR_768,
+        C1_BLOCK_SIZE_768,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+    >(secret_as_ntt,t_as_ntt,A_transpose,implicit_rejection_value,ind_cpa_public_key_hash,ciphertext)
 }
 
 #[cfg(test)]

--- a/tests/kyber.rs
+++ b/tests/kyber.rs
@@ -41,31 +41,30 @@ macro_rules! impl_consistency_unpacked {
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
         #[test]
         fn $name() {
-	    use rand::RngCore;
- 	    use rand_core::OsRng;
+            use rand::RngCore;
+            use rand_core::OsRng;
             let mut rng = OsRng;
 
             let mut seed = [0; 64];
             rng.fill_bytes(&mut seed);
-            let (sku,pubkey) =
-                     libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed.clone());
+            let (sk_state, pubkey) =
+                libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed.clone());
 
-            let kp =
-                libcrux::kem::kyber::kyber768::generate_key_pair(seed);
-            assert_eq!(pubkey.as_slice(),kp.public_key().as_slice());
+            let kp = libcrux::kem::kyber::kyber768::generate_key_pair(seed);
+            assert_eq!(pubkey.as_slice(), kp.public_key().as_slice());
 
             let mut rand = [0; 32];
             rng.fill_bytes(&mut rand);
-            let (ciphertext,shared_secret) = libcrux::kem::kyber::kyber768::encapsulate(&pubkey,rand);
-            let shared_secret_decapsulated = 
-                    libcrux::kem::kyber::kyber768::decapsulate_unpacked(&sku.0,&sku.1,&sku.2,&sku.3,&sku.4,&ciphertext);
+            let (ciphertext, shared_secret) =
+                libcrux::kem::kyber::kyber768::encapsulate(&pubkey, rand);
+            let shared_secret_decapsulated =
+                libcrux::kem::kyber::kyber768::decapsulate_unpacked(&sk_state, &ciphertext);
 
-            let shared_secret_decapsulated2 = 
-                    libcrux::kem::kyber::kyber768::decapsulate(&kp.private_key(),&ciphertext);
+            let shared_secret_decapsulated2 =
+                libcrux::kem::kyber::kyber768::decapsulate(&kp.private_key(), &ciphertext);
             assert_eq!(shared_secret, shared_secret_decapsulated2);
 
             assert_eq!(shared_secret, shared_secret_decapsulated);
-            
         }
     };
 }

--- a/tests/kyber.rs
+++ b/tests/kyber.rs
@@ -48,14 +48,24 @@ macro_rules! impl_consistency_unpacked {
             let mut seed = [0; 64];
             rng.fill_bytes(&mut seed);
             let (sku,pubkey) =
-                     libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed);
+                     libcrux::kem::kyber::kyber768::generate_key_pair_unpacked(seed.clone());
+
+            let kp =
+                libcrux::kem::kyber::kyber768::generate_key_pair(seed);
+            assert_eq!(pubkey.as_slice(),kp.public_key().as_slice());
 
             let mut rand = [0; 32];
             rng.fill_bytes(&mut rand);
             let (ciphertext,shared_secret) = libcrux::kem::kyber::kyber768::encapsulate(&pubkey,rand);
             let shared_secret_decapsulated = 
                     libcrux::kem::kyber::kyber768::decapsulate_unpacked(&sku.0,&sku.1,&sku.2,&sku.3,&sku.4,&ciphertext);
+
+            let shared_secret_decapsulated2 = 
+                    libcrux::kem::kyber::kyber768::decapsulate(&kp.private_key(),&ciphertext);
+            assert_eq!(shared_secret, shared_secret_decapsulated2);
+
             assert_eq!(shared_secret, shared_secret_decapsulated);
+            
         }
     };
 }


### PR DESCRIPTION
In addition to Karthik's API improvements, this PR contains a few more goodies on top, notably:
- generating code for all three variants of kyber, but in separate files
- putting all of the shared code in a header where everything is marked as static inline
- updated config.yaml for all of the above
- addition of a few well-chosen type declarations to generate prettier C code

I think this would be worth merging now.

PR on the hacl-packages side forthcoming