### PR TITLE
Make vector/portable/arithmetic.rs panic-free

### DIFF
--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Arithmetic.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Arithmetic.fst
@@ -6,6 +6,18 @@ open FStar.Mul
 let get_n_least_significant_bits (n: u8) (value: u32) = value &. ((1ul <<! n <: u32) -! 1ul <: u32)
 
 let barrett_reduce_element (value: i16) =
+  let _:Prims.unit =
+    Hax_lib.v_assert ((Core.Convert.f_from #i32 #i16 #FStar.Tactics.Typeclasses.solve value <: i32) <=.
+        (Core.Num.impl__i32__MAX /! v_BARRETT_MULTIPLIER <: i32)
+        <:
+        bool)
+  in
+  let _:Prims.unit =
+    Hax_lib.v_assert ((Core.Convert.f_from #i32 #i16 #FStar.Tactics.Typeclasses.solve value <: i32) >=.
+        (Core.Num.impl__i32__MIN /! v_BARRETT_MULTIPLIER <: i32)
+        <:
+        bool)
+  in
   let t:i32 =
     ((Core.Convert.f_from #i32 #i16 #FStar.Tactics.Typeclasses.solve value <: i32) *!
       v_BARRETT_MULTIPLIER
@@ -14,13 +26,66 @@ let barrett_reduce_element (value: i16) =
     (v_BARRETT_R >>! 1l <: i32)
   in
   let quotient:i16 = cast (t >>! v_BARRETT_SHIFT <: i32) <: i16 in
+  let _:Prims.unit =
+    Hax_lib.v_assert (quotient <=.
+        (Core.Num.impl__i16__MAX /! Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16)
+        <:
+        bool)
+  in
+  let _:Prims.unit =
+    Hax_lib.v_assert (quotient >=.
+        (Core.Num.impl__i16__MIN /! Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16)
+        <:
+        bool)
+  in
+  let _:Prims.unit =
+    Hax_lib.v_assert (value >=. (quotient *! Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16)
+        <:
+        bool)
+  in
   value -! (quotient *! Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16)
 
 let montgomery_reduce_element (value: i32) =
   let _:i32 = v_MONTGOMERY_R in
+  let _:Prims.unit =
+    Hax_lib.v_assert ((cast (cast (value <: i32) <: i16) <: i32) <=.
+        (Core.Num.impl__i32__MAX /!
+          (cast (Libcrux_ml_kem.Vector.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R <: u32) <: i32)
+          <:
+          i32)
+        <:
+        bool)
+  in
+  let _:Prims.unit =
+    Hax_lib.v_assert ((cast (cast (value <: i32) <: i16) <: i32) >=.
+        (Core.Num.impl__i32__MIN /!
+          (cast (Libcrux_ml_kem.Vector.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R <: u32) <: i32)
+          <:
+          i32)
+        <:
+        bool)
+  in
   let k:i32 =
     (cast (cast (value <: i32) <: i16) <: i32) *!
     (cast (Libcrux_ml_kem.Vector.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R <: u32) <: i32)
+  in
+  let _:Prims.unit =
+    Hax_lib.v_assert ((cast (cast (k <: i32) <: i16) <: i32) <=.
+        (Core.Num.impl__i32__MAX /!
+          (cast (Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16) <: i32)
+          <:
+          i32)
+        <:
+        bool)
+  in
+  let _:Prims.unit =
+    Hax_lib.v_assert ((cast (cast (k <: i32) <: i16) <: i32) >=.
+        (Core.Num.impl__i32__MIN /!
+          (cast (Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16) <: i32)
+          <:
+          i32)
+        <:
+        bool)
   in
   let k_times_modulus:i32 =
     (cast (cast (k <: i32) <: i16) <: i32) *!
@@ -28,9 +93,28 @@ let montgomery_reduce_element (value: i32) =
   in
   let c:i16 = cast (k_times_modulus >>! v_MONTGOMERY_SHIFT <: i32) <: i16 in
   let value_high:i16 = cast (value >>! v_MONTGOMERY_SHIFT <: i32) <: i16 in
+  let _:Prims.unit = Hax_lib.v_assert (value_high >=. c <: bool) in
   value_high -! c
 
 let montgomery_multiply_fe_by_fer (fe fer: i16) =
+  let _:Prims.unit =
+    Hax_lib.v_assert (((Rust_primitives.Hax.Int.from_machine fe <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine fer <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine Core.Num.impl__i32__MAX <: Hax_lib.Int.t_Int)
+        <:
+        bool)
+  in
+  let _:Prims.unit =
+    Hax_lib.v_assert (((Rust_primitives.Hax.Int.from_machine fe <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine fer <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine Core.Num.impl__i32__MIN <: Hax_lib.Int.t_Int)
+        <:
+        bool)
+  in
   montgomery_reduce_element ((cast (fe <: i16) <: i32) *! (cast (fer <: i16) <: i32) <: i32)
 
 let add (lhs rhs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
@@ -50,22 +134,27 @@ let add (lhs rhs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
       (fun lhs i ->
           let lhs:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector = lhs in
           let i:usize = i in
-          {
-            lhs with
-            Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-            =
-            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize lhs
-                .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-              i
-              ((lhs.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) +!
-                (rhs.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16)
-                <:
-                i16)
+          let _:Prims.unit = () <: Prims.unit in
+          let lhs:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
+            {
+              lhs with
+              Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize lhs
+                  .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+                i
+                (Core.Num.impl__i16__wrapping_add (lhs
+                        .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ]
+                      <:
+                      i16)
+                    (rhs.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16)
+                  <:
+                  i16)
+            }
             <:
-            t_Array i16 (sz 16)
-          }
-          <:
-          Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+            Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+          in
+          lhs)
   in
   lhs
 
@@ -86,23 +175,47 @@ let barrett_reduce (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVect
       (fun v i ->
           let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector = v in
           let i:usize = i in
-          {
-            v with
-            Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-            =
-            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-                .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-              i
-              (barrett_reduce_element (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ]
-                    <:
-                    i16)
+          let _:Prims.unit =
+            Hax_lib.v_assert ((Core.Convert.f_from #i32
+                    #i16
+                    #FStar.Tactics.Typeclasses.solve
+                    (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16)
+                  <:
+                  i32) >.
+                (Core.Ops.Arith.Neg.neg v_BARRETT_R <: i32)
                 <:
-                i16)
+                bool)
+          in
+          let _:Prims.unit =
+            Hax_lib.v_assert ((Core.Convert.f_from #i32
+                    #i16
+                    #FStar.Tactics.Typeclasses.solve
+                    (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16)
+                  <:
+                  i32) <.
+                v_BARRETT_R
+                <:
+                bool)
+          in
+          let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
+            {
+              v with
+              Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
+                  .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+                i
+                (barrett_reduce_element (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i
+                      ]
+                      <:
+                      i16)
+                  <:
+                  i16)
+            }
             <:
-            t_Array i16 (sz 16)
-          }
-          <:
-          Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+            Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+          in
+          v)
   in
   v
 
@@ -159,25 +272,7 @@ let cond_subtract_3329_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_Portabl
       (fun v i ->
           let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector = v in
           let i:usize = i in
-          let _:Prims.unit =
-            if true
-            then
-              let _:Prims.unit =
-                if
-                  ~.(((v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) >=. 0s
-                      <:
-                      bool) &&
-                    ((v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) <. 4096s
-                      <:
-                      bool))
-                then
-                  Rust_primitives.Hax.never_to_any (Core.Panicking.panic "assertion failed: v.elements[i] >= 0 && v.elements[i] < 4096"
-
-                      <:
-                      Rust_primitives.Hax.t_Never)
-              in
-              ()
-          in
+          let _:Prims.unit = () <: Prims.unit in
           if (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) >=. 3329s
           then
             {
@@ -256,19 +351,27 @@ let multiply_by_constant (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_Portab
       (fun v i ->
           let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector = v in
           let i:usize = i in
-          {
-            v with
-            Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-            =
-            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-                .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-              i
-              ((v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) *! c <: i16)
+          let _:Prims.unit = () <: Prims.unit in
+          let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
+            {
+              v with
+              Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
+                  .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+                i
+                (Core.Num.impl__i16__wrapping_mul (v
+                        .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ]
+                      <:
+                      i16)
+                    c
+                  <:
+                  i16)
+            }
             <:
-            t_Array i16 (sz 16)
-          }
-          <:
-          Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+            Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+          in
+          v)
   in
   v
 
@@ -324,21 +427,26 @@ let sub (lhs rhs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
       (fun lhs i ->
           let lhs:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector = lhs in
           let i:usize = i in
-          {
-            lhs with
-            Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-            =
-            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize lhs
-                .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-              i
-              ((lhs.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) -!
-                (rhs.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16)
-                <:
-                i16)
+          let _:Prims.unit = () <: Prims.unit in
+          let lhs:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
+            {
+              lhs with
+              Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+              =
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize lhs
+                  .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+                i
+                (Core.Num.impl__i16__wrapping_sub (lhs
+                        .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ]
+                      <:
+                      i16)
+                    (rhs.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16)
+                  <:
+                  i16)
+            }
             <:
-            t_Array i16 (sz 16)
-          }
-          <:
-          Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+            Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+          in
+          lhs)
   in
   lhs

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Arithmetic.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Arithmetic.fst
@@ -39,7 +39,18 @@ let barrett_reduce_element (value: i16) =
         bool)
   in
   let _:Prims.unit =
-    Hax_lib.v_assert (value >=. (quotient *! Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16)
+    Hax_lib.v_assert ((value -! (quotient *! Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16)
+          <:
+          i16) >=.
+        Core.Num.impl__i16__MIN
+        <:
+        bool)
+  in
+  let _:Prims.unit =
+    Hax_lib.v_assert ((value -! (quotient *! Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16)
+          <:
+          i16) <=.
+        Core.Num.impl__i16__MAX
         <:
         bool)
   in
@@ -93,13 +104,20 @@ let montgomery_reduce_element (value: i32) =
   in
   let c:i16 = cast (k_times_modulus >>! v_MONTGOMERY_SHIFT <: i32) <: i16 in
   let value_high:i16 = cast (value >>! v_MONTGOMERY_SHIFT <: i32) <: i16 in
-  let _:Prims.unit = Hax_lib.v_assert (value_high >=. c <: bool) in
+  let _:Prims.unit =
+    Hax_lib.v_assert ((value_high -! c <: i16) >=. Core.Num.impl__i16__MIN <: bool)
+  in
+  let _:Prims.unit =
+    Hax_lib.v_assert ((value_high -! c <: i16) <=. Core.Num.impl__i16__MAX <: bool)
+  in
   value_high -! c
 
 let montgomery_multiply_fe_by_fer (fe fer: i16) =
   let _:Prims.unit =
-    Hax_lib.v_assert (((Rust_primitives.Hax.Int.from_machine fe <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine fer <: Hax_lib.Int.t_Int)
+    Hax_lib.v_assert (((Rust_primitives.Hax.Int.from_machine (cast (fe <: i16) <: i32)
+            <:
+            Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine (cast (fer <: i16) <: i32) <: Hax_lib.Int.t_Int)
           <:
           Hax_lib.Int.t_Int) <=
         (Rust_primitives.Hax.Int.from_machine Core.Num.impl__i32__MAX <: Hax_lib.Int.t_Int)
@@ -107,8 +125,10 @@ let montgomery_multiply_fe_by_fer (fe fer: i16) =
         bool)
   in
   let _:Prims.unit =
-    Hax_lib.v_assert (((Rust_primitives.Hax.Int.from_machine fe <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine fer <: Hax_lib.Int.t_Int)
+    Hax_lib.v_assert (((Rust_primitives.Hax.Int.from_machine (cast (fe <: i16) <: i32)
+            <:
+            Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine (cast (fer <: i16) <: i32) <: Hax_lib.Int.t_Int)
           <:
           Hax_lib.Int.t_Int) >=
         (Rust_primitives.Hax.Int.from_machine Core.Num.impl__i32__MIN <: Hax_lib.Int.t_Int)

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Arithmetic.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Arithmetic.fsti
@@ -17,14 +17,7 @@ let v_MONTGOMERY_R: i32 = 1l <<! v_MONTGOMERY_SHIFT
 val get_n_least_significant_bits (n: u8) (value: u32)
     : Prims.Pure u32
       (requires n =. 4uy || n =. 5uy || n =. 10uy || n =. 11uy || n =. v_MONTGOMERY_SHIFT)
-      (ensures
-        fun result ->
-          let result:u32 = result in
-          result <.
-          (Core.Num.impl__u32__pow 2ul
-              (Core.Convert.f_into #u8 #u32 #FStar.Tactics.Typeclasses.solve n <: u32)
-            <:
-            u32))
+      (fun _ -> Prims.l_True)
 
 /// Signed Barrett Reduction
 /// Given an input `value`, `barrett_reduce` outputs a representative `result`
@@ -40,11 +33,7 @@ val barrett_reduce_element (value: i16)
         (Core.Ops.Arith.Neg.neg v_BARRETT_R <: i32) &&
         (Core.Convert.f_from #i32 #i16 #FStar.Tactics.Typeclasses.solve value <: i32) <. v_BARRETT_R
       )
-      (ensures
-        fun result ->
-          let result:i16 = result in
-          result >. (Core.Ops.Arith.Neg.neg Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16) &&
-          result <. Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS)
+      (fun _ -> Prims.l_True)
 
 /// Signed Montgomery Reduction
 /// Given an input `value`, `montgomery_reduce` outputs a representative `o`
@@ -53,31 +42,7 @@ val barrett_reduce_element (value: i16)
 /// - the absolute value of `o` is bound as follows:
 /// `|result| ≤ (|value| / MONTGOMERY_R) + (FIELD_MODULUS / 2)
 /// In particular, if `|value| ≤ FIELD_MODULUS * MONTGOMERY_R`, then `|o| < (3 · FIELD_MODULUS) / 2`.
-val montgomery_reduce_element (value: i32)
-    : Prims.Pure i16
-      (requires
-        value >=.
-        ((Core.Ops.Arith.Neg.neg (cast (Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16) <: i32)
-            <:
-            i32) *!
-          v_MONTGOMERY_R
-          <:
-          i32) &&
-        value <=.
-        ((cast (Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16) <: i32) *! v_MONTGOMERY_R
-          <:
-          i32))
-      (ensures
-        fun result ->
-          let result:i16 = result in
-          result >=.
-          ((Core.Ops.Arith.Neg.neg (3s *! Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16)
-              <:
-              i16) /!
-            2s
-            <:
-            i16) &&
-          result <=. ((3s *! Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS <: i16) /! 2s <: i16))
+val montgomery_reduce_element (value: i32) : Prims.Pure i16 Prims.l_True (fun _ -> Prims.l_True)
 
 /// If `fe` is some field element 'x' of the Kyber field and `fer` is congruent to
 /// `y · MONTGOMERY_R`, this procedure outputs a value that is congruent to
@@ -124,7 +89,7 @@ val multiply_by_constant (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_Portab
 
 val shift_right (v_SHIFT_BY: i32) (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
     : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-      Prims.l_True
+      (requires v_SHIFT_BY >=. 0l && v_SHIFT_BY <. 16l)
       (fun _ -> Prims.l_True)
 
 val sub (lhs rhs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)


### PR DESCRIPTION
This PR makes sure that Libcrux_ml_kem.Vector.Portable.Arithmetic.fst is verifiable by assisting the resolver where needed and put pre-conditions for certain functions in that module.

These changes require some properties in hax that have been added to `ml-kem-lax-check` branch

Part of #454 