### PR TITLE
Fixing hax.py to generate .fst files

### DIFF
--- a/libcrux-ml-kem/hax.py
+++ b/libcrux-ml-kem/hax.py
@@ -101,8 +101,8 @@ class extractAction(argparse.Action):
         )
 
         # Extract ml-kem
-        include_str = "+:** -libcrux_ml_kem::types::index_impls::**"
-        interface_include = "+*"
+        include_str = "+** -libcrux_ml_kem::types::index_impls::**"
+        interface_include = "+**"
         cargo_hax_into = [
             "cargo",
             "hax",


### PR DESCRIPTION
The hax.py merged in PR #308 was only generating .fsti files for libcrux-ml-kem.
This PR fixes that bug.