### PR TITLE
ML-DSA: Moved all the encoding code and more of the arithmetic code to a vectorized structure.

### DIFF
--- a/libcrux-ml-dsa/src/arithmetic.rs
+++ b/libcrux-ml-dsa/src/arithmetic.rs
@@ -165,16 +165,20 @@ pub(crate) fn decompose_vector<const DIMENSION: usize, const GAMMA2: i32>(
 }
 
 #[inline(always)]
-fn compute_hint_value<const GAMMA2: i32>(low: i32, high: i32) -> bool {
-    (low > GAMMA2) || (low < -GAMMA2) || (low == -GAMMA2 && high != 0)
+fn compute_hint_value<const GAMMA2: i32>(low: i32, high: i32) -> i32 {
+    if (low > GAMMA2) || (low < -GAMMA2) || (low == -GAMMA2 && high != 0) {
+        1
+    } else {
+        0
+    }
 }
 
 #[inline(always)]
 pub(crate) fn make_hint<const DIMENSION: usize, const GAMMA2: i32>(
     low: [PolynomialRingElement; DIMENSION],
     high: [PolynomialRingElement; DIMENSION],
-) -> ([[bool; COEFFICIENTS_IN_RING_ELEMENT]; DIMENSION], usize) {
-    let mut hint = [[false; COEFFICIENTS_IN_RING_ELEMENT]; DIMENSION];
+) -> ([[i32; COEFFICIENTS_IN_RING_ELEMENT]; DIMENSION], usize) {
+    let mut hint = [[0; COEFFICIENTS_IN_RING_ELEMENT]; DIMENSION];
     let mut true_hints = 0;
 
     for i in 0..DIMENSION {
@@ -192,10 +196,10 @@ pub(crate) fn make_hint<const DIMENSION: usize, const GAMMA2: i32>(
 }
 
 #[inline(always)]
-pub(crate) fn use_hint_value<const GAMMA2: i32>(r: i32, hint: bool) -> i32 {
+pub(crate) fn use_hint_value<const GAMMA2: i32>(r: i32, hint: i32) -> i32 {
     let (r0, r1) = decompose::<GAMMA2>(r);
 
-    if !hint {
+    if hint == 0 {
         return r1;
     }
 
@@ -228,7 +232,7 @@ pub(crate) fn use_hint_value<const GAMMA2: i32>(r: i32, hint: bool) -> i32 {
 
 #[inline(always)]
 pub(crate) fn use_hint<const DIMENSION: usize, const GAMMA2: i32>(
-    hint: [[bool; COEFFICIENTS_IN_RING_ELEMENT]; DIMENSION],
+    hint: [[i32; COEFFICIENTS_IN_RING_ELEMENT]; DIMENSION],
     re_vector: [PolynomialRingElement; DIMENSION],
 ) -> [PolynomialRingElement; DIMENSION] {
     let mut result = [PolynomialRingElement::ZERO; DIMENSION];
@@ -260,10 +264,10 @@ mod tests {
 
     #[test]
     fn test_use_hint_value() {
-        assert_eq!(use_hint_value::<95_232>(7622170, false), 40);
-        assert_eq!(use_hint_value::<95_232>(2332762, true), 13);
+        assert_eq!(use_hint_value::<95_232>(7622170, 0), 40);
+        assert_eq!(use_hint_value::<95_232>(2332762, 1), 13);
 
-        assert_eq!(use_hint_value::<261_888>(7691572, false), 15);
-        assert_eq!(use_hint_value::<261_888>(6635697, true), 12);
+        assert_eq!(use_hint_value::<261_888>(7691572, 0), 15);
+        assert_eq!(use_hint_value::<261_888>(6635697, 1), 12);
     }
 }

--- a/libcrux-ml-dsa/src/encoding/gamma1.rs
+++ b/libcrux-ml-dsa/src/encoding/gamma1.rs
@@ -9,7 +9,7 @@ pub(crate) fn serialize<const GAMMA1_EXPONENT: usize, const OUTPUT_BYTES: usize>
 ) -> [u8; OUTPUT_BYTES] {
     let mut serialized = [0u8; OUTPUT_BYTES];
 
-    let mut v_re = SIMDPolynomialRingElement::<PortableSIMDUnit>::from_polynomial_ring_element(re);
+    let v_re = SIMDPolynomialRingElement::<PortableSIMDUnit>::from_polynomial_ring_element(re);
 
     match GAMMA1_EXPONENT {
         17 => {

--- a/libcrux-ml-dsa/src/encoding/gamma1.rs
+++ b/libcrux-ml-dsa/src/encoding/gamma1.rs
@@ -18,7 +18,6 @@ pub(crate) fn serialize<const GAMMA1_EXPONENT: usize, const OUTPUT_BYTES: usize>
             for (i, simd_unit) in v_re.simd_units.iter().enumerate() {
                 serialized[i * OUTPUT_BYTES_PER_SIMD_UNIT..(i + 1) * OUTPUT_BYTES_PER_SIMD_UNIT]
                     .copy_from_slice(&PortableSIMDUnit::gamma1_serialize::<
-                        GAMMA1_EXPONENT,
                         OUTPUT_BYTES_PER_SIMD_UNIT,
                     >(*simd_unit));
             }
@@ -31,7 +30,6 @@ pub(crate) fn serialize<const GAMMA1_EXPONENT: usize, const OUTPUT_BYTES: usize>
             for (i, simd_unit) in v_re.simd_units.iter().enumerate() {
                 serialized[i * OUTPUT_BYTES_PER_SIMD_UNIT..(i + 1) * OUTPUT_BYTES_PER_SIMD_UNIT]
                     .copy_from_slice(&PortableSIMDUnit::gamma1_serialize::<
-                        GAMMA1_EXPONENT,
                         OUTPUT_BYTES_PER_SIMD_UNIT,
                     >(*simd_unit));
             }

--- a/libcrux-ml-dsa/src/encoding/t1.rs
+++ b/libcrux-ml-dsa/src/encoding/t1.rs
@@ -1,6 +1,7 @@
 use crate::{
-    constants::{BITS_IN_UPPER_PART_OF_T, RING_ELEMENT_OF_T1S_SIZE},
-    polynomial::PolynomialRingElement,
+    constants::RING_ELEMENT_OF_T1S_SIZE,
+    polynomial::{PolynomialRingElement, SIMDPolynomialRingElement},
+    simd::{portable::PortableSIMDUnit, traits::Operations},
 };
 
 // Each coefficient takes up 10 bits.
@@ -9,40 +10,28 @@ use crate::{
 pub(crate) fn serialize(re: PolynomialRingElement) -> [u8; RING_ELEMENT_OF_T1S_SIZE] {
     let mut serialized = [0u8; RING_ELEMENT_OF_T1S_SIZE];
 
-    for (i, coefficients) in re.coefficients.chunks_exact(4).enumerate() {
-        serialized[5 * i] = (coefficients[0] & 0xFF) as u8;
-        serialized[5 * i + 1] =
-            ((coefficients[1] & 0x3F) as u8) << 2 | ((coefficients[0] >> 8) & 0x03) as u8;
-        serialized[5 * i + 2] =
-            ((coefficients[2] & 0x0F) as u8) << 4 | ((coefficients[1] >> 6) & 0x0F) as u8;
-        serialized[5 * i + 3] =
-            ((coefficients[3] & 0x03) as u8) << 6 | ((coefficients[2] >> 4) & 0x3F) as u8;
-        serialized[5 * i + 4] = ((coefficients[3] >> 2) & 0xFF) as u8;
+    let v_re = SIMDPolynomialRingElement::<PortableSIMDUnit>::from_polynomial_ring_element(re);
+
+    const OUTPUT_BYTES_PER_SIMD_UNIT: usize = 10;
+
+    for (i, simd_unit) in v_re.simd_units.iter().enumerate() {
+        serialized[i * OUTPUT_BYTES_PER_SIMD_UNIT..(i + 1) * OUTPUT_BYTES_PER_SIMD_UNIT]
+            .copy_from_slice(&PortableSIMDUnit::t1_serialize(*simd_unit));
     }
 
     serialized
 }
 
 pub(crate) fn deserialize(serialized: &[u8]) -> PolynomialRingElement {
-    debug_assert_eq!(serialized.len(), RING_ELEMENT_OF_T1S_SIZE);
+    let mut serialized_chunks = serialized.chunks(10);
 
-    let mut out = PolynomialRingElement::ZERO;
-    let mask = (1 << BITS_IN_UPPER_PART_OF_T) - 1;
+    let mut result = SIMDPolynomialRingElement::ZERO();
 
-    for (i, bytes) in serialized.chunks_exact(5).enumerate() {
-        let byte0 = bytes[0] as i32;
-        let byte1 = bytes[1] as i32;
-        let byte2 = bytes[2] as i32;
-        let byte3 = bytes[3] as i32;
-        let byte4 = bytes[4] as i32;
-
-        out.coefficients[4 * i] = (byte0 | (byte1 << 8)) & mask;
-        out.coefficients[4 * i + 1] = ((byte1 >> 2) | (byte2 << 6)) & mask;
-        out.coefficients[4 * i + 2] = ((byte2 >> 4) | (byte3 << 4)) & mask;
-        out.coefficients[4 * i + 3] = ((byte3 >> 6) | (byte4 << 2)) & mask;
+    for i in 0..result.simd_units.len() {
+        result.simd_units[i] = PortableSIMDUnit::t1_deserialize(&serialized_chunks.next().unwrap());
     }
 
-    out
+    result.to_polynomial_ring_element()
 }
 
 #[cfg(test)]

--- a/libcrux-ml-dsa/src/matrix.rs
+++ b/libcrux-ml-dsa/src/matrix.rs
@@ -1,5 +1,5 @@
 use crate::{
-    arithmetic::shift_coefficients_left_then_reduce,
+    arithmetic::shift_left_then_reduce,
     constants::BITS_IN_LOWER_PART_OF_T,
     ntt::{invert_ntt_montgomery, ntt, ntt_multiply_montgomery},
     polynomial::{PolynomialRingElement, SIMDPolynomialRingElement},
@@ -150,7 +150,7 @@ pub(crate) fn compute_w_approx<const ROWS_IN_A: usize, const COLUMNS_IN_A: usize
             result[i] = result[i].add(&product);
         }
 
-        let t1_shifted = shift_coefficients_left_then_reduce(t1[i], BITS_IN_LOWER_PART_OF_T);
+        let t1_shifted = shift_left_then_reduce(t1[i], BITS_IN_LOWER_PART_OF_T);
         let challenge_times_t1_shifted =
             ntt_multiply_montgomery(&verifier_challenge_as_ntt, &ntt(t1_shifted));
         result[i] = invert_ntt_montgomery(result[i].sub(&challenge_times_t1_shifted));

--- a/libcrux-ml-dsa/src/ml_dsa_generic.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_generic.rs
@@ -87,7 +87,7 @@ struct Signature<
 > {
     commitment_hash: [u8; COMMITMENT_HASH_SIZE],
     signer_response: [PolynomialRingElement; COLUMNS_IN_A],
-    hint: [[bool; COEFFICIENTS_IN_RING_ELEMENT]; ROWS_IN_A],
+    hint: [[i32; COEFFICIENTS_IN_RING_ELEMENT]; ROWS_IN_A],
 }
 
 impl<const COMMITMENT_HASH_SIZE: usize, const COLUMNS_IN_A: usize, const ROWS_IN_A: usize>
@@ -123,7 +123,7 @@ impl<const COMMITMENT_HASH_SIZE: usize, const COLUMNS_IN_A: usize, const ROWS_IN
 
         for i in 0..ROWS_IN_A {
             for (j, hint) in self.hint[i].into_iter().enumerate() {
-                if hint {
+                if hint == 1 {
                     hint_serialized[true_hints_seen] = j as u8;
                     true_hints_seen += 1;
                 }
@@ -159,7 +159,7 @@ impl<const COMMITMENT_HASH_SIZE: usize, const COLUMNS_IN_A: usize, const ROWS_IN
 
         // While there are several ways to encode the same hint vector, we
         // allow only one such encoding, to ensure strong unforgeability.
-        let mut hint = [[false; COEFFICIENTS_IN_RING_ELEMENT]; ROWS_IN_A];
+        let mut hint = [[0; COEFFICIENTS_IN_RING_ELEMENT]; ROWS_IN_A];
 
         let mut previous_true_hints_seen = 0usize;
 
@@ -185,7 +185,7 @@ impl<const COMMITMENT_HASH_SIZE: usize, const COLUMNS_IN_A: usize, const ROWS_IN
                     return Err(VerificationError::MalformedHintError);
                 }
 
-                hint[i][hint_serialized[j] as usize] = true;
+                hint[i][hint_serialized[j] as usize] = 1;
             }
             previous_true_hints_seen = current_true_hints_seen;
         }

--- a/libcrux-ml-dsa/src/sample.rs
+++ b/libcrux-ml-dsa/src/sample.rs
@@ -248,7 +248,7 @@ pub(crate) fn sample_challenge_ring_element<const NUMBER_OF_ONES: usize>(
 mod tests {
     use super::*;
 
-    use crate::{arithmetic::FieldElement, constants::COEFFICIENTS_IN_RING_ELEMENT};
+    use crate::constants::COEFFICIENTS_IN_RING_ELEMENT;
 
     #[test]
     fn test_sample_ring_element_uniform() {
@@ -257,7 +257,7 @@ mod tests {
             91, 80, 128, 195, 219, 203, 149, 170, 233, 16, 232, 209, 105, 4, 5,
         ];
 
-        let expected_coefficients: [FieldElement; COEFFICIENTS_IN_RING_ELEMENT] = [
+        let expected_coefficients: [i32; COEFFICIENTS_IN_RING_ELEMENT] = [
             886541, 1468422, 793958, 7610434, 3986512, 913782, 2546456, 5820798, 1940159, 10062,
             3303190, 3831326, 4834267, 3500674, 16909, 8314529, 7469249, 5611755, 6181076, 269257,
             3566448, 2968856, 7556314, 6685884, 129963, 8017973, 1087829, 5842199, 6867133, 442098,

--- a/libcrux-ml-dsa/src/simd/portable.rs
+++ b/libcrux-ml-dsa/src/simd/portable.rs
@@ -58,7 +58,7 @@ impl Operations for PortableSIMDUnit {
     }
 
     fn gamma1_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE] {
-        encoding::gamma1::serialize::<OUTPUT_SIZE>(simd_unit)
+        encoding::gamma1::serialize(simd_unit)
     }
     fn gamma1_deserialize<const GAMMA1_EXPONENT: usize>(serialized: &[u8]) -> Self {
         encoding::gamma1::deserialize::<GAMMA1_EXPONENT>(serialized)
@@ -66,6 +66,13 @@ impl Operations for PortableSIMDUnit {
 
     fn commitment_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE] {
         encoding::commitment::serialize(simd_unit)
+    }
+
+    fn error_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE] {
+        encoding::error::serialize(simd_unit)
+    }
+    fn error_deserialize<const ETA: usize>(serialized: &[u8]) -> Self {
+        encoding::error::deserialize::<ETA>(serialized)
     }
 
     fn ntt_at_layer_0(simd_unit: Self, zeta0: i32, zeta1: i32, zeta2: i32, zeta3: i32) -> Self {

--- a/libcrux-ml-dsa/src/simd/portable.rs
+++ b/libcrux-ml-dsa/src/simd/portable.rs
@@ -57,11 +57,15 @@ impl Operations for PortableSIMDUnit {
         sample::rejection_sample_less_than_eta_equals_4(randomness, out)
     }
 
-    fn gamma1_serialize<const OUTPUT_BYTES: usize>(simd_unit: Self) -> [u8; OUTPUT_BYTES] {
-        encoding::gamma1::serialize::<OUTPUT_BYTES>(simd_unit)
+    fn gamma1_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE] {
+        encoding::gamma1::serialize::<OUTPUT_SIZE>(simd_unit)
     }
     fn gamma1_deserialize<const GAMMA1_EXPONENT: usize>(serialized: &[u8]) -> Self {
         encoding::gamma1::deserialize::<GAMMA1_EXPONENT>(serialized)
+    }
+
+    fn commitment_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE] {
+        encoding::commitment::serialize(simd_unit)
     }
 
     fn ntt_at_layer_0(simd_unit: Self, zeta0: i32, zeta1: i32, zeta2: i32, zeta3: i32) -> Self {

--- a/libcrux-ml-dsa/src/simd/portable.rs
+++ b/libcrux-ml-dsa/src/simd/portable.rs
@@ -57,10 +57,8 @@ impl Operations for PortableSIMDUnit {
         sample::rejection_sample_less_than_eta_equals_4(randomness, out)
     }
 
-    fn gamma1_serialize<const GAMMA1_EXPONENT: usize, const OUTPUT_BYTES: usize>(
-        simd_unit: Self,
-    ) -> [u8; OUTPUT_BYTES] {
-        encoding::gamma1::serialize::<GAMMA1_EXPONENT, OUTPUT_BYTES>(simd_unit)
+    fn gamma1_serialize<const OUTPUT_BYTES: usize>(simd_unit: Self) -> [u8; OUTPUT_BYTES] {
+        encoding::gamma1::serialize::<OUTPUT_BYTES>(simd_unit)
     }
     fn gamma1_deserialize<const GAMMA1_EXPONENT: usize>(serialized: &[u8]) -> Self {
         encoding::gamma1::deserialize::<GAMMA1_EXPONENT>(serialized)

--- a/libcrux-ml-dsa/src/simd/portable.rs
+++ b/libcrux-ml-dsa/src/simd/portable.rs
@@ -47,6 +47,10 @@ impl Operations for PortableSIMDUnit {
         arithmetic::infinity_norm_exceeds(simd_unit, bound)
     }
 
+    fn compute_hint<const GAMMA2: i32>(low: Self, high: Self) -> (usize, Self) {
+        arithmetic::compute_hint::<GAMMA2>(low, high)
+    }
+
     fn rejection_sample_less_than_field_modulus(randomness: &[u8], out: &mut [i32]) -> usize {
         sample::rejection_sample_less_than_field_modulus(randomness, out)
     }

--- a/libcrux-ml-dsa/src/simd/portable.rs
+++ b/libcrux-ml-dsa/src/simd/portable.rs
@@ -35,6 +35,9 @@ impl Operations for PortableSIMDUnit {
     fn montgomery_multiply(lhs: Self, rhs: Self) -> Self {
         arithmetic::montgomery_multiply(&lhs, &rhs)
     }
+    fn shift_left_then_reduce(simd_unit: Self, shift_by: usize) -> Self {
+        arithmetic::shift_left_then_reduce(simd_unit, shift_by)
+    }
 
     fn power2round(simd_unit: Self) -> (Self, Self) {
         arithmetic::power2round(simd_unit)

--- a/libcrux-ml-dsa/src/simd/portable.rs
+++ b/libcrux-ml-dsa/src/simd/portable.rs
@@ -75,6 +75,20 @@ impl Operations for PortableSIMDUnit {
         encoding::error::deserialize::<ETA>(serialized)
     }
 
+    fn t0_serialize(simd_unit: Self) -> [u8; 13] {
+        encoding::t0::serialize(simd_unit)
+    }
+    fn t0_deserialize(serialized: &[u8]) -> Self {
+        encoding::t0::deserialize(serialized)
+    }
+
+    fn t1_serialize(simd_unit: Self) -> [u8; 10] {
+        encoding::t1::serialize(simd_unit)
+    }
+    fn t1_deserialize(serialized: &[u8]) -> Self {
+        encoding::t1::deserialize(serialized)
+    }
+
     fn ntt_at_layer_0(simd_unit: Self, zeta0: i32, zeta1: i32, zeta2: i32, zeta3: i32) -> Self {
         ntt::ntt_at_layer_0(simd_unit, zeta0, zeta1, zeta2, zeta3)
     }

--- a/libcrux-ml-dsa/src/simd/portable/arithmetic.rs
+++ b/libcrux-ml-dsa/src/simd/portable/arithmetic.rs
@@ -167,6 +167,24 @@ pub fn infinity_norm_exceeds(simd_unit: PortableSIMDUnit, bound: i32) -> bool {
     exceeds
 }
 
+#[inline(always)]
+fn reduce_element(fe: FieldElement) -> FieldElement {
+    let quotient = (fe + (1 << 22)) >> 23;
+
+    fe - (quotient * FIELD_MODULUS)
+}
+
+#[inline(always)]
+pub fn shift_left_then_reduce(simd_unit: PortableSIMDUnit, shift_by: usize) -> PortableSIMDUnit {
+    let mut out = ZERO();
+
+    for i in 0..simd_unit.coefficients.len() {
+        out.coefficients[i] = reduce_element(simd_unit.coefficients[i] << shift_by);
+    }
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libcrux-ml-dsa/src/simd/portable/arithmetic.rs
+++ b/libcrux-ml-dsa/src/simd/portable/arithmetic.rs
@@ -185,6 +185,32 @@ pub fn shift_left_then_reduce(simd_unit: PortableSIMDUnit, shift_by: usize) -> P
     out
 }
 
+#[inline(always)]
+fn compute_one_hint<const GAMMA2: i32>(low: i32, high: i32) -> i32 {
+    if (low > GAMMA2) || (low < -GAMMA2) || (low == -GAMMA2 && high != 0) {
+        1
+    } else {
+        0
+    }
+}
+
+#[inline(always)]
+pub fn compute_hint<const GAMMA2: i32>(
+    low: PortableSIMDUnit,
+    high: PortableSIMDUnit,
+) -> (usize, PortableSIMDUnit) {
+    let mut hint = ZERO();
+    let mut one_hints_count = 0;
+
+    for i in 0..hint.coefficients.len() {
+        hint.coefficients[i] =
+            compute_one_hint::<GAMMA2>(low.coefficients[i], high.coefficients[i]);
+        one_hints_count += hint.coefficients[i] as usize;
+    }
+
+    (one_hints_count, hint)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libcrux-ml-dsa/src/simd/portable/encoding.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding.rs
@@ -1,3 +1,5 @@
 pub mod commitment;
 pub mod error;
 pub mod gamma1;
+pub mod t0;
+pub mod t1;

--- a/libcrux-ml-dsa/src/simd/portable/encoding.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding.rs
@@ -1,1 +1,2 @@
+pub mod commitment;
 pub mod gamma1;

--- a/libcrux-ml-dsa/src/simd/portable/encoding.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding.rs
@@ -1,2 +1,3 @@
 pub mod commitment;
+pub mod error;
 pub mod gamma1;

--- a/libcrux-ml-dsa/src/simd/portable/encoding/commitment.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/commitment.rs
@@ -1,0 +1,40 @@
+use crate::simd::portable::simd_unit_type::PortableSIMDUnit;
+
+#[inline(always)]
+pub fn serialize<const OUTPUT_SIZE: usize>(simd_unit: PortableSIMDUnit) -> [u8; OUTPUT_SIZE] {
+    let mut serialized = [0u8; OUTPUT_SIZE];
+
+    match OUTPUT_SIZE {
+        4 => {
+            // The commitment has coefficients in [0,15] => each coefficient occupies
+            // 4 bits.
+            for (i, coefficients) in simd_unit.coefficients.chunks_exact(2).enumerate() {
+                let coefficient0 = coefficients[0] as u8;
+                let coefficient1 = coefficients[1] as u8;
+
+                serialized[i] = (coefficient1 << 4) | coefficient0;
+            }
+
+            serialized
+        }
+
+        6 => {
+            // The commitment has coefficients in [0,43] => each coefficient occupies
+            // 6 bits.
+            for (i, coefficients) in simd_unit.coefficients.chunks_exact(4).enumerate() {
+                let coefficient0 = coefficients[0] as u8;
+                let coefficient1 = coefficients[1] as u8;
+                let coefficient2 = coefficients[2] as u8;
+                let coefficient3 = coefficients[3] as u8;
+
+                serialized[3 * i] = (coefficient1 << 6) | coefficient0;
+                serialized[3 * i + 1] = (coefficient2 << 4) | coefficient1 >> 2;
+                serialized[3 * i + 2] = (coefficient3 << 2) | coefficient2 >> 4;
+            }
+
+            serialized
+        }
+
+        _ => unreachable!(),
+    }
+}

--- a/libcrux-ml-dsa/src/simd/portable/encoding/error.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/error.rs
@@ -1,0 +1,96 @@
+use crate::simd::portable::simd_unit_type::{self, PortableSIMDUnit};
+
+#[inline(always)]
+fn serialize_when_eta_is_2<const OUTPUT_SIZE: usize>(
+    simd_unit: PortableSIMDUnit,
+) -> [u8; OUTPUT_SIZE] {
+    let mut serialized = [0u8; OUTPUT_SIZE];
+    const ETA: i32 = 2;
+
+    let coefficient0 = (ETA - simd_unit.coefficients[0]) as u8;
+    let coefficient1 = (ETA - simd_unit.coefficients[1]) as u8;
+    let coefficient2 = (ETA - simd_unit.coefficients[2]) as u8;
+    let coefficient3 = (ETA - simd_unit.coefficients[3]) as u8;
+    let coefficient4 = (ETA - simd_unit.coefficients[4]) as u8;
+    let coefficient5 = (ETA - simd_unit.coefficients[5]) as u8;
+    let coefficient6 = (ETA - simd_unit.coefficients[6]) as u8;
+    let coefficient7 = (ETA - simd_unit.coefficients[7]) as u8;
+
+    serialized[0] = (coefficient2 << 6) | (coefficient1 << 3) | coefficient0;
+    serialized[1] =
+        (coefficient5 << 7) | (coefficient4 << 4) | (coefficient3 << 1) | (coefficient2 >> 2);
+    serialized[2] = (coefficient7 << 5) | (coefficient6 << 2) | (coefficient5 >> 1);
+
+    serialized
+}
+#[inline(always)]
+fn serialize_when_eta_is_4<const OUTPUT_SIZE: usize>(
+    simd_unit: PortableSIMDUnit,
+) -> [u8; OUTPUT_SIZE] {
+    let mut serialized = [0u8; OUTPUT_SIZE];
+    const ETA: i32 = 4;
+
+    for (i, coefficients) in simd_unit.coefficients.chunks_exact(2).enumerate() {
+        let coefficient0 = (ETA - coefficients[0]) as u8;
+        let coefficient1 = (ETA - coefficients[1]) as u8;
+
+        serialized[i] = (coefficient1 << 4) | coefficient0;
+    }
+
+    serialized
+}
+#[inline(always)]
+pub(crate) fn serialize<const OUTPUT_SIZE: usize>(
+    simd_unit: PortableSIMDUnit,
+) -> [u8; OUTPUT_SIZE] {
+    match OUTPUT_SIZE {
+        3 => serialize_when_eta_is_2::<OUTPUT_SIZE>(simd_unit),
+        4 => serialize_when_eta_is_4::<OUTPUT_SIZE>(simd_unit),
+        _ => unreachable!(),
+    }
+}
+
+#[inline(always)]
+fn deserialize_when_eta_is_2(serialized: &[u8]) -> PortableSIMDUnit {
+    debug_assert!(serialized.len() == 3);
+
+    let mut simd_unit = simd_unit_type::ZERO();
+    const ETA: i32 = 2;
+
+    let byte0 = serialized[0] as i32;
+    let byte1 = serialized[1] as i32;
+    let byte2 = serialized[2] as i32;
+
+    simd_unit.coefficients[0] = ETA - (byte0 & 7);
+    simd_unit.coefficients[1] = ETA - ((byte0 >> 3) & 7);
+    simd_unit.coefficients[2] = ETA - (((byte0 >> 6) | (byte1 << 2)) & 7);
+    simd_unit.coefficients[3] = ETA - ((byte1 >> 1) & 7);
+    simd_unit.coefficients[4] = ETA - ((byte1 >> 4) & 7);
+    simd_unit.coefficients[5] = ETA - (((byte1 >> 7) | (byte2 << 1)) & 7);
+    simd_unit.coefficients[6] = ETA - ((byte2 >> 2) & 7);
+    simd_unit.coefficients[7] = ETA - ((byte2 >> 5) & 7);
+
+    simd_unit
+}
+#[inline(always)]
+fn deserialize_when_eta_is_4(serialized: &[u8]) -> PortableSIMDUnit {
+    debug_assert!(serialized.len() == 4);
+
+    let mut simd_unit = simd_unit_type::ZERO();
+    const ETA: i32 = 4;
+
+    for (i, byte) in serialized.iter().enumerate() {
+        simd_unit.coefficients[2 * i] = ETA - ((byte & 0xF) as i32);
+        simd_unit.coefficients[2 * i + 1] = ETA - ((byte >> 4) as i32);
+    }
+
+    simd_unit
+}
+#[inline(always)]
+pub(crate) fn deserialize<const ETA: usize>(serialized: &[u8]) -> PortableSIMDUnit {
+    match ETA {
+        2 => deserialize_when_eta_is_2(serialized),
+        4 => deserialize_when_eta_is_4(serialized),
+        _ => unreachable!(),
+    }
+}

--- a/libcrux-ml-dsa/src/simd/portable/encoding/gamma1.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/gamma1.rs
@@ -61,12 +61,12 @@ fn serialize_when_gamma1_is_2_pow_19<const OUTPUT_BYTES: usize>(
     serialized
 }
 #[inline(always)]
-pub(crate) fn serialize<const GAMMA1_EXPONENT: usize, const OUTPUT_BYTES: usize>(
+pub(crate) fn serialize<const OUTPUT_BYTES: usize>(
     simd_unit: PortableSIMDUnit,
 ) -> [u8; OUTPUT_BYTES] {
-    match GAMMA1_EXPONENT {
-        17 => serialize_when_gamma1_is_2_pow_17::<OUTPUT_BYTES>(simd_unit),
-        19 => serialize_when_gamma1_is_2_pow_19::<OUTPUT_BYTES>(simd_unit),
+    match OUTPUT_BYTES {
+        18 => serialize_when_gamma1_is_2_pow_17::<OUTPUT_BYTES>(simd_unit),
+        20 => serialize_when_gamma1_is_2_pow_19::<OUTPUT_BYTES>(simd_unit),
         _ => unreachable!(),
     }
 }

--- a/libcrux-ml-dsa/src/simd/portable/encoding/gamma1.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/gamma1.rs
@@ -1,12 +1,12 @@
 use crate::simd::portable::simd_unit_type::*;
 
 #[inline(always)]
-fn serialize_when_gamma1_is_2_pow_17<const OUTPUT_BYTES: usize>(
+fn serialize_when_gamma1_is_2_pow_17<const OUTPUT_SIZE: usize>(
     simd_unit: PortableSIMDUnit,
-) -> [u8; OUTPUT_BYTES] {
+) -> [u8; OUTPUT_SIZE] {
     const GAMMA1: i32 = 1 << 17;
 
-    let mut serialized = [0u8; OUTPUT_BYTES];
+    let mut serialized = [0u8; OUTPUT_SIZE];
 
     for (i, coefficients) in simd_unit.coefficients.chunks_exact(4).enumerate() {
         let coefficient0 = GAMMA1 - coefficients[0];
@@ -37,12 +37,12 @@ fn serialize_when_gamma1_is_2_pow_17<const OUTPUT_BYTES: usize>(
     serialized
 }
 #[inline(always)]
-fn serialize_when_gamma1_is_2_pow_19<const OUTPUT_BYTES: usize>(
+fn serialize_when_gamma1_is_2_pow_19<const OUTPUT_SIZE: usize>(
     simd_unit: PortableSIMDUnit,
-) -> [u8; OUTPUT_BYTES] {
+) -> [u8; OUTPUT_SIZE] {
     const GAMMA1: i32 = 1 << 19;
 
-    let mut serialized = [0u8; OUTPUT_BYTES];
+    let mut serialized = [0u8; OUTPUT_SIZE];
 
     for (i, coefficients) in simd_unit.coefficients.chunks_exact(2).enumerate() {
         let coefficient0 = GAMMA1 - coefficients[0];
@@ -61,12 +61,12 @@ fn serialize_when_gamma1_is_2_pow_19<const OUTPUT_BYTES: usize>(
     serialized
 }
 #[inline(always)]
-pub(crate) fn serialize<const OUTPUT_BYTES: usize>(
+pub(crate) fn serialize<const OUTPUT_SIZE: usize>(
     simd_unit: PortableSIMDUnit,
-) -> [u8; OUTPUT_BYTES] {
-    match OUTPUT_BYTES {
-        18 => serialize_when_gamma1_is_2_pow_17::<OUTPUT_BYTES>(simd_unit),
-        20 => serialize_when_gamma1_is_2_pow_19::<OUTPUT_BYTES>(simd_unit),
+) -> [u8; OUTPUT_SIZE] {
+    match OUTPUT_SIZE {
+        18 => serialize_when_gamma1_is_2_pow_17::<OUTPUT_SIZE>(simd_unit),
+        20 => serialize_when_gamma1_is_2_pow_19::<OUTPUT_SIZE>(simd_unit),
         _ => unreachable!(),
     }
 }

--- a/libcrux-ml-dsa/src/simd/portable/encoding/t0.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/t0.rs
@@ -1,0 +1,130 @@
+use crate::{
+    constants::BITS_IN_LOWER_PART_OF_T,
+    simd::portable::simd_unit_type::{self, PortableSIMDUnit},
+};
+
+// If t0 is a signed representative, change it to an unsigned one and
+// vice versa.
+#[inline(always)]
+fn change_t0_interval(t0: i32) -> i32 {
+    (1 << (BITS_IN_LOWER_PART_OF_T - 1)) - t0
+}
+
+#[inline(always)]
+pub fn serialize(simd_unit: PortableSIMDUnit) -> [u8; 13] {
+    let mut serialized = [0u8; 13];
+
+    let coefficient0 = change_t0_interval(simd_unit.coefficients[0]);
+    let coefficient1 = change_t0_interval(simd_unit.coefficients[1]);
+    let coefficient2 = change_t0_interval(simd_unit.coefficients[2]);
+    let coefficient3 = change_t0_interval(simd_unit.coefficients[3]);
+    let coefficient4 = change_t0_interval(simd_unit.coefficients[4]);
+    let coefficient5 = change_t0_interval(simd_unit.coefficients[5]);
+    let coefficient6 = change_t0_interval(simd_unit.coefficients[6]);
+    let coefficient7 = change_t0_interval(simd_unit.coefficients[7]);
+
+    serialized[0] = coefficient0 as u8;
+
+    serialized[1] = (coefficient0 >> 8) as u8;
+    serialized[1] |= (coefficient1 << 5) as u8;
+
+    serialized[2] = (coefficient1 >> 3) as u8;
+
+    serialized[3] = (coefficient1 >> 11) as u8;
+    serialized[3] |= (coefficient2 << 2) as u8;
+
+    serialized[4] = (coefficient2 >> 6) as u8;
+    serialized[4] |= (coefficient3 << 7) as u8;
+
+    serialized[5] = (coefficient3 >> 1) as u8;
+
+    serialized[6] = (coefficient3 >> 9) as u8;
+    serialized[6] |= (coefficient4 << 4) as u8;
+
+    serialized[7] = (coefficient4 >> 4) as u8;
+
+    serialized[8] = (coefficient4 >> 12) as u8;
+    serialized[8] |= (coefficient5 << 1) as u8;
+
+    serialized[9] = (coefficient5 >> 7) as u8;
+    serialized[9] |= (coefficient6 << 6) as u8;
+
+    serialized[10] = (coefficient6 >> 2) as u8;
+
+    serialized[11] = (coefficient6 >> 10) as u8;
+    serialized[11] |= (coefficient7 << 3) as u8;
+
+    serialized[12] = (coefficient7 >> 5) as u8;
+
+    serialized
+}
+
+#[inline(always)]
+pub fn deserialize(serialized: &[u8]) -> PortableSIMDUnit {
+    debug_assert!(serialized.len() == 13);
+
+    let mut simd_unit = simd_unit_type::ZERO();
+
+    const BITS_IN_LOWER_PART_OF_T_MASK: i32 = (1 << (BITS_IN_LOWER_PART_OF_T as i32)) - 1;
+
+    let byte0 = serialized[0] as i32;
+    let byte1 = serialized[1] as i32;
+    let byte2 = serialized[2] as i32;
+    let byte3 = serialized[3] as i32;
+    let byte4 = serialized[4] as i32;
+    let byte5 = serialized[5] as i32;
+    let byte6 = serialized[6] as i32;
+    let byte7 = serialized[7] as i32;
+    let byte8 = serialized[8] as i32;
+    let byte9 = serialized[9] as i32;
+    let byte10 = serialized[10] as i32;
+    let byte11 = serialized[11] as i32;
+    let byte12 = serialized[12] as i32;
+
+    simd_unit.coefficients[0] = byte0;
+    simd_unit.coefficients[0] |= byte1 << 8;
+    simd_unit.coefficients[0] &= BITS_IN_LOWER_PART_OF_T_MASK;
+
+    simd_unit.coefficients[1] = byte1 >> 5;
+    simd_unit.coefficients[1] |= byte2 << 3;
+    simd_unit.coefficients[1] |= byte3 << 11;
+    simd_unit.coefficients[1] &= BITS_IN_LOWER_PART_OF_T_MASK;
+
+    simd_unit.coefficients[2] = byte3 >> 2;
+    simd_unit.coefficients[2] |= byte4 << 6;
+    simd_unit.coefficients[2] &= BITS_IN_LOWER_PART_OF_T_MASK;
+
+    simd_unit.coefficients[3] = byte4 >> 7;
+    simd_unit.coefficients[3] |= byte5 << 1;
+    simd_unit.coefficients[3] |= byte6 << 9;
+    simd_unit.coefficients[3] &= BITS_IN_LOWER_PART_OF_T_MASK;
+
+    simd_unit.coefficients[4] = byte6 >> 4;
+    simd_unit.coefficients[4] |= byte7 << 4;
+    simd_unit.coefficients[4] |= byte8 << 12;
+    simd_unit.coefficients[4] &= BITS_IN_LOWER_PART_OF_T_MASK;
+
+    simd_unit.coefficients[5] = byte8 >> 1;
+    simd_unit.coefficients[5] |= byte9 << 7;
+    simd_unit.coefficients[5] &= BITS_IN_LOWER_PART_OF_T_MASK;
+
+    simd_unit.coefficients[6] = byte9 >> 6;
+    simd_unit.coefficients[6] |= byte10 << 2;
+    simd_unit.coefficients[6] |= byte11 << 10;
+    simd_unit.coefficients[6] &= BITS_IN_LOWER_PART_OF_T_MASK;
+
+    simd_unit.coefficients[7] = byte11 >> 3;
+    simd_unit.coefficients[7] |= byte12 << 5;
+    simd_unit.coefficients[7] &= BITS_IN_LOWER_PART_OF_T_MASK;
+
+    simd_unit.coefficients[0] = change_t0_interval(simd_unit.coefficients[0]);
+    simd_unit.coefficients[1] = change_t0_interval(simd_unit.coefficients[1]);
+    simd_unit.coefficients[2] = change_t0_interval(simd_unit.coefficients[2]);
+    simd_unit.coefficients[3] = change_t0_interval(simd_unit.coefficients[3]);
+    simd_unit.coefficients[4] = change_t0_interval(simd_unit.coefficients[4]);
+    simd_unit.coefficients[5] = change_t0_interval(simd_unit.coefficients[5]);
+    simd_unit.coefficients[6] = change_t0_interval(simd_unit.coefficients[6]);
+    simd_unit.coefficients[7] = change_t0_interval(simd_unit.coefficients[7]);
+
+    simd_unit
+}

--- a/libcrux-ml-dsa/src/simd/portable/encoding/t1.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/t1.rs
@@ -1,0 +1,45 @@
+use crate::{
+    constants::BITS_IN_UPPER_PART_OF_T,
+    simd::portable::simd_unit_type::{self, PortableSIMDUnit},
+};
+
+#[inline(always)]
+pub fn serialize(simd_unit: PortableSIMDUnit) -> [u8; 10] {
+    let mut serialized = [0u8; 10];
+
+    for (i, coefficients) in simd_unit.coefficients.chunks_exact(4).enumerate() {
+        serialized[5 * i] = (coefficients[0] & 0xFF) as u8;
+        serialized[5 * i + 1] =
+            ((coefficients[1] & 0x3F) as u8) << 2 | ((coefficients[0] >> 8) & 0x03) as u8;
+        serialized[5 * i + 2] =
+            ((coefficients[2] & 0x0F) as u8) << 4 | ((coefficients[1] >> 6) & 0x0F) as u8;
+        serialized[5 * i + 3] =
+            ((coefficients[3] & 0x03) as u8) << 6 | ((coefficients[2] >> 4) & 0x3F) as u8;
+        serialized[5 * i + 4] = ((coefficients[3] >> 2) & 0xFF) as u8;
+    }
+
+    serialized
+}
+
+#[inline(always)]
+pub fn deserialize(serialized: &[u8]) -> PortableSIMDUnit {
+    debug_assert!(serialized.len() == 10);
+
+    let mut simd_unit = simd_unit_type::ZERO();
+    let mask = (1 << BITS_IN_UPPER_PART_OF_T) - 1;
+
+    for (i, bytes) in serialized.chunks_exact(5).enumerate() {
+        let byte0 = bytes[0] as i32;
+        let byte1 = bytes[1] as i32;
+        let byte2 = bytes[2] as i32;
+        let byte3 = bytes[3] as i32;
+        let byte4 = bytes[4] as i32;
+
+        simd_unit.coefficients[4 * i] = (byte0 | (byte1 << 8)) & mask;
+        simd_unit.coefficients[4 * i + 1] = ((byte1 >> 2) | (byte2 << 6)) & mask;
+        simd_unit.coefficients[4 * i + 2] = ((byte2 >> 4) | (byte3 << 4)) & mask;
+        simd_unit.coefficients[4 * i + 3] = ((byte3 >> 6) | (byte4 << 2)) & mask;
+    }
+
+    simd_unit
+}

--- a/libcrux-ml-dsa/src/simd/traits.rs
+++ b/libcrux-ml-dsa/src/simd/traits.rs
@@ -46,6 +46,9 @@ pub(crate) trait Operations: Copy + Clone {
 
     fn commitment_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE];
 
+    fn error_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE];
+    fn error_deserialize<const ETA: usize>(serialized: &[u8]) -> Self;
+
     // NTT
     fn ntt_at_layer_0(simd_unit: Self, zeta0: i32, zeta1: i32, zeta2: i32, zeta3: i32) -> Self;
     fn ntt_at_layer_1(simd_unit: Self, zeta0: i32, zeta1: i32) -> Self;

--- a/libcrux-ml-dsa/src/simd/traits.rs
+++ b/libcrux-ml-dsa/src/simd/traits.rs
@@ -40,10 +40,8 @@ pub(crate) trait Operations: Copy + Clone {
     fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32]) -> usize;
     fn rejection_sample_less_than_eta_equals_4(randomness: &[u8], out: &mut [i32]) -> usize;
 
-    // Deserialization
-    fn gamma1_serialize<const GAMMA1_EXPONENT: usize, const OUTPUT_BYTES: usize>(
-        simd_unit: Self,
-    ) -> [u8; OUTPUT_BYTES];
+    // Serialization
+    fn gamma1_serialize<const OUTPUT_BYTES: usize>(simd_unit: Self) -> [u8; OUTPUT_BYTES];
     fn gamma1_deserialize<const GAMMA1_EXPONENT: usize>(serialized: &[u8]) -> Self;
 
     // NTT

--- a/libcrux-ml-dsa/src/simd/traits.rs
+++ b/libcrux-ml-dsa/src/simd/traits.rs
@@ -17,6 +17,7 @@ pub(crate) trait Operations: Copy + Clone {
     fn add(lhs: &Self, rhs: &Self) -> Self;
     fn subtract(lhs: &Self, rhs: &Self) -> Self;
     fn infinity_norm_exceeds(simd_unit: Self, bound: i32) -> bool;
+    fn compute_hint<const GAMMA2: i32>(low: Self, high: Self) -> (usize, Self);
 
     // Modular operations
     fn montgomery_multiply(lhs: Self, rhs: Self) -> Self;

--- a/libcrux-ml-dsa/src/simd/traits.rs
+++ b/libcrux-ml-dsa/src/simd/traits.rs
@@ -40,9 +40,11 @@ pub(crate) trait Operations: Copy + Clone {
     fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32]) -> usize;
     fn rejection_sample_less_than_eta_equals_4(randomness: &[u8], out: &mut [i32]) -> usize;
 
-    // Serialization
-    fn gamma1_serialize<const OUTPUT_BYTES: usize>(simd_unit: Self) -> [u8; OUTPUT_BYTES];
+    // Encoding operations
+    fn gamma1_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE];
     fn gamma1_deserialize<const GAMMA1_EXPONENT: usize>(serialized: &[u8]) -> Self;
+
+    fn commitment_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE];
 
     // NTT
     fn ntt_at_layer_0(simd_unit: Self, zeta0: i32, zeta1: i32, zeta2: i32, zeta3: i32) -> Self;

--- a/libcrux-ml-dsa/src/simd/traits.rs
+++ b/libcrux-ml-dsa/src/simd/traits.rs
@@ -21,6 +21,7 @@ pub(crate) trait Operations: Copy + Clone {
     // Modular operations
     fn montgomery_multiply(lhs: Self, rhs: Self) -> Self;
     fn montgomery_multiply_by_constant(simd_unit: Self, c: i32) -> Self;
+    fn shift_left_then_reduce(simd_unit: Self, shift_by: usize) -> Self;
 
     // Decomposition operations
     fn power2round(simd_unit: Self) -> (Self, Self);

--- a/libcrux-ml-dsa/src/simd/traits.rs
+++ b/libcrux-ml-dsa/src/simd/traits.rs
@@ -41,13 +41,25 @@ pub(crate) trait Operations: Copy + Clone {
     fn rejection_sample_less_than_eta_equals_4(randomness: &[u8], out: &mut [i32]) -> usize;
 
     // Encoding operations
+
+    // Gamma1
     fn gamma1_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE];
     fn gamma1_deserialize<const GAMMA1_EXPONENT: usize>(serialized: &[u8]) -> Self;
 
+    // Commitment
     fn commitment_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE];
 
+    // Error
     fn error_serialize<const OUTPUT_SIZE: usize>(simd_unit: Self) -> [u8; OUTPUT_SIZE];
     fn error_deserialize<const ETA: usize>(serialized: &[u8]) -> Self;
+
+    // t0
+    fn t0_serialize(simd_unit: Self) -> [u8; 13];
+    fn t0_deserialize(serialized: &[u8]) -> Self;
+
+    // t1
+    fn t1_serialize(simd_unit: Self) -> [u8; 10];
+    fn t1_deserialize(serialized: &[u8]) -> Self;
 
     // NTT
     fn ntt_at_layer_0(simd_unit: Self, zeta0: i32, zeta1: i32, zeta2: i32, zeta3: i32) -> Self;


### PR DESCRIPTION
- hints are now represented using `i32`s instead of `bool`s.