### PR TITLE
Drop `libcrux` dependency in `libcrux-ecdh`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,10 +951,10 @@ name = "libcrux-ecdh"
 version = "0.0.2-alpha.1"
 dependencies = [
  "hex",
- "libcrux",
  "libcrux-hacl",
  "pretty_env_logger",
  "rand",
+ "rand_core",
  "serde",
  "serde_json",
 ]

--- a/libcrux-ecdh/Cargo.toml
+++ b/libcrux-ecdh/Cargo.toml
@@ -17,7 +17,7 @@ rand = { version = "0.8" }
 libcrux-hacl = { version = "=0.0.2-alpha.1", path = "../sys/hacl" }
 
 [dev-dependencies]
-libcrux = { version = "=0.0.2-alpha.1", path = "../", features = ["rand"] }
+rand_core = { version = "0.6" }
 hex = { version = "0.4.3", features = ["serde"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/libcrux-ecdh/tests/p256.rs
+++ b/libcrux-ecdh/tests/p256.rs
@@ -1,15 +1,9 @@
-#[cfg(not(target_arch = "wasm32"))]
-use libcrux::drbg;
 use libcrux_ecdh::{self, key_gen};
-#[cfg(target_arch = "wasm32")]
 use rand_core::OsRng;
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn derive_rand() {
-    #[cfg(not(target_arch = "wasm32"))]
-    let mut rng = drbg::Drbg::new(libcrux::digest::Algorithm::Sha256).unwrap();
-    #[cfg(target_arch = "wasm32")]
     let mut rng = OsRng;
 
     let (private_a, public_a) = key_gen(libcrux_ecdh::Algorithm::P256, &mut rng).unwrap();

--- a/libcrux-ecdh/tests/x25519.rs
+++ b/libcrux-ecdh/tests/x25519.rs
@@ -3,28 +3,22 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use test_util::*;
 
-#[cfg(not(target_arch = "wasm32"))]
-use libcrux::drbg;
-#[cfg(target_arch = "wasm32")]
 use rand_core::OsRng;
 
-use libcrux::ecdh::{self, key_gen, Algorithm, Error};
+use libcrux_ecdh::{self, key_gen, Algorithm, Error};
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn derive() {
     let _ = pretty_env_logger::try_init();
 
-    #[cfg(not(target_arch = "wasm32"))]
-    let mut rng = drbg::Drbg::new(libcrux::digest::Algorithm::Sha256).unwrap();
-    #[cfg(target_arch = "wasm32")]
     let mut rng = OsRng;
 
     let (private_a, public_a) = key_gen(Algorithm::X25519, &mut rng).unwrap();
     let (private_b, public_b) = key_gen(Algorithm::X25519, &mut rng).unwrap();
 
-    let shared_a = ecdh::derive(Algorithm::X25519, &public_b, &private_a).unwrap();
-    let shared_b = ecdh::derive(Algorithm::X25519, &public_a, &private_b).unwrap();
+    let shared_a = libcrux_ecdh::derive(Algorithm::X25519, &public_b, &private_a).unwrap();
+    let shared_b = libcrux_ecdh::derive(Algorithm::X25519, &public_a, &private_b).unwrap();
     assert_eq!(shared_a, shared_b);
 }
 
@@ -122,7 +116,7 @@ fn wycheproof() {
             let private = hex_str_to_bytes(&test.private);
             let shared = hex_str_to_bytes(&test.shared);
 
-            match ecdh::derive(Algorithm::X25519, &public, &private) {
+            match libcrux_ecdh::derive(Algorithm::X25519, &public, &private) {
                 Ok(r) => {
                     assert!(valid);
                     assert_eq!(r[..], shared[..]);


### PR DESCRIPTION
This PR gets rid of the `libcrux` dependency for testing in `libcrux-ecdh`. To do this, I've replaced the `libcrux` Drbg with `OsRng`, that was previously only used for the `wasm32` target.