### PR TITLE
Remove `libcrux` dependency in `libcrux-kem`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,6 @@ dependencies = [
  "libcrux-ml-kem",
  "libcrux-sha3",
  "rand",
- "rand_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,12 +1003,12 @@ name = "libcrux-kem"
 version = "0.0.2-alpha.1"
 dependencies = [
  "hex",
- "libcrux",
  "libcrux-ecdh",
  "libcrux-kem",
  "libcrux-ml-kem",
  "libcrux-sha3",
  "rand",
+ "rand_core",
 ]
 
 [[package]]

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -25,5 +25,4 @@ pre-verification = ["libcrux-ml-kem/pre-verification"]
 
 [dev-dependencies]
 libcrux-kem = { version = "0.0.2-alpha.1", path = "./", features = ["tests"] }
-rand_core = { version = "0.6" }
 hex = { version = "0.4.3", features = ["serde"] }

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 repository.workspace = true
 readme.workspace = true
 description = "Libcrux KEM implementation"
+exclude = ["/tests"]
 
 [lib]
 path = "src/kem.rs"

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -25,5 +25,5 @@ kyber = ["libcrux-ml-kem/kyber"]
 pre-verification = ["libcrux-ml-kem/pre-verification"]
 
 [dev-dependencies]
-libcrux-kem = { version = "0.0.2-alpha.1", path = "./", features = ["tests"] }
+libcrux-kem = { path = "./", features = ["tests"] }
 hex = { version = "0.4.3", features = ["serde"] }

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -25,5 +25,5 @@ pre-verification = ["libcrux-ml-kem/pre-verification"]
 
 [dev-dependencies]
 libcrux-kem = { version = "0.0.2-alpha.1", path = "./", features = ["tests"] }
-libcrux = { version = "0.0.2-alpha.1", path = "../", features = ["rand"] }
+rand_core = { version = "0.6" }
 hex = { version = "0.4.3", features = ["serde"] }

--- a/libcrux-kem/README.md
+++ b/libcrux-kem/README.md
@@ -1,0 +1,31 @@
+# Key Encapsulation Mechanism
+
+A KEM interface.
+
+Available algorithms:
+
+* [`Algorithm::X25519`]\: x25519 ECDH KEM.
+* [`Algorithm::Secp256r1`]\: NIST P256 ECDH KEM.
+* [`Algorithm::MlKem512`]\: ML-KEM 512 from [FIPS 203].
+* [`Algorithm::MlKem768`]\: ML-KEM 768 from [FIPS 203].
+* [`Algorithm::MlKem1024`]\: ML-KEM 1024 from [FIPS 203].
+* [`Algorithm::X25519MlKem768Draft00`]\: Hybrid x25519 - ML-KEM 768 [draft kem for hpke](https://www.ietf.org/archive/id/draft-westerbaan-cfrg-hpke-xyber768d00-00.html).
+* [`Algorithm::XWingKemDraft02`]\: Hybrid x25519 - ML-KEM 768 [draft xwing kem for hpke](https://www.ietf.org/archive/id/draft-connolly-cfrg-xwing-kem-02.html).
+
+```Rust
+use libcrux_kem::*;
+
+let mut rng = rand::rngs::OsRng;
+let (sk_a, pk_a) = key_gen(Algorithm::MlKem768, &mut rng).unwrap();
+let received_pk = pk_a.encode();
+
+let pk = PublicKey::decode(Algorithm::MlKem768, &received_pk).unwrap();
+let (ss_b, ct_b) = pk.encapsulate(&mut rng).unwrap();
+let received_ct = ct_b.encode();
+
+let ct_a = Ct::decode(Algorithm::MlKem768, &received_ct).unwrap();
+let ss_a = ct_a.decapsulate(&sk_a).unwrap();
+assert_eq!(ss_b.encode(), ss_a.encode());
+```
+
+[FIPS 203]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.ipd.pdf

--- a/libcrux-kem/src/kem.rs
+++ b/libcrux-kem/src/kem.rs
@@ -14,10 +14,9 @@
 //! * [`Algorithm::XWingKemDraft02`]\: Hybrid x25519 - ML-KEM 768 [draft xwing kem for hpke](https://www.ietf.org/archive/id/draft-connolly-cfrg-xwing-kem-02.html).
 //!
 //! ```
-//! use libcrux::{drbg::Drbg, digest::Algorithm::Sha256};
 //! use libcrux_kem::*;
 //!
-//! let mut rng = Drbg::new(Sha256).unwrap();
+//! let mut rng = rand_core::OsRng;
 //! let (sk_a, pk_a) = key_gen(Algorithm::MlKem768, &mut rng).unwrap();
 //! let received_pk = pk_a.encode();
 //!

--- a/libcrux-kem/src/kem.rs
+++ b/libcrux-kem/src/kem.rs
@@ -16,7 +16,7 @@
 //! ```
 //! use libcrux_kem::*;
 //!
-//! let mut rng = rand_core::OsRng;
+//! let mut rng = rand::rngs::OsRng;
 //! let (sk_a, pk_a) = key_gen(Algorithm::MlKem768, &mut rng).unwrap();
 //! let received_pk = pk_a.encode();
 //!


### PR DESCRIPTION
Same procedure as #347, replacing `libcrux` `Drbg` with `OsRng`.