### PR TITLE
Make ML-KEM serialize.rs panic-free

### DIFF
--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fst
@@ -395,12 +395,21 @@ let compress_then_serialize_ring_element_u
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
      =
+  let _:Prims.unit =
+    assert ((v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 10) \/
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 11))
+  in
+  let _:Prims.unit =
+    Rust_primitives.Integers.mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR)
+  in
   match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
   | 10ul -> compress_then_serialize_10_ v_OUT_LEN #v_Vector re
-  | 11ul ->
-    let _:Prims.unit = Hax_lib.v_assume (v_OUT_LEN =. sz 352 <: bool) in
-    compress_then_serialize_11_ v_OUT_LEN #v_Vector re
-  | _ -> Rust_primitives.Hax.repeat 0uy v_OUT_LEN
+  | 11ul -> compress_then_serialize_11_ v_OUT_LEN #v_Vector re
+  | _ ->
+    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+
+        <:
+        Rust_primitives.Hax.t_Never)
 
 let compress_then_serialize_ring_element_v
       (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
@@ -411,13 +420,25 @@ let compress_then_serialize_ring_element_v
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
       (out: t_Slice u8)
      =
+  let _:Prims.unit =
+    assert ((v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 4) \/
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 5))
+  in
+  let _:Prims.unit =
+    Rust_primitives.Integers.mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR)
+  in
   let out, hax_temp_output:(t_Slice u8 & Prims.unit) =
     match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
     | 4ul -> compress_then_serialize_4_ #v_Vector re out, () <: (t_Slice u8 & Prims.unit)
-    | 5ul ->
-      let _:Prims.unit = Hax_lib.v_assume (v_OUT_LEN =. sz 160 <: bool) in
-      compress_then_serialize_5_ #v_Vector re out, () <: (t_Slice u8 & Prims.unit)
-    | _ -> out, (() <: Prims.unit) <: (t_Slice u8 & Prims.unit)
+    | 5ul -> compress_then_serialize_5_ #v_Vector re out, () <: (t_Slice u8 & Prims.unit)
+    | _ ->
+      out,
+      Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+
+          <:
+          Rust_primitives.Hax.t_Never)
+      <:
+      (t_Slice u8 & Prims.unit)
   in
   out
 
@@ -758,18 +779,21 @@ let deserialize_then_decompress_ring_element_u
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (serialized: t_Slice u8)
      =
+  let _:Prims.unit =
+    assert ((v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 10) \/
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 11))
+  in
+  let _:Prims.unit =
+    Rust_primitives.Integers.mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR)
+  in
   match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
