### PR TITLE
Run benchmarks on merge queue, or manually

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -57,5 +57,5 @@ jobs:
 
       - name: 🏃🏻‍♀️ Benchmark
         run: ./build/ml_kem_bench
-        if: ${{ matrix.os != 'windows-latest' && github.event_name == 'merge_group' }}
+        if: ${{ matrix.os != 'windows-latest' && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') }}
 

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -57,5 +57,5 @@ jobs:
 
       - name: 🏃🏻‍♀️ Benchmark
         run: ./build/ml_kem_bench
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows-latest' && github.event_name == 'merge_group' }}
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev"]
+  merge_group:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -11,6 +11,7 @@ on:
     - cron: "0 0 * * *"
 
   workflow_dispatch:
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -170,6 +170,7 @@ jobs:
           cargo hack test --each-feature $EXCLUDE_FEATURES --verbose $RUST_TARGET_FLAG
 
   benchmarks:
+    if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
+  merge_group:
 
 jobs:
   nix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -141,7 +141,7 @@ jobs:
         run: CC=emcc AR=emar wasm-pack test --node --features wasm
 
   benchmarks:
-    if: ${{ github.event_name = 'merge_group' || github.event_name = 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -141,6 +141,7 @@ jobs:
         run: CC=emcc AR=emar wasm-pack test --node --features wasm
 
   benchmarks:
+    if: ${{ github.event_name = 'merge_group' || github.event_name = 'workflow_dispatch' }}
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
This PR introduces `merge_queue` triggers for all jobs that are run on PRs and makes it so that benchmarks are only run on the `merge_queue` event, or when manually triggered.