### PR TITLE
Update C extraction Docker file

### DIFF
--- a/.docker/c/Dockerfile
+++ b/.docker/c/Dockerfile
@@ -4,12 +4,12 @@
 FROM ubuntu:24.04
 LABEL maintainer="Franziskus Kiefer <franziskuskiefer@gmail.com>"
 
-ENV SHELL /bin/bash
-ENV USER user
-ENV LOGNAME $USER
-ENV HOME /home/$USER
-ENV LANG en_US.UTF-8
-ENV LC_ALL $LANG
+ENV SHELL=/bin/bash
+ENV USER=user
+ENV LOGNAME=$USER
+ENV HOME=/home/$USER
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=$LANG
 ENV PATH="$HOME/.cargo/bin:${PATH}"
 
 # Install dependencies.
@@ -24,9 +24,9 @@ COPY --chown=$USER:$USER . $HOME/$USER
 ADD install.sh /tmp/install.sh
 RUN bash /tmp/install.sh
 
-ENV FSTAR_HOME $HOME/fstar
-ENV HACL_HOME $HOME/hacl-star
-ENV KRML_HOME $HOME/karamel
-ENV EURYDICE_HOME $HOME/eurydice
-ENV CHARON_HOME $HOME/charon
-ENV PATH "${PATH}:$HOME/fstar/bin:$HOME/z3/bin"
+ENV FSTAR_HOME=$HOME/fstar
+ENV HACL_HOME=$HOME/hacl-star
+ENV KRML_HOME=$HOME/karamel
+ENV EURYDICE_HOME=$HOME/eurydice
+ENV CHARON_HOME=$HOME/charon
+ENV PATH="${PATH}:$HOME/fstar/bin:$HOME/z3/bin"

--- a/.docker/c/install.sh
+++ b/.docker/c/install.sh
@@ -19,29 +19,30 @@ unzip z3.zip
 rm -rf z3.zip
 mv z3-4.8.5-x64-ubuntu-16.04/ z3
 
-curl -L https://github.com/hacl-star/hacl-star/archive/443aed2deccfbee84f928fadc1f594f729c3aad4.zip \
+curl -L https://github.com/hacl-star/hacl-star/archive/2a8b61343a1a7232611cb763b0dc3e4dff84d656.zip \
     --output hacl-star.zip
 unzip hacl-star.zip
 rm -rf hacl-star.zip
-mv hacl-star-443aed2deccfbee84f928fadc1f594f729c3aad4/ hacl-star
+mv hacl-star-2a8b61343a1a7232611cb763b0dc3e4dff84d656/ hacl-star
 
-curl -L https://github.com/AeneasVerif/charon/archive/89cecf5d1074fae7e8007be7f6cdf2f38e9782b1.zip \
+curl -L https://github.com/AeneasVerif/charon/archive/3f02eeef60c96793e6ae50391a4c4c8925262dc5.zip \
     --output charon.zip
 unzip charon.zip
 rm -rf charon.zip
-mv charon-89cecf5d1074fae7e8007be7f6cdf2f38e9782b1/ charon
+mv charon-3f02eeef60c96793e6ae50391a4c4c8925262dc5/ charon
 
-curl -L https://github.com/FStarLang/karamel/archive/08bfa78ae1df5639446e6c5897b07c9823fbf3b0.zip \
+
+curl -L https://github.com/FStarLang/karamel/archive/65aab550cf3ba36d52ae6ad1ad962bb573406395.zip \
     --output karamel.zip
 unzip karamel.zip
 rm -rf karamel.zip
-mv karamel-08bfa78ae1df5639446e6c5897b07c9823fbf3b0/ karamel
+mv karamel-65aab550cf3ba36d52ae6ad1ad962bb573406395/ karamel
 
-curl -L https://github.com/AeneasVerif/eurydice/archive/7780d2b4c44c7811d02d7e05789b5611fd497480.zip \
+curl -L https://github.com/AeneasVerif/eurydice/archive/e888878c640c71e2cd0456ed51d70c9b054470e6.zip \
     --output eurydice.zip
 unzip eurydice.zip
 rm -rf eurydice.zip
-mv eurydice-7780d2b4c44c7811d02d7e05789b5611fd497480/ eurydice
+mv eurydice-e888878c640c71e2cd0456ed51d70c9b054470e6/ eurydice
 
 echo "export FSTAR_HOME=$HOME/fstar" >>$HOME/.profile
 echo "export HACL_HOME=$HOME/hacl-star" >>$HOME/.profile
@@ -53,7 +54,7 @@ echo "export PATH=\"${PATH}:$HOME/fstar/bin:$HOME/z3/bin\"" >>$HOME/.profile
 echo "[[ ! -r /home/$USER/.opam/opam-init/init.sh ]] || source /home/$USER/.opam/opam-init/init.sh  > /dev/null 2> /dev/null" >>$HOME/.profile
 
 source $HOME/.profile
-opam install --yes ocamlfind visitors menhir ppx_deriving_yojson sedlex wasm fix process pprint zarith yaml easy_logging terminal
+opam install --yes ocamlfind visitors menhir ppx_deriving_yojson core_unix sedlex wasm fix process pprint zarith yaml easy_logging terminal
 eval $(opam env)
 
 # Build everything

--- a/.docker/c/setup.sh
+++ b/.docker/c/setup.sh
@@ -12,6 +12,8 @@ apt-get install -y \
     jq \
     libgmp-dev \
     locales \
+    pkg-config \
+    clang-format\
     curl
 curl -fsSL https://deb.nodesource.com/setup_21.x | bash -
 apt-get update


### PR DESCRIPTION
This PR is a first step towards getting C extraction on CI:

- Update the revisions of HACL*, Charon, Karamel and Eurydice to their current latest main branch state.
- Fix depencencies for these tools in the Docker image.

With this, the image could be published I think.