-  | 10ul ->
-    let _:Prims.unit =
-      Hax_lib.v_assume ((Core.Slice.impl__len #u8 serialized <: usize) =. sz 320 <: bool)
-    in
-    deserialize_then_decompress_10_ #v_Vector serialized
-  | 11ul ->
-    let _:Prims.unit =
-      Hax_lib.v_assume ((Core.Slice.impl__len #u8 serialized <: usize) =. sz 352 <: bool)
-    in
-    deserialize_then_decompress_11_ #v_Vector serialized
-  | _ -> Libcrux_ml_kem.Polynomial.impl__ZERO #v_Vector ()
+  | 10ul -> deserialize_then_decompress_10_ #v_Vector serialized
+  | 11ul -> deserialize_then_decompress_11_ #v_Vector serialized
+  | _ ->
+    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+
+        <:
+        Rust_primitives.Hax.t_Never)
 
 let deserialize_then_decompress_ring_element_v
       (v_COMPRESSION_FACTOR: usize)
@@ -779,18 +803,21 @@ let deserialize_then_decompress_ring_element_v
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (serialized: t_Slice u8)
      =
+  let _:Prims.unit =
+    assert ((v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 4) \/
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 5))
+  in
+  let _:Prims.unit =
+    Rust_primitives.Integers.mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR)
+  in
   match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
-  | 4ul ->
-    let _:Prims.unit =
-      Hax_lib.v_assume ((Core.Slice.impl__len #u8 serialized <: usize) =. sz 128 <: bool)
-    in
-    deserialize_then_decompress_4_ #v_Vector serialized
-  | 5ul ->
-    let _:Prims.unit =
-      Hax_lib.v_assume ((Core.Slice.impl__len #u8 serialized <: usize) =. sz 160 <: bool)
-    in
-    deserialize_then_decompress_5_ #v_Vector serialized
-  | _ -> Libcrux_ml_kem.Polynomial.impl__ZERO #v_Vector ()
+  | 4ul -> deserialize_then_decompress_4_ #v_Vector serialized
+  | 5ul -> deserialize_then_decompress_5_ #v_Vector serialized
+  | _ ->
+    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+
+        <:
+        Rust_primitives.Hax.t_Never)
 
 let deserialize_to_reduced_ring_element
       (#v_Vector: Type0)

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fst
@@ -34,6 +34,14 @@ let compress_then_serialize_10_
       (fun serialized i ->
           let serialized:t_Array u8 v_OUT_LEN = serialized in
           let i:usize = i in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_compress_pre #v_Vector
+                  10l
+                  (Libcrux_ml_kem.Vector.Traits.to_unsigned_representative #v_Vector
+                      (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
+                    <:
+                    v_Vector))
+          in
           let coefficient:v_Vector =
             Libcrux_ml_kem.Vector.Traits.f_compress #v_Vector
               #FStar.Tactics.Typeclasses.solve
@@ -42,6 +50,9 @@ let compress_then_serialize_10_
                   (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
                 <:
                 v_Vector)
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_serialize_10_pre #v_Vector coefficient)
           in
           let bytes:t_Array u8 (sz 20) =
             Libcrux_ml_kem.Vector.Traits.f_serialize_10_ #v_Vector
@@ -98,6 +109,14 @@ let compress_then_serialize_11_
       (fun serialized i ->
           let serialized:t_Array u8 v_OUT_LEN = serialized in
           let i:usize = i in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_compress_pre #v_Vector
+                  11l
+                  (Libcrux_ml_kem.Vector.Traits.to_unsigned_representative #v_Vector
+                      (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
+                    <:
+                    v_Vector))
+          in
           let coefficient:v_Vector =
             Libcrux_ml_kem.Vector.Traits.f_compress #v_Vector
               #FStar.Tactics.Typeclasses.solve
@@ -106,6 +125,9 @@ let compress_then_serialize_11_
                   (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
                 <:
                 v_Vector)
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_serialize_11_pre #v_Vector coefficient)
           in
           let bytes:t_Array u8 (sz 22) =
             Libcrux_ml_kem.Vector.Traits.f_serialize_11_ #v_Vector
@@ -145,6 +167,7 @@ let compress_then_serialize_4_
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
       (serialized: t_Slice u8)
      =
+  let serialized_len:usize = Core.Slice.impl__len #u8 serialized in
   let serialized:t_Slice u8 =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter #(Core.Ops.Range.t_Range
             usize)
@@ -161,6 +184,19 @@ let compress_then_serialize_4_
       (fun serialized i ->
           let serialized:t_Slice u8 = serialized in
           let i:usize = i in
+          let _:Prims.unit =
+            Hax_lib.v_assume ((Core.Slice.impl__len #u8 serialized <: usize) =. serialized_len
+                <:
+                bool)
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_compress_pre #v_Vector
+                  4l
+                  (Libcrux_ml_kem.Vector.Traits.to_unsigned_representative #v_Vector
+                      (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
+                    <:
+                    v_Vector))
+          in
           let coefficient:v_Vector =
             Libcrux_ml_kem.Vector.Traits.f_compress #v_Vector
               #FStar.Tactics.Typeclasses.solve
@@ -169,6 +205,9 @@ let compress_then_serialize_4_
                   (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
                 <:
                 v_Vector)
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_serialize_4_pre #v_Vector coefficient)
           in
           let bytes:t_Array u8 (sz 8) =
             Libcrux_ml_kem.Vector.Traits.f_serialize_4_ #v_Vector
@@ -209,6 +248,7 @@ let compress_then_serialize_5_
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
       (serialized: t_Slice u8)
      =
+  let serialized_len:usize = Core.Slice.impl__len #u8 serialized in
   let serialized:t_Slice u8 =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter #(Core.Ops.Range.t_Range
             usize)
@@ -225,6 +265,19 @@ let compress_then_serialize_5_
       (fun serialized i ->
           let serialized:t_Slice u8 = serialized in
           let i:usize = i in
+          let _:Prims.unit =
+            Hax_lib.v_assume ((Core.Slice.impl__len #u8 serialized <: usize) =. serialized_len
+                <:
+                bool)
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_compress_pre #v_Vector
+                  5l
+                  (Libcrux_ml_kem.Vector.Traits.to_unsigned_representative #v_Vector
+                      (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
+                    <:
+                    v_Vector))
+          in
           let coefficients:v_Vector =
             Libcrux_ml_kem.Vector.Traits.f_compress #v_Vector
               #FStar.Tactics.Typeclasses.solve
@@ -233,6 +286,9 @@ let compress_then_serialize_5_
                   (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
                 <:
                 v_Vector)
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_serialize_5_pre #v_Vector coefficients)
           in
           let bytes:t_Array u8 (sz 10) =
             Libcrux_ml_kem.Vector.Traits.f_serialize_5_ #v_Vector
@@ -290,10 +346,16 @@ let compress_then_serialize_message
             Libcrux_ml_kem.Vector.Traits.to_unsigned_representative #v_Vector
               (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
           in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_compress_1_pre #v_Vector coefficient)
+          in
           let coefficient_compressed:v_Vector =
             Libcrux_ml_kem.Vector.Traits.f_compress_1_ #v_Vector
               #FStar.Tactics.Typeclasses.solve
               coefficient
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_serialize_1_pre #v_Vector coefficient_compressed)
           in
           let bytes:t_Array u8 (sz 2) =
             Libcrux_ml_kem.Vector.Traits.f_serialize_1_ #v_Vector
@@ -335,12 +397,10 @@ let compress_then_serialize_ring_element_u
      =
   match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
   | 10ul -> compress_then_serialize_10_ v_OUT_LEN #v_Vector re
-  | 11ul -> compress_then_serialize_11_ v_OUT_LEN #v_Vector re
-  | _ ->
-    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
-
-        <:
-        Rust_primitives.Hax.t_Never)
+  | 11ul ->
+    let _:Prims.unit = Hax_lib.v_assume (v_OUT_LEN =. sz 352 <: bool) in
+    compress_then_serialize_11_ v_OUT_LEN #v_Vector re
+  | _ -> Rust_primitives.Hax.repeat 0uy v_OUT_LEN
 
 let compress_then_serialize_ring_element_v
       (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
@@ -354,15 +414,10 @@ let compress_then_serialize_ring_element_v
   let out, hax_temp_output:(t_Slice u8 & Prims.unit) =
     match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
     | 4ul -> compress_then_serialize_4_ #v_Vector re out, () <: (t_Slice u8 & Prims.unit)
-    | 5ul -> compress_then_serialize_5_ #v_Vector re out, () <: (t_Slice u8 & Prims.unit)
-    | _ ->
-      out,
-      Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
-
-          <:
-          Rust_primitives.Hax.t_Never)
-      <:
-      (t_Slice u8 & Prims.unit)
+    | 5ul ->
+      let _:Prims.unit = Hax_lib.v_assume (v_OUT_LEN =. sz 160 <: bool) in
+      compress_then_serialize_5_ #v_Vector re out, () <: (t_Slice u8 & Prims.unit)
+    | _ -> out, (() <: Prims.unit) <: (t_Slice u8 & Prims.unit)
   in
   out
 
@@ -393,10 +448,19 @@ let deserialize_then_decompress_10_
       (fun re temp_1_ ->
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = re in
           let i, bytes:(usize & t_Slice u8) = temp_1_ in
+          let _:Prims.unit = Hax_lib.v_assume (i <. sz 16 <: bool) in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_10_pre #v_Vector bytes)
+          in
           let coefficient:v_Vector =
             Libcrux_ml_kem.Vector.Traits.f_deserialize_10_ #v_Vector
               #FStar.Tactics.Typeclasses.solve
               bytes
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_decompress_ciphertext_coefficient_pre #v_Vector
+                  10l
+                  coefficient)
           in
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector =
             {
@@ -447,10 +511,19 @@ let deserialize_then_decompress_11_
       (fun re temp_1_ ->
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = re in
           let i, bytes:(usize & t_Slice u8) = temp_1_ in
+          let _:Prims.unit = Hax_lib.v_assume (i <. sz 16 <: bool) in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_11_pre #v_Vector bytes)
+          in
           let coefficient:v_Vector =
             Libcrux_ml_kem.Vector.Traits.f_deserialize_11_ #v_Vector
               #FStar.Tactics.Typeclasses.solve
               bytes
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_decompress_ciphertext_coefficient_pre #v_Vector
+                  11l
+                  coefficient)
           in
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector =
             {
@@ -501,10 +574,19 @@ let deserialize_then_decompress_4_
       (fun re temp_1_ ->
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = re in
           let i, bytes:(usize & t_Slice u8) = temp_1_ in
+          let _:Prims.unit = Hax_lib.v_assume (i <. sz 16 <: bool) in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_4_pre #v_Vector bytes)
+          in
           let coefficient:v_Vector =
             Libcrux_ml_kem.Vector.Traits.f_deserialize_4_ #v_Vector
               #FStar.Tactics.Typeclasses.solve
               bytes
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_decompress_ciphertext_coefficient_pre #v_Vector
+                  4l
+                  coefficient)
           in
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector =
             {
@@ -555,6 +637,10 @@ let deserialize_then_decompress_5_
       (fun re temp_1_ ->
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = re in
           let i, bytes:(usize & t_Slice u8) = temp_1_ in
+          let _:Prims.unit = Hax_lib.v_assume (i <. sz 16 <: bool) in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_5_pre #v_Vector bytes)
+          in
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector =
             {
               re with
@@ -571,6 +657,11 @@ let deserialize_then_decompress_5_
             }
             <:
             Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_decompress_ciphertext_coefficient_pre #v_Vector
+                  5l
+                  (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector))
           in
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector =
             {
@@ -617,6 +708,17 @@ let deserialize_then_decompress_message
       (fun re i ->
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = re in
           let i:usize = i in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_1_pre #v_Vector
+                  (serialized.[ {
+                        Core.Ops.Range.f_start = sz 2 *! i <: usize;
+                        Core.Ops.Range.f_end = (sz 2 *! i <: usize) +! sz 2 <: usize
+                      }
+                      <:
+                      Core.Ops.Range.t_Range usize ]
+                    <:
+                    t_Slice u8))
+          in
           let coefficient_compressed:v_Vector =
             Libcrux_ml_kem.Vector.Traits.f_deserialize_1_ #v_Vector
               #FStar.Tactics.Typeclasses.solve
@@ -657,13 +759,17 @@ let deserialize_then_decompress_ring_element_u
       (serialized: t_Slice u8)
      =
   match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
-  | 10ul -> deserialize_then_decompress_10_ #v_Vector serialized
-  | 11ul -> deserialize_then_decompress_11_ #v_Vector serialized
-  | _ ->
-    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
-
-        <:
-        Rust_primitives.Hax.t_Never)
+  | 10ul ->
+    let _:Prims.unit =
+      Hax_lib.v_assume ((Core.Slice.impl__len #u8 serialized <: usize) =. sz 320 <: bool)
+    in
+    deserialize_then_decompress_10_ #v_Vector serialized
+  | 11ul ->
+    let _:Prims.unit =
+      Hax_lib.v_assume ((Core.Slice.impl__len #u8 serialized <: usize) =. sz 352 <: bool)
+    in
+    deserialize_then_decompress_11_ #v_Vector serialized
+  | _ -> Libcrux_ml_kem.Polynomial.impl__ZERO #v_Vector ()
 
 let deserialize_then_decompress_ring_element_v
       (v_COMPRESSION_FACTOR: usize)
@@ -674,13 +780,17 @@ let deserialize_then_decompress_ring_element_v
       (serialized: t_Slice u8)
      =
   match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
-  | 4ul -> deserialize_then_decompress_4_ #v_Vector serialized
-  | 5ul -> deserialize_then_decompress_5_ #v_Vector serialized
-  | _ ->
-    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
-
-        <:
-        Rust_primitives.Hax.t_Never)
+  | 4ul ->
+    let _:Prims.unit =
+      Hax_lib.v_assume ((Core.Slice.impl__len #u8 serialized <: usize) =. sz 128 <: bool)
+    in
+    deserialize_then_decompress_4_ #v_Vector serialized
+  | 5ul ->
+    let _:Prims.unit =
+      Hax_lib.v_assume ((Core.Slice.impl__len #u8 serialized <: usize) =. sz 160 <: bool)
+    in
+    deserialize_then_decompress_5_ #v_Vector serialized
+  | _ -> Libcrux_ml_kem.Polynomial.impl__ZERO #v_Vector ()
 
 let deserialize_to_reduced_ring_element
       (#v_Vector: Type0)
@@ -709,10 +819,17 @@ let deserialize_to_reduced_ring_element
       (fun re temp_1_ ->
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = re in
           let i, bytes:(usize & t_Slice u8) = temp_1_ in
+          let _:Prims.unit = Hax_lib.v_assume (i <. sz 16 <: bool) in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_12_pre #v_Vector bytes)
+          in
           let coefficient:v_Vector =
             Libcrux_ml_kem.Vector.Traits.f_deserialize_12_ #v_Vector
               #FStar.Tactics.Typeclasses.solve
               bytes
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_cond_subtract_3329_pre #v_Vector coefficient)
           in
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector =
             {
@@ -774,13 +891,22 @@ let deserialize_ring_elements_reduced
             deserialized_pk
           in
           let i, ring_element:(usize & t_Slice u8) = temp_1_ in
-          Rust_primitives.Hax.Monomorphized_update_at.update_at_usize deserialized_pk
-            i
-            (deserialize_to_reduced_ring_element #v_Vector ring_element
-              <:
-              Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-          <:
-          t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K)
+          let _:Prims.unit = Hax_lib.v_assume (i <. v_K <: bool) in
+          let _:Prims.unit =
+            Hax_lib.v_assume ((Core.Slice.impl__len #u8 ring_element <: usize) =.
+                Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT
+                <:
+                bool)
+          in
+          let deserialized_pk:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
+            v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize deserialized_pk
+              i
+              (deserialize_to_reduced_ring_element #v_Vector ring_element
+                <:
+                Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
+          in
+          deserialized_pk)
   in
   deserialized_pk
 
@@ -811,23 +937,28 @@ let deserialize_to_uncompressed_ring_element
       (fun re temp_1_ ->
           let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = re in
           let i, bytes:(usize & t_Slice u8) = temp_1_ in
-          {
-            re with
-            Libcrux_ml_kem.Polynomial.f_coefficients
-            =
-            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-                .Libcrux_ml_kem.Polynomial.f_coefficients
-              i
-              (Libcrux_ml_kem.Vector.Traits.f_deserialize_12_ #v_Vector
-                  #FStar.Tactics.Typeclasses.solve
-                  bytes
-                <:
-                v_Vector)
+          let _:Prims.unit = Hax_lib.v_assume (i <. sz 16 <: bool) in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_12_pre #v_Vector bytes)
+          in
+          let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector =
+            {
+              re with
+              Libcrux_ml_kem.Polynomial.f_coefficients
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
+                  .Libcrux_ml_kem.Polynomial.f_coefficients
+                i
+                (Libcrux_ml_kem.Vector.Traits.f_deserialize_12_ #v_Vector
+                    #FStar.Tactics.Typeclasses.solve
+                    bytes
+                  <:
+                  v_Vector)
+            }
             <:
-            t_Array v_Vector (sz 16)
-          }
-          <:
-          Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
+            Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector
+          in
+          re)
   in
   re
 
@@ -858,6 +989,9 @@ let serialize_uncompressed_ring_element
           let coefficient:v_Vector =
             Libcrux_ml_kem.Vector.Traits.to_unsigned_representative #v_Vector
               (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
+          in
+          let _:Prims.unit =
+            assume (Libcrux_ml_kem.Vector.Traits.f_serialize_12_pre #v_Vector coefficient)
           in
           let bytes:t_Array u8 (sz 24) =
             Libcrux_ml_kem.Vector.Traits.f_serialize_12_ #v_Vector

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fsti
@@ -69,9 +69,7 @@ val compress_then_serialize_message
       (#v_Vector: Type0)
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-    : Prims.Pure (t_Array u8 (sz 32))
-      (requires (sz 32 +! sz 2 <: usize) <=. Libcrux_ml_kem.Constants.v_SHARED_SECRET_SIZE)
-      (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
 
 val compress_then_serialize_ring_element_u
       (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
@@ -210,7 +208,9 @@ val deserialize_ring_elements_reduced
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (public_key: t_Slice u8)
     : Prims.Pure (t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K)
-      Prims.l_True
+      (requires
+        (Core.Slice.impl__len #u8 public_key <: usize) =. v_PUBLIC_KEY_SIZE &&
+        (v_PUBLIC_KEY_SIZE /! Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT <: usize) =. v_K)
       (fun _ -> Prims.l_True)
 
 val deserialize_to_uncompressed_ring_element

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fsti
@@ -14,41 +14,79 @@ val compress_then_serialize_10_
       (#v_Vector: Type0)
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Array u8 v_OUT_LEN)
+      (requires
+        ((sz 20 *! (Libcrux_ml_kem.Polynomial.v_VECTORS_IN_RING_ELEMENT -! sz 1 <: usize) <: usize) +!
+          sz 20
+          <:
+          usize) <=.
+        v_OUT_LEN)
+      (fun _ -> Prims.l_True)
 
 val compress_then_serialize_11_
       (v_OUT_LEN: usize)
       (#v_Vector: Type0)
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Array u8 v_OUT_LEN)
+      (requires
+        ((sz 22 *! (Libcrux_ml_kem.Polynomial.v_VECTORS_IN_RING_ELEMENT -! sz 1 <: usize) <: usize) +!
+          sz 22
+          <:
+          usize) <=.
+        v_OUT_LEN)
+      (fun _ -> Prims.l_True)
 
 val compress_then_serialize_4_
       (#v_Vector: Type0)
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
       (serialized: t_Slice u8)
-    : Prims.Pure (t_Slice u8) Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        ((sz 8 *! (Libcrux_ml_kem.Polynomial.v_VECTORS_IN_RING_ELEMENT -! sz 1 <: usize) <: usize) +!
+          sz 8
+          <:
+          usize) <=.
+        (Core.Slice.impl__len #u8 serialized <: usize))
+      (fun _ -> Prims.l_True)
 
 val compress_then_serialize_5_
       (#v_Vector: Type0)
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
       (serialized: t_Slice u8)
-    : Prims.Pure (t_Slice u8) Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        ((sz 10 *! (Libcrux_ml_kem.Polynomial.v_VECTORS_IN_RING_ELEMENT -! sz 1 <: usize) <: usize) +!
+          sz 10
+          <:
+          usize) <=.
+        (Core.Slice.impl__len #u8 serialized <: usize))
+      (fun _ -> Prims.l_True)
 
 val compress_then_serialize_message
       (#v_Vector: Type0)
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-    : Prims.Pure (t_Array u8 (sz 32)) Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Array u8 (sz 32))
+      (requires (sz 32 +! sz 2 <: usize) <=. Libcrux_ml_kem.Constants.v_SHARED_SECRET_SIZE)
+      (fun _ -> Prims.l_True)
 
 val compress_then_serialize_ring_element_u
       (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
       (#v_Vector: Type0)
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-    : Prims.Pure (t_Array u8 v_OUT_LEN) Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Array u8 v_OUT_LEN)
+      (requires
+        (v_COMPRESSION_FACTOR =. sz 10 || v_COMPRESSION_FACTOR =. sz 11) &&
+        ((Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_COMPRESSION_FACTOR <: usize) /!
+          sz 8
+          <:
+          usize) =.
+        v_OUT_LEN)
+      (fun _ -> Prims.l_True)
 
 val compress_then_serialize_ring_element_v
       (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
@@ -56,14 +94,27 @@ val compress_then_serialize_ring_element_v
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
       (out: t_Slice u8)
-    : Prims.Pure (t_Slice u8) Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (v_COMPRESSION_FACTOR =. sz 4 || v_COMPRESSION_FACTOR =. sz 5) &&
+        ((Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_COMPRESSION_FACTOR <: usize) /!
+          sz 8
+          <:
+          usize) =.
+        v_OUT_LEN &&
+        (Core.Slice.impl__len #u8 out <: usize) =. v_OUT_LEN)
+      (fun _ -> Prims.l_True)
 
 val deserialize_then_decompress_10_
       (#v_Vector: Type0)
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (serialized: t_Slice u8)
     : Prims.Pure (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-      Prims.l_True
+      (requires
+        (Core.Slice.impl__len #u8 serialized <: usize) =.
+        ((Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! sz 10 <: usize) /! sz 8
+          <:
+          usize))
       (fun _ -> Prims.l_True)
 
 val deserialize_then_decompress_11_
@@ -71,7 +122,11 @@ val deserialize_then_decompress_11_
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (serialized: t_Slice u8)
     : Prims.Pure (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-      Prims.l_True
+      (requires
+        (Core.Slice.impl__len #u8 serialized <: usize) =.
+        ((Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! sz 11 <: usize) /! sz 8
+          <:
+          usize))
       (fun _ -> Prims.l_True)
 
 val deserialize_then_decompress_4_
@@ -79,7 +134,10 @@ val deserialize_then_decompress_4_
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (serialized: t_Slice u8)
     : Prims.Pure (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-      Prims.l_True
+      (requires
+        (Core.Slice.impl__len #u8 serialized <: usize) =.
+        ((Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! sz 4 <: usize) /! sz 8 <: usize
+        ))
       (fun _ -> Prims.l_True)
 
 val deserialize_then_decompress_5_
@@ -87,7 +145,10 @@ val deserialize_then_decompress_5_
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (serialized: t_Slice u8)
     : Prims.Pure (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-      Prims.l_True
+      (requires
+        (Core.Slice.impl__len #u8 serialized <: usize) =.
+        ((Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! sz 5 <: usize) /! sz 8 <: usize
+        ))
       (fun _ -> Prims.l_True)
 
 val deserialize_then_decompress_message
@@ -104,7 +165,13 @@ val deserialize_then_decompress_ring_element_u
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (serialized: t_Slice u8)
     : Prims.Pure (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-      Prims.l_True
+      (requires
+        (v_COMPRESSION_FACTOR =. sz 10 || v_COMPRESSION_FACTOR =. sz 11) &&
+        (Core.Slice.impl__len #u8 serialized <: usize) =.
+        ((Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_COMPRESSION_FACTOR <: usize) /!
+          sz 8
+          <:
+          usize))
       (fun _ -> Prims.l_True)
 
 val deserialize_then_decompress_ring_element_v
@@ -113,7 +180,13 @@ val deserialize_then_decompress_ring_element_v
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (serialized: t_Slice u8)
     : Prims.Pure (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-      Prims.l_True
+      (requires
+        (v_COMPRESSION_FACTOR =. sz 4 || v_COMPRESSION_FACTOR =. sz 5) &&
+        (Core.Slice.impl__len #u8 serialized <: usize) =.
+        ((Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_COMPRESSION_FACTOR <: usize) /!
+          sz 8
+          <:
+          usize))
       (fun _ -> Prims.l_True)
 
 /// Only use with public values.
@@ -123,7 +196,9 @@ val deserialize_to_reduced_ring_element
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (serialized: t_Slice u8)
     : Prims.Pure (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-      Prims.l_True
+      (requires
+        (Core.Slice.impl__len #u8 serialized <: usize) =.
+        Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT)
       (fun _ -> Prims.l_True)
 
 /// This function deserializes ring elements and reduces the result by the field
@@ -143,7 +218,9 @@ val deserialize_to_uncompressed_ring_element
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (serialized: t_Slice u8)
     : Prims.Pure (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-      Prims.l_True
+      (requires
+        (Core.Slice.impl__len #u8 serialized <: usize) =.
+        Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT)
       (fun _ -> Prims.l_True)
 
 val serialize_uncompressed_ring_element

--- a/libcrux-ml-kem/proofs/fstar/extraction/Makefile
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Makefile
@@ -96,6 +96,7 @@ PANIC_FREE = Libcrux_ml_kem.Constant_time_ops.fst \
              Libcrux_ml_kem.Ntt.fsti \
              Libcrux_ml_kem.Polynomial.fsti \
              Libcrux_ml_kem.Sampling.fsti \
+             Libcrux_ml_kem.Serialize.fst \
              Libcrux_ml_kem.Serialize.fsti \
              Libcrux_ml_kem.Types.fst \
              Libcrux_ml_kem.Types.fsti \

--- a/libcrux-ml-kem/src/serialize.rs
+++ b/libcrux-ml-kem/src/serialize.rs
@@ -1,20 +1,27 @@
 use crate::{
-    constants::{BYTES_PER_RING_ELEMENT, SHARED_SECRET_SIZE},
-    hax_utils::hax_debug_assert,
+    constants::{COEFFICIENTS_IN_RING_ELEMENT, BYTES_PER_RING_ELEMENT, SHARED_SECRET_SIZE},
     helper::cloop,
     polynomial::{PolynomialRingElement, VECTORS_IN_RING_ELEMENT},
     vector::{decompress_1, to_unsigned_representative, Operations},
 };
 
+use hax_lib::*;
+use hax_lib::int::*;
+
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    32 + 2 <= SHARED_SECRET_SIZE
+))]
 pub(super) fn compress_then_serialize_message<Vector: Operations>(
     re: PolynomialRingElement<Vector>,
 ) -> [u8; SHARED_SECRET_SIZE] {
     let mut serialized = [0u8; SHARED_SECRET_SIZE];
     for i in 0..16 {
         let coefficient = to_unsigned_representative::<Vector>(re.coefficients[i]);
+        fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_compress_1_pre #v_Vector coefficient)");
         let coefficient_compressed = Vector::compress_1(coefficient);
 
+        fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_serialize_1_pre #v_Vector coefficient_compressed)");
         let bytes = Vector::serialize_1(coefficient_compressed);
         serialized[2 * i..2 * i + 2].copy_from_slice(&bytes);
     }
@@ -27,6 +34,14 @@ pub(super) fn deserialize_then_decompress_message<Vector: Operations>(
 ) -> PolynomialRingElement<Vector> {
     let mut re = PolynomialRingElement::<Vector>::ZERO();
     for i in 0..16 {
+        fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_1_pre #v_Vector (serialized.[ {
+                Core.Ops.Range.f_start = sz 2 *! i <: usize;
+                Core.Ops.Range.f_end = (sz 2 *! i <: usize) +! sz 2 <: usize
+                }
+                <:
+                Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8))");
         let coefficient_compressed = Vector::deserialize_1(&serialized[2 * i..2 * i + 2]);
         re.coefficients[i] = decompress_1::<Vector>(coefficient_compressed);
     }
@@ -41,6 +56,7 @@ pub(super) fn serialize_uncompressed_ring_element<Vector: Operations>(
     for i in 0..VECTORS_IN_RING_ELEMENT {
         let coefficient = to_unsigned_representative::<Vector>(re.coefficients[i]);
 
+        fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_serialize_12_pre #v_Vector coefficient)");
         let bytes = Vector::serialize_12(coefficient);
         serialized[24 * i..24 * i + 24].copy_from_slice(&bytes);
     }
@@ -48,15 +64,21 @@ pub(super) fn serialize_uncompressed_ring_element<Vector: Operations>(
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    serialized.len() == BYTES_PER_RING_ELEMENT
+))]
 pub(super) fn deserialize_to_uncompressed_ring_element<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
-    hax_debug_assert!(serialized.len() == BYTES_PER_RING_ELEMENT);
-
     let mut re = PolynomialRingElement::<Vector>::ZERO();
 
     cloop! {
         for (i, bytes) in serialized.chunks_exact(24).enumerate() {
+            // Core.Iter.Traits.Iterator.f_enumerate is supposed to keep track on iteration index,
+            // part of https://github.com/hacspec/hax/issues/394
+            assume!(i < 16);
+            
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_12_pre #v_Vector bytes)");
             re.coefficients[i] = Vector::deserialize_12(bytes);
         }
     }
@@ -68,16 +90,23 @@ pub(super) fn deserialize_to_uncompressed_ring_element<Vector: Operations>(
 ///
 /// This MUST NOT be used with secret inputs, like its caller `deserialize_ring_elements_reduced`.
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    serialized.len() == BYTES_PER_RING_ELEMENT
+))]
 fn deserialize_to_reduced_ring_element<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
-    hax_debug_assert!(serialized.len() == BYTES_PER_RING_ELEMENT);
-
     let mut re = PolynomialRingElement::<Vector>::ZERO();
 
     cloop! {
         for (i, bytes) in serialized.chunks_exact(24).enumerate() {
+            // Core.Iter.Traits.Iterator.f_enumerate is supposed to keep track on iteration index,
+            // part of https://github.com/hacspec/hax/issues/394
+            assume!(i < 16);
+            
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_12_pre #v_Vector bytes)");
             let coefficient = Vector::deserialize_12(bytes);
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_cond_subtract_3329_pre #v_Vector coefficient)");
             re.coefficients[i] = Vector::cond_subtract_3329(coefficient);
         }
     }
@@ -102,6 +131,11 @@ pub(super) fn deserialize_ring_elements_reduced<
             .chunks_exact(BYTES_PER_RING_ELEMENT)
             .enumerate()
         {
+            // Core.Iter.Traits.Iterator.f_enumerate is supposed to keep track on iteration index,
+            // part of https://github.com/hacspec/hax/issues/394
+            assume!(i < K);
+            assume!(ring_element.len() == BYTES_PER_RING_ELEMENT);
+            
             deserialized_pk[i] = deserialize_to_reduced_ring_element(ring_element);
         }
     }
@@ -109,14 +143,24 @@ pub(super) fn deserialize_ring_elements_reduced<
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    20 * (VECTORS_IN_RING_ELEMENT - 1) + 20 <= OUT_LEN
+))]
 fn compress_then_serialize_10<const OUT_LEN: usize, Vector: Operations>(
     re: &PolynomialRingElement<Vector>,
 ) -> [u8; OUT_LEN] {
     let mut serialized = [0u8; OUT_LEN];
     for i in 0..VECTORS_IN_RING_ELEMENT {
+        fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_compress_pre #v_Vector
+            10l
+            (Libcrux_ml_kem.Vector.Traits.to_unsigned_representative #v_Vector
+                (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
+            <:
+            v_Vector))");
         let coefficient =
             Vector::compress::<10>(to_unsigned_representative::<Vector>(re.coefficients[i]));
 
+        fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_serialize_10_pre #v_Vector coefficient)");
         let bytes = Vector::serialize_10(coefficient);
         serialized[20 * i..20 * i + 20].copy_from_slice(&bytes);
     }
@@ -124,14 +168,24 @@ fn compress_then_serialize_10<const OUT_LEN: usize, Vector: Operations>(
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    22 * (VECTORS_IN_RING_ELEMENT - 1) + 22 <= OUT_LEN
+))]
 fn compress_then_serialize_11<const OUT_LEN: usize, Vector: Operations>(
     re: &PolynomialRingElement<Vector>,
 ) -> [u8; OUT_LEN] {
     let mut serialized = [0u8; OUT_LEN];
     for i in 0..VECTORS_IN_RING_ELEMENT {
+        fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_compress_pre #v_Vector
+            11l
+            (Libcrux_ml_kem.Vector.Traits.to_unsigned_representative #v_Vector
+                (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
+            <:
+            v_Vector))");
         let coefficient =
             Vector::compress::<11>(to_unsigned_representative::<Vector>(re.coefficients[i]));
 
+        fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_serialize_11_pre #v_Vector coefficient)");
         let bytes = Vector::serialize_11(coefficient);
         serialized[22 * i..22 * i + 22].copy_from_slice(&bytes);
     }
@@ -139,6 +193,10 @@ fn compress_then_serialize_11<const OUT_LEN: usize, Vector: Operations>(
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    (COMPRESSION_FACTOR == 10 || COMPRESSION_FACTOR == 11) &&
+    (COEFFICIENTS_IN_RING_ELEMENT * COMPRESSION_FACTOR) / 8 == OUT_LEN
+))]
 pub(super) fn compress_then_serialize_ring_element_u<
     const COMPRESSION_FACTOR: usize,
     const OUT_LEN: usize,
@@ -146,26 +204,41 @@ pub(super) fn compress_then_serialize_ring_element_u<
 >(
     re: &PolynomialRingElement<Vector>,
 ) -> [u8; OUT_LEN] {
-    hax_debug_assert!((COEFFICIENTS_IN_RING_ELEMENT * COMPRESSION_FACTOR) / 8 == OUT_LEN);
-
     match COMPRESSION_FACTOR as u32 {
         10 => compress_then_serialize_10(re),
-        11 => compress_then_serialize_11(re),
-        _ => unreachable!(),
+        // Why it needs assumption here?
+        11 => {assume!(OUT_LEN == 352); compress_then_serialize_11(re)},
+        // unreachable!() does't verify, Option enum works but we have
+        // to edit refrences!!?
+        _ => [0u8; OUT_LEN],
     }
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    8 * (VECTORS_IN_RING_ELEMENT - 1) + 8 <= serialized.len()
+))]
 fn compress_then_serialize_4<Vector: Operations>(
     re: PolynomialRingElement<Vector>,
     serialized: &mut [u8],
 ) {
+    let serialized_len = serialized.len();
     // The semicolon and parentheses at the end of loop are a workaround
     // for the following bug https://github.com/hacspec/hax/issues/720
     for i in 0..VECTORS_IN_RING_ELEMENT {
+        // Loop invariant assumption, this issue is part of https://github.com/hacspec/hax/issues/394
+        assume!(serialized.len() == serialized_len);
+  
+        fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_compress_pre #v_Vector
+            4l
+            (Libcrux_ml_kem.Vector.Traits.to_unsigned_representative #v_Vector
+                (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
+            <:
+            v_Vector))");
         let coefficient =
             Vector::compress::<4>(to_unsigned_representative::<Vector>(re.coefficients[i]));
 
+        fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_serialize_4_pre #v_Vector coefficient)");
         let bytes = Vector::serialize_4(coefficient);
         serialized[8 * i..8 * i + 8].copy_from_slice(&bytes);
     }
@@ -173,16 +246,29 @@ fn compress_then_serialize_4<Vector: Operations>(
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    10 * (VECTORS_IN_RING_ELEMENT - 1) + 10 <= serialized.len()
+))]
 fn compress_then_serialize_5<Vector: Operations>(
     re: PolynomialRingElement<Vector>,
     serialized: &mut [u8],
 ) {
+    let serialized_len = serialized.len();
     // The semicolon and parentheses at the end of loop are a workaround
     // for the following bug https://github.com/hacspec/hax/issues/720
     for i in 0..VECTORS_IN_RING_ELEMENT {
+        // Loop invariant assumption, this issue is part of https://github.com/hacspec/hax/issues/394
+        assume!(serialized.len() == serialized_len);
+        fstar!("assume(Libcrux_ml_kem.Vector.Traits.f_compress_pre #v_Vector
+            5l
+            (Libcrux_ml_kem.Vector.Traits.to_unsigned_representative #v_Vector
+                (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector)
+            <:
+            v_Vector))");
         let coefficients =
             Vector::compress::<5>(to_unsigned_representative::<Vector>(re.coefficients[i]));
 
+        fstar!("assume(Libcrux_ml_kem.Vector.Traits.f_serialize_5_pre #v_Vector coefficients)");
         let bytes = Vector::serialize_5(coefficients);
         serialized[10 * i..10 * i + 10].copy_from_slice(&bytes);
     }
@@ -190,6 +276,11 @@ fn compress_then_serialize_5<Vector: Operations>(
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    (COMPRESSION_FACTOR == 4 || COMPRESSION_FACTOR == 5) &&
+    (COEFFICIENTS_IN_RING_ELEMENT * COMPRESSION_FACTOR) / 8 == OUT_LEN &&
+    out.len() == OUT_LEN
+))]
 pub(super) fn compress_then_serialize_ring_element_v<
     const COMPRESSION_FACTOR: usize,
     const OUT_LEN: usize,
@@ -198,26 +289,33 @@ pub(super) fn compress_then_serialize_ring_element_v<
     re: PolynomialRingElement<Vector>,
     out: &mut [u8],
 ) {
-    hax_debug_assert!((COEFFICIENTS_IN_RING_ELEMENT * COMPRESSION_FACTOR) / 8 == OUT_LEN);
-
     match COMPRESSION_FACTOR as u32 {
         4 => compress_then_serialize_4(re, out),
-        5 => compress_then_serialize_5(re, out),
-        _ => unreachable!(),
+        5 => {assume!(OUT_LEN == 160); compress_then_serialize_5(re, out)},
+        _ => (),
     }
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * 10) / 8
+))]
 fn deserialize_then_decompress_10<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
-    hax_debug_assert!(serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * 10) / 8);
-
     let mut re = PolynomialRingElement::<Vector>::ZERO();
 
     cloop! {
         for (i, bytes) in serialized.chunks_exact(20).enumerate() {
+            // Core.Iter.Traits.Iterator.f_enumerate is supposed to keep track on iteration index,
+            // part of https://github.com/hacspec/hax/issues/394
+            assume!(i < 16);
+
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_10_pre #v_Vector bytes)");
             let coefficient = Vector::deserialize_10(bytes);
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_decompress_ciphertext_coefficient_pre #v_Vector
+                10l
+                coefficient)");
             re.coefficients[i] = Vector::decompress_ciphertext_coefficient::<10>(coefficient);
         }
     }
@@ -225,16 +323,25 @@ fn deserialize_then_decompress_10<Vector: Operations>(
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * 11) / 8
+))]
 fn deserialize_then_decompress_11<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
-    hax_debug_assert!(serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * 11) / 8);
-
     let mut re = PolynomialRingElement::<Vector>::ZERO();
 
     cloop! {
         for (i, bytes) in serialized.chunks_exact(22).enumerate() {
+            // Core.Iter.Traits.Iterator.f_enumerate is supposed to keep track on iteration index,
+            // part of https://github.com/hacspec/hax/issues/394
+            assume!(i < 16);
+            
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_11_pre #v_Vector bytes)");
             let coefficient = Vector::deserialize_11(bytes);
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_decompress_ciphertext_coefficient_pre #v_Vector
+                11l
+                coefficient)");
             re.coefficients[i] = Vector::decompress_ciphertext_coefficient::<11>(coefficient);
         }
     }
@@ -243,30 +350,42 @@ fn deserialize_then_decompress_11<Vector: Operations>(
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    (COMPRESSION_FACTOR == 10 || COMPRESSION_FACTOR == 11) &&
+    serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * COMPRESSION_FACTOR) / 8
+))]
 pub(super) fn deserialize_then_decompress_ring_element_u<
     const COMPRESSION_FACTOR: usize,
     Vector: Operations,
 >(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
-    hax_debug_assert!(serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * COMPRESSION_FACTOR) / 8);
-
     match COMPRESSION_FACTOR as u32 {
-        10 => deserialize_then_decompress_10(serialized),
-        11 => deserialize_then_decompress_11(serialized),
-        _ => unreachable!(),
+        10 => {assume!(serialized.len() == 320); deserialize_then_decompress_10(serialized)},
+        11 => {assume!(serialized.len() == 352); deserialize_then_decompress_11(serialized)},
+        _ => PolynomialRingElement::<Vector>::ZERO(),
     }
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * 4) / 8
+))]
 fn deserialize_then_decompress_4<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
-    hax_debug_assert!(serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * 4) / 8);
     let mut re = PolynomialRingElement::<Vector>::ZERO();
     cloop! {
         for (i, bytes) in serialized.chunks_exact(8).enumerate() {
+            // Core.Iter.Traits.Iterator.f_enumerate is supposed to keep track on iteration index,
+            // part of https://github.com/hacspec/hax/issues/394
+            assume!(i < 16);
+            
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_4_pre #v_Vector bytes)");
             let coefficient = Vector::deserialize_4(bytes);
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_decompress_ciphertext_coefficient_pre #v_Vector
+                4l
+                coefficient)");
             re.coefficients[i] = Vector::decompress_ciphertext_coefficient::<4>(coefficient);
         }
     }
@@ -274,16 +393,25 @@ fn deserialize_then_decompress_4<Vector: Operations>(
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * 5) / 8
+))]
 fn deserialize_then_decompress_5<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
-    hax_debug_assert!(serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * 5) / 8);
-
     let mut re = PolynomialRingElement::<Vector>::ZERO();
 
     cloop! {
         for (i, bytes) in serialized.chunks_exact(10).enumerate() {
+            // Core.Iter.Traits.Iterator.f_enumerate is supposed to keep track on iteration index,
+            // part of https://github.com/hacspec/hax/issues/394
+            assume!(i < 16);
+
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_deserialize_5_pre #v_Vector bytes)");
             re.coefficients[i] = Vector::deserialize_5(bytes);
+            fstar!("assume (Libcrux_ml_kem.Vector.Traits.f_decompress_ciphertext_coefficient_pre #v_Vector
+                5l
+                (re.Libcrux_ml_kem.Polynomial.f_coefficients.[ i ] <: v_Vector))");
             re.coefficients[i] = Vector::decompress_ciphertext_coefficient::<5>(re.coefficients[i]);
         }
     }
@@ -291,17 +419,19 @@ fn deserialize_then_decompress_5<Vector: Operations>(
 }
 
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    (COMPRESSION_FACTOR == 4 || COMPRESSION_FACTOR == 5) &&
+    serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * COMPRESSION_FACTOR) / 8
+))]
 pub(super) fn deserialize_then_decompress_ring_element_v<
     const COMPRESSION_FACTOR: usize,
     Vector: Operations,
 >(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
-    hax_debug_assert!(serialized.len() == (COEFFICIENTS_IN_RING_ELEMENT * COMPRESSION_FACTOR) / 8);
-
     match COMPRESSION_FACTOR as u32 {
-        4 => deserialize_then_decompress_4(serialized),
-        5 => deserialize_then_decompress_5(serialized),
-        _ => unreachable!(),
+        4 => {assume!(serialized.len() == 128); deserialize_then_decompress_4(serialized)},
+        5 => {assume!(serialized.len() == 160); deserialize_then_decompress_5(serialized)},
+        _ => PolynomialRingElement::<Vector>::ZERO(),
     }
 }

--- a/libcrux-ml-kem/src/serialize.rs
+++ b/libcrux-ml-kem/src/serialize.rs
@@ -204,13 +204,14 @@ pub(super) fn compress_then_serialize_ring_element_u<
 >(
     re: &PolynomialRingElement<Vector>,
 ) -> [u8; OUT_LEN] {
+    fstar!("assert (
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 10) \\/
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 11))");
+    fstar!("Rust_primitives.Integers.mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR)");
     match COMPRESSION_FACTOR as u32 {
         10 => compress_then_serialize_10(re),
-        // Why it needs assumption here?
-        11 => {assume!(OUT_LEN == 352); compress_then_serialize_11(re)},
-        // unreachable!() does't verify, Option enum works but we have
-        // to edit refrences!!?
-        _ => [0u8; OUT_LEN],
+        11 => compress_then_serialize_11(re),
+        _ => unreachable!(),
     }
 }
 
@@ -289,10 +290,14 @@ pub(super) fn compress_then_serialize_ring_element_v<
     re: PolynomialRingElement<Vector>,
     out: &mut [u8],
 ) {
+    fstar!("assert (
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 4) \\/
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 5))");
+    fstar!("Rust_primitives.Integers.mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR)");
     match COMPRESSION_FACTOR as u32 {
         4 => compress_then_serialize_4(re, out),
-        5 => {assume!(OUT_LEN == 160); compress_then_serialize_5(re, out)},
-        _ => (),
+        5 => compress_then_serialize_5(re, out),
+        _ => unreachable!(),
     }
 }
 
@@ -360,10 +365,14 @@ pub(super) fn deserialize_then_decompress_ring_element_u<
 >(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    fstar!("assert (
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 10) \\/
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 11))");
+    fstar!("Rust_primitives.Integers.mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR)");
     match COMPRESSION_FACTOR as u32 {
-        10 => {assume!(serialized.len() == 320); deserialize_then_decompress_10(serialized)},
-        11 => {assume!(serialized.len() == 352); deserialize_then_decompress_11(serialized)},
-        _ => PolynomialRingElement::<Vector>::ZERO(),
+        10 => deserialize_then_decompress_10(serialized),
+        11 => deserialize_then_decompress_11(serialized),
+        _ => unreachable!(),
     }
 }
 
@@ -429,9 +438,13 @@ pub(super) fn deserialize_then_decompress_ring_element_v<
 >(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    fstar!("assert (
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 4) \\/
+        (v (cast (v_COMPRESSION_FACTOR <: usize) <: u32) == 5))");
+    fstar!("Rust_primitives.Integers.mk_int_equiv_lemma #usize_inttype (v v_COMPRESSION_FACTOR)");
     match COMPRESSION_FACTOR as u32 {
-        4 => {assume!(serialized.len() == 128); deserialize_then_decompress_4(serialized)},
-        5 => {assume!(serialized.len() == 160); deserialize_then_decompress_5(serialized)},
-        _ => PolynomialRingElement::<Vector>::ZERO(),
+        4 => deserialize_then_decompress_4(serialized),
+        5 => deserialize_then_decompress_5(serialized),
+        _ => unreachable!(),
     }
 }

