### PR TITLE
Fix specs CI

### DIFF
--- a/specs/kyber/Cargo.toml
+++ b/specs/kyber/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libcrux = { version = "=0.0.2-alpha.1", path = "../../" }
+libcrux = { version = "=0.0.2-alpha.3", path = "../../" }
 hacspec-lib = { version = "0.0.1", path = "../hacspec-lib" }
 
 [dev-dependencies]
-libcrux-kem = { version = "=0.0.2-alpha.1", path = "../../libcrux-kem", features = [
+libcrux-kem = { version = "=0.0.2-alpha.3", path = "../../libcrux-kem", features = [
     "tests",
 ] }
 hex = { version = "0.4.3", features = ["serde"] }


### PR DESCRIPTION
Updates Kyber spec dependency on `libcrux`/`libcrux-ml-kem`.