### PR TITLE
Implement `Clone` and `Send` for SHA2 state and hasher types

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -257,6 +257,7 @@ pub fn sha2_512(payload: &[u8]) -> Sha2_512Digest {
 // Streaming API - This is the recommended one.
 macro_rules! impl_streaming {
     ($name:ident, $state:ty, $result:ty) => {
+        #[derive(Clone)]
         pub struct $name {
             state: $state,
         }

--- a/src/hacl/sha2.rs
+++ b/src/hacl/sha2.rs
@@ -130,6 +130,8 @@ pub mod streaming {
                     }
                 }
             }
+
+            unsafe impl Send for $name {}
         };
     }
 

--- a/src/hacl/sha2.rs
+++ b/src/hacl/sha2.rs
@@ -65,18 +65,18 @@ pub fn sha512(payload: &[u8]) -> [u8; 64] {
 
 pub mod streaming {
     use libcrux_hacl::{
-        Hacl_Hash_SHA2_digest_224, Hacl_Hash_SHA2_digest_256, Hacl_Hash_SHA2_digest_384,
-        Hacl_Hash_SHA2_digest_512, Hacl_Hash_SHA2_free_224, Hacl_Hash_SHA2_free_256,
-        Hacl_Hash_SHA2_free_384, Hacl_Hash_SHA2_free_512, Hacl_Hash_SHA2_malloc_224,
-        Hacl_Hash_SHA2_malloc_256, Hacl_Hash_SHA2_malloc_384, Hacl_Hash_SHA2_malloc_512,
-        Hacl_Hash_SHA2_reset_224, Hacl_Hash_SHA2_reset_256, Hacl_Hash_SHA2_reset_384,
-        Hacl_Hash_SHA2_reset_512, Hacl_Hash_SHA2_state_t_224, Hacl_Hash_SHA2_state_t_384,
-        Hacl_Hash_SHA2_update_224, Hacl_Hash_SHA2_update_256, Hacl_Hash_SHA2_update_384,
-        Hacl_Hash_SHA2_update_512,
+        Hacl_Hash_SHA2_copy_256, Hacl_Hash_SHA2_copy_512, Hacl_Hash_SHA2_digest_224,
+        Hacl_Hash_SHA2_digest_256, Hacl_Hash_SHA2_digest_384, Hacl_Hash_SHA2_digest_512,
+        Hacl_Hash_SHA2_free_224, Hacl_Hash_SHA2_free_256, Hacl_Hash_SHA2_free_384,
+        Hacl_Hash_SHA2_free_512, Hacl_Hash_SHA2_malloc_224, Hacl_Hash_SHA2_malloc_256,
+        Hacl_Hash_SHA2_malloc_384, Hacl_Hash_SHA2_malloc_512, Hacl_Hash_SHA2_reset_224,
+        Hacl_Hash_SHA2_reset_256, Hacl_Hash_SHA2_reset_384, Hacl_Hash_SHA2_reset_512,
+        Hacl_Hash_SHA2_state_t_224, Hacl_Hash_SHA2_state_t_384, Hacl_Hash_SHA2_update_224,
+        Hacl_Hash_SHA2_update_256, Hacl_Hash_SHA2_update_384, Hacl_Hash_SHA2_update_512,
     };
 
     macro_rules! impl_streaming {
-        ($name:ident, $digest_size:literal, $state:ty, $malloc:expr, $reset:expr, $update:expr, $finish:expr, $free:expr) => {
+        ($name:ident, $digest_size:literal, $state:ty, $malloc:expr, $reset:expr, $update:expr, $finish:expr, $free:expr, $copy:expr) => {
             pub struct $name {
                 state: *mut $state,
             }
@@ -120,6 +120,16 @@ pub mod streaming {
                     unsafe { $free(self.state) };
                 }
             }
+
+            impl Clone for $name {
+                fn clone(&self) -> Self {
+                    unsafe {
+                        Self {
+                            state: $copy(self.state),
+                        }
+                    }
+                }
+            }
         };
     }
 
@@ -131,7 +141,8 @@ pub mod streaming {
         Hacl_Hash_SHA2_reset_224,
         Hacl_Hash_SHA2_update_224,
         Hacl_Hash_SHA2_digest_224,
-        Hacl_Hash_SHA2_free_224
+        Hacl_Hash_SHA2_free_224,
+        Hacl_Hash_SHA2_copy_256
     );
 
     impl_streaming!(
@@ -142,7 +153,8 @@ pub mod streaming {
         Hacl_Hash_SHA2_reset_256,
         Hacl_Hash_SHA2_update_256,
         Hacl_Hash_SHA2_digest_256,
-        Hacl_Hash_SHA2_free_256
+        Hacl_Hash_SHA2_free_256,
+        Hacl_Hash_SHA2_copy_256
     );
 
     impl_streaming!(
@@ -153,7 +165,8 @@ pub mod streaming {
         Hacl_Hash_SHA2_reset_384,
         Hacl_Hash_SHA2_update_384,
         Hacl_Hash_SHA2_digest_384,
-        Hacl_Hash_SHA2_free_384
+        Hacl_Hash_SHA2_free_384,
+        Hacl_Hash_SHA2_copy_512
     );
 
     impl_streaming!(
@@ -164,6 +177,7 @@ pub mod streaming {
         Hacl_Hash_SHA2_reset_512,
         Hacl_Hash_SHA2_update_512,
         Hacl_Hash_SHA2_digest_512,
-        Hacl_Hash_SHA2_free_512
+        Hacl_Hash_SHA2_free_512,
+        Hacl_Hash_SHA2_copy_512
     );
 }

--- a/tests/sha2.rs
+++ b/tests/sha2.rs
@@ -19,3 +19,50 @@ fn sha256_kat_oneshot() {
     let expected = "8683520e19e5b33db33c8fb90918c0c96fcdfd9a17c695ce0f0ea2eaa0c95956";
     assert_eq!(hex::encode(&d), expected);
 }
+
+#[test]
+fn sha2_clone() {
+    let mut hasher_224 = libcrux::digest::Sha2_224::new();
+    hasher_224.update(b"test 224");
+    let mut hasher224_2 = hasher_224.clone();
+    hasher_224.update(b"more 224");
+    hasher224_2.update(b"more 224");
+    let digest = hasher_224.finish();
+    let digest_2 = hasher224_2.finish();
+
+    assert_eq!(digest, digest_2);
+    assert_eq!(digest, libcrux::digest::sha2_224(b"test 224more 224"));
+
+    let mut hasher_256 = libcrux::digest::Sha2_256::new();
+    hasher_256.update(b"test 256");
+    let mut hasher256_2 = hasher_256.clone();
+    hasher_256.update(b"more 256");
+    hasher256_2.update(b"more 256");
+    let digest = hasher_256.finish();
+    let digest_2 = hasher256_2.finish();
+
+    assert_eq!(digest, digest_2);
+    assert_eq!(digest, libcrux::digest::sha2_256(b"test 256more 256"));
+
+    let mut hasher_384 = libcrux::digest::Sha2_384::new();
+    hasher_384.update(b"test 384");
+    let mut hasher384_2 = hasher_384.clone();
+    hasher_384.update(b"more 384");
+    hasher384_2.update(b"more 384");
+    let digest = hasher_384.finish();
+    let digest_2 = hasher384_2.finish();
+
+    assert_eq!(digest, digest_2);
+    assert_eq!(digest, libcrux::digest::sha2_384(b"test 384more 384"));
+
+    let mut hasher_512 = libcrux::digest::Sha2_512::new();
+    hasher_512.update(b"test 512");
+    let mut hasher512_2 = hasher_512.clone();
+    hasher_512.update(b"more 512");
+    hasher512_2.update(b"more 512");
+    let digest = hasher_512.finish();
+    let digest_2 = hasher512_2.finish();
+
+    assert_eq!(digest, digest_2);
+    assert_eq!(digest, libcrux::digest::sha2_512(b"test 512more 512"));
+}


### PR DESCRIPTION
We need these implementations for implementing a provider that requires these features.

`Send` should be safe, since there is no other thread in C-land that operates on the data in the hash state. We already did the same for Drbg: #205 