--- a/libcrux-ml-kem/src/serialize.rs
+++ b/libcrux-ml-kem/src/serialize.rs
@@ -6,12 +6,8 @@ use crate::{
 };
 
 use hax_lib::*;
-use hax_lib::int::*;
 
 #[inline(always)]
-#[cfg_attr(hax, requires(
-    32 + 2 <= SHARED_SECRET_SIZE
-))]
 pub(super) fn compress_then_serialize_message<Vector: Operations>(
     re: PolynomialRingElement<Vector>,
 ) -> [u8; SHARED_SECRET_SIZE] {
@@ -118,6 +114,10 @@ fn deserialize_to_reduced_ring_element<Vector: Operations>(
 ///
 /// This function MUST NOT be used on secret inputs.
 #[inline(always)]
+#[cfg_attr(hax, requires(
+    public_key.len() == PUBLIC_KEY_SIZE &&
+    PUBLIC_KEY_SIZE / BYTES_PER_RING_ELEMENT == K
+))]
 pub(super) fn deserialize_ring_elements_reduced<
     const PUBLIC_KEY_SIZE: usize,
     const K: usize,
@@ -131,8 +131,8 @@ pub(super) fn deserialize_ring_elements_reduced<
             .chunks_exact(BYTES_PER_RING_ELEMENT)
             .enumerate()
         {
-            // Core.Iter.Traits.Iterator.f_enumerate is supposed to keep track on iteration index,
-            // part of https://github.com/hacspec/hax/issues/394
+            // Core.Iter.Traits.Iterator.f_enumerate is supposed to keep track on iteration index and
+            // chunk length. This issue is part of https://github.com/hacspec/hax/issues/394
             assume!(i < K);
             assume!(ring_element.len() == BYTES_PER_RING_ELEMENT);
             


### PR DESCRIPTION
This patch adds pre-conditions and workaround assumptions to serialize.rs to make Libcrux_ml_kem.Serialize.fst verifiable.
It also adds Libcrux_ml_kem.Serialize.fst to PANIC_FREE category in ML-KEM Makefile.