### PR TITLE
fix(mlkem/fstar): fix regression introduced by hacspec/hax#864

### DIFF
--- a/libcrux-ml-kem/src/mlkem1024.rs
+++ b/libcrux-ml-kem/src/mlkem1024.rs
@@ -234,6 +234,7 @@ macro_rules! instantiate {
             #[cfg_attr(
                 hax,
                 hax_lib::fstar::before(
+                    interface,
                     "
 let _ =
     (* This module has implicit dependencies, here we make them explicit. *)

--- a/libcrux-ml-kem/src/mlkem512.rs
+++ b/libcrux-ml-kem/src/mlkem512.rs
@@ -227,6 +227,7 @@ macro_rules! instantiate {
             #[cfg_attr(
                 hax,
                 hax_lib::fstar::before(
+                    interface,
                     "
 let _ =
     (* This module has implicit dependencies, here we make them explicit. *)

--- a/libcrux-ml-kem/src/mlkem768.rs
+++ b/libcrux-ml-kem/src/mlkem768.rs
@@ -230,6 +230,7 @@ macro_rules! instantiate {
             #[cfg_attr(
                 hax,
                 hax_lib::fstar::before(
+                    interface,
                     "
 let _ =
     (* This module has implicit dependencies, here we make them explicit. *)


### PR DESCRIPTION
https://github.com/hacspec/hax/pull/846 makes `fstar::before` and `fstar::after` chunks of code default to implementation files (fst).

This commit backports that change and makes some code go explicitly to interfaces.