### PR TITLE
Pure Rust version of PSQ

### DIFF
--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -24,6 +24,9 @@ rand = { version = "0.8" }
 libcrux-ecdh = { version = "0.0.2-alpha.3", path = "../libcrux-ecdh" }
 libcrux = { version = "0.0.2-alpha.3", path = ".." }
 
+[features]
+hacl-rs = ["libcrux-ecdh/hacl-rs"]
+
 [dev-dependencies]
 criterion = "0.5"
 


### PR DESCRIPTION
This adds a `hacl-rs` features to `libcrux-psq` which makes use of the feature of the same name in `libcrux-ecdh`. This means there should only be pure Rust dependencies (compiled anyway, there is still `libcrux` in the dependencies).