### PR TITLE
[ML-KEM] Address changes from FIPS 203 IPD to final version

### DIFF
--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -156,7 +156,7 @@ jobs:
       - name: 🏃🏻‍♀️ Test Kyber
         run: |
           cargo clean
-          cargo test --features kyber --verbose $RUST_TARGET_FLAG
+          cargo test --features pre-verification,kyber --verbose $RUST_TARGET_FLAG
 
       - name: 🏃🏻‍♀️ Cargo Check Features
         if: ${{ matrix.bits == 64 }}

--- a/libcrux-ml-kem/c/code_gen.txt
+++ b/libcrux-ml-kem/c/code_gen.txt
@@ -2,5 +2,5 @@ This code was generated with the following revisions:
 Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
 Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
 Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
-F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
-Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d

--- a/libcrux-ml-kem/c/internal/libcrux_core.h
+++ b/libcrux-ml-kem/c/internal/libcrux_core.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __internal_libcrux_core_H
@@ -75,7 +75,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_b6
 with const generics
 - SIZE= 1568
 */
-libcrux_ml_kem_types_MlKemPublicKey_1f libcrux_ml_kem_types_from_b6_8e1(
+libcrux_ml_kem_types_MlKemPublicKey_1f libcrux_ml_kem_types_from_b6_b01(
     uint8_t value[1568U]);
 
 /**
@@ -91,7 +91,7 @@ with const generics
 - PRIVATE_KEY_SIZE= 3168
 - PUBLIC_KEY_SIZE= 1568
 */
-libcrux_ml_kem_mlkem1024_MlKem1024KeyPair libcrux_ml_kem_types_from_17_121(
+libcrux_ml_kem_mlkem1024_MlKem1024KeyPair libcrux_ml_kem_types_from_17_9c1(
     libcrux_ml_kem_types_MlKemPrivateKey_95 sk,
     libcrux_ml_kem_types_MlKemPublicKey_1f pk);
 
@@ -104,7 +104,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_05
 with const generics
 - SIZE= 3168
 */
-libcrux_ml_kem_types_MlKemPrivateKey_95 libcrux_ml_kem_types_from_05_db1(
+libcrux_ml_kem_types_MlKemPrivateKey_95 libcrux_ml_kem_types_from_05_0b1(
     uint8_t value[3168U]);
 
 /**
@@ -116,7 +116,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_01
 with const generics
 - SIZE= 1568
 */
-libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext libcrux_ml_kem_types_from_01_ec1(
+libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext libcrux_ml_kem_types_from_01_2d1(
     uint8_t value[1568U]);
 
 /**
@@ -130,7 +130,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_slice_cb
 with const generics
 - SIZE= 1568
 */
-uint8_t *libcrux_ml_kem_types_as_slice_cb_6f1(
+uint8_t *libcrux_ml_kem_types_as_slice_cb_331(
     libcrux_ml_kem_types_MlKemPublicKey_1f *self);
 
 /**
@@ -142,7 +142,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_ref_00
 with const generics
 - SIZE= 1568
 */
-Eurydice_slice libcrux_ml_kem_types_as_ref_00_b41(
+Eurydice_slice libcrux_ml_kem_types_as_ref_00_fd1(
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *self);
 
 /**
@@ -165,7 +165,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_b6
 with const generics
 - SIZE= 1184
 */
-libcrux_ml_kem_types_MlKemPublicKey_15 libcrux_ml_kem_types_from_b6_8e0(
+libcrux_ml_kem_types_MlKemPublicKey_15 libcrux_ml_kem_types_from_b6_b00(
     uint8_t value[1184U]);
 
 /**
@@ -181,7 +181,7 @@ with const generics
 - PRIVATE_KEY_SIZE= 2400
 - PUBLIC_KEY_SIZE= 1184
 */
-libcrux_ml_kem_mlkem768_MlKem768KeyPair libcrux_ml_kem_types_from_17_120(
+libcrux_ml_kem_mlkem768_MlKem768KeyPair libcrux_ml_kem_types_from_17_9c0(
     libcrux_ml_kem_types_MlKemPrivateKey_55 sk,
     libcrux_ml_kem_types_MlKemPublicKey_15 pk);
 
@@ -194,7 +194,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_05
 with const generics
 - SIZE= 2400
 */
-libcrux_ml_kem_types_MlKemPrivateKey_55 libcrux_ml_kem_types_from_05_db0(
+libcrux_ml_kem_types_MlKemPrivateKey_55 libcrux_ml_kem_types_from_05_0b0(
     uint8_t value[2400U]);
 
 /**
@@ -206,7 +206,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_01
 with const generics
 - SIZE= 1088
 */
-libcrux_ml_kem_mlkem768_MlKem768Ciphertext libcrux_ml_kem_types_from_01_ec0(
+libcrux_ml_kem_mlkem768_MlKem768Ciphertext libcrux_ml_kem_types_from_01_2d0(
     uint8_t value[1088U]);
 
 /**
@@ -220,7 +220,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_slice_cb
 with const generics
 - SIZE= 1184
 */
-uint8_t *libcrux_ml_kem_types_as_slice_cb_6f0(
+uint8_t *libcrux_ml_kem_types_as_slice_cb_330(
     libcrux_ml_kem_types_MlKemPublicKey_15 *self);
 
 /**
@@ -232,7 +232,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_ref_00
 with const generics
 - SIZE= 1088
 */
-Eurydice_slice libcrux_ml_kem_types_as_ref_00_b40(
+Eurydice_slice libcrux_ml_kem_types_as_ref_00_fd0(
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *self);
 
 /**
@@ -255,7 +255,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_b6
 with const generics
 - SIZE= 800
 */
-libcrux_ml_kem_types_MlKemPublicKey_be libcrux_ml_kem_types_from_b6_8e(
+libcrux_ml_kem_types_MlKemPublicKey_be libcrux_ml_kem_types_from_b6_b0(
     uint8_t value[800U]);
 
 /**
@@ -271,7 +271,7 @@ with const generics
 - PRIVATE_KEY_SIZE= 1632
 - PUBLIC_KEY_SIZE= 800
 */
-libcrux_ml_kem_types_MlKemKeyPair_cb libcrux_ml_kem_types_from_17_12(
+libcrux_ml_kem_types_MlKemKeyPair_cb libcrux_ml_kem_types_from_17_9c(
     libcrux_ml_kem_types_MlKemPrivateKey_5e sk,
     libcrux_ml_kem_types_MlKemPublicKey_be pk);
 
@@ -284,7 +284,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_05
 with const generics
 - SIZE= 1632
 */
-libcrux_ml_kem_types_MlKemPrivateKey_5e libcrux_ml_kem_types_from_05_db(
+libcrux_ml_kem_types_MlKemPrivateKey_5e libcrux_ml_kem_types_from_05_0b(
     uint8_t value[1632U]);
 
 /**
@@ -319,7 +319,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_01
 with const generics
 - SIZE= 768
 */
-libcrux_ml_kem_types_MlKemCiphertext_e8 libcrux_ml_kem_types_from_01_ec(
+libcrux_ml_kem_types_MlKemCiphertext_e8 libcrux_ml_kem_types_from_01_2d(
     uint8_t value[768U]);
 
 /**
@@ -333,7 +333,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_slice_cb
 with const generics
 - SIZE= 800
 */
-uint8_t *libcrux_ml_kem_types_as_slice_cb_6f(
+uint8_t *libcrux_ml_kem_types_as_slice_cb_33(
     libcrux_ml_kem_types_MlKemPublicKey_be *self);
 
 /**
@@ -367,7 +367,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_ref_00
 with const generics
 - SIZE= 768
 */
-Eurydice_slice libcrux_ml_kem_types_as_ref_00_b4(
+Eurydice_slice libcrux_ml_kem_types_as_ref_00_fd(
     libcrux_ml_kem_types_MlKemCiphertext_e8 *self);
 
 /**

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __internal_libcrux_mlkem_avx2_H
@@ -32,7 +32,7 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_f91(uint8_t *public_key);
+bool libcrux_ml_kem_ind_cca_validate_public_key_a71(uint8_t *public_key);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair_unpacked
@@ -47,7 +47,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_271(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_911(uint8_t randomness[64U]);
 
 /**
  Packed API
@@ -60,7 +60,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_271(uint8_t randomness[64U]);
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 3
 - CPA_PRIVATE_KEY_SIZE= 1152
 - PRIVATE_KEY_SIZE= 2400
@@ -70,7 +71,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_mlkem768_MlKem768KeyPair
-libcrux_ml_kem_ind_cca_generate_keypair_0d1(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_501(uint8_t randomness[64U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate_unpacked
@@ -90,14 +91,14 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e1(
+tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_f21(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0 *public_key,
     uint8_t randomness[32U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
@@ -113,7 +114,7 @@ with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_3c libcrux_ml_kem_ind_cca_encapsulate_411(
+tuple_3c libcrux_ml_kem_ind_cca_encapsulate_e21(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]);
 
@@ -138,14 +139,14 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f1(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_591(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0 *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 3
 - SECRET_KEY_SIZE= 2400
@@ -164,7 +165,7 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-void libcrux_ml_kem_ind_cca_decapsulate_6e1(
+void libcrux_ml_kem_ind_cca_decapsulate_ff1(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]);
 
@@ -176,7 +177,7 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1536
 - PUBLIC_KEY_SIZE= 1568
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_f90(uint8_t *public_key);
+bool libcrux_ml_kem_ind_cca_validate_public_key_a70(uint8_t *public_key);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair_unpacked
@@ -191,7 +192,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_01
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_270(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_910(uint8_t randomness[64U]);
 
 /**
  Packed API
@@ -204,7 +205,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_270(uint8_t randomness[64U]);
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 4
 - CPA_PRIVATE_KEY_SIZE= 1536
 - PRIVATE_KEY_SIZE= 3168
@@ -214,7 +216,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_mlkem1024_MlKem1024KeyPair
-libcrux_ml_kem_ind_cca_generate_keypair_0d0(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_500(uint8_t randomness[64U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate_unpacked
@@ -234,14 +236,14 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e0(
+tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_f20(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_01 *public_key,
     uint8_t randomness[32U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 4
 - CIPHERTEXT_SIZE= 1568
@@ -257,7 +259,7 @@ with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_21 libcrux_ml_kem_ind_cca_encapsulate_410(
+tuple_21 libcrux_ml_kem_ind_cca_encapsulate_e20(
     libcrux_ml_kem_types_MlKemPublicKey_1f *public_key,
     uint8_t randomness[32U]);
 
@@ -282,14 +284,14 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f0(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_590(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_01 *key_pair,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext, uint8_t ret[32U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 4
 - SECRET_KEY_SIZE= 3168
@@ -308,7 +310,7 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-void libcrux_ml_kem_ind_cca_decapsulate_6e0(
+void libcrux_ml_kem_ind_cca_decapsulate_ff0(
     libcrux_ml_kem_types_MlKemPrivateKey_95 *private_key,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext, uint8_t ret[32U]);
 
@@ -320,7 +322,7 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 768
 - PUBLIC_KEY_SIZE= 800
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_f9(uint8_t *public_key);
+bool libcrux_ml_kem_ind_cca_validate_public_key_a7(uint8_t *public_key);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair_unpacked
@@ -335,7 +337,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 192
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_d6
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_27(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_91(uint8_t randomness[64U]);
 
 /**
  Packed API
@@ -348,7 +350,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_27(uint8_t randomness[64U]);
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 2
 - CPA_PRIVATE_KEY_SIZE= 768
 - PRIVATE_KEY_SIZE= 1632
@@ -357,7 +360,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-libcrux_ml_kem_types_MlKemKeyPair_cb libcrux_ml_kem_ind_cca_generate_keypair_0d(
+libcrux_ml_kem_types_MlKemKeyPair_cb libcrux_ml_kem_ind_cca_generate_keypair_50(
     uint8_t randomness[64U]);
 
 /**
@@ -378,14 +381,14 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e(
+tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_f2(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_d6 *public_key,
     uint8_t randomness[32U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 2
 - CIPHERTEXT_SIZE= 768
@@ -401,7 +404,7 @@ with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_ec libcrux_ml_kem_ind_cca_encapsulate_41(
+tuple_ec libcrux_ml_kem_ind_cca_encapsulate_e2(
     libcrux_ml_kem_types_MlKemPublicKey_be *public_key,
     uint8_t randomness[32U]);
 
@@ -426,14 +429,14 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_59(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_d6 *key_pair,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 2
 - SECRET_KEY_SIZE= 1632
@@ -452,7 +455,7 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-void libcrux_ml_kem_ind_cca_decapsulate_6e(
+void libcrux_ml_kem_ind_cca_decapsulate_ff(
     libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]);
 

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __internal_libcrux_mlkem_portable_H
@@ -37,7 +37,7 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1536
 - PUBLIC_KEY_SIZE= 1568
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_c21(uint8_t *public_key);
+bool libcrux_ml_kem_ind_cca_validate_public_key_6d1(uint8_t *public_key);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair_unpacked
@@ -53,7 +53,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_42
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c81(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_2c1(uint8_t randomness[64U]);
 
 /**
  Packed API
@@ -66,8 +66,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c81(uint8_t randomness[64U]);
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 4
 - CPA_PRIVATE_KEY_SIZE= 1536
 - PRIVATE_KEY_SIZE= 3168
@@ -77,7 +77,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_mlkem1024_MlKem1024KeyPair
-libcrux_ml_kem_ind_cca_generate_keypair_f91(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_951(uint8_t randomness[64U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate_unpacked
@@ -98,7 +98,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_de1(
+tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_511(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_42 *public_key,
     uint8_t randomness[32U]);
 
@@ -106,7 +106,7 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_de1(
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 4
 - CIPHERTEXT_SIZE= 1568
 - PUBLIC_KEY_SIZE= 1568
@@ -121,7 +121,7 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_21 libcrux_ml_kem_ind_cca_encapsulate_8f1(
+tuple_21 libcrux_ml_kem_ind_cca_encapsulate_511(
     libcrux_ml_kem_types_MlKemPublicKey_1f *public_key,
     uint8_t randomness[32U]);
 
@@ -147,7 +147,7 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c1(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_881(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_42 *key_pair,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext, uint8_t ret[32U]);
 
@@ -155,7 +155,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c1(
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 4
 - SECRET_KEY_SIZE= 3168
 - CPA_SECRET_KEY_SIZE= 1536
@@ -173,7 +173,7 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-void libcrux_ml_kem_ind_cca_decapsulate_811(
+void libcrux_ml_kem_ind_cca_decapsulate_461(
     libcrux_ml_kem_types_MlKemPrivateKey_95 *private_key,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext, uint8_t ret[32U]);
 
@@ -185,7 +185,7 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 768
 - PUBLIC_KEY_SIZE= 800
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_c20(uint8_t *public_key);
+bool libcrux_ml_kem_ind_cca_validate_public_key_6d0(uint8_t *public_key);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair_unpacked
@@ -201,7 +201,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 192
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_ae
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c80(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_2c0(uint8_t randomness[64U]);
 
 /**
  Packed API
@@ -214,8 +214,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c80(uint8_t randomness[64U]);
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 2
 - CPA_PRIVATE_KEY_SIZE= 768
 - PRIVATE_KEY_SIZE= 1632
@@ -225,7 +225,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 192
 */
 libcrux_ml_kem_types_MlKemKeyPair_cb
-libcrux_ml_kem_ind_cca_generate_keypair_f90(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_950(uint8_t randomness[64U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate_unpacked
@@ -246,7 +246,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_de0(
+tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_510(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_ae *public_key,
     uint8_t randomness[32U]);
 
@@ -254,7 +254,7 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_de0(
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 2
 - CIPHERTEXT_SIZE= 768
 - PUBLIC_KEY_SIZE= 800
@@ -269,7 +269,7 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_ec libcrux_ml_kem_ind_cca_encapsulate_8f0(
+tuple_ec libcrux_ml_kem_ind_cca_encapsulate_510(
     libcrux_ml_kem_types_MlKemPublicKey_be *public_key,
     uint8_t randomness[32U]);
 
@@ -295,7 +295,7 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c0(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_880(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_ae *key_pair,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]);
 
@@ -303,7 +303,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c0(
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 2
 - SECRET_KEY_SIZE= 1632
 - CPA_SECRET_KEY_SIZE= 768
@@ -321,7 +321,7 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-void libcrux_ml_kem_ind_cca_decapsulate_810(
+void libcrux_ml_kem_ind_cca_decapsulate_460(
     libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]);
 
@@ -333,7 +333,7 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_c2(uint8_t *public_key);
+bool libcrux_ml_kem_ind_cca_validate_public_key_6d(uint8_t *public_key);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair_unpacked
@@ -349,7 +349,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c8(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_2c(uint8_t randomness[64U]);
 
 /**
  Packed API
@@ -362,8 +362,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c8(uint8_t randomness[64U]);
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - CPA_PRIVATE_KEY_SIZE= 1152
 - PRIVATE_KEY_SIZE= 2400
@@ -373,7 +373,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_mlkem768_MlKem768KeyPair
-libcrux_ml_kem_ind_cca_generate_keypair_f9(uint8_t randomness[64U]);
+libcrux_ml_kem_ind_cca_generate_keypair_95(uint8_t randomness[64U]);
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate_unpacked
@@ -394,7 +394,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_de(
+tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_51(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_f8 *public_key,
     uint8_t randomness[32U]);
 
@@ -402,7 +402,7 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_de(
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
 - PUBLIC_KEY_SIZE= 1184
@@ -417,7 +417,7 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_3c libcrux_ml_kem_ind_cca_encapsulate_8f(
+tuple_3c libcrux_ml_kem_ind_cca_encapsulate_51(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]);
 
@@ -443,7 +443,7 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_88(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8 *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]);
 
@@ -451,7 +451,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c(
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - SECRET_KEY_SIZE= 2400
 - CPA_SECRET_KEY_SIZE= 1152
@@ -469,7 +469,7 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-void libcrux_ml_kem_ind_cca_decapsulate_81(
+void libcrux_ml_kem_ind_cca_decapsulate_46(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]);
 

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __internal_libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __internal_libcrux_sha3_internal_H

--- a/libcrux-ml-kem/c/libcrux_core.c
+++ b/libcrux-ml-kem/c/libcrux_core.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "internal/libcrux_core.h"
@@ -96,7 +96,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_b6
 with const generics
 - SIZE= 1568
 */
-libcrux_ml_kem_types_MlKemPublicKey_1f libcrux_ml_kem_types_from_b6_8e1(
+libcrux_ml_kem_types_MlKemPublicKey_1f libcrux_ml_kem_types_from_b6_b01(
     uint8_t value[1568U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[1568U];
@@ -119,7 +119,7 @@ with const generics
 - PRIVATE_KEY_SIZE= 3168
 - PUBLIC_KEY_SIZE= 1568
 */
-libcrux_ml_kem_mlkem1024_MlKem1024KeyPair libcrux_ml_kem_types_from_17_121(
+libcrux_ml_kem_mlkem1024_MlKem1024KeyPair libcrux_ml_kem_types_from_17_9c1(
     libcrux_ml_kem_types_MlKemPrivateKey_95 sk,
     libcrux_ml_kem_types_MlKemPublicKey_1f pk) {
   return (
@@ -135,7 +135,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_05
 with const generics
 - SIZE= 3168
 */
-libcrux_ml_kem_types_MlKemPrivateKey_95 libcrux_ml_kem_types_from_05_db1(
+libcrux_ml_kem_types_MlKemPrivateKey_95 libcrux_ml_kem_types_from_05_0b1(
     uint8_t value[3168U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[3168U];
@@ -154,7 +154,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_01
 with const generics
 - SIZE= 1568
 */
-libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext libcrux_ml_kem_types_from_01_ec1(
+libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext libcrux_ml_kem_types_from_01_2d1(
     uint8_t value[1568U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[1568U];
@@ -175,7 +175,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_slice_cb
 with const generics
 - SIZE= 1568
 */
-uint8_t *libcrux_ml_kem_types_as_slice_cb_6f1(
+uint8_t *libcrux_ml_kem_types_as_slice_cb_331(
     libcrux_ml_kem_types_MlKemPublicKey_1f *self) {
   return self->value;
 }
@@ -189,7 +189,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_ref_00
 with const generics
 - SIZE= 1568
 */
-Eurydice_slice libcrux_ml_kem_types_as_ref_00_b41(
+Eurydice_slice libcrux_ml_kem_types_as_ref_00_fd1(
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *self) {
   return Eurydice_array_to_slice((size_t)1568U, self->value, uint8_t);
 }
@@ -222,7 +222,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_b6
 with const generics
 - SIZE= 1184
 */
-libcrux_ml_kem_types_MlKemPublicKey_15 libcrux_ml_kem_types_from_b6_8e0(
+libcrux_ml_kem_types_MlKemPublicKey_15 libcrux_ml_kem_types_from_b6_b00(
     uint8_t value[1184U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[1184U];
@@ -245,7 +245,7 @@ with const generics
 - PRIVATE_KEY_SIZE= 2400
 - PUBLIC_KEY_SIZE= 1184
 */
-libcrux_ml_kem_mlkem768_MlKem768KeyPair libcrux_ml_kem_types_from_17_120(
+libcrux_ml_kem_mlkem768_MlKem768KeyPair libcrux_ml_kem_types_from_17_9c0(
     libcrux_ml_kem_types_MlKemPrivateKey_55 sk,
     libcrux_ml_kem_types_MlKemPublicKey_15 pk) {
   return (
@@ -261,7 +261,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_05
 with const generics
 - SIZE= 2400
 */
-libcrux_ml_kem_types_MlKemPrivateKey_55 libcrux_ml_kem_types_from_05_db0(
+libcrux_ml_kem_types_MlKemPrivateKey_55 libcrux_ml_kem_types_from_05_0b0(
     uint8_t value[2400U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[2400U];
@@ -280,7 +280,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_01
 with const generics
 - SIZE= 1088
 */
-libcrux_ml_kem_mlkem768_MlKem768Ciphertext libcrux_ml_kem_types_from_01_ec0(
+libcrux_ml_kem_mlkem768_MlKem768Ciphertext libcrux_ml_kem_types_from_01_2d0(
     uint8_t value[1088U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[1088U];
@@ -301,7 +301,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_slice_cb
 with const generics
 - SIZE= 1184
 */
-uint8_t *libcrux_ml_kem_types_as_slice_cb_6f0(
+uint8_t *libcrux_ml_kem_types_as_slice_cb_330(
     libcrux_ml_kem_types_MlKemPublicKey_15 *self) {
   return self->value;
 }
@@ -315,7 +315,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_ref_00
 with const generics
 - SIZE= 1088
 */
-Eurydice_slice libcrux_ml_kem_types_as_ref_00_b40(
+Eurydice_slice libcrux_ml_kem_types_as_ref_00_fd0(
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *self) {
   return Eurydice_array_to_slice((size_t)1088U, self->value, uint8_t);
 }
@@ -348,7 +348,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_b6
 with const generics
 - SIZE= 800
 */
-libcrux_ml_kem_types_MlKemPublicKey_be libcrux_ml_kem_types_from_b6_8e(
+libcrux_ml_kem_types_MlKemPublicKey_be libcrux_ml_kem_types_from_b6_b0(
     uint8_t value[800U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[800U];
@@ -371,7 +371,7 @@ with const generics
 - PRIVATE_KEY_SIZE= 1632
 - PUBLIC_KEY_SIZE= 800
 */
-libcrux_ml_kem_types_MlKemKeyPair_cb libcrux_ml_kem_types_from_17_12(
+libcrux_ml_kem_types_MlKemKeyPair_cb libcrux_ml_kem_types_from_17_9c(
     libcrux_ml_kem_types_MlKemPrivateKey_5e sk,
     libcrux_ml_kem_types_MlKemPublicKey_be pk) {
   return (CLITERAL(libcrux_ml_kem_types_MlKemKeyPair_cb){.sk = sk, .pk = pk});
@@ -386,7 +386,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_05
 with const generics
 - SIZE= 1632
 */
-libcrux_ml_kem_types_MlKemPrivateKey_5e libcrux_ml_kem_types_from_05_db(
+libcrux_ml_kem_types_MlKemPrivateKey_5e libcrux_ml_kem_types_from_05_0b(
     uint8_t value[1632U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[1632U];
@@ -425,7 +425,7 @@ A monomorphic instance of libcrux_ml_kem.types.from_01
 with const generics
 - SIZE= 768
 */
-libcrux_ml_kem_types_MlKemCiphertext_e8 libcrux_ml_kem_types_from_01_ec(
+libcrux_ml_kem_types_MlKemCiphertext_e8 libcrux_ml_kem_types_from_01_2d(
     uint8_t value[768U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[768U];
@@ -446,7 +446,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_slice_cb
 with const generics
 - SIZE= 800
 */
-uint8_t *libcrux_ml_kem_types_as_slice_cb_6f(
+uint8_t *libcrux_ml_kem_types_as_slice_cb_33(
     libcrux_ml_kem_types_MlKemPublicKey_be *self) {
   return self->value;
 }
@@ -498,7 +498,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_ref_00
 with const generics
 - SIZE= 768
 */
-Eurydice_slice libcrux_ml_kem_types_as_ref_00_b4(
+Eurydice_slice libcrux_ml_kem_types_as_ref_00_fd(
     libcrux_ml_kem_types_MlKemCiphertext_e8 *self) {
   return Eurydice_array_to_slice((size_t)768U, self->value, uint8_t);
 }

--- a/libcrux-ml-kem/c/libcrux_core.h
+++ b/libcrux-ml-kem/c/libcrux_core.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_core_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem1024_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "libcrux_mlkem1024_avx2.h"
@@ -38,11 +38,11 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-static void decapsulate_ea(
+static void decapsulate_6e(
     libcrux_ml_kem_types_MlKemPrivateKey_95 *private_key,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_6e0(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_ff0(private_key, ciphertext, ret);
 }
 
 /**
@@ -56,7 +56,7 @@ void libcrux_ml_kem_mlkem1024_avx2_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_95 *private_key,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
-  decapsulate_ea(private_key, ciphertext, ret);
+  decapsulate_6e(private_key, ciphertext, ret);
 }
 
 /**
@@ -83,11 +83,11 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-static void decapsulate_unpacked_d0(
+static void decapsulate_unpacked_98(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_01 *key_pair,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f0(key_pair, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_unpacked_590(key_pair, ciphertext, ret);
 }
 
 /**
@@ -101,7 +101,7 @@ void libcrux_ml_kem_mlkem1024_avx2_decapsulate_unpacked(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_01 *private_key,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
-  decapsulate_unpacked_d0(private_key, ciphertext, ret);
+  decapsulate_unpacked_98(private_key, ciphertext, ret);
 }
 
 /**
@@ -121,14 +121,14 @@ with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_21 encapsulate_14(
+static tuple_21 encapsulate_46(
     libcrux_ml_kem_types_MlKemPublicKey_1f *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_1f *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_410(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_encapsulate_e20(uu____0, copy_of_randomness);
 }
 
 /**
@@ -145,7 +145,7 @@ tuple_21 libcrux_ml_kem_mlkem1024_avx2_encapsulate(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_14(uu____0, copy_of_randomness);
+  return encapsulate_46(uu____0, copy_of_randomness);
 }
 
 /**
@@ -169,7 +169,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_21 encapsulate_unpacked_4c(
+static tuple_21 encapsulate_unpacked_e3(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_01 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_01 *uu____0 =
@@ -177,7 +177,7 @@ static tuple_21 encapsulate_unpacked_4c(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e0(uu____0,
+  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_f20(uu____0,
                                                          copy_of_randomness);
 }
 
@@ -199,7 +199,7 @@ tuple_21 libcrux_ml_kem_mlkem1024_avx2_encapsulate_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_unpacked_4c(uu____0, copy_of_randomness);
+  return encapsulate_unpacked_e3(uu____0, copy_of_randomness);
 }
 
 /**
@@ -216,12 +216,12 @@ libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_mlkem1024_MlKem1024KeyPair generate_keypair_1a(
+static libcrux_ml_kem_mlkem1024_MlKem1024KeyPair generate_keypair_32(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_0d0(copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_generate_keypair_500(copy_of_randomness);
 }
 
 /**
@@ -232,7 +232,7 @@ libcrux_ml_kem_mlkem1024_avx2_generate_key_pair(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_1a(copy_of_randomness);
+  return generate_keypair_32(copy_of_randomness);
 }
 
 /**
@@ -251,11 +251,11 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 static libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_01
-generate_keypair_unpacked_c0(uint8_t randomness[64U]) {
+generate_keypair_unpacked_71(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_270(
+  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_910(
       copy_of_randomness);
 }
 
@@ -268,7 +268,7 @@ libcrux_ml_kem_mlkem1024_avx2_generate_key_pair_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_unpacked_c0(copy_of_randomness);
+  return generate_keypair_unpacked_71(copy_of_randomness);
 }
 
 /**
@@ -282,8 +282,8 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1536
 - PUBLIC_KEY_SIZE= 1568
 */
-static bool validate_public_key_c90(uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_f90(public_key);
+static bool validate_public_key_370(uint8_t *public_key) {
+  return libcrux_ml_kem_ind_cca_validate_public_key_a70(public_key);
 }
 
 /**
@@ -294,7 +294,7 @@ static bool validate_public_key_c90(uint8_t *public_key) {
 core_option_Option_99 libcrux_ml_kem_mlkem1024_avx2_validate_public_key(
     libcrux_ml_kem_types_MlKemPublicKey_1f public_key) {
   core_option_Option_99 uu____0;
-  if (validate_public_key_c90(public_key.value)) {
+  if (validate_public_key_370(public_key.value)) {
     uu____0 = (CLITERAL(core_option_Option_99){.tag = core_option_Some,
                                                .f0 = public_key});
   } else {

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem1024_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "libcrux_mlkem1024_portable.h"
@@ -38,11 +38,11 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-static void decapsulate_3c(
+static void decapsulate_7a(
     libcrux_ml_kem_types_MlKemPrivateKey_95 *private_key,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_811(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_461(private_key, ciphertext, ret);
 }
 
 /**
@@ -56,7 +56,7 @@ void libcrux_ml_kem_mlkem1024_portable_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_95 *private_key,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
-  decapsulate_3c(private_key, ciphertext, ret);
+  decapsulate_7a(private_key, ciphertext, ret);
 }
 
 /**
@@ -83,11 +83,11 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-static void decapsulate_unpacked_d0(
+static void decapsulate_unpacked_ff(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_42 *key_pair,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c1(key_pair, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_unpacked_881(key_pair, ciphertext, ret);
 }
 
 /**
@@ -101,7 +101,7 @@ void libcrux_ml_kem_mlkem1024_portable_decapsulate_unpacked(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_42 *private_key,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
-  decapsulate_unpacked_d0(private_key, ciphertext, ret);
+  decapsulate_unpacked_ff(private_key, ciphertext, ret);
 }
 
 /**
@@ -121,14 +121,14 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_21 encapsulate_a5(
+static tuple_21 encapsulate_a1(
     libcrux_ml_kem_types_MlKemPublicKey_1f *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_1f *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_8f1(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_encapsulate_511(uu____0, copy_of_randomness);
 }
 
 /**
@@ -145,7 +145,7 @@ tuple_21 libcrux_ml_kem_mlkem1024_portable_encapsulate(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_a5(uu____0, copy_of_randomness);
+  return encapsulate_a1(uu____0, copy_of_randomness);
 }
 
 /**
@@ -169,7 +169,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_21 encapsulate_unpacked_5a(
+static tuple_21 encapsulate_unpacked_f3(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_42 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_42 *uu____0 =
@@ -177,7 +177,7 @@ static tuple_21 encapsulate_unpacked_5a(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_de1(uu____0,
+  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_511(uu____0,
                                                          copy_of_randomness);
 }
 
@@ -199,7 +199,7 @@ tuple_21 libcrux_ml_kem_mlkem1024_portable_encapsulate_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_unpacked_5a(uu____0, copy_of_randomness);
+  return encapsulate_unpacked_f3(uu____0, copy_of_randomness);
 }
 
 /**
@@ -217,12 +217,12 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_mlkem1024_MlKem1024KeyPair generate_keypair_00(
+static libcrux_ml_kem_mlkem1024_MlKem1024KeyPair generate_keypair_e3(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_f91(copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_generate_keypair_951(copy_of_randomness);
 }
 
 /**
@@ -233,7 +233,7 @@ libcrux_ml_kem_mlkem1024_portable_generate_key_pair(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_00(copy_of_randomness);
+  return generate_keypair_e3(copy_of_randomness);
 }
 
 /**
@@ -252,11 +252,11 @@ const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 static libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_42
-generate_keypair_unpacked_d2(uint8_t randomness[64U]) {
+generate_keypair_unpacked_24(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c81(
+  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_2c1(
       copy_of_randomness);
 }
 
@@ -269,7 +269,7 @@ libcrux_ml_kem_mlkem1024_portable_generate_key_pair_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_unpacked_d2(copy_of_randomness);
+  return generate_keypair_unpacked_24(copy_of_randomness);
 }
 
 /**
@@ -283,8 +283,8 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1536
 - PUBLIC_KEY_SIZE= 1568
 */
-static bool validate_public_key_9d1(uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_c21(public_key);
+static bool validate_public_key_561(uint8_t *public_key) {
+  return libcrux_ml_kem_ind_cca_validate_public_key_6d1(public_key);
 }
 
 /**
@@ -295,7 +295,7 @@ static bool validate_public_key_9d1(uint8_t *public_key) {
 core_option_Option_99 libcrux_ml_kem_mlkem1024_portable_validate_public_key(
     libcrux_ml_kem_types_MlKemPublicKey_1f public_key) {
   core_option_Option_99 uu____0;
-  if (validate_public_key_9d1(public_key.value)) {
+  if (validate_public_key_561(public_key.value)) {
     uu____0 = (CLITERAL(core_option_Option_99){.tag = core_option_Some,
                                                .f0 = public_key});
   } else {

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem1024_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem512_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "libcrux_mlkem512_avx2.h"
@@ -38,10 +38,10 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-static void decapsulate_d3(libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
+static void decapsulate_db(libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
                            libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext,
                            uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_6e(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_ff(private_key, ciphertext, ret);
 }
 
 /**
@@ -54,7 +54,7 @@ static void decapsulate_d3(libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
 void libcrux_ml_kem_mlkem512_avx2_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]) {
-  decapsulate_d3(private_key, ciphertext, ret);
+  decapsulate_db(private_key, ciphertext, ret);
 }
 
 /**
@@ -81,10 +81,10 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-static void decapsulate_unpacked_d9(
+static void decapsulate_unpacked_8b(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_d6 *key_pair,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f(key_pair, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_unpacked_59(key_pair, ciphertext, ret);
 }
 
 /**
@@ -97,7 +97,7 @@ static void decapsulate_unpacked_d9(
 void libcrux_ml_kem_mlkem512_avx2_decapsulate_unpacked(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_d6 *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]) {
-  decapsulate_unpacked_d9(private_key, ciphertext, ret);
+  decapsulate_unpacked_8b(private_key, ciphertext, ret);
 }
 
 /**
@@ -117,14 +117,14 @@ with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_ec encapsulate_bd(
+static tuple_ec encapsulate_c2(
     libcrux_ml_kem_types_MlKemPublicKey_be *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_be *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_41(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_encapsulate_e2(uu____0, copy_of_randomness);
 }
 
 /**
@@ -141,7 +141,7 @@ tuple_ec libcrux_ml_kem_mlkem512_avx2_encapsulate(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_bd(uu____0, copy_of_randomness);
+  return encapsulate_c2(uu____0, copy_of_randomness);
 }
 
 /**
@@ -165,7 +165,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_ec encapsulate_unpacked_2e(
+static tuple_ec encapsulate_unpacked_a4(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_d6 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_d6 *uu____0 =
@@ -173,7 +173,7 @@ static tuple_ec encapsulate_unpacked_2e(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e(uu____0,
+  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_f2(uu____0,
                                                         copy_of_randomness);
 }
 
@@ -193,7 +193,7 @@ tuple_ec libcrux_ml_kem_mlkem512_avx2_encapsulate_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_unpacked_2e(uu____0, copy_of_randomness);
+  return encapsulate_unpacked_a4(uu____0, copy_of_randomness);
 }
 
 /**
@@ -210,12 +210,12 @@ libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair with const generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static libcrux_ml_kem_types_MlKemKeyPair_cb generate_keypair_3e(
+static libcrux_ml_kem_types_MlKemKeyPair_cb generate_keypair_1d(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_0d(copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_generate_keypair_50(copy_of_randomness);
 }
 
 /**
@@ -226,7 +226,7 @@ libcrux_ml_kem_mlkem512_avx2_generate_key_pair(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_3e(copy_of_randomness);
+  return generate_keypair_1d(copy_of_randomness);
 }
 
 /**
@@ -245,11 +245,11 @@ generics
 - ETA1_RANDOMNESS_SIZE= 192
 */
 static libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_d6
-generate_keypair_unpacked_7f(uint8_t randomness[64U]) {
+generate_keypair_unpacked_22(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_27(
+  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_91(
       copy_of_randomness);
 }
 
@@ -262,7 +262,7 @@ libcrux_ml_kem_mlkem512_avx2_generate_key_pair_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_unpacked_7f(copy_of_randomness);
+  return generate_keypair_unpacked_22(copy_of_randomness);
 }
 
 /**
@@ -276,8 +276,8 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 768
 - PUBLIC_KEY_SIZE= 800
 */
-static bool validate_public_key_c9(uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_f9(public_key);
+static bool validate_public_key_37(uint8_t *public_key) {
+  return libcrux_ml_kem_ind_cca_validate_public_key_a7(public_key);
 }
 
 /**
@@ -288,7 +288,7 @@ static bool validate_public_key_c9(uint8_t *public_key) {
 core_option_Option_04 libcrux_ml_kem_mlkem512_avx2_validate_public_key(
     libcrux_ml_kem_types_MlKemPublicKey_be public_key) {
   core_option_Option_04 uu____0;
-  if (validate_public_key_c9(public_key.value)) {
+  if (validate_public_key_37(public_key.value)) {
     uu____0 = (CLITERAL(core_option_Option_04){.tag = core_option_Some,
                                                .f0 = public_key});
   } else {

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem512_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "libcrux_mlkem512_portable.h"
@@ -38,10 +38,10 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-static void decapsulate_60(libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
+static void decapsulate_35(libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
                            libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext,
                            uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_810(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_460(private_key, ciphertext, ret);
 }
 
 /**
@@ -54,7 +54,7 @@ static void decapsulate_60(libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
 void libcrux_ml_kem_mlkem512_portable_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]) {
-  decapsulate_60(private_key, ciphertext, ret);
+  decapsulate_35(private_key, ciphertext, ret);
 }
 
 /**
@@ -81,10 +81,10 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-static void decapsulate_unpacked_4f(
+static void decapsulate_unpacked_fd(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_ae *key_pair,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c0(key_pair, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_unpacked_880(key_pair, ciphertext, ret);
 }
 
 /**
@@ -97,7 +97,7 @@ static void decapsulate_unpacked_4f(
 void libcrux_ml_kem_mlkem512_portable_decapsulate_unpacked(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_ae *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]) {
-  decapsulate_unpacked_4f(private_key, ciphertext, ret);
+  decapsulate_unpacked_fd(private_key, ciphertext, ret);
 }
 
 /**
@@ -117,14 +117,14 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_ec encapsulate_51(
+static tuple_ec encapsulate_28(
     libcrux_ml_kem_types_MlKemPublicKey_be *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_be *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_8f0(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_encapsulate_510(uu____0, copy_of_randomness);
 }
 
 /**
@@ -141,7 +141,7 @@ tuple_ec libcrux_ml_kem_mlkem512_portable_encapsulate(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_51(uu____0, copy_of_randomness);
+  return encapsulate_28(uu____0, copy_of_randomness);
 }
 
 /**
@@ -165,7 +165,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_ec encapsulate_unpacked_b3(
+static tuple_ec encapsulate_unpacked_83(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_ae *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_ae *uu____0 =
@@ -173,7 +173,7 @@ static tuple_ec encapsulate_unpacked_b3(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_de0(uu____0,
+  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_510(uu____0,
                                                          copy_of_randomness);
 }
 
@@ -193,7 +193,7 @@ tuple_ec libcrux_ml_kem_mlkem512_portable_encapsulate_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_unpacked_b3(uu____0, copy_of_randomness);
+  return encapsulate_unpacked_83(uu____0, copy_of_randomness);
 }
 
 /**
@@ -211,12 +211,12 @@ generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static libcrux_ml_kem_types_MlKemKeyPair_cb generate_keypair_68(
+static libcrux_ml_kem_types_MlKemKeyPair_cb generate_keypair_fd(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_f90(copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_generate_keypair_950(copy_of_randomness);
 }
 
 /**
@@ -227,7 +227,7 @@ libcrux_ml_kem_mlkem512_portable_generate_key_pair(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_68(copy_of_randomness);
+  return generate_keypair_fd(copy_of_randomness);
 }
 
 /**
@@ -246,11 +246,11 @@ const generics
 - ETA1_RANDOMNESS_SIZE= 192
 */
 static libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_ae
-generate_keypair_unpacked_9e(uint8_t randomness[64U]) {
+generate_keypair_unpacked_21(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c80(
+  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_2c0(
       copy_of_randomness);
 }
 
@@ -263,7 +263,7 @@ libcrux_ml_kem_mlkem512_portable_generate_key_pair_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_unpacked_9e(copy_of_randomness);
+  return generate_keypair_unpacked_21(copy_of_randomness);
 }
 
 /**
@@ -277,8 +277,8 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 768
 - PUBLIC_KEY_SIZE= 800
 */
-static bool validate_public_key_9d0(uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_c20(public_key);
+static bool validate_public_key_560(uint8_t *public_key) {
+  return libcrux_ml_kem_ind_cca_validate_public_key_6d0(public_key);
 }
 
 /**
@@ -289,7 +289,7 @@ static bool validate_public_key_9d0(uint8_t *public_key) {
 core_option_Option_04 libcrux_ml_kem_mlkem512_portable_validate_public_key(
     libcrux_ml_kem_types_MlKemPublicKey_be public_key) {
   core_option_Option_04 uu____0;
-  if (validate_public_key_9d0(public_key.value)) {
+  if (validate_public_key_560(public_key.value)) {
     uu____0 = (CLITERAL(core_option_Option_04){.tag = core_option_Some,
                                                .f0 = public_key});
   } else {

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem512_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem768_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "libcrux_mlkem768_avx2.h"
@@ -38,10 +38,10 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static void decapsulate_25(
+static void decapsulate_d4(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_6e1(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_ff1(private_key, ciphertext, ret);
 }
 
 /**
@@ -54,7 +54,7 @@ static void decapsulate_25(
 void libcrux_ml_kem_mlkem768_avx2_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  decapsulate_25(private_key, ciphertext, ret);
+  decapsulate_d4(private_key, ciphertext, ret);
 }
 
 /**
@@ -81,10 +81,10 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static void decapsulate_unpacked_b4(
+static void decapsulate_unpacked_1e(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0 *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f1(key_pair, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_unpacked_591(key_pair, ciphertext, ret);
 }
 
 /**
@@ -97,7 +97,7 @@ static void decapsulate_unpacked_b4(
 void libcrux_ml_kem_mlkem768_avx2_decapsulate_unpacked(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  decapsulate_unpacked_b4(private_key, ciphertext, ret);
+  decapsulate_unpacked_1e(private_key, ciphertext, ret);
 }
 
 /**
@@ -117,14 +117,14 @@ with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_3c encapsulate_27(
+static tuple_3c encapsulate_ce(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_15 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_411(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_encapsulate_e21(uu____0, copy_of_randomness);
 }
 
 /**
@@ -141,7 +141,7 @@ tuple_3c libcrux_ml_kem_mlkem768_avx2_encapsulate(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_27(uu____0, copy_of_randomness);
+  return encapsulate_ce(uu____0, copy_of_randomness);
 }
 
 /**
@@ -165,7 +165,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_3c encapsulate_unpacked_ff(
+static tuple_3c encapsulate_unpacked_04(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0 *uu____0 =
@@ -173,7 +173,7 @@ static tuple_3c encapsulate_unpacked_ff(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e1(uu____0,
+  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_f21(uu____0,
                                                          copy_of_randomness);
 }
 
@@ -193,7 +193,7 @@ tuple_3c libcrux_ml_kem_mlkem768_avx2_encapsulate_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_unpacked_ff(uu____0, copy_of_randomness);
+  return encapsulate_unpacked_04(uu____0, copy_of_randomness);
 }
 
 /**
@@ -210,12 +210,12 @@ libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_mlkem768_MlKem768KeyPair generate_keypair_93(
+static libcrux_ml_kem_mlkem768_MlKem768KeyPair generate_keypair_02(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_0d1(copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_generate_keypair_501(copy_of_randomness);
 }
 
 /**
@@ -226,7 +226,7 @@ libcrux_ml_kem_mlkem768_avx2_generate_key_pair(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_93(copy_of_randomness);
+  return generate_keypair_02(copy_of_randomness);
 }
 
 /**
@@ -245,11 +245,11 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 static libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0
-generate_keypair_unpacked_51(uint8_t randomness[64U]) {
+generate_keypair_unpacked_3c(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_271(
+  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_911(
       copy_of_randomness);
 }
 
@@ -262,7 +262,7 @@ libcrux_ml_kem_mlkem768_avx2_generate_key_pair_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_unpacked_51(copy_of_randomness);
+  return generate_keypair_unpacked_3c(copy_of_randomness);
 }
 
 /**
@@ -276,8 +276,8 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-static bool validate_public_key_c91(uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_f91(public_key);
+static bool validate_public_key_371(uint8_t *public_key) {
+  return libcrux_ml_kem_ind_cca_validate_public_key_a71(public_key);
 }
 
 /**
@@ -288,7 +288,7 @@ static bool validate_public_key_c91(uint8_t *public_key) {
 core_option_Option_92 libcrux_ml_kem_mlkem768_avx2_validate_public_key(
     libcrux_ml_kem_types_MlKemPublicKey_15 public_key) {
   core_option_Option_92 uu____0;
-  if (validate_public_key_c91(public_key.value)) {
+  if (validate_public_key_371(public_key.value)) {
     uu____0 = (CLITERAL(core_option_Option_92){.tag = core_option_Some,
                                                .f0 = public_key});
   } else {

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem768_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "libcrux_mlkem768_portable.h"
@@ -38,10 +38,10 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static void decapsulate_e3(
+static void decapsulate_82(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_81(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_46(private_key, ciphertext, ret);
 }
 
 /**
@@ -54,7 +54,7 @@ static void decapsulate_e3(
 void libcrux_ml_kem_mlkem768_portable_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  decapsulate_e3(private_key, ciphertext, ret);
+  decapsulate_82(private_key, ciphertext, ret);
 }
 
 /**
@@ -81,10 +81,10 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static void decapsulate_unpacked_fc(
+static void decapsulate_unpacked_17(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8 *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c(key_pair, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_unpacked_88(key_pair, ciphertext, ret);
 }
 
 /**
@@ -97,7 +97,7 @@ static void decapsulate_unpacked_fc(
 void libcrux_ml_kem_mlkem768_portable_decapsulate_unpacked(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  decapsulate_unpacked_fc(private_key, ciphertext, ret);
+  decapsulate_unpacked_17(private_key, ciphertext, ret);
 }
 
 /**
@@ -117,14 +117,14 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_3c encapsulate_30(
+static tuple_3c encapsulate_4f(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_15 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_8f(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_encapsulate_51(uu____0, copy_of_randomness);
 }
 
 /**
@@ -141,7 +141,7 @@ tuple_3c libcrux_ml_kem_mlkem768_portable_encapsulate(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_30(uu____0, copy_of_randomness);
+  return encapsulate_4f(uu____0, copy_of_randomness);
 }
 
 /**
@@ -165,7 +165,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_3c encapsulate_unpacked_d1(
+static tuple_3c encapsulate_unpacked_11(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_f8 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_f8 *uu____0 =
@@ -173,7 +173,7 @@ static tuple_3c encapsulate_unpacked_d1(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_de(uu____0,
+  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_51(uu____0,
                                                         copy_of_randomness);
 }
 
@@ -193,7 +193,7 @@ tuple_3c libcrux_ml_kem_mlkem768_portable_encapsulate_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return encapsulate_unpacked_d1(uu____0, copy_of_randomness);
+  return encapsulate_unpacked_11(uu____0, copy_of_randomness);
 }
 
 /**
@@ -211,12 +211,12 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_mlkem768_MlKem768KeyPair generate_keypair_c1(
+static libcrux_ml_kem_mlkem768_MlKem768KeyPair generate_keypair_19(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_f9(copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_generate_keypair_95(copy_of_randomness);
 }
 
 /**
@@ -227,7 +227,7 @@ libcrux_ml_kem_mlkem768_portable_generate_key_pair(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_c1(copy_of_randomness);
+  return generate_keypair_19(copy_of_randomness);
 }
 
 /**
@@ -246,11 +246,11 @@ const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 static libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8
-generate_keypair_unpacked_05(uint8_t randomness[64U]) {
+generate_keypair_unpacked_ef(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c8(
+  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_2c(
       copy_of_randomness);
 }
 
@@ -263,7 +263,7 @@ libcrux_ml_kem_mlkem768_portable_generate_key_pair_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return generate_keypair_unpacked_05(copy_of_randomness);
+  return generate_keypair_unpacked_ef(copy_of_randomness);
 }
 
 /**
@@ -277,8 +277,8 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-static bool validate_public_key_9d(uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_c2(public_key);
+static bool validate_public_key_56(uint8_t *public_key) {
+  return libcrux_ml_kem_ind_cca_validate_public_key_6d(public_key);
 }
 
 /**
@@ -289,7 +289,7 @@ static bool validate_public_key_9d(uint8_t *public_key) {
 core_option_Option_92 libcrux_ml_kem_mlkem768_portable_validate_public_key(
     libcrux_ml_kem_types_MlKemPublicKey_15 public_key) {
   core_option_Option_92 uu____0;
-  if (validate_public_key_9d(public_key.value)) {
+  if (validate_public_key_56(public_key.value)) {
     uu____0 = (CLITERAL(core_option_Option_92){.tag = core_option_Some,
                                                .f0 = public_key});
   } else {

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem768_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "internal/libcrux_mlkem_avx2.h"
@@ -1069,7 +1069,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_to_reduced_ring_element_71(Eurydice_slice serialized) {
+deserialize_to_reduced_ring_element_ab(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re = ZERO_89_9b();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)24U; i++) {
@@ -1096,7 +1096,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - PUBLIC_KEY_SIZE= 1184
 - K= 3
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a84(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a54(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[3U];
@@ -1113,7 +1113,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a84(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        deserialize_to_reduced_ring_element_71(ring_element);
+        deserialize_to_reduced_ring_element_ab(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -1126,7 +1126,7 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.arithmetic.shift_right
 with const generics
 - SHIFT_BY= 15
 */
-static KRML_MUSTINLINE __m256i shift_right_66(__m256i vector) {
+static KRML_MUSTINLINE __m256i shift_right_a3(__m256i vector) {
   return mm256_srai_epi16((int32_t)15, vector, __m256i);
 }
 
@@ -1139,8 +1139,8 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.shift_right_ea
 with const generics
 - SHIFT_BY= 15
 */
-static __m256i shift_right_ea_fc(__m256i vector) {
-  return shift_right_66(vector);
+static __m256i shift_right_ea_42(__m256i vector) {
+  return shift_right_a3(vector);
 }
 
 /**
@@ -1150,7 +1150,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 
 */
 static __m256i to_unsigned_representative_14(__m256i a) {
-  __m256i t = shift_right_ea_fc(a);
+  __m256i t = shift_right_ea_42(a);
   __m256i fm = libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
       t, LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
   return libcrux_ml_kem_vector_avx2_add_ea(a, &fm);
@@ -1250,9 +1250,9 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_f91(uint8_t *public_key) {
+bool libcrux_ml_kem_ind_cca_validate_public_key_a71(uint8_t *public_key) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[3U];
-  deserialize_ring_elements_reduced_a84(
+  deserialize_ring_elements_reduced_a54(
       Eurydice_array_to_subslice_to((size_t)1184U, public_key, (size_t)1152U,
                                     uint8_t, size_t),
       deserialized_pk);
@@ -1291,6 +1291,31 @@ with const generics
 */
 static KRML_MUSTINLINE void G_a9_e11(Eurydice_slice input, uint8_t ret[64U]) {
   libcrux_ml_kem_hash_functions_avx2_G(input, ret);
+}
+
+/**
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.variant.cpa_keygen_seed_d8
+with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
+with const generics
+- K= 3
+*/
+static KRML_MUSTINLINE void cpa_keygen_seed_d8_451(
+    Eurydice_slice key_generation_seed, uint8_t ret[64U]) {
+  uint8_t seed[33U] = {0U};
+  Eurydice_slice_copy(
+      Eurydice_array_to_subslice2(
+          seed, (size_t)0U,
+          LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t),
+      key_generation_seed, uint8_t);
+  seed[LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE] =
+      (uint8_t)(size_t)3U;
+  uint8_t ret0[64U];
+  G_a9_e11(Eurydice_array_to_slice((size_t)33U, seed, uint8_t), ret0);
+  memcpy(ret, ret0, (size_t)64U * sizeof(uint8_t));
 }
 
 /**
@@ -2372,10 +2397,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static tuple_9b0 generate_keypair_unpacked_e81(
+static tuple_9b0 generate_keypair_unpacked_581(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_a9_e11(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_451(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -2458,7 +2483,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static void closure_a71(
+static void closure_991(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[3U]) {
   KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U,
                   ret[i] = ZERO_89_9b(););
@@ -2474,7 +2499,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static inline libcrux_ml_kem_polynomial_PolynomialRingElement_d2 clone_d5_d6(
+static inline libcrux_ml_kem_polynomial_PolynomialRingElement_d2 clone_d5_4c(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *self) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 lit;
   __m256i ret[16U];
@@ -2510,7 +2535,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_271(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_911(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -2518,18 +2543,18 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_271(uint8_t randomness[64U]) {
       (size_t)64U, randomness,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
-  tuple_9b0 uu____0 = generate_keypair_unpacked_e81(ind_cpa_keypair_randomness);
+  tuple_9b0 uu____0 = generate_keypair_unpacked_581(ind_cpa_keypair_randomness);
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_a0
       ind_cpa_private_key = uu____0.fst;
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_a0
       ind_cpa_public_key = uu____0.snd;
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 A[3U][3U];
-  KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U, closure_a71(A[i]););
+  KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U, closure_991(A[i]););
   KRML_MAYBE_FOR3(
       i0, (size_t)0U, (size_t)3U, (size_t)1U, size_t i1 = i0; KRML_MAYBE_FOR3(
           i, (size_t)0U, (size_t)3U, (size_t)1U, size_t j = i;
           libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____1 =
-              clone_d5_d6(&ind_cpa_public_key.A[j][i1]);
+              clone_d5_4c(&ind_cpa_public_key.A[j][i1]);
           A[i1][j] = uu____1;););
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____2[3U][3U];
   memcpy(uu____2, A,
@@ -2579,7 +2604,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_271(uint8_t randomness[64U]) {
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cpa.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 3
 - PRIVATE_KEY_SIZE= 1152
 - PUBLIC_KEY_SIZE= 1184
@@ -2587,10 +2613,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair768 generate_keypair_931(
+static libcrux_ml_kem_utils_extraction_helper_Keypair768 generate_keypair_b71(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_a9_e11(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_451(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -2658,7 +2684,7 @@ with const generics
 - K= 3
 - SERIALIZED_KEY_LEN= 2400
 */
-static KRML_MUSTINLINE void serialize_kem_secret_key_8e1(
+static KRML_MUSTINLINE void serialize_kem_secret_key_5a1(
     Eurydice_slice private_key, Eurydice_slice public_key,
     Eurydice_slice implicit_rejection_value, uint8_t ret[2400U]) {
   uint8_t out[2400U] = {0U};
@@ -2711,7 +2737,8 @@ static KRML_MUSTINLINE void serialize_kem_secret_key_8e1(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 3
 - CPA_PRIVATE_KEY_SIZE= 1152
 - PRIVATE_KEY_SIZE= 2400
@@ -2721,7 +2748,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_mlkem768_MlKem768KeyPair
-libcrux_ml_kem_ind_cca_generate_keypair_0d1(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_501(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -2730,13 +2757,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_0d1(uint8_t randomness[64U]) {
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
   libcrux_ml_kem_utils_extraction_helper_Keypair768 uu____0 =
-      generate_keypair_931(ind_cpa_keypair_randomness);
+      generate_keypair_b71(ind_cpa_keypair_randomness);
   uint8_t ind_cpa_private_key[1152U];
   memcpy(ind_cpa_private_key, uu____0.fst, (size_t)1152U * sizeof(uint8_t));
   uint8_t public_key[1184U];
   memcpy(public_key, uu____0.snd, (size_t)1184U * sizeof(uint8_t));
   uint8_t secret_key_serialized[2400U];
-  serialize_kem_secret_key_8e1(
+  serialize_kem_secret_key_5a1(
       Eurydice_array_to_slice((size_t)1152U, ind_cpa_private_key, uint8_t),
       Eurydice_array_to_slice((size_t)1184U, public_key, uint8_t),
       implicit_rejection_value, secret_key_serialized);
@@ -2745,13 +2772,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_0d1(uint8_t randomness[64U]) {
   memcpy(copy_of_secret_key_serialized, secret_key_serialized,
          (size_t)2400U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemPrivateKey_55 private_key =
-      libcrux_ml_kem_types_from_05_db0(copy_of_secret_key_serialized);
+      libcrux_ml_kem_types_from_05_0b0(copy_of_secret_key_serialized);
   libcrux_ml_kem_types_MlKemPrivateKey_55 uu____2 = private_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_public_key[1184U];
   memcpy(copy_of_public_key, public_key, (size_t)1184U * sizeof(uint8_t));
-  return libcrux_ml_kem_types_from_17_120(
-      uu____2, libcrux_ml_kem_types_from_b6_8e0(copy_of_public_key));
+  return libcrux_ml_kem_types_from_17_9c0(
+      uu____2, libcrux_ml_kem_types_from_b6_b00(copy_of_public_key));
 }
 
 /**
@@ -2766,7 +2793,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 */
 static KRML_MUSTINLINE tuple_b00
-sample_ring_element_cbd_581(uint8_t prf_input[33U], uint8_t domain_separator) {
+sample_ring_element_cbd_321(uint8_t prf_input[33U], uint8_t domain_separator) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[3U];
   KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U,
                   error_1[i] = ZERO_89_9b(););
@@ -2834,7 +2861,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static KRML_MUSTINLINE void invert_ntt_at_layer_1_3d(
+static KRML_MUSTINLINE void invert_ntt_at_layer_1_48(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re) {
   KRML_MAYBE_FOR16(
       i, (size_t)0U, (size_t)16U, (size_t)1U, size_t round = i;
@@ -2858,7 +2885,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static KRML_MUSTINLINE void invert_ntt_at_layer_2_64(
+static KRML_MUSTINLINE void invert_ntt_at_layer_2_10(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re) {
   KRML_MAYBE_FOR16(
       i, (size_t)0U, (size_t)16U, (size_t)1U, size_t round = i;
@@ -2878,7 +2905,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static KRML_MUSTINLINE void invert_ntt_at_layer_3_fb(
+static KRML_MUSTINLINE void invert_ntt_at_layer_3_b5(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re) {
   KRML_MAYBE_FOR16(
       i, (size_t)0U, (size_t)16U, (size_t)1U, size_t round = i;
@@ -2896,7 +2923,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_vector_avx2_SIMD256Vector_x2
-inv_ntt_layer_int_vec_step_reduce_eb(__m256i a, __m256i b, int16_t zeta_r) {
+inv_ntt_layer_int_vec_step_reduce_b3(__m256i a, __m256i b, int16_t zeta_r) {
   __m256i a_minus_b = libcrux_ml_kem_vector_avx2_sub_ea(b, &a);
   a = libcrux_ml_kem_vector_avx2_barrett_reduce_ea(
       libcrux_ml_kem_vector_avx2_add_ea(a, &b));
@@ -2911,7 +2938,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static KRML_MUSTINLINE void invert_ntt_at_layer_4_plus_39(
+static KRML_MUSTINLINE void invert_ntt_at_layer_4_plus_6e(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re,
     size_t layer) {
   size_t step = (size_t)1U << (uint32_t)layer;
@@ -2926,7 +2953,7 @@ static KRML_MUSTINLINE void invert_ntt_at_layer_4_plus_39(
     for (size_t i = offset_vec; i < offset_vec + step_vec; i++) {
       size_t j = i;
       libcrux_ml_kem_vector_avx2_SIMD256Vector_x2 uu____0 =
-          inv_ntt_layer_int_vec_step_reduce_eb(
+          inv_ntt_layer_int_vec_step_reduce_b3(
               re->coefficients[j], re->coefficients[j + step_vec],
               libcrux_ml_kem_polynomial_ZETAS_TIMES_MONTGOMERY_R[zeta_i[0U]]);
       __m256i x = uu____0.fst;
@@ -2943,17 +2970,17 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void invert_ntt_montgomery_e61(
+static KRML_MUSTINLINE void invert_ntt_montgomery_4e1(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re) {
   size_t zeta_i =
       LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT / (size_t)2U;
-  invert_ntt_at_layer_1_3d(&zeta_i, re);
-  invert_ntt_at_layer_2_64(&zeta_i, re);
-  invert_ntt_at_layer_3_fb(&zeta_i, re);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)4U);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)5U);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)6U);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)7U);
+  invert_ntt_at_layer_1_48(&zeta_i, re);
+  invert_ntt_at_layer_2_10(&zeta_i, re);
+  invert_ntt_at_layer_3_b5(&zeta_i, re);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)4U);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)5U);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)6U);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)7U);
   poly_barrett_reduce_89_e6(re);
 }
 
@@ -2967,7 +2994,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static KRML_MUSTINLINE void add_error_reduce_89_c7(
+static KRML_MUSTINLINE void add_error_reduce_89_db(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *self,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *error) {
   for (size_t i = (size_t)0U;
@@ -2991,7 +3018,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void compute_vector_u_541(
+static KRML_MUSTINLINE void compute_vector_u_a31(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 (*a_as_ntt)[3U],
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *error_1,
@@ -3021,8 +3048,8 @@ static KRML_MUSTINLINE void compute_vector_u_541(
           ntt_multiply_89_44(a_element, &r_as_ntt[j]);
       add_to_ring_element_89_ce1(&result[i1], &product);
     }
-    invert_ntt_montgomery_e61(&result[i1]);
-    add_error_reduce_89_c7(&result[i1], &error_1[i1]);
+    invert_ntt_montgomery_4e1(&result[i1]);
+    add_error_reduce_89_db(&result[i1], &error_1[i1]);
   }
   memcpy(
       ret, result,
@@ -3035,7 +3062,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static __m256i decompress_1_d7(__m256i v) {
+static __m256i decompress_1_80(__m256i v) {
   return libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
       libcrux_ml_kem_vector_avx2_sub_ea(libcrux_ml_kem_vector_avx2_ZERO_ea(),
                                         &v),
@@ -3049,7 +3076,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_then_decompress_message_d3(uint8_t serialized[32U]) {
+deserialize_then_decompress_message_f3(uint8_t serialized[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re = ZERO_89_9b();
   KRML_MAYBE_FOR16(
       i, (size_t)0U, (size_t)16U, (size_t)1U, size_t i0 = i;
@@ -3058,7 +3085,7 @@ deserialize_then_decompress_message_d3(uint8_t serialized[32U]) {
               Eurydice_array_to_subslice2(serialized, (size_t)2U * i0,
                                           (size_t)2U * i0 + (size_t)2U,
                                           uint8_t));
-      re.coefficients[i0] = decompress_1_d7(coefficient_compressed););
+      re.coefficients[i0] = decompress_1_80(coefficient_compressed););
   return re;
 }
 
@@ -3073,7 +3100,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-add_message_error_reduce_89_6a(
+add_message_error_reduce_89_bd(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *self,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *message,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 result) {
@@ -3103,7 +3130,7 @@ with const generics
 - K= 3
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-compute_ring_element_v_f91(
+compute_ring_element_v_301(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *t_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *error_2,
@@ -3113,8 +3140,8 @@ compute_ring_element_v_f91(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 product =
                       ntt_multiply_89_44(&t_as_ntt[i0], &r_as_ntt[i0]);
                   add_to_ring_element_89_ce1(&result, &product););
-  invert_ntt_montgomery_e61(&result);
-  result = add_message_error_reduce_89_6a(error_2, message, result);
+  invert_ntt_montgomery_4e1(&result);
+  result = add_message_error_reduce_89_bd(error_2, message, result);
   return result;
 }
 
@@ -3125,7 +3152,7 @@ generics
 - COEFFICIENT_BITS= 10
 */
 static KRML_MUSTINLINE __m256i
-compress_ciphertext_coefficient_e0(__m256i vector) {
+compress_ciphertext_coefficient_05(__m256i vector) {
   __m256i field_modulus_halved = mm256_set1_epi32(
       ((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS - (int32_t)1) /
       (int32_t)2);
@@ -3172,8 +3199,8 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.compress_ea
 with const generics
 - COEFFICIENT_BITS= 10
 */
-static __m256i compress_ea_9b(__m256i vector) {
-  return compress_ciphertext_coefficient_e0(vector);
+static __m256i compress_ea_01(__m256i vector) {
+  return compress_ciphertext_coefficient_05(vector);
 }
 
 /**
@@ -3182,14 +3209,14 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - OUT_LEN= 320
 */
-static KRML_MUSTINLINE void compress_then_serialize_10_d0(
+static KRML_MUSTINLINE void compress_then_serialize_10_27(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re, uint8_t ret[320U]) {
   uint8_t serialized[320U] = {0U};
   for (size_t i = (size_t)0U;
        i < LIBCRUX_ML_KEM_POLYNOMIAL_VECTORS_IN_RING_ELEMENT; i++) {
     size_t i0 = i;
     __m256i coefficient =
-        compress_ea_9b(to_unsigned_representative_14(re->coefficients[i0]));
+        compress_ea_01(to_unsigned_representative_14(re->coefficients[i0]));
     uint8_t bytes[20U];
     libcrux_ml_kem_vector_avx2_serialize_10_ea(coefficient, bytes);
     Eurydice_slice uu____0 = Eurydice_array_to_subslice2(
@@ -3207,7 +3234,7 @@ generics
 - COEFFICIENT_BITS= 11
 */
 static KRML_MUSTINLINE __m256i
-compress_ciphertext_coefficient_e00(__m256i vector) {
+compress_ciphertext_coefficient_050(__m256i vector) {
   __m256i field_modulus_halved = mm256_set1_epi32(
       ((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS - (int32_t)1) /
       (int32_t)2);
@@ -3254,8 +3281,8 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.compress_ea
 with const generics
 - COEFFICIENT_BITS= 11
 */
-static __m256i compress_ea_9b0(__m256i vector) {
-  return compress_ciphertext_coefficient_e00(vector);
+static __m256i compress_ea_010(__m256i vector) {
+  return compress_ciphertext_coefficient_050(vector);
 }
 
 /**
@@ -3265,10 +3292,10 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - COMPRESSION_FACTOR= 10
 - OUT_LEN= 320
 */
-static KRML_MUSTINLINE void compress_then_serialize_ring_element_u_56(
+static KRML_MUSTINLINE void compress_then_serialize_ring_element_u_ae(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re, uint8_t ret[320U]) {
   uint8_t uu____0[320U];
-  compress_then_serialize_10_d0(re, uu____0);
+  compress_then_serialize_10_27(re, uu____0);
   memcpy(ret, uu____0, (size_t)320U * sizeof(uint8_t));
 }
 
@@ -3284,7 +3311,7 @@ with const generics
 - COMPRESSION_FACTOR= 10
 - BLOCK_LEN= 320
 */
-static void compress_then_serialize_u_9b1(
+static void compress_then_serialize_u_c11(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 input[3U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -3300,7 +3327,7 @@ static void compress_then_serialize_u_9b1(
         out, i0 * ((size_t)960U / (size_t)3U),
         (i0 + (size_t)1U) * ((size_t)960U / (size_t)3U), uint8_t);
     uint8_t ret[320U];
-    compress_then_serialize_ring_element_u_56(&re, ret);
+    compress_then_serialize_ring_element_u_ae(&re, ret);
     Eurydice_slice_copy(
         uu____0, Eurydice_array_to_slice((size_t)320U, ret, uint8_t), uint8_t);
   }
@@ -3313,7 +3340,7 @@ generics
 - COEFFICIENT_BITS= 4
 */
 static KRML_MUSTINLINE __m256i
-compress_ciphertext_coefficient_e01(__m256i vector) {
+compress_ciphertext_coefficient_051(__m256i vector) {
   __m256i field_modulus_halved = mm256_set1_epi32(
       ((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS - (int32_t)1) /
       (int32_t)2);
@@ -3360,8 +3387,8 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.compress_ea
 with const generics
 - COEFFICIENT_BITS= 4
 */
-static __m256i compress_ea_9b1(__m256i vector) {
-  return compress_ciphertext_coefficient_e01(vector);
+static __m256i compress_ea_011(__m256i vector) {
+  return compress_ciphertext_coefficient_051(vector);
 }
 
 /**
@@ -3370,14 +3397,14 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static KRML_MUSTINLINE void compress_then_serialize_4_fb(
+static KRML_MUSTINLINE void compress_then_serialize_4_d8(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re,
     Eurydice_slice serialized) {
   for (size_t i = (size_t)0U;
        i < LIBCRUX_ML_KEM_POLYNOMIAL_VECTORS_IN_RING_ELEMENT; i++) {
     size_t i0 = i;
     __m256i coefficient =
-        compress_ea_9b1(to_unsigned_representative_14(re.coefficients[i0]));
+        compress_ea_011(to_unsigned_representative_14(re.coefficients[i0]));
     uint8_t bytes[8U];
     libcrux_ml_kem_vector_avx2_serialize_4_ea(coefficient, bytes);
     Eurydice_slice_copy(
@@ -3394,7 +3421,7 @@ generics
 - COEFFICIENT_BITS= 5
 */
 static KRML_MUSTINLINE __m256i
-compress_ciphertext_coefficient_e02(__m256i vector) {
+compress_ciphertext_coefficient_052(__m256i vector) {
   __m256i field_modulus_halved = mm256_set1_epi32(
       ((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS - (int32_t)1) /
       (int32_t)2);
@@ -3441,8 +3468,8 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.compress_ea
 with const generics
 - COEFFICIENT_BITS= 5
 */
-static __m256i compress_ea_9b2(__m256i vector) {
-  return compress_ciphertext_coefficient_e02(vector);
+static __m256i compress_ea_012(__m256i vector) {
+  return compress_ciphertext_coefficient_052(vector);
 }
 
 /**
@@ -3451,14 +3478,14 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static KRML_MUSTINLINE void compress_then_serialize_5_8e(
+static KRML_MUSTINLINE void compress_then_serialize_5_14(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re,
     Eurydice_slice serialized) {
   for (size_t i = (size_t)0U;
        i < LIBCRUX_ML_KEM_POLYNOMIAL_VECTORS_IN_RING_ELEMENT; i++) {
     size_t i0 = i;
     __m256i coefficients =
-        compress_ea_9b2(to_unsigned_representative_14(re.coefficients[i0]));
+        compress_ea_012(to_unsigned_representative_14(re.coefficients[i0]));
     uint8_t bytes[10U];
     libcrux_ml_kem_vector_avx2_serialize_5_ea(coefficients, bytes);
     Eurydice_slice_copy(
@@ -3475,9 +3502,9 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - COMPRESSION_FACTOR= 4
 - OUT_LEN= 128
 */
-static KRML_MUSTINLINE void compress_then_serialize_ring_element_v_6d(
+static KRML_MUSTINLINE void compress_then_serialize_ring_element_v_13(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re, Eurydice_slice out) {
-  compress_then_serialize_4_fb(re, out);
+  compress_then_serialize_4_d8(re, out);
 }
 
 /**
@@ -3538,7 +3565,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_af1(
+static void encrypt_unpacked_ce1(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_a0 *public_key,
     uint8_t message[32U], Eurydice_slice randomness, uint8_t ret[1088U]) {
   uint8_t prf_input[33U];
@@ -3556,7 +3583,7 @@ static void encrypt_unpacked_af1(
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_b00 uu____3 =
-      sample_ring_element_cbd_581(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_321(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[3U];
   memcpy(
       error_1, uu____3.fst,
@@ -3570,25 +3597,25 @@ static void encrypt_unpacked_af1(
       sample_from_binomial_distribution_730(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u[3U];
-  compute_vector_u_541(public_key->A, r_as_ntt, error_1, u);
+  compute_vector_u_a31(public_key->A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message_as_ring_element =
-      deserialize_then_decompress_message_d3(copy_of_message);
+      deserialize_then_decompress_message_f3(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      compute_ring_element_v_f91(public_key->t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_301(public_key->t_as_ntt, r_as_ntt, &error_2,
                                  &message_as_ring_element);
   uint8_t ciphertext[1088U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____5[3U];
   memcpy(
       uu____5, u,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
-  compress_then_serialize_u_9b1(
+  compress_then_serialize_u_c11(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)960U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____6 = v;
-  compress_then_serialize_ring_element_v_6d(
+  compress_then_serialize_ring_element_v_13(
       uu____6, Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                                (size_t)960U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1088U * sizeof(uint8_t));
@@ -3612,7 +3639,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e1(
+tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_f21(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0 *public_key,
     uint8_t randomness[32U]) {
   uint8_t to_hash[64U];
@@ -3639,7 +3666,7 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e1(
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1088U];
-  encrypt_unpacked_af1(uu____2, copy_of_randomness, pseudorandomness,
+  encrypt_unpacked_ce1(uu____2, copy_of_randomness, pseudorandomness,
                        ciphertext);
   uint8_t shared_secret_array[32U] = {0U};
   Eurydice_slice_copy(
@@ -3649,7 +3676,7 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e1(
   uint8_t copy_of_ciphertext[1088U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1088U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext uu____5 =
-      libcrux_ml_kem_types_from_01_ec0(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d0(copy_of_ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
   memcpy(copy_of_shared_secret_array, shared_secret_array,
@@ -3661,16 +3688,16 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e1(
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.entropy_preprocess_af
+A monomorphic instance of libcrux_ml_kem.variant.entropy_preprocess_d8
 with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void entropy_preprocess_af_c11(Eurydice_slice randomness,
+static KRML_MUSTINLINE void entropy_preprocess_d8_f41(Eurydice_slice randomness,
                                                       uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -3691,7 +3718,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - PUBLIC_KEY_SIZE= 1152
 - K= 3
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a83(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a53(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[3U];
@@ -3708,7 +3735,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a83(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        deserialize_to_reduced_ring_element_71(ring_element);
+        deserialize_to_reduced_ring_element_ab(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -3733,10 +3760,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_a31(Eurydice_slice public_key, uint8_t message[32U],
+static void encrypt_c01(Eurydice_slice public_key, uint8_t message[32U],
                         Eurydice_slice randomness, uint8_t ret[1088U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 t_as_ntt[3U];
-  deserialize_ring_elements_reduced_a83(
+  deserialize_ring_elements_reduced_a53(
       Eurydice_slice_subslice_to(public_key, (size_t)1152U, uint8_t, size_t),
       t_as_ntt);
   Eurydice_slice seed =
@@ -3760,7 +3787,7 @@ static void encrypt_a31(Eurydice_slice public_key, uint8_t message[32U],
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_b00 uu____3 =
-      sample_ring_element_cbd_581(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_321(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[3U];
   memcpy(
       error_1, uu____3.fst,
@@ -3774,42 +3801,42 @@ static void encrypt_a31(Eurydice_slice public_key, uint8_t message[32U],
       sample_from_binomial_distribution_730(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u[3U];
-  compute_vector_u_541(A, r_as_ntt, error_1, u);
+  compute_vector_u_a31(A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message_as_ring_element =
-      deserialize_then_decompress_message_d3(copy_of_message);
+      deserialize_then_decompress_message_f3(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      compute_ring_element_v_f91(t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_301(t_as_ntt, r_as_ntt, &error_2,
                                  &message_as_ring_element);
   uint8_t ciphertext[1088U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____5[3U];
   memcpy(
       uu____5, u,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
-  compress_then_serialize_u_9b1(
+  compress_then_serialize_u_c11(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)960U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____6 = v;
-  compress_then_serialize_ring_element_v_6d(
+  compress_then_serialize_ring_element_v_13(
       uu____6, Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                                (size_t)960U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1088U * sizeof(uint8_t));
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.kdf_af
+A monomorphic instance of libcrux_ml_kem.variant.kdf_d8
 with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
 */
-static KRML_MUSTINLINE void kdf_af_be1(Eurydice_slice shared_secret,
+static KRML_MUSTINLINE void kdf_d8_aa1(Eurydice_slice shared_secret,
                                        uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -3820,7 +3847,7 @@ static KRML_MUSTINLINE void kdf_af_be1(Eurydice_slice shared_secret,
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
@@ -3836,11 +3863,11 @@ with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_3c libcrux_ml_kem_ind_cca_encapsulate_411(
+tuple_3c libcrux_ml_kem_ind_cca_encapsulate_e21(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
-  entropy_preprocess_af_c11(
+  entropy_preprocess_d8_f41(
       Eurydice_array_to_slice((size_t)32U, randomness, uint8_t), randomness0);
   uint8_t to_hash[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -3850,7 +3877,7 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_411(
       size_t);
   uint8_t ret[32U];
   H_a9_a11(Eurydice_array_to_slice(
-               (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_6f0(public_key),
+               (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_330(public_key),
                uint8_t),
            ret);
   Eurydice_slice_copy(
@@ -3864,19 +3891,19 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_411(
   Eurydice_slice shared_secret = uu____1.fst;
   Eurydice_slice pseudorandomness = uu____1.snd;
   Eurydice_slice uu____2 = Eurydice_array_to_slice(
-      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_6f0(public_key), uint8_t);
+      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_330(public_key), uint8_t);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness0, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1088U];
-  encrypt_a31(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
+  encrypt_c01(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_ciphertext[1088U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1088U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext ciphertext0 =
-      libcrux_ml_kem_types_from_01_ec0(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d0(copy_of_ciphertext);
   uint8_t shared_secret_array[32U];
-  kdf_af_be1(shared_secret, shared_secret_array);
+  kdf_d8_aa1(shared_secret, shared_secret_array);
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext uu____5 = ciphertext0;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
@@ -3895,7 +3922,7 @@ generics
 - COEFFICIENT_BITS= 10
 */
 static KRML_MUSTINLINE __m256i
-decompress_ciphertext_coefficient_57(__m256i vector) {
+decompress_ciphertext_coefficient_ab(__m256i vector) {
   __m256i field_modulus =
       mm256_set1_epi32((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
   __m256i two_pow_coefficient_bits =
@@ -3939,8 +3966,8 @@ libcrux_ml_kem.vector.avx2.decompress_ciphertext_coefficient_ea with const
 generics
 - COEFFICIENT_BITS= 10
 */
-static __m256i decompress_ciphertext_coefficient_ea_8c(__m256i vector) {
-  return decompress_ciphertext_coefficient_57(vector);
+static __m256i decompress_ciphertext_coefficient_ea_de(__m256i vector) {
+  return decompress_ciphertext_coefficient_ab(vector);
 }
 
 /**
@@ -3950,7 +3977,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_then_decompress_10_94(Eurydice_slice serialized) {
+deserialize_then_decompress_10_66(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re = ZERO_89_9b();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)20U; i++) {
@@ -3958,7 +3985,7 @@ deserialize_then_decompress_10_94(Eurydice_slice serialized) {
     Eurydice_slice bytes = Eurydice_slice_subslice2(
         serialized, i0 * (size_t)20U, i0 * (size_t)20U + (size_t)20U, uint8_t);
     __m256i coefficient = libcrux_ml_kem_vector_avx2_deserialize_10_ea(bytes);
-    re.coefficients[i0] = decompress_ciphertext_coefficient_ea_8c(coefficient);
+    re.coefficients[i0] = decompress_ciphertext_coefficient_ea_de(coefficient);
   }
   return re;
 }
@@ -3970,7 +3997,7 @@ generics
 - COEFFICIENT_BITS= 11
 */
 static KRML_MUSTINLINE __m256i
-decompress_ciphertext_coefficient_570(__m256i vector) {
+decompress_ciphertext_coefficient_ab0(__m256i vector) {
   __m256i field_modulus =
       mm256_set1_epi32((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
   __m256i two_pow_coefficient_bits =
@@ -4014,8 +4041,8 @@ libcrux_ml_kem.vector.avx2.decompress_ciphertext_coefficient_ea with const
 generics
 - COEFFICIENT_BITS= 11
 */
-static __m256i decompress_ciphertext_coefficient_ea_8c0(__m256i vector) {
-  return decompress_ciphertext_coefficient_570(vector);
+static __m256i decompress_ciphertext_coefficient_ea_de0(__m256i vector) {
+  return decompress_ciphertext_coefficient_ab0(vector);
 }
 
 /**
@@ -4025,7 +4052,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_then_decompress_11_ec(Eurydice_slice serialized) {
+deserialize_then_decompress_11_af(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re = ZERO_89_9b();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)22U; i++) {
@@ -4033,7 +4060,7 @@ deserialize_then_decompress_11_ec(Eurydice_slice serialized) {
     Eurydice_slice bytes = Eurydice_slice_subslice2(
         serialized, i0 * (size_t)22U, i0 * (size_t)22U + (size_t)22U, uint8_t);
     __m256i coefficient = libcrux_ml_kem_vector_avx2_deserialize_11_ea(bytes);
-    re.coefficients[i0] = decompress_ciphertext_coefficient_ea_8c0(coefficient);
+    re.coefficients[i0] = decompress_ciphertext_coefficient_ea_de0(coefficient);
   }
   return re;
 }
@@ -4045,8 +4072,8 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - COMPRESSION_FACTOR= 10
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_then_decompress_ring_element_u_0e(Eurydice_slice serialized) {
-  return deserialize_then_decompress_10_94(serialized);
+deserialize_then_decompress_ring_element_u_9c(Eurydice_slice serialized) {
+  return deserialize_then_decompress_10_66(serialized);
 }
 
 /**
@@ -4055,7 +4082,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - VECTOR_U_COMPRESSION_FACTOR= 10
 */
-static KRML_MUSTINLINE void ntt_vector_u_c1(
+static KRML_MUSTINLINE void ntt_vector_u_e0(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re) {
   size_t zeta_i = (size_t)0U;
   ntt_at_layer_4_plus_5a(&zeta_i, re, (size_t)7U);
@@ -4080,7 +4107,7 @@ with const generics
 - CIPHERTEXT_SIZE= 1088
 - U_COMPRESSION_FACTOR= 10
 */
-static KRML_MUSTINLINE void deserialize_then_decompress_u_7a1(
+static KRML_MUSTINLINE void deserialize_then_decompress_u_7b1(
     uint8_t *ciphertext,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u_as_ntt[3U];
@@ -4103,8 +4130,8 @@ static KRML_MUSTINLINE void deserialize_then_decompress_u_7a1(
             LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT *
                 (size_t)10U / (size_t)8U,
         uint8_t);
-    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_0e(u_bytes);
-    ntt_vector_u_c1(&u_as_ntt[i0]);
+    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_9c(u_bytes);
+    ntt_vector_u_e0(&u_as_ntt[i0]);
   }
   memcpy(
       ret, u_as_ntt,
@@ -4118,7 +4145,7 @@ generics
 - COEFFICIENT_BITS= 4
 */
 static KRML_MUSTINLINE __m256i
-decompress_ciphertext_coefficient_571(__m256i vector) {
+decompress_ciphertext_coefficient_ab1(__m256i vector) {
   __m256i field_modulus =
       mm256_set1_epi32((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
   __m256i two_pow_coefficient_bits =
@@ -4162,8 +4189,8 @@ libcrux_ml_kem.vector.avx2.decompress_ciphertext_coefficient_ea with const
 generics
 - COEFFICIENT_BITS= 4
 */
-static __m256i decompress_ciphertext_coefficient_ea_8c1(__m256i vector) {
-  return decompress_ciphertext_coefficient_571(vector);
+static __m256i decompress_ciphertext_coefficient_ea_de1(__m256i vector) {
+  return decompress_ciphertext_coefficient_ab1(vector);
 }
 
 /**
@@ -4173,7 +4200,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_then_decompress_4_cc(Eurydice_slice serialized) {
+deserialize_then_decompress_4_fa(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re = ZERO_89_9b();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)8U; i++) {
@@ -4181,7 +4208,7 @@ deserialize_then_decompress_4_cc(Eurydice_slice serialized) {
     Eurydice_slice bytes = Eurydice_slice_subslice2(
         serialized, i0 * (size_t)8U, i0 * (size_t)8U + (size_t)8U, uint8_t);
     __m256i coefficient = libcrux_ml_kem_vector_avx2_deserialize_4_ea(bytes);
-    re.coefficients[i0] = decompress_ciphertext_coefficient_ea_8c1(coefficient);
+    re.coefficients[i0] = decompress_ciphertext_coefficient_ea_de1(coefficient);
   }
   return re;
 }
@@ -4193,7 +4220,7 @@ generics
 - COEFFICIENT_BITS= 5
 */
 static KRML_MUSTINLINE __m256i
-decompress_ciphertext_coefficient_572(__m256i vector) {
+decompress_ciphertext_coefficient_ab2(__m256i vector) {
   __m256i field_modulus =
       mm256_set1_epi32((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
   __m256i two_pow_coefficient_bits =
@@ -4237,8 +4264,8 @@ libcrux_ml_kem.vector.avx2.decompress_ciphertext_coefficient_ea with const
 generics
 - COEFFICIENT_BITS= 5
 */
-static __m256i decompress_ciphertext_coefficient_ea_8c2(__m256i vector) {
-  return decompress_ciphertext_coefficient_572(vector);
+static __m256i decompress_ciphertext_coefficient_ea_de2(__m256i vector) {
+  return decompress_ciphertext_coefficient_ab2(vector);
 }
 
 /**
@@ -4248,7 +4275,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_then_decompress_5_21(Eurydice_slice serialized) {
+deserialize_then_decompress_5_6a(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re = ZERO_89_9b();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)10U; i++) {
@@ -4257,7 +4284,7 @@ deserialize_then_decompress_5_21(Eurydice_slice serialized) {
         serialized, i0 * (size_t)10U, i0 * (size_t)10U + (size_t)10U, uint8_t);
     re.coefficients[i0] = libcrux_ml_kem_vector_avx2_deserialize_5_ea(bytes);
     re.coefficients[i0] =
-        decompress_ciphertext_coefficient_ea_8c2(re.coefficients[i0]);
+        decompress_ciphertext_coefficient_ea_de2(re.coefficients[i0]);
   }
   return re;
 }
@@ -4269,8 +4296,8 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - COMPRESSION_FACTOR= 4
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_then_decompress_ring_element_v_13(Eurydice_slice serialized) {
-  return deserialize_then_decompress_4_cc(serialized);
+deserialize_then_decompress_ring_element_v_ac(Eurydice_slice serialized) {
+  return deserialize_then_decompress_4_fa(serialized);
 }
 
 /**
@@ -4284,7 +4311,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-subtract_reduce_89_97(libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *self,
+subtract_reduce_89_36(libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *self,
                       libcrux_ml_kem_polynomial_PolynomialRingElement_d2 b) {
   for (size_t i = (size_t)0U;
        i < LIBCRUX_ML_KEM_POLYNOMIAL_VECTORS_IN_RING_ELEMENT; i++) {
@@ -4312,7 +4339,7 @@ with const generics
 - K= 3
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-compute_message_3b1(
+compute_message_a61(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *v,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *secret_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *u_as_ntt) {
@@ -4321,8 +4348,8 @@ compute_message_3b1(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 product =
                       ntt_multiply_89_44(&secret_as_ntt[i0], &u_as_ntt[i0]);
                   add_to_ring_element_89_ce1(&result, &product););
-  invert_ntt_montgomery_e61(&result);
-  result = subtract_reduce_89_97(v, result);
+  invert_ntt_montgomery_4e1(&result);
+  result = subtract_reduce_89_36(v, result);
   return result;
 }
 
@@ -4332,7 +4359,7 @@ libcrux_ml_kem.serialize.compress_then_serialize_message with types
 libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 
 */
-static KRML_MUSTINLINE void compress_then_serialize_message_97(
+static KRML_MUSTINLINE void compress_then_serialize_message_0b(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re, uint8_t ret[32U]) {
   uint8_t serialized[32U] = {0U};
   KRML_MAYBE_FOR16(
@@ -4384,19 +4411,19 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_unpacked_8c1(
+static void decrypt_unpacked_5f1(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_a0 *secret_key,
     uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u_as_ntt[3U];
-  deserialize_then_decompress_u_7a1(ciphertext, u_as_ntt);
+  deserialize_then_decompress_u_7b1(ciphertext, u_as_ntt);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      deserialize_then_decompress_ring_element_v_13(
+      deserialize_then_decompress_ring_element_v_ac(
           Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                           (size_t)960U, uint8_t, size_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message =
-      compute_message_3b1(&v, secret_key->secret_as_ntt, u_as_ntt);
+      compute_message_a61(&v, secret_key->secret_as_ntt, u_as_ntt);
   uint8_t ret0[32U];
-  compress_then_serialize_message_97(message, ret0);
+  compress_then_serialize_message_0b(message, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -4447,11 +4474,11 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f1(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_591(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0 *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   uint8_t decrypted[32U];
-  decrypt_unpacked_8c1(&key_pair->private_key.ind_cpa_private_key,
+  decrypt_unpacked_5f1(&key_pair->private_key.ind_cpa_private_key,
                        ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -4480,7 +4507,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f1(
   Eurydice_slice uu____2 = Eurydice_array_to_subslice_from(
       (size_t)1120U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_b40(ciphertext),
+  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_fd0(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret[32U];
   PRF_a9_dd3(Eurydice_array_to_slice((size_t)1120U, to_hash, uint8_t),
@@ -4491,11 +4518,11 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f1(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1088U];
-  encrypt_unpacked_af1(uu____3, copy_of_decrypted, pseudorandomness,
+  encrypt_unpacked_ce1(uu____3, copy_of_decrypted, pseudorandomness,
                        expected_ciphertext);
   uint8_t selector =
       libcrux_ml_kem_constant_time_ops_compare_ciphertexts_in_constant_time(
-          libcrux_ml_kem_types_as_ref_00_b40(ciphertext),
+          libcrux_ml_kem_types_as_ref_00_fd0(ciphertext),
           Eurydice_array_to_slice((size_t)1088U, expected_ciphertext, uint8_t));
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_select_shared_secret_in_constant_time(
@@ -4513,7 +4540,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_to_uncompressed_ring_element_0e(Eurydice_slice serialized) {
+deserialize_to_uncompressed_ring_element_81(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re = ZERO_89_9b();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)24U; i++) {
@@ -4534,7 +4561,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void deserialize_secret_key_d71(
+static KRML_MUSTINLINE void deserialize_secret_key_461(
     Eurydice_slice secret_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 secret_as_ntt[3U];
@@ -4551,7 +4578,7 @@ static KRML_MUSTINLINE void deserialize_secret_key_d71(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        deserialize_to_uncompressed_ring_element_0e(secret_bytes);
+        deserialize_to_uncompressed_ring_element_81(secret_bytes);
     secret_as_ntt[i0] = uu____0;
   }
   memcpy(
@@ -4569,10 +4596,10 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_191(Eurydice_slice secret_key, uint8_t *ciphertext,
+static void decrypt_a81(Eurydice_slice secret_key, uint8_t *ciphertext,
                         uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 secret_as_ntt[3U];
-  deserialize_secret_key_d71(secret_key, secret_as_ntt);
+  deserialize_secret_key_461(secret_key, secret_as_ntt);
   /* Passing arrays by value in Rust generates a copy in C */
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 copy_of_secret_as_ntt[3U];
   memcpy(
@@ -4584,14 +4611,14 @@ static void decrypt_191(Eurydice_slice secret_key, uint8_t *ciphertext,
       secret_key_unpacked.secret_as_ntt, copy_of_secret_as_ntt,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
   uint8_t ret0[32U];
-  decrypt_unpacked_8c1(&secret_key_unpacked, ciphertext, ret0);
+  decrypt_unpacked_5f1(&secret_key_unpacked, ciphertext, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 3
 - SECRET_KEY_SIZE= 2400
@@ -4610,7 +4637,7 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-void libcrux_ml_kem_ind_cca_decapsulate_6e1(
+void libcrux_ml_kem_ind_cca_decapsulate_ff1(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -4628,7 +4655,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_6e1(
   Eurydice_slice ind_cpa_public_key_hash = uu____2.fst;
   Eurydice_slice implicit_rejection_value = uu____2.snd;
   uint8_t decrypted[32U];
-  decrypt_191(ind_cpa_secret_key, ciphertext->value, decrypted);
+  decrypt_a81(ind_cpa_secret_key, ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
       Eurydice_array_to_slice((size_t)32U, decrypted, uint8_t), to_hash0);
@@ -4650,7 +4677,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_6e1(
   Eurydice_slice uu____4 = Eurydice_array_to_subslice_from(
       (size_t)1120U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_b40(ciphertext),
+  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_fd0(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret0[32U];
   PRF_a9_dd3(Eurydice_array_to_slice((size_t)1120U, to_hash, uint8_t),
@@ -4660,17 +4687,17 @@ void libcrux_ml_kem_ind_cca_decapsulate_6e1(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1088U];
-  encrypt_a31(uu____5, copy_of_decrypted, pseudorandomness,
+  encrypt_c01(uu____5, copy_of_decrypted, pseudorandomness,
               expected_ciphertext);
   uint8_t implicit_rejection_shared_secret[32U];
-  kdf_af_be1(Eurydice_array_to_slice(
+  kdf_d8_aa1(Eurydice_array_to_slice(
                  (size_t)32U, implicit_rejection_shared_secret0, uint8_t),
              implicit_rejection_shared_secret);
   uint8_t shared_secret[32U];
-  kdf_af_be1(shared_secret0, shared_secret);
+  kdf_d8_aa1(shared_secret0, shared_secret);
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_compare_ciphertexts_select_shared_secret_in_constant_time(
-      libcrux_ml_kem_types_as_ref_00_b40(ciphertext),
+      libcrux_ml_kem_types_as_ref_00_fd0(ciphertext),
       Eurydice_array_to_slice((size_t)1088U, expected_ciphertext, uint8_t),
       Eurydice_array_to_slice((size_t)32U, shared_secret, uint8_t),
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret,
@@ -4692,7 +4719,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - PUBLIC_KEY_SIZE= 1568
 - K= 4
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a82(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a52(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[4U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[4U];
@@ -4709,7 +4736,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a82(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        deserialize_to_reduced_ring_element_71(ring_element);
+        deserialize_to_reduced_ring_element_ab(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -4788,9 +4815,9 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1536
 - PUBLIC_KEY_SIZE= 1568
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_f90(uint8_t *public_key) {
+bool libcrux_ml_kem_ind_cca_validate_public_key_a70(uint8_t *public_key) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[4U];
-  deserialize_ring_elements_reduced_a82(
+  deserialize_ring_elements_reduced_a52(
       Eurydice_array_to_subslice_to((size_t)1568U, public_key, (size_t)1536U,
                                     uint8_t, size_t),
       deserialized_pk);
@@ -4829,6 +4856,31 @@ with const generics
 */
 static KRML_MUSTINLINE void G_a9_e10(Eurydice_slice input, uint8_t ret[64U]) {
   libcrux_ml_kem_hash_functions_avx2_G(input, ret);
+}
+
+/**
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.variant.cpa_keygen_seed_d8
+with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
+with const generics
+- K= 4
+*/
+static KRML_MUSTINLINE void cpa_keygen_seed_d8_450(
+    Eurydice_slice key_generation_seed, uint8_t ret[64U]) {
+  uint8_t seed[33U] = {0U};
+  Eurydice_slice_copy(
+      Eurydice_array_to_subslice2(
+          seed, (size_t)0U,
+          LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t),
+      key_generation_seed, uint8_t);
+  seed[LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE] =
+      (uint8_t)(size_t)4U;
+  uint8_t ret0[64U];
+  G_a9_e10(Eurydice_array_to_slice((size_t)33U, seed, uint8_t), ret0);
+  memcpy(ret, ret0, (size_t)64U * sizeof(uint8_t));
 }
 
 /**
@@ -5474,10 +5526,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static tuple_54 generate_keypair_unpacked_e80(
+static tuple_54 generate_keypair_unpacked_580(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_a9_e10(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_450(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -5560,7 +5612,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static void closure_a70(
+static void closure_990(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[4U]) {
   KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U,
                   ret[i] = ZERO_89_9b(););
@@ -5592,7 +5644,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_01
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_270(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_910(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -5600,18 +5652,18 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_270(uint8_t randomness[64U]) {
       (size_t)64U, randomness,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
-  tuple_54 uu____0 = generate_keypair_unpacked_e80(ind_cpa_keypair_randomness);
+  tuple_54 uu____0 = generate_keypair_unpacked_580(ind_cpa_keypair_randomness);
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_01
       ind_cpa_private_key = uu____0.fst;
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_01
       ind_cpa_public_key = uu____0.snd;
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 A[4U][4U];
-  KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U, closure_a70(A[i]););
+  KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U, closure_990(A[i]););
   KRML_MAYBE_FOR4(
       i0, (size_t)0U, (size_t)4U, (size_t)1U, size_t i1 = i0; KRML_MAYBE_FOR4(
           i, (size_t)0U, (size_t)4U, (size_t)1U, size_t j = i;
           libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____1 =
-              clone_d5_d6(&ind_cpa_public_key.A[j][i1]);
+              clone_d5_4c(&ind_cpa_public_key.A[j][i1]);
           A[i1][j] = uu____1;););
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____2[4U][4U];
   memcpy(uu____2, A,
@@ -5661,7 +5713,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_270(uint8_t randomness[64U]) {
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cpa.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 4
 - PRIVATE_KEY_SIZE= 1536
 - PUBLIC_KEY_SIZE= 1568
@@ -5669,10 +5722,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair1024 generate_keypair_930(
+static libcrux_ml_kem_utils_extraction_helper_Keypair1024 generate_keypair_b70(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_a9_e10(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_450(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -5740,7 +5793,7 @@ with const generics
 - K= 4
 - SERIALIZED_KEY_LEN= 3168
 */
-static KRML_MUSTINLINE void serialize_kem_secret_key_8e0(
+static KRML_MUSTINLINE void serialize_kem_secret_key_5a0(
     Eurydice_slice private_key, Eurydice_slice public_key,
     Eurydice_slice implicit_rejection_value, uint8_t ret[3168U]) {
   uint8_t out[3168U] = {0U};
@@ -5793,7 +5846,8 @@ static KRML_MUSTINLINE void serialize_kem_secret_key_8e0(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 4
 - CPA_PRIVATE_KEY_SIZE= 1536
 - PRIVATE_KEY_SIZE= 3168
@@ -5803,7 +5857,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_mlkem1024_MlKem1024KeyPair
-libcrux_ml_kem_ind_cca_generate_keypair_0d0(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_500(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -5812,13 +5866,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_0d0(uint8_t randomness[64U]) {
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
   libcrux_ml_kem_utils_extraction_helper_Keypair1024 uu____0 =
-      generate_keypair_930(ind_cpa_keypair_randomness);
+      generate_keypair_b70(ind_cpa_keypair_randomness);
   uint8_t ind_cpa_private_key[1536U];
   memcpy(ind_cpa_private_key, uu____0.fst, (size_t)1536U * sizeof(uint8_t));
   uint8_t public_key[1568U];
   memcpy(public_key, uu____0.snd, (size_t)1568U * sizeof(uint8_t));
   uint8_t secret_key_serialized[3168U];
-  serialize_kem_secret_key_8e0(
+  serialize_kem_secret_key_5a0(
       Eurydice_array_to_slice((size_t)1536U, ind_cpa_private_key, uint8_t),
       Eurydice_array_to_slice((size_t)1568U, public_key, uint8_t),
       implicit_rejection_value, secret_key_serialized);
@@ -5827,13 +5881,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_0d0(uint8_t randomness[64U]) {
   memcpy(copy_of_secret_key_serialized, secret_key_serialized,
          (size_t)3168U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemPrivateKey_95 private_key =
-      libcrux_ml_kem_types_from_05_db1(copy_of_secret_key_serialized);
+      libcrux_ml_kem_types_from_05_0b1(copy_of_secret_key_serialized);
   libcrux_ml_kem_types_MlKemPrivateKey_95 uu____2 = private_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_public_key[1568U];
   memcpy(copy_of_public_key, public_key, (size_t)1568U * sizeof(uint8_t));
-  return libcrux_ml_kem_types_from_17_121(
-      uu____2, libcrux_ml_kem_types_from_b6_8e1(copy_of_public_key));
+  return libcrux_ml_kem_types_from_17_9c1(
+      uu____2, libcrux_ml_kem_types_from_b6_b01(copy_of_public_key));
 }
 
 /**
@@ -5848,7 +5902,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 */
 static KRML_MUSTINLINE tuple_71
-sample_ring_element_cbd_580(uint8_t prf_input[33U], uint8_t domain_separator) {
+sample_ring_element_cbd_320(uint8_t prf_input[33U], uint8_t domain_separator) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[4U];
   KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U,
                   error_1[i] = ZERO_89_9b(););
@@ -5904,17 +5958,17 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - K= 4
 */
-static KRML_MUSTINLINE void invert_ntt_montgomery_e60(
+static KRML_MUSTINLINE void invert_ntt_montgomery_4e0(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re) {
   size_t zeta_i =
       LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT / (size_t)2U;
-  invert_ntt_at_layer_1_3d(&zeta_i, re);
-  invert_ntt_at_layer_2_64(&zeta_i, re);
-  invert_ntt_at_layer_3_fb(&zeta_i, re);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)4U);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)5U);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)6U);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)7U);
+  invert_ntt_at_layer_1_48(&zeta_i, re);
+  invert_ntt_at_layer_2_10(&zeta_i, re);
+  invert_ntt_at_layer_3_b5(&zeta_i, re);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)4U);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)5U);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)6U);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)7U);
   poly_barrett_reduce_89_e6(re);
 }
 
@@ -5927,7 +5981,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - K= 4
 */
-static KRML_MUSTINLINE void compute_vector_u_540(
+static KRML_MUSTINLINE void compute_vector_u_a30(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 (*a_as_ntt)[4U],
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *error_1,
@@ -5957,8 +6011,8 @@ static KRML_MUSTINLINE void compute_vector_u_540(
           ntt_multiply_89_44(a_element, &r_as_ntt[j]);
       add_to_ring_element_89_ce0(&result[i1], &product);
     }
-    invert_ntt_montgomery_e60(&result[i1]);
-    add_error_reduce_89_c7(&result[i1], &error_1[i1]);
+    invert_ntt_montgomery_4e0(&result[i1]);
+    add_error_reduce_89_db(&result[i1], &error_1[i1]);
   }
   memcpy(
       ret, result,
@@ -5975,7 +6029,7 @@ with const generics
 - K= 4
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-compute_ring_element_v_f90(
+compute_ring_element_v_300(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *t_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *error_2,
@@ -5985,8 +6039,8 @@ compute_ring_element_v_f90(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 product =
                       ntt_multiply_89_44(&t_as_ntt[i0], &r_as_ntt[i0]);
                   add_to_ring_element_89_ce0(&result, &product););
-  invert_ntt_montgomery_e60(&result);
-  result = add_message_error_reduce_89_6a(error_2, message, result);
+  invert_ntt_montgomery_4e0(&result);
+  result = add_message_error_reduce_89_bd(error_2, message, result);
   return result;
 }
 
@@ -5996,14 +6050,14 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - OUT_LEN= 352
 */
-static KRML_MUSTINLINE void compress_then_serialize_11_280(
+static KRML_MUSTINLINE void compress_then_serialize_11_cf0(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re, uint8_t ret[352U]) {
   uint8_t serialized[352U] = {0U};
   for (size_t i = (size_t)0U;
        i < LIBCRUX_ML_KEM_POLYNOMIAL_VECTORS_IN_RING_ELEMENT; i++) {
     size_t i0 = i;
     __m256i coefficient =
-        compress_ea_9b0(to_unsigned_representative_14(re->coefficients[i0]));
+        compress_ea_010(to_unsigned_representative_14(re->coefficients[i0]));
     uint8_t bytes[22U];
     libcrux_ml_kem_vector_avx2_serialize_11_ea(coefficient, bytes);
     Eurydice_slice uu____0 = Eurydice_array_to_subslice2(
@@ -6021,10 +6075,10 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - COMPRESSION_FACTOR= 11
 - OUT_LEN= 352
 */
-static KRML_MUSTINLINE void compress_then_serialize_ring_element_u_560(
+static KRML_MUSTINLINE void compress_then_serialize_ring_element_u_ae0(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re, uint8_t ret[352U]) {
   uint8_t uu____0[352U];
-  compress_then_serialize_11_280(re, uu____0);
+  compress_then_serialize_11_cf0(re, uu____0);
   memcpy(ret, uu____0, (size_t)352U * sizeof(uint8_t));
 }
 
@@ -6040,7 +6094,7 @@ with const generics
 - COMPRESSION_FACTOR= 11
 - BLOCK_LEN= 352
 */
-static void compress_then_serialize_u_9b0(
+static void compress_then_serialize_u_c10(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 input[4U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -6056,7 +6110,7 @@ static void compress_then_serialize_u_9b0(
         out, i0 * ((size_t)1408U / (size_t)4U),
         (i0 + (size_t)1U) * ((size_t)1408U / (size_t)4U), uint8_t);
     uint8_t ret[352U];
-    compress_then_serialize_ring_element_u_560(&re, ret);
+    compress_then_serialize_ring_element_u_ae0(&re, ret);
     Eurydice_slice_copy(
         uu____0, Eurydice_array_to_slice((size_t)352U, ret, uint8_t), uint8_t);
   }
@@ -6069,9 +6123,9 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - COMPRESSION_FACTOR= 5
 - OUT_LEN= 160
 */
-static KRML_MUSTINLINE void compress_then_serialize_ring_element_v_6d0(
+static KRML_MUSTINLINE void compress_then_serialize_ring_element_v_130(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re, Eurydice_slice out) {
-  compress_then_serialize_5_8e(re, out);
+  compress_then_serialize_5_14(re, out);
 }
 
 /**
@@ -6132,7 +6186,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_af0(
+static void encrypt_unpacked_ce0(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_01 *public_key,
     uint8_t message[32U], Eurydice_slice randomness, uint8_t ret[1568U]) {
   uint8_t prf_input[33U];
@@ -6150,7 +6204,7 @@ static void encrypt_unpacked_af0(
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_71 uu____3 =
-      sample_ring_element_cbd_580(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_320(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[4U];
   memcpy(
       error_1, uu____3.fst,
@@ -6164,25 +6218,25 @@ static void encrypt_unpacked_af0(
       sample_from_binomial_distribution_730(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u[4U];
-  compute_vector_u_540(public_key->A, r_as_ntt, error_1, u);
+  compute_vector_u_a30(public_key->A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message_as_ring_element =
-      deserialize_then_decompress_message_d3(copy_of_message);
+      deserialize_then_decompress_message_f3(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      compute_ring_element_v_f90(public_key->t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_300(public_key->t_as_ntt, r_as_ntt, &error_2,
                                  &message_as_ring_element);
   uint8_t ciphertext[1568U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____5[4U];
   memcpy(
       uu____5, u,
       (size_t)4U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
-  compress_then_serialize_u_9b0(
+  compress_then_serialize_u_c10(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U,
                                            (size_t)1408U, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____6 = v;
-  compress_then_serialize_ring_element_v_6d0(
+  compress_then_serialize_ring_element_v_130(
       uu____6, Eurydice_array_to_subslice_from((size_t)1568U, ciphertext,
                                                (size_t)1408U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1568U * sizeof(uint8_t));
@@ -6206,7 +6260,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e0(
+tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_f20(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_01 *public_key,
     uint8_t randomness[32U]) {
   uint8_t to_hash[64U];
@@ -6233,7 +6287,7 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e0(
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1568U];
-  encrypt_unpacked_af0(uu____2, copy_of_randomness, pseudorandomness,
+  encrypt_unpacked_ce0(uu____2, copy_of_randomness, pseudorandomness,
                        ciphertext);
   uint8_t shared_secret_array[32U] = {0U};
   Eurydice_slice_copy(
@@ -6243,7 +6297,7 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e0(
   uint8_t copy_of_ciphertext[1568U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1568U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext uu____5 =
-      libcrux_ml_kem_types_from_01_ec1(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d1(copy_of_ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
   memcpy(copy_of_shared_secret_array, shared_secret_array,
@@ -6255,16 +6309,16 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e0(
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.entropy_preprocess_af
+A monomorphic instance of libcrux_ml_kem.variant.entropy_preprocess_d8
 with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
 - K= 4
 */
-static KRML_MUSTINLINE void entropy_preprocess_af_c10(Eurydice_slice randomness,
+static KRML_MUSTINLINE void entropy_preprocess_d8_f40(Eurydice_slice randomness,
                                                       uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -6285,7 +6339,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - PUBLIC_KEY_SIZE= 1536
 - K= 4
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a81(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a51(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[4U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[4U];
@@ -6302,7 +6356,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a81(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        deserialize_to_reduced_ring_element_71(ring_element);
+        deserialize_to_reduced_ring_element_ab(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -6327,10 +6381,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_a30(Eurydice_slice public_key, uint8_t message[32U],
+static void encrypt_c00(Eurydice_slice public_key, uint8_t message[32U],
                         Eurydice_slice randomness, uint8_t ret[1568U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 t_as_ntt[4U];
-  deserialize_ring_elements_reduced_a81(
+  deserialize_ring_elements_reduced_a51(
       Eurydice_slice_subslice_to(public_key, (size_t)1536U, uint8_t, size_t),
       t_as_ntt);
   Eurydice_slice seed =
@@ -6354,7 +6408,7 @@ static void encrypt_a30(Eurydice_slice public_key, uint8_t message[32U],
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_71 uu____3 =
-      sample_ring_element_cbd_580(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_320(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[4U];
   memcpy(
       error_1, uu____3.fst,
@@ -6368,42 +6422,42 @@ static void encrypt_a30(Eurydice_slice public_key, uint8_t message[32U],
       sample_from_binomial_distribution_730(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u[4U];
-  compute_vector_u_540(A, r_as_ntt, error_1, u);
+  compute_vector_u_a30(A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message_as_ring_element =
-      deserialize_then_decompress_message_d3(copy_of_message);
+      deserialize_then_decompress_message_f3(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      compute_ring_element_v_f90(t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_300(t_as_ntt, r_as_ntt, &error_2,
                                  &message_as_ring_element);
   uint8_t ciphertext[1568U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____5[4U];
   memcpy(
       uu____5, u,
       (size_t)4U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
-  compress_then_serialize_u_9b0(
+  compress_then_serialize_u_c10(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U,
                                            (size_t)1408U, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____6 = v;
-  compress_then_serialize_ring_element_v_6d0(
+  compress_then_serialize_ring_element_v_130(
       uu____6, Eurydice_array_to_subslice_from((size_t)1568U, ciphertext,
                                                (size_t)1408U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1568U * sizeof(uint8_t));
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.kdf_af
+A monomorphic instance of libcrux_ml_kem.variant.kdf_d8
 with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
 - K= 4
 - CIPHERTEXT_SIZE= 1568
 */
-static KRML_MUSTINLINE void kdf_af_be0(Eurydice_slice shared_secret,
+static KRML_MUSTINLINE void kdf_d8_aa0(Eurydice_slice shared_secret,
                                        uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -6414,7 +6468,7 @@ static KRML_MUSTINLINE void kdf_af_be0(Eurydice_slice shared_secret,
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 4
 - CIPHERTEXT_SIZE= 1568
@@ -6430,11 +6484,11 @@ with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_21 libcrux_ml_kem_ind_cca_encapsulate_410(
+tuple_21 libcrux_ml_kem_ind_cca_encapsulate_e20(
     libcrux_ml_kem_types_MlKemPublicKey_1f *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
-  entropy_preprocess_af_c10(
+  entropy_preprocess_d8_f40(
       Eurydice_array_to_slice((size_t)32U, randomness, uint8_t), randomness0);
   uint8_t to_hash[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -6444,7 +6498,7 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_410(
       size_t);
   uint8_t ret[32U];
   H_a9_a10(Eurydice_array_to_slice(
-               (size_t)1568U, libcrux_ml_kem_types_as_slice_cb_6f1(public_key),
+               (size_t)1568U, libcrux_ml_kem_types_as_slice_cb_331(public_key),
                uint8_t),
            ret);
   Eurydice_slice_copy(
@@ -6458,19 +6512,19 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_410(
   Eurydice_slice shared_secret = uu____1.fst;
   Eurydice_slice pseudorandomness = uu____1.snd;
   Eurydice_slice uu____2 = Eurydice_array_to_slice(
-      (size_t)1568U, libcrux_ml_kem_types_as_slice_cb_6f1(public_key), uint8_t);
+      (size_t)1568U, libcrux_ml_kem_types_as_slice_cb_331(public_key), uint8_t);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness0, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1568U];
-  encrypt_a30(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
+  encrypt_c00(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_ciphertext[1568U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1568U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext ciphertext0 =
-      libcrux_ml_kem_types_from_01_ec1(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d1(copy_of_ciphertext);
   uint8_t shared_secret_array[32U];
-  kdf_af_be0(shared_secret, shared_secret_array);
+  kdf_d8_aa0(shared_secret, shared_secret_array);
   libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext uu____5 = ciphertext0;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
@@ -6489,8 +6543,8 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - COMPRESSION_FACTOR= 11
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_then_decompress_ring_element_u_0e0(Eurydice_slice serialized) {
-  return deserialize_then_decompress_11_ec(serialized);
+deserialize_then_decompress_ring_element_u_9c0(Eurydice_slice serialized) {
+  return deserialize_then_decompress_11_af(serialized);
 }
 
 /**
@@ -6499,7 +6553,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - VECTOR_U_COMPRESSION_FACTOR= 11
 */
-static KRML_MUSTINLINE void ntt_vector_u_c10(
+static KRML_MUSTINLINE void ntt_vector_u_e00(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re) {
   size_t zeta_i = (size_t)0U;
   ntt_at_layer_4_plus_5a(&zeta_i, re, (size_t)7U);
@@ -6524,7 +6578,7 @@ with const generics
 - CIPHERTEXT_SIZE= 1568
 - U_COMPRESSION_FACTOR= 11
 */
-static KRML_MUSTINLINE void deserialize_then_decompress_u_7a0(
+static KRML_MUSTINLINE void deserialize_then_decompress_u_7b0(
     uint8_t *ciphertext,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[4U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u_as_ntt[4U];
@@ -6547,8 +6601,8 @@ static KRML_MUSTINLINE void deserialize_then_decompress_u_7a0(
             LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT *
                 (size_t)11U / (size_t)8U,
         uint8_t);
-    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_0e0(u_bytes);
-    ntt_vector_u_c10(&u_as_ntt[i0]);
+    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_9c0(u_bytes);
+    ntt_vector_u_e00(&u_as_ntt[i0]);
   }
   memcpy(
       ret, u_as_ntt,
@@ -6562,8 +6616,8 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - COMPRESSION_FACTOR= 5
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-deserialize_then_decompress_ring_element_v_130(Eurydice_slice serialized) {
-  return deserialize_then_decompress_5_21(serialized);
+deserialize_then_decompress_ring_element_v_ac0(Eurydice_slice serialized) {
+  return deserialize_then_decompress_5_6a(serialized);
 }
 
 /**
@@ -6579,7 +6633,7 @@ with const generics
 - K= 4
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-compute_message_3b0(
+compute_message_a60(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *v,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *secret_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *u_as_ntt) {
@@ -6588,8 +6642,8 @@ compute_message_3b0(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 product =
                       ntt_multiply_89_44(&secret_as_ntt[i0], &u_as_ntt[i0]);
                   add_to_ring_element_89_ce0(&result, &product););
-  invert_ntt_montgomery_e60(&result);
-  result = subtract_reduce_89_97(v, result);
+  invert_ntt_montgomery_4e0(&result);
+  result = subtract_reduce_89_36(v, result);
   return result;
 }
 
@@ -6627,19 +6681,19 @@ with const generics
 - U_COMPRESSION_FACTOR= 11
 - V_COMPRESSION_FACTOR= 5
 */
-static void decrypt_unpacked_8c0(
+static void decrypt_unpacked_5f0(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_01 *secret_key,
     uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u_as_ntt[4U];
-  deserialize_then_decompress_u_7a0(ciphertext, u_as_ntt);
+  deserialize_then_decompress_u_7b0(ciphertext, u_as_ntt);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      deserialize_then_decompress_ring_element_v_130(
+      deserialize_then_decompress_ring_element_v_ac0(
           Eurydice_array_to_subslice_from((size_t)1568U, ciphertext,
                                           (size_t)1408U, uint8_t, size_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message =
-      compute_message_3b0(&v, secret_key->secret_as_ntt, u_as_ntt);
+      compute_message_a60(&v, secret_key->secret_as_ntt, u_as_ntt);
   uint8_t ret0[32U];
-  compress_then_serialize_message_97(message, ret0);
+  compress_then_serialize_message_0b(message, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -6678,12 +6732,12 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f0(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_590(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_01 *key_pair,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
   uint8_t decrypted[32U];
-  decrypt_unpacked_8c0(&key_pair->private_key.ind_cpa_private_key,
+  decrypt_unpacked_5f0(&key_pair->private_key.ind_cpa_private_key,
                        ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -6712,7 +6766,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f0(
   Eurydice_slice uu____2 = Eurydice_array_to_subslice_from(
       (size_t)1600U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_b41(ciphertext),
+  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_fd1(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret[32U];
   PRF_a9_dd1(Eurydice_array_to_slice((size_t)1600U, to_hash, uint8_t),
@@ -6723,11 +6777,11 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f0(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1568U];
-  encrypt_unpacked_af0(uu____3, copy_of_decrypted, pseudorandomness,
+  encrypt_unpacked_ce0(uu____3, copy_of_decrypted, pseudorandomness,
                        expected_ciphertext);
   uint8_t selector =
       libcrux_ml_kem_constant_time_ops_compare_ciphertexts_in_constant_time(
-          libcrux_ml_kem_types_as_ref_00_b41(ciphertext),
+          libcrux_ml_kem_types_as_ref_00_fd1(ciphertext),
           Eurydice_array_to_slice((size_t)1568U, expected_ciphertext, uint8_t));
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_select_shared_secret_in_constant_time(
@@ -6747,7 +6801,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - K= 4
 */
-static KRML_MUSTINLINE void deserialize_secret_key_d70(
+static KRML_MUSTINLINE void deserialize_secret_key_460(
     Eurydice_slice secret_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[4U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 secret_as_ntt[4U];
@@ -6764,7 +6818,7 @@ static KRML_MUSTINLINE void deserialize_secret_key_d70(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        deserialize_to_uncompressed_ring_element_0e(secret_bytes);
+        deserialize_to_uncompressed_ring_element_81(secret_bytes);
     secret_as_ntt[i0] = uu____0;
   }
   memcpy(
@@ -6782,10 +6836,10 @@ with const generics
 - U_COMPRESSION_FACTOR= 11
 - V_COMPRESSION_FACTOR= 5
 */
-static void decrypt_190(Eurydice_slice secret_key, uint8_t *ciphertext,
+static void decrypt_a80(Eurydice_slice secret_key, uint8_t *ciphertext,
                         uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 secret_as_ntt[4U];
-  deserialize_secret_key_d70(secret_key, secret_as_ntt);
+  deserialize_secret_key_460(secret_key, secret_as_ntt);
   /* Passing arrays by value in Rust generates a copy in C */
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 copy_of_secret_as_ntt[4U];
   memcpy(
@@ -6797,14 +6851,14 @@ static void decrypt_190(Eurydice_slice secret_key, uint8_t *ciphertext,
       secret_key_unpacked.secret_as_ntt, copy_of_secret_as_ntt,
       (size_t)4U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
   uint8_t ret0[32U];
-  decrypt_unpacked_8c0(&secret_key_unpacked, ciphertext, ret0);
+  decrypt_unpacked_5f0(&secret_key_unpacked, ciphertext, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 4
 - SECRET_KEY_SIZE= 3168
@@ -6823,7 +6877,7 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-void libcrux_ml_kem_ind_cca_decapsulate_6e0(
+void libcrux_ml_kem_ind_cca_decapsulate_ff0(
     libcrux_ml_kem_types_MlKemPrivateKey_95 *private_key,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
@@ -6842,7 +6896,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_6e0(
   Eurydice_slice ind_cpa_public_key_hash = uu____2.fst;
   Eurydice_slice implicit_rejection_value = uu____2.snd;
   uint8_t decrypted[32U];
-  decrypt_190(ind_cpa_secret_key, ciphertext->value, decrypted);
+  decrypt_a80(ind_cpa_secret_key, ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
       Eurydice_array_to_slice((size_t)32U, decrypted, uint8_t), to_hash0);
@@ -6864,7 +6918,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_6e0(
   Eurydice_slice uu____4 = Eurydice_array_to_subslice_from(
       (size_t)1600U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_b41(ciphertext),
+  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_fd1(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret0[32U];
   PRF_a9_dd1(Eurydice_array_to_slice((size_t)1600U, to_hash, uint8_t),
@@ -6874,17 +6928,17 @@ void libcrux_ml_kem_ind_cca_decapsulate_6e0(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1568U];
-  encrypt_a30(uu____5, copy_of_decrypted, pseudorandomness,
+  encrypt_c00(uu____5, copy_of_decrypted, pseudorandomness,
               expected_ciphertext);
   uint8_t implicit_rejection_shared_secret[32U];
-  kdf_af_be0(Eurydice_array_to_slice(
+  kdf_d8_aa0(Eurydice_array_to_slice(
                  (size_t)32U, implicit_rejection_shared_secret0, uint8_t),
              implicit_rejection_shared_secret);
   uint8_t shared_secret[32U];
-  kdf_af_be0(shared_secret0, shared_secret);
+  kdf_d8_aa0(shared_secret0, shared_secret);
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_compare_ciphertexts_select_shared_secret_in_constant_time(
-      libcrux_ml_kem_types_as_ref_00_b41(ciphertext),
+      libcrux_ml_kem_types_as_ref_00_fd1(ciphertext),
       Eurydice_array_to_slice((size_t)1568U, expected_ciphertext, uint8_t),
       Eurydice_array_to_slice((size_t)32U, shared_secret, uint8_t),
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret,
@@ -6906,7 +6960,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - PUBLIC_KEY_SIZE= 800
 - K= 2
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a80(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a50(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[2U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[2U];
@@ -6923,7 +6977,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a80(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        deserialize_to_reduced_ring_element_71(ring_element);
+        deserialize_to_reduced_ring_element_ab(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -7002,9 +7056,9 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 768
 - PUBLIC_KEY_SIZE= 800
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_f9(uint8_t *public_key) {
+bool libcrux_ml_kem_ind_cca_validate_public_key_a7(uint8_t *public_key) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[2U];
-  deserialize_ring_elements_reduced_a80(
+  deserialize_ring_elements_reduced_a50(
       Eurydice_array_to_subslice_to((size_t)800U, public_key, (size_t)768U,
                                     uint8_t, size_t),
       deserialized_pk);
@@ -7043,6 +7097,31 @@ with const generics
 */
 static KRML_MUSTINLINE void G_a9_e1(Eurydice_slice input, uint8_t ret[64U]) {
   libcrux_ml_kem_hash_functions_avx2_G(input, ret);
+}
+
+/**
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.variant.cpa_keygen_seed_d8
+with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
+with const generics
+- K= 2
+*/
+static KRML_MUSTINLINE void cpa_keygen_seed_d8_45(
+    Eurydice_slice key_generation_seed, uint8_t ret[64U]) {
+  uint8_t seed[33U] = {0U};
+  Eurydice_slice_copy(
+      Eurydice_array_to_subslice2(
+          seed, (size_t)0U,
+          LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t),
+      key_generation_seed, uint8_t);
+  seed[LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE] =
+      (uint8_t)(size_t)2U;
+  uint8_t ret0[64U];
+  G_a9_e1(Eurydice_array_to_slice((size_t)33U, seed, uint8_t), ret0);
+  memcpy(ret, ret0, (size_t)64U * sizeof(uint8_t));
 }
 
 /**
@@ -7681,10 +7760,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static tuple_4c generate_keypair_unpacked_e8(
+static tuple_4c generate_keypair_unpacked_58(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_a9_e1(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_45(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -7767,7 +7846,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static void closure_a7(
+static void closure_99(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[2U]) {
   KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U,
                   ret[i] = ZERO_89_9b(););
@@ -7799,7 +7878,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 192
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_d6
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_27(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_91(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -7807,18 +7886,18 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_27(uint8_t randomness[64U]) {
       (size_t)64U, randomness,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
-  tuple_4c uu____0 = generate_keypair_unpacked_e8(ind_cpa_keypair_randomness);
+  tuple_4c uu____0 = generate_keypair_unpacked_58(ind_cpa_keypair_randomness);
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_d6
       ind_cpa_private_key = uu____0.fst;
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_d6
       ind_cpa_public_key = uu____0.snd;
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 A[2U][2U];
-  KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U, closure_a7(A[i]););
+  KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U, closure_99(A[i]););
   KRML_MAYBE_FOR2(
       i0, (size_t)0U, (size_t)2U, (size_t)1U, size_t i1 = i0; KRML_MAYBE_FOR2(
           i, (size_t)0U, (size_t)2U, (size_t)1U, size_t j = i;
           libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____1 =
-              clone_d5_d6(&ind_cpa_public_key.A[j][i1]);
+              clone_d5_4c(&ind_cpa_public_key.A[j][i1]);
           A[i1][j] = uu____1;););
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____2[2U][2U];
   memcpy(uu____2, A,
@@ -7868,7 +7947,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_27(uint8_t randomness[64U]) {
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cpa.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 2
 - PRIVATE_KEY_SIZE= 768
 - PUBLIC_KEY_SIZE= 800
@@ -7876,10 +7956,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair512 generate_keypair_93(
+static libcrux_ml_kem_utils_extraction_helper_Keypair512 generate_keypair_b7(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_a9_e1(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_45(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -7947,7 +8027,7 @@ with const generics
 - K= 2
 - SERIALIZED_KEY_LEN= 1632
 */
-static KRML_MUSTINLINE void serialize_kem_secret_key_8e(
+static KRML_MUSTINLINE void serialize_kem_secret_key_5a(
     Eurydice_slice private_key, Eurydice_slice public_key,
     Eurydice_slice implicit_rejection_value, uint8_t ret[1632U]) {
   uint8_t out[1632U] = {0U};
@@ -8000,7 +8080,8 @@ static KRML_MUSTINLINE void serialize_kem_secret_key_8e(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 2
 - CPA_PRIVATE_KEY_SIZE= 768
 - PRIVATE_KEY_SIZE= 1632
@@ -8009,7 +8090,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-libcrux_ml_kem_types_MlKemKeyPair_cb libcrux_ml_kem_ind_cca_generate_keypair_0d(
+libcrux_ml_kem_types_MlKemKeyPair_cb libcrux_ml_kem_ind_cca_generate_keypair_50(
     uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
@@ -8019,13 +8100,13 @@ libcrux_ml_kem_types_MlKemKeyPair_cb libcrux_ml_kem_ind_cca_generate_keypair_0d(
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
   libcrux_ml_kem_utils_extraction_helper_Keypair512 uu____0 =
-      generate_keypair_93(ind_cpa_keypair_randomness);
+      generate_keypair_b7(ind_cpa_keypair_randomness);
   uint8_t ind_cpa_private_key[768U];
   memcpy(ind_cpa_private_key, uu____0.fst, (size_t)768U * sizeof(uint8_t));
   uint8_t public_key[800U];
   memcpy(public_key, uu____0.snd, (size_t)800U * sizeof(uint8_t));
   uint8_t secret_key_serialized[1632U];
-  serialize_kem_secret_key_8e(
+  serialize_kem_secret_key_5a(
       Eurydice_array_to_slice((size_t)768U, ind_cpa_private_key, uint8_t),
       Eurydice_array_to_slice((size_t)800U, public_key, uint8_t),
       implicit_rejection_value, secret_key_serialized);
@@ -8034,13 +8115,13 @@ libcrux_ml_kem_types_MlKemKeyPair_cb libcrux_ml_kem_ind_cca_generate_keypair_0d(
   memcpy(copy_of_secret_key_serialized, secret_key_serialized,
          (size_t)1632U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemPrivateKey_5e private_key =
-      libcrux_ml_kem_types_from_05_db(copy_of_secret_key_serialized);
+      libcrux_ml_kem_types_from_05_0b(copy_of_secret_key_serialized);
   libcrux_ml_kem_types_MlKemPrivateKey_5e uu____2 = private_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_public_key[800U];
   memcpy(copy_of_public_key, public_key, (size_t)800U * sizeof(uint8_t));
-  return libcrux_ml_kem_types_from_17_12(
-      uu____2, libcrux_ml_kem_types_from_b6_8e(copy_of_public_key));
+  return libcrux_ml_kem_types_from_17_9c(
+      uu____2, libcrux_ml_kem_types_from_b6_b0(copy_of_public_key));
 }
 
 /**
@@ -8101,7 +8182,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 */
 static KRML_MUSTINLINE tuple_74
-sample_ring_element_cbd_58(uint8_t prf_input[33U], uint8_t domain_separator) {
+sample_ring_element_cbd_32(uint8_t prf_input[33U], uint8_t domain_separator) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[2U];
   KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U,
                   error_1[i] = ZERO_89_9b(););
@@ -8157,17 +8238,17 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - K= 2
 */
-static KRML_MUSTINLINE void invert_ntt_montgomery_e6(
+static KRML_MUSTINLINE void invert_ntt_montgomery_4e(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re) {
   size_t zeta_i =
       LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT / (size_t)2U;
-  invert_ntt_at_layer_1_3d(&zeta_i, re);
-  invert_ntt_at_layer_2_64(&zeta_i, re);
-  invert_ntt_at_layer_3_fb(&zeta_i, re);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)4U);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)5U);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)6U);
-  invert_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)7U);
+  invert_ntt_at_layer_1_48(&zeta_i, re);
+  invert_ntt_at_layer_2_10(&zeta_i, re);
+  invert_ntt_at_layer_3_b5(&zeta_i, re);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)4U);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)5U);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)6U);
+  invert_ntt_at_layer_4_plus_6e(&zeta_i, re, (size_t)7U);
   poly_barrett_reduce_89_e6(re);
 }
 
@@ -8180,7 +8261,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - K= 2
 */
-static KRML_MUSTINLINE void compute_vector_u_54(
+static KRML_MUSTINLINE void compute_vector_u_a3(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 (*a_as_ntt)[2U],
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *error_1,
@@ -8210,8 +8291,8 @@ static KRML_MUSTINLINE void compute_vector_u_54(
           ntt_multiply_89_44(a_element, &r_as_ntt[j]);
       add_to_ring_element_89_ce(&result[i1], &product);
     }
-    invert_ntt_montgomery_e6(&result[i1]);
-    add_error_reduce_89_c7(&result[i1], &error_1[i1]);
+    invert_ntt_montgomery_4e(&result[i1]);
+    add_error_reduce_89_db(&result[i1], &error_1[i1]);
   }
   memcpy(
       ret, result,
@@ -8228,7 +8309,7 @@ with const generics
 - K= 2
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-compute_ring_element_v_f9(
+compute_ring_element_v_30(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *t_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *error_2,
@@ -8238,8 +8319,8 @@ compute_ring_element_v_f9(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 product =
                       ntt_multiply_89_44(&t_as_ntt[i0], &r_as_ntt[i0]);
                   add_to_ring_element_89_ce(&result, &product););
-  invert_ntt_montgomery_e6(&result);
-  result = add_message_error_reduce_89_6a(error_2, message, result);
+  invert_ntt_montgomery_4e(&result);
+  result = add_message_error_reduce_89_bd(error_2, message, result);
   return result;
 }
 
@@ -8255,7 +8336,7 @@ with const generics
 - COMPRESSION_FACTOR= 10
 - BLOCK_LEN= 320
 */
-static void compress_then_serialize_u_9b(
+static void compress_then_serialize_u_c1(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 input[2U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -8271,7 +8352,7 @@ static void compress_then_serialize_u_9b(
         out, i0 * ((size_t)640U / (size_t)2U),
         (i0 + (size_t)1U) * ((size_t)640U / (size_t)2U), uint8_t);
     uint8_t ret[320U];
-    compress_then_serialize_ring_element_u_56(&re, ret);
+    compress_then_serialize_ring_element_u_ae(&re, ret);
     Eurydice_slice_copy(
         uu____0, Eurydice_array_to_slice((size_t)320U, ret, uint8_t), uint8_t);
   }
@@ -8335,7 +8416,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_af(
+static void encrypt_unpacked_ce(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_d6 *public_key,
     uint8_t message[32U], Eurydice_slice randomness, uint8_t ret[768U]) {
   uint8_t prf_input[33U];
@@ -8353,7 +8434,7 @@ static void encrypt_unpacked_af(
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_74 uu____3 =
-      sample_ring_element_cbd_58(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_32(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[2U];
   memcpy(
       error_1, uu____3.fst,
@@ -8367,25 +8448,25 @@ static void encrypt_unpacked_af(
       sample_from_binomial_distribution_730(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u[2U];
-  compute_vector_u_54(public_key->A, r_as_ntt, error_1, u);
+  compute_vector_u_a3(public_key->A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message_as_ring_element =
-      deserialize_then_decompress_message_d3(copy_of_message);
+      deserialize_then_decompress_message_f3(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      compute_ring_element_v_f9(public_key->t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_30(public_key->t_as_ntt, r_as_ntt, &error_2,
                                 &message_as_ring_element);
   uint8_t ciphertext[768U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____5[2U];
   memcpy(
       uu____5, u,
       (size_t)2U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
-  compress_then_serialize_u_9b(
+  compress_then_serialize_u_c1(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)640U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____6 = v;
-  compress_then_serialize_ring_element_v_6d(
+  compress_then_serialize_ring_element_v_13(
       uu____6, Eurydice_array_to_subslice_from((size_t)768U, ciphertext,
                                                (size_t)640U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)768U * sizeof(uint8_t));
@@ -8409,7 +8490,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e(
+tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_f2(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_d6 *public_key,
     uint8_t randomness[32U]) {
   uint8_t to_hash[64U];
@@ -8436,7 +8517,7 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e(
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[768U];
-  encrypt_unpacked_af(uu____2, copy_of_randomness, pseudorandomness,
+  encrypt_unpacked_ce(uu____2, copy_of_randomness, pseudorandomness,
                       ciphertext);
   uint8_t shared_secret_array[32U] = {0U};
   Eurydice_slice_copy(
@@ -8446,7 +8527,7 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e(
   uint8_t copy_of_ciphertext[768U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)768U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemCiphertext_e8 uu____5 =
-      libcrux_ml_kem_types_from_01_ec(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d(copy_of_ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
   memcpy(copy_of_shared_secret_array, shared_secret_array,
@@ -8458,16 +8539,16 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_9e(
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.entropy_preprocess_af
+A monomorphic instance of libcrux_ml_kem.variant.entropy_preprocess_d8
 with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
 - K= 2
 */
-static KRML_MUSTINLINE void entropy_preprocess_af_c1(Eurydice_slice randomness,
+static KRML_MUSTINLINE void entropy_preprocess_d8_f4(Eurydice_slice randomness,
                                                      uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -8488,7 +8569,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 - PUBLIC_KEY_SIZE= 768
 - K= 2
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a8(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a5(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[2U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[2U];
@@ -8505,7 +8586,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_a8(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        deserialize_to_reduced_ring_element_71(ring_element);
+        deserialize_to_reduced_ring_element_ab(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -8530,10 +8611,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_a3(Eurydice_slice public_key, uint8_t message[32U],
+static void encrypt_c0(Eurydice_slice public_key, uint8_t message[32U],
                        Eurydice_slice randomness, uint8_t ret[768U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 t_as_ntt[2U];
-  deserialize_ring_elements_reduced_a8(
+  deserialize_ring_elements_reduced_a5(
       Eurydice_slice_subslice_to(public_key, (size_t)768U, uint8_t, size_t),
       t_as_ntt);
   Eurydice_slice seed =
@@ -8557,7 +8638,7 @@ static void encrypt_a3(Eurydice_slice public_key, uint8_t message[32U],
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_74 uu____3 =
-      sample_ring_element_cbd_58(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_32(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[2U];
   memcpy(
       error_1, uu____3.fst,
@@ -8571,42 +8652,42 @@ static void encrypt_a3(Eurydice_slice public_key, uint8_t message[32U],
       sample_from_binomial_distribution_730(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u[2U];
-  compute_vector_u_54(A, r_as_ntt, error_1, u);
+  compute_vector_u_a3(A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message_as_ring_element =
-      deserialize_then_decompress_message_d3(copy_of_message);
+      deserialize_then_decompress_message_f3(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      compute_ring_element_v_f9(t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_30(t_as_ntt, r_as_ntt, &error_2,
                                 &message_as_ring_element);
   uint8_t ciphertext[768U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____5[2U];
   memcpy(
       uu____5, u,
       (size_t)2U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
-  compress_then_serialize_u_9b(
+  compress_then_serialize_u_c1(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)640U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____6 = v;
-  compress_then_serialize_ring_element_v_6d(
+  compress_then_serialize_ring_element_v_13(
       uu____6, Eurydice_array_to_subslice_from((size_t)768U, ciphertext,
                                                (size_t)640U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)768U * sizeof(uint8_t));
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.kdf_af
+A monomorphic instance of libcrux_ml_kem.variant.kdf_d8
 with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
 - K= 2
 - CIPHERTEXT_SIZE= 768
 */
-static KRML_MUSTINLINE void kdf_af_be(Eurydice_slice shared_secret,
+static KRML_MUSTINLINE void kdf_d8_aa(Eurydice_slice shared_secret,
                                       uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -8617,7 +8698,7 @@ static KRML_MUSTINLINE void kdf_af_be(Eurydice_slice shared_secret,
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 2
 - CIPHERTEXT_SIZE= 768
@@ -8633,11 +8714,11 @@ with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_ec libcrux_ml_kem_ind_cca_encapsulate_41(
+tuple_ec libcrux_ml_kem_ind_cca_encapsulate_e2(
     libcrux_ml_kem_types_MlKemPublicKey_be *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
-  entropy_preprocess_af_c1(
+  entropy_preprocess_d8_f4(
       Eurydice_array_to_slice((size_t)32U, randomness, uint8_t), randomness0);
   uint8_t to_hash[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -8647,7 +8728,7 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_41(
       size_t);
   uint8_t ret[32U];
   H_a9_a1(Eurydice_array_to_slice(
-              (size_t)800U, libcrux_ml_kem_types_as_slice_cb_6f(public_key),
+              (size_t)800U, libcrux_ml_kem_types_as_slice_cb_33(public_key),
               uint8_t),
           ret);
   Eurydice_slice_copy(
@@ -8661,19 +8742,19 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_41(
   Eurydice_slice shared_secret = uu____1.fst;
   Eurydice_slice pseudorandomness = uu____1.snd;
   Eurydice_slice uu____2 = Eurydice_array_to_slice(
-      (size_t)800U, libcrux_ml_kem_types_as_slice_cb_6f(public_key), uint8_t);
+      (size_t)800U, libcrux_ml_kem_types_as_slice_cb_33(public_key), uint8_t);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness0, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[768U];
-  encrypt_a3(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
+  encrypt_c0(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_ciphertext[768U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)768U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemCiphertext_e8 ciphertext0 =
-      libcrux_ml_kem_types_from_01_ec(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d(copy_of_ciphertext);
   uint8_t shared_secret_array[32U];
-  kdf_af_be(shared_secret, shared_secret_array);
+  kdf_d8_aa(shared_secret, shared_secret_array);
   libcrux_ml_kem_types_MlKemCiphertext_e8 uu____5 = ciphertext0;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
@@ -8697,7 +8778,7 @@ with const generics
 - CIPHERTEXT_SIZE= 768
 - U_COMPRESSION_FACTOR= 10
 */
-static KRML_MUSTINLINE void deserialize_then_decompress_u_7a(
+static KRML_MUSTINLINE void deserialize_then_decompress_u_7b(
     uint8_t *ciphertext,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[2U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u_as_ntt[2U];
@@ -8720,8 +8801,8 @@ static KRML_MUSTINLINE void deserialize_then_decompress_u_7a(
             LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT *
                 (size_t)10U / (size_t)8U,
         uint8_t);
-    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_0e(u_bytes);
-    ntt_vector_u_c1(&u_as_ntt[i0]);
+    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_9c(u_bytes);
+    ntt_vector_u_e0(&u_as_ntt[i0]);
   }
   memcpy(
       ret, u_as_ntt,
@@ -8741,7 +8822,7 @@ with const generics
 - K= 2
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-compute_message_3b(
+compute_message_a6(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *v,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *secret_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *u_as_ntt) {
@@ -8750,8 +8831,8 @@ compute_message_3b(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 product =
                       ntt_multiply_89_44(&secret_as_ntt[i0], &u_as_ntt[i0]);
                   add_to_ring_element_89_ce(&result, &product););
-  invert_ntt_montgomery_e6(&result);
-  result = subtract_reduce_89_97(v, result);
+  invert_ntt_montgomery_4e(&result);
+  result = subtract_reduce_89_36(v, result);
   return result;
 }
 
@@ -8789,19 +8870,19 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_unpacked_8c(
+static void decrypt_unpacked_5f(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_d6 *secret_key,
     uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u_as_ntt[2U];
-  deserialize_then_decompress_u_7a(ciphertext, u_as_ntt);
+  deserialize_then_decompress_u_7b(ciphertext, u_as_ntt);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      deserialize_then_decompress_ring_element_v_13(
+      deserialize_then_decompress_ring_element_v_ac(
           Eurydice_array_to_subslice_from((size_t)768U, ciphertext,
                                           (size_t)640U, uint8_t, size_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message =
-      compute_message_3b(&v, secret_key->secret_as_ntt, u_as_ntt);
+      compute_message_a6(&v, secret_key->secret_as_ntt, u_as_ntt);
   uint8_t ret0[32U];
-  compress_then_serialize_message_97(message, ret0);
+  compress_then_serialize_message_0b(message, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -8840,11 +8921,11 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_59(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_d6 *key_pair,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]) {
   uint8_t decrypted[32U];
-  decrypt_unpacked_8c(&key_pair->private_key.ind_cpa_private_key,
+  decrypt_unpacked_5f(&key_pair->private_key.ind_cpa_private_key,
                       ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -8873,7 +8954,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f(
   Eurydice_slice uu____2 = Eurydice_array_to_subslice_from(
       (size_t)800U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_b4(ciphertext),
+  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_fd(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret[32U];
   PRF_a9_dd(Eurydice_array_to_slice((size_t)800U, to_hash, uint8_t),
@@ -8884,11 +8965,11 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_0f(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[768U];
-  encrypt_unpacked_af(uu____3, copy_of_decrypted, pseudorandomness,
+  encrypt_unpacked_ce(uu____3, copy_of_decrypted, pseudorandomness,
                       expected_ciphertext);
   uint8_t selector =
       libcrux_ml_kem_constant_time_ops_compare_ciphertexts_in_constant_time(
-          libcrux_ml_kem_types_as_ref_00_b4(ciphertext),
+          libcrux_ml_kem_types_as_ref_00_fd(ciphertext),
           Eurydice_array_to_slice((size_t)768U, expected_ciphertext, uint8_t));
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_select_shared_secret_in_constant_time(
@@ -8908,7 +8989,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 - K= 2
 */
-static KRML_MUSTINLINE void deserialize_secret_key_d7(
+static KRML_MUSTINLINE void deserialize_secret_key_46(
     Eurydice_slice secret_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[2U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 secret_as_ntt[2U];
@@ -8925,7 +9006,7 @@ static KRML_MUSTINLINE void deserialize_secret_key_d7(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        deserialize_to_uncompressed_ring_element_0e(secret_bytes);
+        deserialize_to_uncompressed_ring_element_81(secret_bytes);
     secret_as_ntt[i0] = uu____0;
   }
   memcpy(
@@ -8943,10 +9024,10 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_19(Eurydice_slice secret_key, uint8_t *ciphertext,
+static void decrypt_a8(Eurydice_slice secret_key, uint8_t *ciphertext,
                        uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 secret_as_ntt[2U];
-  deserialize_secret_key_d7(secret_key, secret_as_ntt);
+  deserialize_secret_key_46(secret_key, secret_as_ntt);
   /* Passing arrays by value in Rust generates a copy in C */
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 copy_of_secret_as_ntt[2U];
   memcpy(
@@ -8958,14 +9039,14 @@ static void decrypt_19(Eurydice_slice secret_key, uint8_t *ciphertext,
       secret_key_unpacked.secret_as_ntt, copy_of_secret_as_ntt,
       (size_t)2U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
   uint8_t ret0[32U];
-  decrypt_unpacked_8c(&secret_key_unpacked, ciphertext, ret0);
+  decrypt_unpacked_5f(&secret_key_unpacked, ciphertext, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 2
 - SECRET_KEY_SIZE= 1632
@@ -8984,7 +9065,7 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-void libcrux_ml_kem_ind_cca_decapsulate_6e(
+void libcrux_ml_kem_ind_cca_decapsulate_ff(
     libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -9002,7 +9083,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_6e(
   Eurydice_slice ind_cpa_public_key_hash = uu____2.fst;
   Eurydice_slice implicit_rejection_value = uu____2.snd;
   uint8_t decrypted[32U];
-  decrypt_19(ind_cpa_secret_key, ciphertext->value, decrypted);
+  decrypt_a8(ind_cpa_secret_key, ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
       Eurydice_array_to_slice((size_t)32U, decrypted, uint8_t), to_hash0);
@@ -9024,7 +9105,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_6e(
   Eurydice_slice uu____4 = Eurydice_array_to_subslice_from(
       (size_t)800U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_b4(ciphertext),
+  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_fd(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret0[32U];
   PRF_a9_dd(Eurydice_array_to_slice((size_t)800U, to_hash, uint8_t),
@@ -9034,16 +9115,16 @@ void libcrux_ml_kem_ind_cca_decapsulate_6e(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[768U];
-  encrypt_a3(uu____5, copy_of_decrypted, pseudorandomness, expected_ciphertext);
+  encrypt_c0(uu____5, copy_of_decrypted, pseudorandomness, expected_ciphertext);
   uint8_t implicit_rejection_shared_secret[32U];
-  kdf_af_be(Eurydice_array_to_slice((size_t)32U,
+  kdf_d8_aa(Eurydice_array_to_slice((size_t)32U,
                                     implicit_rejection_shared_secret0, uint8_t),
             implicit_rejection_shared_secret);
   uint8_t shared_secret[32U];
-  kdf_af_be(shared_secret0, shared_secret);
+  kdf_d8_aa(shared_secret0, shared_secret);
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_compare_ciphertexts_select_shared_secret_in_constant_time(
-      libcrux_ml_kem_types_as_ref_00_b4(ciphertext),
+      libcrux_ml_kem_types_as_ref_00_fd(ciphertext),
       Eurydice_array_to_slice((size_t)768U, expected_ciphertext, uint8_t),
       Eurydice_array_to_slice((size_t)32U, shared_secret, uint8_t),
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret,

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_neon.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_neon.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "libcrux_mlkem_neon.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem_neon.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_neon.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem_neon_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "internal/libcrux_mlkem_portable.h"
@@ -2275,7 +2275,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_to_reduced_ring_element_e1(Eurydice_slice serialized) {
+deserialize_to_reduced_ring_element_b0(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re = ZERO_89_8d();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)24U; i++) {
@@ -2304,7 +2304,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - PUBLIC_KEY_SIZE= 1568
 - K= 4
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d4(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_b74(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[4U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[4U];
@@ -2321,7 +2321,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d4(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        deserialize_to_reduced_ring_element_e1(ring_element);
+        deserialize_to_reduced_ring_element_b0(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -2470,9 +2470,9 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1536
 - PUBLIC_KEY_SIZE= 1568
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_c21(uint8_t *public_key) {
+bool libcrux_ml_kem_ind_cca_validate_public_key_6d1(uint8_t *public_key) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[4U];
-  deserialize_ring_elements_reduced_9d4(
+  deserialize_ring_elements_reduced_b74(
       Eurydice_array_to_subslice_to((size_t)1568U, public_key, (size_t)1536U,
                                     uint8_t, size_t),
       deserialized_pk);
@@ -2511,6 +2511,31 @@ with const generics
 */
 static KRML_MUSTINLINE void G_f1_e41(Eurydice_slice input, uint8_t ret[64U]) {
   libcrux_ml_kem_hash_functions_portable_G(input, ret);
+}
+
+/**
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.variant.cpa_keygen_seed_d8
+with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]]
+with const generics
+- K= 4
+*/
+static KRML_MUSTINLINE void cpa_keygen_seed_d8_1a(
+    Eurydice_slice key_generation_seed, uint8_t ret[64U]) {
+  uint8_t seed[33U] = {0U};
+  Eurydice_slice_copy(
+      Eurydice_array_to_subslice2(
+          seed, (size_t)0U,
+          LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t),
+      key_generation_seed, uint8_t);
+  seed[LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE] =
+      (uint8_t)(size_t)4U;
+  uint8_t ret0[64U];
+  G_f1_e41(Eurydice_array_to_slice((size_t)33U, seed, uint8_t), ret0);
+  memcpy(ret, ret0, (size_t)64U * sizeof(uint8_t));
 }
 
 /**
@@ -3604,10 +3629,10 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static tuple_540 generate_keypair_unpacked_421(
+static tuple_540 generate_keypair_unpacked_c11(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_f1_e41(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_1a(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -3691,7 +3716,7 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static void closure_881(
+static void closure_e71(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[4U]) {
   KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U,
                   ret[i] = ZERO_89_8d(););
@@ -3707,7 +3732,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static inline libcrux_ml_kem_polynomial_PolynomialRingElement_f0 clone_d5_84(
+static inline libcrux_ml_kem_polynomial_PolynomialRingElement_f0 clone_d5_51(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *self) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 lit;
   libcrux_ml_kem_vector_portable_vector_type_PortableVector ret[16U];
@@ -3747,7 +3772,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_42
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c81(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_2c1(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -3755,18 +3780,18 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c81(uint8_t randomness[64U]) {
       (size_t)64U, randomness,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
-  tuple_540 uu____0 = generate_keypair_unpacked_421(ind_cpa_keypair_randomness);
+  tuple_540 uu____0 = generate_keypair_unpacked_c11(ind_cpa_keypair_randomness);
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_42
       ind_cpa_private_key = uu____0.fst;
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_42
       ind_cpa_public_key = uu____0.snd;
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 A[4U][4U];
-  KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U, closure_881(A[i]););
+  KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U, closure_e71(A[i]););
   KRML_MAYBE_FOR4(
       i0, (size_t)0U, (size_t)4U, (size_t)1U, size_t i1 = i0; KRML_MAYBE_FOR4(
           i, (size_t)0U, (size_t)4U, (size_t)1U, size_t j = i;
           libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____1 =
-              clone_d5_84(&ind_cpa_public_key.A[j][i1]);
+              clone_d5_51(&ind_cpa_public_key.A[j][i1]);
           A[i1][j] = uu____1;););
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____2[4U][4U];
   memcpy(uu____2, A,
@@ -3816,8 +3841,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c81(uint8_t randomness[64U]) {
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cpa.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 4
 - PRIVATE_KEY_SIZE= 1536
 - PUBLIC_KEY_SIZE= 1568
@@ -3825,10 +3850,10 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair1024 generate_keypair_6e1(
+static libcrux_ml_kem_utils_extraction_helper_Keypair1024 generate_keypair_d51(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_f1_e41(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_1a(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -3896,7 +3921,7 @@ with const generics
 - K= 4
 - SERIALIZED_KEY_LEN= 3168
 */
-static KRML_MUSTINLINE void serialize_kem_secret_key_d8(
+static KRML_MUSTINLINE void serialize_kem_secret_key_2d(
     Eurydice_slice private_key, Eurydice_slice public_key,
     Eurydice_slice implicit_rejection_value, uint8_t ret[3168U]) {
   uint8_t out[3168U] = {0U};
@@ -3949,8 +3974,8 @@ static KRML_MUSTINLINE void serialize_kem_secret_key_d8(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 4
 - CPA_PRIVATE_KEY_SIZE= 1536
 - PRIVATE_KEY_SIZE= 3168
@@ -3960,7 +3985,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_mlkem1024_MlKem1024KeyPair
-libcrux_ml_kem_ind_cca_generate_keypair_f91(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_951(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -3969,13 +3994,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_f91(uint8_t randomness[64U]) {
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
   libcrux_ml_kem_utils_extraction_helper_Keypair1024 uu____0 =
-      generate_keypair_6e1(ind_cpa_keypair_randomness);
+      generate_keypair_d51(ind_cpa_keypair_randomness);
   uint8_t ind_cpa_private_key[1536U];
   memcpy(ind_cpa_private_key, uu____0.fst, (size_t)1536U * sizeof(uint8_t));
   uint8_t public_key[1568U];
   memcpy(public_key, uu____0.snd, (size_t)1568U * sizeof(uint8_t));
   uint8_t secret_key_serialized[3168U];
-  serialize_kem_secret_key_d8(
+  serialize_kem_secret_key_2d(
       Eurydice_array_to_slice((size_t)1536U, ind_cpa_private_key, uint8_t),
       Eurydice_array_to_slice((size_t)1568U, public_key, uint8_t),
       implicit_rejection_value, secret_key_serialized);
@@ -3984,13 +4009,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_f91(uint8_t randomness[64U]) {
   memcpy(copy_of_secret_key_serialized, secret_key_serialized,
          (size_t)3168U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemPrivateKey_95 private_key =
-      libcrux_ml_kem_types_from_05_db1(copy_of_secret_key_serialized);
+      libcrux_ml_kem_types_from_05_0b1(copy_of_secret_key_serialized);
   libcrux_ml_kem_types_MlKemPrivateKey_95 uu____2 = private_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_public_key[1568U];
   memcpy(copy_of_public_key, public_key, (size_t)1568U * sizeof(uint8_t));
-  return libcrux_ml_kem_types_from_17_121(
-      uu____2, libcrux_ml_kem_types_from_b6_8e1(copy_of_public_key));
+  return libcrux_ml_kem_types_from_17_9c1(
+      uu____2, libcrux_ml_kem_types_from_b6_b01(copy_of_public_key));
 }
 
 /**
@@ -4006,7 +4031,7 @@ generics
 - ETA2= 2
 */
 static KRML_MUSTINLINE tuple_710
-sample_ring_element_cbd_381(uint8_t prf_input[33U], uint8_t domain_separator) {
+sample_ring_element_cbd_f11(uint8_t prf_input[33U], uint8_t domain_separator) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[4U];
   KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U,
                   error_1[i] = ZERO_89_8d(););
@@ -4074,7 +4099,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void invert_ntt_at_layer_1_46(
+static KRML_MUSTINLINE void invert_ntt_at_layer_1_6e(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re) {
   KRML_MAYBE_FOR16(
       i, (size_t)0U, (size_t)16U, (size_t)1U, size_t round = i;
@@ -4098,7 +4123,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void invert_ntt_at_layer_2_53(
+static KRML_MUSTINLINE void invert_ntt_at_layer_2_63(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re) {
   KRML_MAYBE_FOR16(
       i, (size_t)0U, (size_t)16U, (size_t)1U, size_t round = i;
@@ -4118,7 +4143,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void invert_ntt_at_layer_3_17(
+static KRML_MUSTINLINE void invert_ntt_at_layer_3_23(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re) {
   KRML_MAYBE_FOR16(
       i, (size_t)0U, (size_t)16U, (size_t)1U, size_t round = i;
@@ -4138,7 +4163,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 */
 static KRML_MUSTINLINE
     libcrux_ml_kem_vector_portable_vector_type_PortableVector_x2
-    inv_ntt_layer_int_vec_step_reduce_d9(
+    inv_ntt_layer_int_vec_step_reduce_69(
         libcrux_ml_kem_vector_portable_vector_type_PortableVector a,
         libcrux_ml_kem_vector_portable_vector_type_PortableVector b,
         int16_t zeta_r) {
@@ -4158,7 +4183,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void invert_ntt_at_layer_4_plus_1a(
+static KRML_MUSTINLINE void invert_ntt_at_layer_4_plus_3b(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re,
     size_t layer) {
   size_t step = (size_t)1U << (uint32_t)layer;
@@ -4173,7 +4198,7 @@ static KRML_MUSTINLINE void invert_ntt_at_layer_4_plus_1a(
     for (size_t i = offset_vec; i < offset_vec + step_vec; i++) {
       size_t j = i;
       libcrux_ml_kem_vector_portable_vector_type_PortableVector_x2 uu____0 =
-          inv_ntt_layer_int_vec_step_reduce_d9(
+          inv_ntt_layer_int_vec_step_reduce_69(
               re->coefficients[j], re->coefficients[j + step_vec],
               libcrux_ml_kem_polynomial_ZETAS_TIMES_MONTGOMERY_R[zeta_i[0U]]);
       libcrux_ml_kem_vector_portable_vector_type_PortableVector x = uu____0.fst;
@@ -4190,17 +4215,17 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 4
 */
-static KRML_MUSTINLINE void invert_ntt_montgomery_951(
+static KRML_MUSTINLINE void invert_ntt_montgomery_b51(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re) {
   size_t zeta_i =
       LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT / (size_t)2U;
-  invert_ntt_at_layer_1_46(&zeta_i, re);
-  invert_ntt_at_layer_2_53(&zeta_i, re);
-  invert_ntt_at_layer_3_17(&zeta_i, re);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)4U);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)5U);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)6U);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)7U);
+  invert_ntt_at_layer_1_6e(&zeta_i, re);
+  invert_ntt_at_layer_2_63(&zeta_i, re);
+  invert_ntt_at_layer_3_23(&zeta_i, re);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)4U);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)5U);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)6U);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)7U);
   poly_barrett_reduce_89_61(re);
 }
 
@@ -4214,7 +4239,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void add_error_reduce_89_c3(
+static KRML_MUSTINLINE void add_error_reduce_89_7a(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *self,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *error) {
   for (size_t i = (size_t)0U;
@@ -4241,7 +4266,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 4
 */
-static KRML_MUSTINLINE void compute_vector_u_221(
+static KRML_MUSTINLINE void compute_vector_u_e41(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 (*a_as_ntt)[4U],
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *error_1,
@@ -4271,8 +4296,8 @@ static KRML_MUSTINLINE void compute_vector_u_221(
           ntt_multiply_89_17(a_element, &r_as_ntt[j]);
       add_to_ring_element_89_e81(&result[i1], &product);
     }
-    invert_ntt_montgomery_951(&result[i1]);
-    add_error_reduce_89_c3(&result[i1], &error_1[i1]);
+    invert_ntt_montgomery_b51(&result[i1]);
+    add_error_reduce_89_7a(&result[i1], &error_1[i1]);
   }
   memcpy(
       ret, result,
@@ -4286,7 +4311,7 @@ with const generics
 
 */
 static libcrux_ml_kem_vector_portable_vector_type_PortableVector
-decompress_1_b3(libcrux_ml_kem_vector_portable_vector_type_PortableVector v) {
+decompress_1_e7(libcrux_ml_kem_vector_portable_vector_type_PortableVector v) {
   libcrux_ml_kem_vector_portable_vector_type_PortableVector uu____0 =
       libcrux_ml_kem_vector_portable_ZERO_0d();
   return libcrux_ml_kem_vector_portable_bitwise_and_with_constant_0d(
@@ -4300,7 +4325,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_then_decompress_message_6c(uint8_t serialized[32U]) {
+deserialize_then_decompress_message_5e(uint8_t serialized[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re = ZERO_89_8d();
   KRML_MAYBE_FOR16(
       i, (size_t)0U, (size_t)16U, (size_t)1U, size_t i0 = i;
@@ -4311,7 +4336,7 @@ deserialize_then_decompress_message_6c(uint8_t serialized[32U]) {
                                               (size_t)2U * i0 + (size_t)2U,
                                               uint8_t));
       libcrux_ml_kem_vector_portable_vector_type_PortableVector uu____0 =
-          decompress_1_b3(coefficient_compressed);
+          decompress_1_e7(coefficient_compressed);
       re.coefficients[i0] = uu____0;);
   return re;
 }
@@ -4327,7 +4352,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-add_message_error_reduce_89_a1(
+add_message_error_reduce_89_e6(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *self,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *message,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 result) {
@@ -4360,7 +4385,7 @@ with const generics
 - K= 4
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-compute_ring_element_v_ba1(
+compute_ring_element_v_691(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *t_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *error_2,
@@ -4370,8 +4395,8 @@ compute_ring_element_v_ba1(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 product =
                       ntt_multiply_89_17(&t_as_ntt[i0], &r_as_ntt[i0]);
                   add_to_ring_element_89_e81(&result, &product););
-  invert_ntt_montgomery_951(&result);
-  result = add_message_error_reduce_89_a1(error_2, message, result);
+  invert_ntt_montgomery_b51(&result);
+  result = add_message_error_reduce_89_e6(error_2, message, result);
   return result;
 }
 
@@ -4445,7 +4470,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - OUT_LEN= 352
 */
-static KRML_MUSTINLINE void compress_then_serialize_11_f80(
+static KRML_MUSTINLINE void compress_then_serialize_11_210(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re, uint8_t ret[352U]) {
   uint8_t serialized[352U] = {0U};
   for (size_t i = (size_t)0U;
@@ -4470,10 +4495,10 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - COMPRESSION_FACTOR= 11
 - OUT_LEN= 352
 */
-static KRML_MUSTINLINE void compress_then_serialize_ring_element_u_540(
+static KRML_MUSTINLINE void compress_then_serialize_ring_element_u_960(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re, uint8_t ret[352U]) {
   uint8_t uu____0[352U];
-  compress_then_serialize_11_f80(re, uu____0);
+  compress_then_serialize_11_210(re, uu____0);
   memcpy(ret, uu____0, (size_t)352U * sizeof(uint8_t));
 }
 
@@ -4489,7 +4514,7 @@ with const generics
 - COMPRESSION_FACTOR= 11
 - BLOCK_LEN= 352
 */
-static void compress_then_serialize_u_621(
+static void compress_then_serialize_u_6e1(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 input[4U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -4505,7 +4530,7 @@ static void compress_then_serialize_u_621(
         out, i0 * ((size_t)1408U / (size_t)4U),
         (i0 + (size_t)1U) * ((size_t)1408U / (size_t)4U), uint8_t);
     uint8_t ret[352U];
-    compress_then_serialize_ring_element_u_540(&re, ret);
+    compress_then_serialize_ring_element_u_960(&re, ret);
     Eurydice_slice_copy(
         uu____0, Eurydice_array_to_slice((size_t)352U, ret, uint8_t), uint8_t);
   }
@@ -4549,7 +4574,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void compress_then_serialize_4_f6(
+static KRML_MUSTINLINE void compress_then_serialize_4_1e(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re,
     Eurydice_slice serialized) {
   for (size_t i = (size_t)0U;
@@ -4604,7 +4629,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void compress_then_serialize_5_06(
+static KRML_MUSTINLINE void compress_then_serialize_5_d3(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re,
     Eurydice_slice serialized) {
   for (size_t i = (size_t)0U;
@@ -4628,9 +4653,9 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - COMPRESSION_FACTOR= 5
 - OUT_LEN= 160
 */
-static KRML_MUSTINLINE void compress_then_serialize_ring_element_v_200(
+static KRML_MUSTINLINE void compress_then_serialize_ring_element_v_bc0(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re, Eurydice_slice out) {
-  compress_then_serialize_5_06(re, out);
+  compress_then_serialize_5_d3(re, out);
 }
 
 /**
@@ -4692,7 +4717,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_c51(
+static void encrypt_unpacked_781(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_42 *public_key,
     uint8_t message[32U], Eurydice_slice randomness, uint8_t ret[1568U]) {
   uint8_t prf_input[33U];
@@ -4710,7 +4735,7 @@ static void encrypt_unpacked_c51(
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_710 uu____3 =
-      sample_ring_element_cbd_381(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_f11(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[4U];
   memcpy(
       error_1, uu____3.fst,
@@ -4724,25 +4749,25 @@ static void encrypt_unpacked_c51(
       sample_from_binomial_distribution_34(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u[4U];
-  compute_vector_u_221(public_key->A, r_as_ntt, error_1, u);
+  compute_vector_u_e41(public_key->A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message_as_ring_element =
-      deserialize_then_decompress_message_6c(copy_of_message);
+      deserialize_then_decompress_message_5e(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      compute_ring_element_v_ba1(public_key->t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_691(public_key->t_as_ntt, r_as_ntt, &error_2,
                                  &message_as_ring_element);
   uint8_t ciphertext[1568U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____5[4U];
   memcpy(
       uu____5, u,
       (size_t)4U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
-  compress_then_serialize_u_621(
+  compress_then_serialize_u_6e1(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U,
                                            (size_t)1408U, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____6 = v;
-  compress_then_serialize_ring_element_v_200(
+  compress_then_serialize_ring_element_v_bc0(
       uu____6, Eurydice_array_to_subslice_from((size_t)1568U, ciphertext,
                                                (size_t)1408U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1568U * sizeof(uint8_t));
@@ -4767,7 +4792,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_de1(
+tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_511(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_42 *public_key,
     uint8_t randomness[32U]) {
   uint8_t to_hash[64U];
@@ -4794,7 +4819,7 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_de1(
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1568U];
-  encrypt_unpacked_c51(uu____2, copy_of_randomness, pseudorandomness,
+  encrypt_unpacked_781(uu____2, copy_of_randomness, pseudorandomness,
                        ciphertext);
   uint8_t shared_secret_array[32U] = {0U};
   Eurydice_slice_copy(
@@ -4804,7 +4829,7 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_de1(
   uint8_t copy_of_ciphertext[1568U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1568U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext uu____5 =
-      libcrux_ml_kem_types_from_01_ec1(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d1(copy_of_ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
   memcpy(copy_of_shared_secret_array, shared_secret_array,
@@ -4816,16 +4841,16 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_unpacked_de1(
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.entropy_preprocess_af
+A monomorphic instance of libcrux_ml_kem.variant.entropy_preprocess_d8
 with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]]
 with const generics
 - K= 4
 */
-static KRML_MUSTINLINE void entropy_preprocess_af_77(Eurydice_slice randomness,
+static KRML_MUSTINLINE void entropy_preprocess_d8_62(Eurydice_slice randomness,
                                                      uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -4846,7 +4871,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - PUBLIC_KEY_SIZE= 1536
 - K= 4
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d3(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_b73(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[4U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[4U];
@@ -4863,7 +4888,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d3(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        deserialize_to_reduced_ring_element_e1(ring_element);
+        deserialize_to_reduced_ring_element_b0(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -4889,10 +4914,10 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_091(Eurydice_slice public_key, uint8_t message[32U],
+static void encrypt_b41(Eurydice_slice public_key, uint8_t message[32U],
                         Eurydice_slice randomness, uint8_t ret[1568U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 t_as_ntt[4U];
-  deserialize_ring_elements_reduced_9d3(
+  deserialize_ring_elements_reduced_b73(
       Eurydice_slice_subslice_to(public_key, (size_t)1536U, uint8_t, size_t),
       t_as_ntt);
   Eurydice_slice seed =
@@ -4916,7 +4941,7 @@ static void encrypt_091(Eurydice_slice public_key, uint8_t message[32U],
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_710 uu____3 =
-      sample_ring_element_cbd_381(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_f11(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[4U];
   memcpy(
       error_1, uu____3.fst,
@@ -4930,42 +4955,42 @@ static void encrypt_091(Eurydice_slice public_key, uint8_t message[32U],
       sample_from_binomial_distribution_34(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u[4U];
-  compute_vector_u_221(A, r_as_ntt, error_1, u);
+  compute_vector_u_e41(A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message_as_ring_element =
-      deserialize_then_decompress_message_6c(copy_of_message);
+      deserialize_then_decompress_message_5e(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      compute_ring_element_v_ba1(t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_691(t_as_ntt, r_as_ntt, &error_2,
                                  &message_as_ring_element);
   uint8_t ciphertext[1568U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____5[4U];
   memcpy(
       uu____5, u,
       (size_t)4U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
-  compress_then_serialize_u_621(
+  compress_then_serialize_u_6e1(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U,
                                            (size_t)1408U, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____6 = v;
-  compress_then_serialize_ring_element_v_200(
+  compress_then_serialize_ring_element_v_bc0(
       uu____6, Eurydice_array_to_subslice_from((size_t)1568U, ciphertext,
                                                (size_t)1408U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1568U * sizeof(uint8_t));
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.kdf_af
+A monomorphic instance of libcrux_ml_kem.variant.kdf_d8
 with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]]
 with const generics
 - K= 4
 - CIPHERTEXT_SIZE= 1568
 */
-static KRML_MUSTINLINE void kdf_af_11(Eurydice_slice shared_secret,
+static KRML_MUSTINLINE void kdf_d8_8d(Eurydice_slice shared_secret,
                                       uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -4977,7 +5002,7 @@ static KRML_MUSTINLINE void kdf_af_11(Eurydice_slice shared_secret,
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 4
 - CIPHERTEXT_SIZE= 1568
 - PUBLIC_KEY_SIZE= 1568
@@ -4992,11 +5017,11 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_21 libcrux_ml_kem_ind_cca_encapsulate_8f1(
+tuple_21 libcrux_ml_kem_ind_cca_encapsulate_511(
     libcrux_ml_kem_types_MlKemPublicKey_1f *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
-  entropy_preprocess_af_77(
+  entropy_preprocess_d8_62(
       Eurydice_array_to_slice((size_t)32U, randomness, uint8_t), randomness0);
   uint8_t to_hash[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -5006,7 +5031,7 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_8f1(
       size_t);
   uint8_t ret[32U];
   H_f1_1a1(Eurydice_array_to_slice(
-               (size_t)1568U, libcrux_ml_kem_types_as_slice_cb_6f1(public_key),
+               (size_t)1568U, libcrux_ml_kem_types_as_slice_cb_331(public_key),
                uint8_t),
            ret);
   Eurydice_slice_copy(
@@ -5020,19 +5045,19 @@ tuple_21 libcrux_ml_kem_ind_cca_encapsulate_8f1(
   Eurydice_slice shared_secret = uu____1.fst;
   Eurydice_slice pseudorandomness = uu____1.snd;
   Eurydice_slice uu____2 = Eurydice_array_to_slice(
-      (size_t)1568U, libcrux_ml_kem_types_as_slice_cb_6f1(public_key), uint8_t);
+      (size_t)1568U, libcrux_ml_kem_types_as_slice_cb_331(public_key), uint8_t);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness0, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1568U];
-  encrypt_091(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
+  encrypt_b41(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_ciphertext[1568U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1568U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext ciphertext0 =
-      libcrux_ml_kem_types_from_01_ec1(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d1(copy_of_ciphertext);
   uint8_t shared_secret_array[32U];
-  kdf_af_11(shared_secret, shared_secret_array);
+  kdf_d8_8d(shared_secret, shared_secret_array);
   libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext uu____5 = ciphertext0;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
@@ -5088,7 +5113,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_then_decompress_10_12(Eurydice_slice serialized) {
+deserialize_then_decompress_10_c6(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re = ZERO_89_8d();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)20U; i++) {
@@ -5148,7 +5173,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_then_decompress_11_3a(Eurydice_slice serialized) {
+deserialize_then_decompress_11_ca(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re = ZERO_89_8d();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)22U; i++) {
@@ -5171,8 +5196,8 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - COMPRESSION_FACTOR= 11
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_then_decompress_ring_element_u_a00(Eurydice_slice serialized) {
-  return deserialize_then_decompress_11_3a(serialized);
+deserialize_then_decompress_ring_element_u_420(Eurydice_slice serialized) {
+  return deserialize_then_decompress_11_ca(serialized);
 }
 
 /**
@@ -5181,7 +5206,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - VECTOR_U_COMPRESSION_FACTOR= 11
 */
-static KRML_MUSTINLINE void ntt_vector_u_500(
+static KRML_MUSTINLINE void ntt_vector_u_c80(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re) {
   size_t zeta_i = (size_t)0U;
   ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)7U);
@@ -5206,7 +5231,7 @@ with const generics
 - CIPHERTEXT_SIZE= 1568
 - U_COMPRESSION_FACTOR= 11
 */
-static KRML_MUSTINLINE void deserialize_then_decompress_u_d71(
+static KRML_MUSTINLINE void deserialize_then_decompress_u_1e1(
     uint8_t *ciphertext,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[4U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u_as_ntt[4U];
@@ -5229,8 +5254,8 @@ static KRML_MUSTINLINE void deserialize_then_decompress_u_d71(
             LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT *
                 (size_t)11U / (size_t)8U,
         uint8_t);
-    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_a00(u_bytes);
-    ntt_vector_u_500(&u_as_ntt[i0]);
+    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_420(u_bytes);
+    ntt_vector_u_c80(&u_as_ntt[i0]);
   }
   memcpy(
       ret, u_as_ntt,
@@ -5281,7 +5306,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_then_decompress_4_1f(Eurydice_slice serialized) {
+deserialize_then_decompress_4_9d(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re = ZERO_89_8d();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)8U; i++) {
@@ -5341,7 +5366,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_then_decompress_5_e2(Eurydice_slice serialized) {
+deserialize_then_decompress_5_89(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re = ZERO_89_8d();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)10U; i++) {
@@ -5364,8 +5389,8 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - COMPRESSION_FACTOR= 5
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_then_decompress_ring_element_v_8e0(Eurydice_slice serialized) {
-  return deserialize_then_decompress_5_e2(serialized);
+deserialize_then_decompress_ring_element_v_220(Eurydice_slice serialized) {
+  return deserialize_then_decompress_5_89(serialized);
 }
 
 /**
@@ -5379,7 +5404,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-subtract_reduce_89_7e(libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *self,
+subtract_reduce_89_84(libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *self,
                       libcrux_ml_kem_polynomial_PolynomialRingElement_f0 b) {
   for (size_t i = (size_t)0U;
        i < LIBCRUX_ML_KEM_POLYNOMIAL_VECTORS_IN_RING_ELEMENT; i++) {
@@ -5410,7 +5435,7 @@ with const generics
 - K= 4
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-compute_message_601(
+compute_message_3f1(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *v,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *secret_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *u_as_ntt) {
@@ -5419,8 +5444,8 @@ compute_message_601(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 product =
                       ntt_multiply_89_17(&secret_as_ntt[i0], &u_as_ntt[i0]);
                   add_to_ring_element_89_e81(&result, &product););
-  invert_ntt_montgomery_951(&result);
-  result = subtract_reduce_89_7e(v, result);
+  invert_ntt_montgomery_b51(&result);
+  result = subtract_reduce_89_84(v, result);
   return result;
 }
 
@@ -5430,7 +5455,7 @@ libcrux_ml_kem.serialize.compress_then_serialize_message with types
 libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
-static KRML_MUSTINLINE void compress_then_serialize_message_15(
+static KRML_MUSTINLINE void compress_then_serialize_message_a9(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re, uint8_t ret[32U]) {
   uint8_t serialized[32U] = {0U};
   KRML_MAYBE_FOR16(
@@ -5484,19 +5509,19 @@ with const generics
 - U_COMPRESSION_FACTOR= 11
 - V_COMPRESSION_FACTOR= 5
 */
-static void decrypt_unpacked_821(
+static void decrypt_unpacked_fe1(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_42 *secret_key,
     uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u_as_ntt[4U];
-  deserialize_then_decompress_u_d71(ciphertext, u_as_ntt);
+  deserialize_then_decompress_u_1e1(ciphertext, u_as_ntt);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      deserialize_then_decompress_ring_element_v_8e0(
+      deserialize_then_decompress_ring_element_v_220(
           Eurydice_array_to_subslice_from((size_t)1568U, ciphertext,
                                           (size_t)1408U, uint8_t, size_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message =
-      compute_message_601(&v, secret_key->secret_as_ntt, u_as_ntt);
+      compute_message_3f1(&v, secret_key->secret_as_ntt, u_as_ntt);
   uint8_t ret0[32U];
-  compress_then_serialize_message_15(message, ret0);
+  compress_then_serialize_message_a9(message, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -5548,12 +5573,12 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c1(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_881(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_42 *key_pair,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
   uint8_t decrypted[32U];
-  decrypt_unpacked_821(&key_pair->private_key.ind_cpa_private_key,
+  decrypt_unpacked_fe1(&key_pair->private_key.ind_cpa_private_key,
                        ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -5582,7 +5607,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c1(
   Eurydice_slice uu____2 = Eurydice_array_to_subslice_from(
       (size_t)1600U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_b41(ciphertext),
+  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_fd1(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret[32U];
   PRF_f1_ee3(Eurydice_array_to_slice((size_t)1600U, to_hash, uint8_t),
@@ -5593,11 +5618,11 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c1(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1568U];
-  encrypt_unpacked_c51(uu____3, copy_of_decrypted, pseudorandomness,
+  encrypt_unpacked_781(uu____3, copy_of_decrypted, pseudorandomness,
                        expected_ciphertext);
   uint8_t selector =
       libcrux_ml_kem_constant_time_ops_compare_ciphertexts_in_constant_time(
-          libcrux_ml_kem_types_as_ref_00_b41(ciphertext),
+          libcrux_ml_kem_types_as_ref_00_fd1(ciphertext),
           Eurydice_array_to_slice((size_t)1568U, expected_ciphertext, uint8_t));
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_select_shared_secret_in_constant_time(
@@ -5615,7 +5640,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_to_uncompressed_ring_element_22(Eurydice_slice serialized) {
+deserialize_to_uncompressed_ring_element_ff(Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re = ZERO_89_8d();
   for (size_t i = (size_t)0U;
        i < Eurydice_slice_len(serialized, uint8_t) / (size_t)24U; i++) {
@@ -5638,7 +5663,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 4
 */
-static KRML_MUSTINLINE void deserialize_secret_key_bb1(
+static KRML_MUSTINLINE void deserialize_secret_key_d21(
     Eurydice_slice secret_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[4U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 secret_as_ntt[4U];
@@ -5655,7 +5680,7 @@ static KRML_MUSTINLINE void deserialize_secret_key_bb1(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        deserialize_to_uncompressed_ring_element_22(secret_bytes);
+        deserialize_to_uncompressed_ring_element_ff(secret_bytes);
     secret_as_ntt[i0] = uu____0;
   }
   memcpy(
@@ -5673,10 +5698,10 @@ with const generics
 - U_COMPRESSION_FACTOR= 11
 - V_COMPRESSION_FACTOR= 5
 */
-static void decrypt_501(Eurydice_slice secret_key, uint8_t *ciphertext,
+static void decrypt_861(Eurydice_slice secret_key, uint8_t *ciphertext,
                         uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 secret_as_ntt[4U];
-  deserialize_secret_key_bb1(secret_key, secret_as_ntt);
+  deserialize_secret_key_d21(secret_key, secret_as_ntt);
   /* Passing arrays by value in Rust generates a copy in C */
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 copy_of_secret_as_ntt[4U];
   memcpy(
@@ -5688,7 +5713,7 @@ static void decrypt_501(Eurydice_slice secret_key, uint8_t *ciphertext,
       secret_key_unpacked.secret_as_ntt, copy_of_secret_as_ntt,
       (size_t)4U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
   uint8_t ret0[32U];
-  decrypt_unpacked_821(&secret_key_unpacked, ciphertext, ret0);
+  decrypt_unpacked_fe1(&secret_key_unpacked, ciphertext, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -5696,7 +5721,7 @@ static void decrypt_501(Eurydice_slice secret_key, uint8_t *ciphertext,
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$4size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 4
 - SECRET_KEY_SIZE= 3168
 - CPA_SECRET_KEY_SIZE= 1536
@@ -5714,7 +5739,7 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-void libcrux_ml_kem_ind_cca_decapsulate_811(
+void libcrux_ml_kem_ind_cca_decapsulate_461(
     libcrux_ml_kem_types_MlKemPrivateKey_95 *private_key,
     libcrux_ml_kem_mlkem1024_MlKem1024Ciphertext *ciphertext,
     uint8_t ret[32U]) {
@@ -5733,7 +5758,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_811(
   Eurydice_slice ind_cpa_public_key_hash = uu____2.fst;
   Eurydice_slice implicit_rejection_value = uu____2.snd;
   uint8_t decrypted[32U];
-  decrypt_501(ind_cpa_secret_key, ciphertext->value, decrypted);
+  decrypt_861(ind_cpa_secret_key, ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
       Eurydice_array_to_slice((size_t)32U, decrypted, uint8_t), to_hash0);
@@ -5755,7 +5780,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_811(
   Eurydice_slice uu____4 = Eurydice_array_to_subslice_from(
       (size_t)1600U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_b41(ciphertext),
+  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_fd1(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret0[32U];
   PRF_f1_ee3(Eurydice_array_to_slice((size_t)1600U, to_hash, uint8_t),
@@ -5765,17 +5790,17 @@ void libcrux_ml_kem_ind_cca_decapsulate_811(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1568U];
-  encrypt_091(uu____5, copy_of_decrypted, pseudorandomness,
+  encrypt_b41(uu____5, copy_of_decrypted, pseudorandomness,
               expected_ciphertext);
   uint8_t implicit_rejection_shared_secret[32U];
-  kdf_af_11(Eurydice_array_to_slice((size_t)32U,
+  kdf_d8_8d(Eurydice_array_to_slice((size_t)32U,
                                     implicit_rejection_shared_secret0, uint8_t),
             implicit_rejection_shared_secret);
   uint8_t shared_secret[32U];
-  kdf_af_11(shared_secret0, shared_secret);
+  kdf_d8_8d(shared_secret0, shared_secret);
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_compare_ciphertexts_select_shared_secret_in_constant_time(
-      libcrux_ml_kem_types_as_ref_00_b41(ciphertext),
+      libcrux_ml_kem_types_as_ref_00_fd1(ciphertext),
       Eurydice_array_to_slice((size_t)1568U, expected_ciphertext, uint8_t),
       Eurydice_array_to_slice((size_t)32U, shared_secret, uint8_t),
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret,
@@ -5797,7 +5822,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - PUBLIC_KEY_SIZE= 800
 - K= 2
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d2(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_b72(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[2U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[2U];
@@ -5814,7 +5839,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d2(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        deserialize_to_reduced_ring_element_e1(ring_element);
+        deserialize_to_reduced_ring_element_b0(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -5893,9 +5918,9 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 768
 - PUBLIC_KEY_SIZE= 800
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_c20(uint8_t *public_key) {
+bool libcrux_ml_kem_ind_cca_validate_public_key_6d0(uint8_t *public_key) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[2U];
-  deserialize_ring_elements_reduced_9d2(
+  deserialize_ring_elements_reduced_b72(
       Eurydice_array_to_subslice_to((size_t)800U, public_key, (size_t)768U,
                                     uint8_t, size_t),
       deserialized_pk);
@@ -5934,6 +5959,31 @@ with const generics
 */
 static KRML_MUSTINLINE void G_f1_e40(Eurydice_slice input, uint8_t ret[64U]) {
   libcrux_ml_kem_hash_functions_portable_G(input, ret);
+}
+
+/**
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.variant.cpa_keygen_seed_d8
+with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]]
+with const generics
+- K= 2
+*/
+static KRML_MUSTINLINE void cpa_keygen_seed_d8_17(
+    Eurydice_slice key_generation_seed, uint8_t ret[64U]) {
+  uint8_t seed[33U] = {0U};
+  Eurydice_slice_copy(
+      Eurydice_array_to_subslice2(
+          seed, (size_t)0U,
+          LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t),
+      key_generation_seed, uint8_t);
+  seed[LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE] =
+      (uint8_t)(size_t)2U;
+  uint8_t ret0[64U];
+  G_f1_e40(Eurydice_array_to_slice((size_t)33U, seed, uint8_t), ret0);
+  memcpy(ret, ret0, (size_t)64U * sizeof(uint8_t));
 }
 
 /**
@@ -6568,10 +6618,10 @@ generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static tuple_4c0 generate_keypair_unpacked_420(
+static tuple_4c0 generate_keypair_unpacked_c10(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_f1_e40(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_17(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -6655,7 +6705,7 @@ generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static void closure_880(
+static void closure_e70(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[2U]) {
   KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U,
                   ret[i] = ZERO_89_8d(););
@@ -6688,7 +6738,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 192
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_ae
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c80(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_2c0(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -6696,18 +6746,18 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c80(uint8_t randomness[64U]) {
       (size_t)64U, randomness,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
-  tuple_4c0 uu____0 = generate_keypair_unpacked_420(ind_cpa_keypair_randomness);
+  tuple_4c0 uu____0 = generate_keypair_unpacked_c10(ind_cpa_keypair_randomness);
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_ae
       ind_cpa_private_key = uu____0.fst;
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_ae
       ind_cpa_public_key = uu____0.snd;
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 A[2U][2U];
-  KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U, closure_880(A[i]););
+  KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U, closure_e70(A[i]););
   KRML_MAYBE_FOR2(
       i0, (size_t)0U, (size_t)2U, (size_t)1U, size_t i1 = i0; KRML_MAYBE_FOR2(
           i, (size_t)0U, (size_t)2U, (size_t)1U, size_t j = i;
           libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____1 =
-              clone_d5_84(&ind_cpa_public_key.A[j][i1]);
+              clone_d5_51(&ind_cpa_public_key.A[j][i1]);
           A[i1][j] = uu____1;););
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____2[2U][2U];
   memcpy(uu____2, A,
@@ -6757,8 +6807,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c80(uint8_t randomness[64U]) {
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cpa.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 2
 - PRIVATE_KEY_SIZE= 768
 - PUBLIC_KEY_SIZE= 800
@@ -6766,10 +6816,10 @@ generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair512 generate_keypair_6e0(
+static libcrux_ml_kem_utils_extraction_helper_Keypair512 generate_keypair_d50(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_f1_e40(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_17(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -6837,7 +6887,7 @@ with const generics
 - K= 2
 - SERIALIZED_KEY_LEN= 1632
 */
-static KRML_MUSTINLINE void serialize_kem_secret_key_48(
+static KRML_MUSTINLINE void serialize_kem_secret_key_f4(
     Eurydice_slice private_key, Eurydice_slice public_key,
     Eurydice_slice implicit_rejection_value, uint8_t ret[1632U]) {
   uint8_t out[1632U] = {0U};
@@ -6890,8 +6940,8 @@ static KRML_MUSTINLINE void serialize_kem_secret_key_48(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 2
 - CPA_PRIVATE_KEY_SIZE= 768
 - PRIVATE_KEY_SIZE= 1632
@@ -6901,7 +6951,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 192
 */
 libcrux_ml_kem_types_MlKemKeyPair_cb
-libcrux_ml_kem_ind_cca_generate_keypair_f90(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_950(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -6910,13 +6960,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_f90(uint8_t randomness[64U]) {
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
   libcrux_ml_kem_utils_extraction_helper_Keypair512 uu____0 =
-      generate_keypair_6e0(ind_cpa_keypair_randomness);
+      generate_keypair_d50(ind_cpa_keypair_randomness);
   uint8_t ind_cpa_private_key[768U];
   memcpy(ind_cpa_private_key, uu____0.fst, (size_t)768U * sizeof(uint8_t));
   uint8_t public_key[800U];
   memcpy(public_key, uu____0.snd, (size_t)800U * sizeof(uint8_t));
   uint8_t secret_key_serialized[1632U];
-  serialize_kem_secret_key_48(
+  serialize_kem_secret_key_f4(
       Eurydice_array_to_slice((size_t)768U, ind_cpa_private_key, uint8_t),
       Eurydice_array_to_slice((size_t)800U, public_key, uint8_t),
       implicit_rejection_value, secret_key_serialized);
@@ -6925,13 +6975,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_f90(uint8_t randomness[64U]) {
   memcpy(copy_of_secret_key_serialized, secret_key_serialized,
          (size_t)1632U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemPrivateKey_5e private_key =
-      libcrux_ml_kem_types_from_05_db(copy_of_secret_key_serialized);
+      libcrux_ml_kem_types_from_05_0b(copy_of_secret_key_serialized);
   libcrux_ml_kem_types_MlKemPrivateKey_5e uu____2 = private_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_public_key[800U];
   memcpy(copy_of_public_key, public_key, (size_t)800U * sizeof(uint8_t));
-  return libcrux_ml_kem_types_from_17_12(
-      uu____2, libcrux_ml_kem_types_from_b6_8e(copy_of_public_key));
+  return libcrux_ml_kem_types_from_17_9c(
+      uu____2, libcrux_ml_kem_types_from_b6_b0(copy_of_public_key));
 }
 
 /**
@@ -6979,7 +7029,7 @@ generics
 - ETA2= 2
 */
 static KRML_MUSTINLINE tuple_740
-sample_ring_element_cbd_380(uint8_t prf_input[33U], uint8_t domain_separator) {
+sample_ring_element_cbd_f10(uint8_t prf_input[33U], uint8_t domain_separator) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[2U];
   KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U,
                   error_1[i] = ZERO_89_8d(););
@@ -7035,17 +7085,17 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 2
 */
-static KRML_MUSTINLINE void invert_ntt_montgomery_950(
+static KRML_MUSTINLINE void invert_ntt_montgomery_b50(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re) {
   size_t zeta_i =
       LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT / (size_t)2U;
-  invert_ntt_at_layer_1_46(&zeta_i, re);
-  invert_ntt_at_layer_2_53(&zeta_i, re);
-  invert_ntt_at_layer_3_17(&zeta_i, re);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)4U);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)5U);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)6U);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)7U);
+  invert_ntt_at_layer_1_6e(&zeta_i, re);
+  invert_ntt_at_layer_2_63(&zeta_i, re);
+  invert_ntt_at_layer_3_23(&zeta_i, re);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)4U);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)5U);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)6U);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)7U);
   poly_barrett_reduce_89_61(re);
 }
 
@@ -7058,7 +7108,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 2
 */
-static KRML_MUSTINLINE void compute_vector_u_220(
+static KRML_MUSTINLINE void compute_vector_u_e40(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 (*a_as_ntt)[2U],
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *error_1,
@@ -7088,8 +7138,8 @@ static KRML_MUSTINLINE void compute_vector_u_220(
           ntt_multiply_89_17(a_element, &r_as_ntt[j]);
       add_to_ring_element_89_e80(&result[i1], &product);
     }
-    invert_ntt_montgomery_950(&result[i1]);
-    add_error_reduce_89_c3(&result[i1], &error_1[i1]);
+    invert_ntt_montgomery_b50(&result[i1]);
+    add_error_reduce_89_7a(&result[i1], &error_1[i1]);
   }
   memcpy(
       ret, result,
@@ -7106,7 +7156,7 @@ with const generics
 - K= 2
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-compute_ring_element_v_ba0(
+compute_ring_element_v_690(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *t_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *error_2,
@@ -7116,8 +7166,8 @@ compute_ring_element_v_ba0(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 product =
                       ntt_multiply_89_17(&t_as_ntt[i0], &r_as_ntt[i0]);
                   add_to_ring_element_89_e80(&result, &product););
-  invert_ntt_montgomery_950(&result);
-  result = add_message_error_reduce_89_a1(error_2, message, result);
+  invert_ntt_montgomery_b50(&result);
+  result = add_message_error_reduce_89_e6(error_2, message, result);
   return result;
 }
 
@@ -7127,7 +7177,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - OUT_LEN= 320
 */
-static KRML_MUSTINLINE void compress_then_serialize_10_c9(
+static KRML_MUSTINLINE void compress_then_serialize_10_b3(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re, uint8_t ret[320U]) {
   uint8_t serialized[320U] = {0U};
   for (size_t i = (size_t)0U;
@@ -7152,10 +7202,10 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - COMPRESSION_FACTOR= 10
 - OUT_LEN= 320
 */
-static KRML_MUSTINLINE void compress_then_serialize_ring_element_u_54(
+static KRML_MUSTINLINE void compress_then_serialize_ring_element_u_96(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re, uint8_t ret[320U]) {
   uint8_t uu____0[320U];
-  compress_then_serialize_10_c9(re, uu____0);
+  compress_then_serialize_10_b3(re, uu____0);
   memcpy(ret, uu____0, (size_t)320U * sizeof(uint8_t));
 }
 
@@ -7171,7 +7221,7 @@ with const generics
 - COMPRESSION_FACTOR= 10
 - BLOCK_LEN= 320
 */
-static void compress_then_serialize_u_620(
+static void compress_then_serialize_u_6e0(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 input[2U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -7187,7 +7237,7 @@ static void compress_then_serialize_u_620(
         out, i0 * ((size_t)640U / (size_t)2U),
         (i0 + (size_t)1U) * ((size_t)640U / (size_t)2U), uint8_t);
     uint8_t ret[320U];
-    compress_then_serialize_ring_element_u_54(&re, ret);
+    compress_then_serialize_ring_element_u_96(&re, ret);
     Eurydice_slice_copy(
         uu____0, Eurydice_array_to_slice((size_t)320U, ret, uint8_t), uint8_t);
   }
@@ -7200,9 +7250,9 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - COMPRESSION_FACTOR= 4
 - OUT_LEN= 128
 */
-static KRML_MUSTINLINE void compress_then_serialize_ring_element_v_20(
+static KRML_MUSTINLINE void compress_then_serialize_ring_element_v_bc(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re, Eurydice_slice out) {
-  compress_then_serialize_4_f6(re, out);
+  compress_then_serialize_4_1e(re, out);
 }
 
 /**
@@ -7264,7 +7314,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_c50(
+static void encrypt_unpacked_780(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_ae *public_key,
     uint8_t message[32U], Eurydice_slice randomness, uint8_t ret[768U]) {
   uint8_t prf_input[33U];
@@ -7282,7 +7332,7 @@ static void encrypt_unpacked_c50(
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_740 uu____3 =
-      sample_ring_element_cbd_380(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_f10(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[2U];
   memcpy(
       error_1, uu____3.fst,
@@ -7296,25 +7346,25 @@ static void encrypt_unpacked_c50(
       sample_from_binomial_distribution_34(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u[2U];
-  compute_vector_u_220(public_key->A, r_as_ntt, error_1, u);
+  compute_vector_u_e40(public_key->A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message_as_ring_element =
-      deserialize_then_decompress_message_6c(copy_of_message);
+      deserialize_then_decompress_message_5e(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      compute_ring_element_v_ba0(public_key->t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_690(public_key->t_as_ntt, r_as_ntt, &error_2,
                                  &message_as_ring_element);
   uint8_t ciphertext[768U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____5[2U];
   memcpy(
       uu____5, u,
       (size_t)2U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
-  compress_then_serialize_u_620(
+  compress_then_serialize_u_6e0(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)640U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____6 = v;
-  compress_then_serialize_ring_element_v_20(
+  compress_then_serialize_ring_element_v_bc(
       uu____6, Eurydice_array_to_subslice_from((size_t)768U, ciphertext,
                                                (size_t)640U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)768U * sizeof(uint8_t));
@@ -7339,7 +7389,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_de0(
+tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_510(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_ae *public_key,
     uint8_t randomness[32U]) {
   uint8_t to_hash[64U];
@@ -7366,7 +7416,7 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_de0(
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[768U];
-  encrypt_unpacked_c50(uu____2, copy_of_randomness, pseudorandomness,
+  encrypt_unpacked_780(uu____2, copy_of_randomness, pseudorandomness,
                        ciphertext);
   uint8_t shared_secret_array[32U] = {0U};
   Eurydice_slice_copy(
@@ -7376,7 +7426,7 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_de0(
   uint8_t copy_of_ciphertext[768U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)768U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemCiphertext_e8 uu____5 =
-      libcrux_ml_kem_types_from_01_ec(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d(copy_of_ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
   memcpy(copy_of_shared_secret_array, shared_secret_array,
@@ -7388,16 +7438,16 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_unpacked_de0(
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.entropy_preprocess_af
+A monomorphic instance of libcrux_ml_kem.variant.entropy_preprocess_d8
 with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]]
 with const generics
 - K= 2
 */
-static KRML_MUSTINLINE void entropy_preprocess_af_cc(Eurydice_slice randomness,
+static KRML_MUSTINLINE void entropy_preprocess_d8_3b(Eurydice_slice randomness,
                                                      uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -7418,7 +7468,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - PUBLIC_KEY_SIZE= 768
 - K= 2
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d1(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_b71(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[2U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[2U];
@@ -7435,7 +7485,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d1(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        deserialize_to_reduced_ring_element_e1(ring_element);
+        deserialize_to_reduced_ring_element_b0(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -7461,10 +7511,10 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_090(Eurydice_slice public_key, uint8_t message[32U],
+static void encrypt_b40(Eurydice_slice public_key, uint8_t message[32U],
                         Eurydice_slice randomness, uint8_t ret[768U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 t_as_ntt[2U];
-  deserialize_ring_elements_reduced_9d1(
+  deserialize_ring_elements_reduced_b71(
       Eurydice_slice_subslice_to(public_key, (size_t)768U, uint8_t, size_t),
       t_as_ntt);
   Eurydice_slice seed =
@@ -7488,7 +7538,7 @@ static void encrypt_090(Eurydice_slice public_key, uint8_t message[32U],
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_740 uu____3 =
-      sample_ring_element_cbd_380(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_f10(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[2U];
   memcpy(
       error_1, uu____3.fst,
@@ -7502,42 +7552,42 @@ static void encrypt_090(Eurydice_slice public_key, uint8_t message[32U],
       sample_from_binomial_distribution_34(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u[2U];
-  compute_vector_u_220(A, r_as_ntt, error_1, u);
+  compute_vector_u_e40(A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message_as_ring_element =
-      deserialize_then_decompress_message_6c(copy_of_message);
+      deserialize_then_decompress_message_5e(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      compute_ring_element_v_ba0(t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_690(t_as_ntt, r_as_ntt, &error_2,
                                  &message_as_ring_element);
   uint8_t ciphertext[768U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____5[2U];
   memcpy(
       uu____5, u,
       (size_t)2U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
-  compress_then_serialize_u_620(
+  compress_then_serialize_u_6e0(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)640U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____6 = v;
-  compress_then_serialize_ring_element_v_20(
+  compress_then_serialize_ring_element_v_bc(
       uu____6, Eurydice_array_to_subslice_from((size_t)768U, ciphertext,
                                                (size_t)640U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)768U * sizeof(uint8_t));
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.kdf_af
+A monomorphic instance of libcrux_ml_kem.variant.kdf_d8
 with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]]
 with const generics
 - K= 2
 - CIPHERTEXT_SIZE= 768
 */
-static KRML_MUSTINLINE void kdf_af_04(Eurydice_slice shared_secret,
+static KRML_MUSTINLINE void kdf_d8_3d(Eurydice_slice shared_secret,
                                       uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -7549,7 +7599,7 @@ static KRML_MUSTINLINE void kdf_af_04(Eurydice_slice shared_secret,
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 2
 - CIPHERTEXT_SIZE= 768
 - PUBLIC_KEY_SIZE= 800
@@ -7564,11 +7614,11 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_ec libcrux_ml_kem_ind_cca_encapsulate_8f0(
+tuple_ec libcrux_ml_kem_ind_cca_encapsulate_510(
     libcrux_ml_kem_types_MlKemPublicKey_be *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
-  entropy_preprocess_af_cc(
+  entropy_preprocess_d8_3b(
       Eurydice_array_to_slice((size_t)32U, randomness, uint8_t), randomness0);
   uint8_t to_hash[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -7578,7 +7628,7 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_8f0(
       size_t);
   uint8_t ret[32U];
   H_f1_1a0(Eurydice_array_to_slice(
-               (size_t)800U, libcrux_ml_kem_types_as_slice_cb_6f(public_key),
+               (size_t)800U, libcrux_ml_kem_types_as_slice_cb_33(public_key),
                uint8_t),
            ret);
   Eurydice_slice_copy(
@@ -7592,19 +7642,19 @@ tuple_ec libcrux_ml_kem_ind_cca_encapsulate_8f0(
   Eurydice_slice shared_secret = uu____1.fst;
   Eurydice_slice pseudorandomness = uu____1.snd;
   Eurydice_slice uu____2 = Eurydice_array_to_slice(
-      (size_t)800U, libcrux_ml_kem_types_as_slice_cb_6f(public_key), uint8_t);
+      (size_t)800U, libcrux_ml_kem_types_as_slice_cb_33(public_key), uint8_t);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness0, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[768U];
-  encrypt_090(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
+  encrypt_b40(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_ciphertext[768U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)768U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemCiphertext_e8 ciphertext0 =
-      libcrux_ml_kem_types_from_01_ec(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d(copy_of_ciphertext);
   uint8_t shared_secret_array[32U];
-  kdf_af_04(shared_secret, shared_secret_array);
+  kdf_d8_3d(shared_secret, shared_secret_array);
   libcrux_ml_kem_types_MlKemCiphertext_e8 uu____5 = ciphertext0;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
@@ -7623,8 +7673,8 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - COMPRESSION_FACTOR= 10
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_then_decompress_ring_element_u_a0(Eurydice_slice serialized) {
-  return deserialize_then_decompress_10_12(serialized);
+deserialize_then_decompress_ring_element_u_42(Eurydice_slice serialized) {
+  return deserialize_then_decompress_10_c6(serialized);
 }
 
 /**
@@ -7633,7 +7683,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - VECTOR_U_COMPRESSION_FACTOR= 10
 */
-static KRML_MUSTINLINE void ntt_vector_u_50(
+static KRML_MUSTINLINE void ntt_vector_u_c8(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re) {
   size_t zeta_i = (size_t)0U;
   ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)7U);
@@ -7658,7 +7708,7 @@ with const generics
 - CIPHERTEXT_SIZE= 768
 - U_COMPRESSION_FACTOR= 10
 */
-static KRML_MUSTINLINE void deserialize_then_decompress_u_d70(
+static KRML_MUSTINLINE void deserialize_then_decompress_u_1e0(
     uint8_t *ciphertext,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[2U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u_as_ntt[2U];
@@ -7681,8 +7731,8 @@ static KRML_MUSTINLINE void deserialize_then_decompress_u_d70(
             LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT *
                 (size_t)10U / (size_t)8U,
         uint8_t);
-    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_a0(u_bytes);
-    ntt_vector_u_50(&u_as_ntt[i0]);
+    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_42(u_bytes);
+    ntt_vector_u_c8(&u_as_ntt[i0]);
   }
   memcpy(
       ret, u_as_ntt,
@@ -7696,8 +7746,8 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - COMPRESSION_FACTOR= 4
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-deserialize_then_decompress_ring_element_v_8e(Eurydice_slice serialized) {
-  return deserialize_then_decompress_4_1f(serialized);
+deserialize_then_decompress_ring_element_v_22(Eurydice_slice serialized) {
+  return deserialize_then_decompress_4_9d(serialized);
 }
 
 /**
@@ -7713,7 +7763,7 @@ with const generics
 - K= 2
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-compute_message_600(
+compute_message_3f0(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *v,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *secret_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *u_as_ntt) {
@@ -7722,8 +7772,8 @@ compute_message_600(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 product =
                       ntt_multiply_89_17(&secret_as_ntt[i0], &u_as_ntt[i0]);
                   add_to_ring_element_89_e80(&result, &product););
-  invert_ntt_montgomery_950(&result);
-  result = subtract_reduce_89_7e(v, result);
+  invert_ntt_montgomery_b50(&result);
+  result = subtract_reduce_89_84(v, result);
   return result;
 }
 
@@ -7761,19 +7811,19 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_unpacked_820(
+static void decrypt_unpacked_fe0(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_ae *secret_key,
     uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u_as_ntt[2U];
-  deserialize_then_decompress_u_d70(ciphertext, u_as_ntt);
+  deserialize_then_decompress_u_1e0(ciphertext, u_as_ntt);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      deserialize_then_decompress_ring_element_v_8e(
+      deserialize_then_decompress_ring_element_v_22(
           Eurydice_array_to_subslice_from((size_t)768U, ciphertext,
                                           (size_t)640U, uint8_t, size_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message =
-      compute_message_600(&v, secret_key->secret_as_ntt, u_as_ntt);
+      compute_message_3f0(&v, secret_key->secret_as_ntt, u_as_ntt);
   uint8_t ret0[32U];
-  compress_then_serialize_message_15(message, ret0);
+  compress_then_serialize_message_a9(message, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -7813,11 +7863,11 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c0(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_880(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_ae *key_pair,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]) {
   uint8_t decrypted[32U];
-  decrypt_unpacked_820(&key_pair->private_key.ind_cpa_private_key,
+  decrypt_unpacked_fe0(&key_pair->private_key.ind_cpa_private_key,
                        ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -7846,7 +7896,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c0(
   Eurydice_slice uu____2 = Eurydice_array_to_subslice_from(
       (size_t)800U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_b4(ciphertext),
+  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_fd(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret[32U];
   PRF_f1_ee1(Eurydice_array_to_slice((size_t)800U, to_hash, uint8_t),
@@ -7857,11 +7907,11 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c0(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[768U];
-  encrypt_unpacked_c50(uu____3, copy_of_decrypted, pseudorandomness,
+  encrypt_unpacked_780(uu____3, copy_of_decrypted, pseudorandomness,
                        expected_ciphertext);
   uint8_t selector =
       libcrux_ml_kem_constant_time_ops_compare_ciphertexts_in_constant_time(
-          libcrux_ml_kem_types_as_ref_00_b4(ciphertext),
+          libcrux_ml_kem_types_as_ref_00_fd(ciphertext),
           Eurydice_array_to_slice((size_t)768U, expected_ciphertext, uint8_t));
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_select_shared_secret_in_constant_time(
@@ -7881,7 +7931,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 2
 */
-static KRML_MUSTINLINE void deserialize_secret_key_bb0(
+static KRML_MUSTINLINE void deserialize_secret_key_d20(
     Eurydice_slice secret_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[2U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 secret_as_ntt[2U];
@@ -7898,7 +7948,7 @@ static KRML_MUSTINLINE void deserialize_secret_key_bb0(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        deserialize_to_uncompressed_ring_element_22(secret_bytes);
+        deserialize_to_uncompressed_ring_element_ff(secret_bytes);
     secret_as_ntt[i0] = uu____0;
   }
   memcpy(
@@ -7916,10 +7966,10 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_500(Eurydice_slice secret_key, uint8_t *ciphertext,
+static void decrypt_860(Eurydice_slice secret_key, uint8_t *ciphertext,
                         uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 secret_as_ntt[2U];
-  deserialize_secret_key_bb0(secret_key, secret_as_ntt);
+  deserialize_secret_key_d20(secret_key, secret_as_ntt);
   /* Passing arrays by value in Rust generates a copy in C */
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 copy_of_secret_as_ntt[2U];
   memcpy(
@@ -7931,7 +7981,7 @@ static void decrypt_500(Eurydice_slice secret_key, uint8_t *ciphertext,
       secret_key_unpacked.secret_as_ntt, copy_of_secret_as_ntt,
       (size_t)2U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
   uint8_t ret0[32U];
-  decrypt_unpacked_820(&secret_key_unpacked, ciphertext, ret0);
+  decrypt_unpacked_fe0(&secret_key_unpacked, ciphertext, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -7939,7 +7989,7 @@ static void decrypt_500(Eurydice_slice secret_key, uint8_t *ciphertext,
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$2size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 2
 - SECRET_KEY_SIZE= 1632
 - CPA_SECRET_KEY_SIZE= 768
@@ -7957,7 +8007,7 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-void libcrux_ml_kem_ind_cca_decapsulate_810(
+void libcrux_ml_kem_ind_cca_decapsulate_460(
     libcrux_ml_kem_types_MlKemPrivateKey_5e *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_e8 *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -7975,7 +8025,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_810(
   Eurydice_slice ind_cpa_public_key_hash = uu____2.fst;
   Eurydice_slice implicit_rejection_value = uu____2.snd;
   uint8_t decrypted[32U];
-  decrypt_500(ind_cpa_secret_key, ciphertext->value, decrypted);
+  decrypt_860(ind_cpa_secret_key, ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
       Eurydice_array_to_slice((size_t)32U, decrypted, uint8_t), to_hash0);
@@ -7997,7 +8047,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_810(
   Eurydice_slice uu____4 = Eurydice_array_to_subslice_from(
       (size_t)800U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_b4(ciphertext),
+  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_fd(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret0[32U];
   PRF_f1_ee1(Eurydice_array_to_slice((size_t)800U, to_hash, uint8_t),
@@ -8007,17 +8057,17 @@ void libcrux_ml_kem_ind_cca_decapsulate_810(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[768U];
-  encrypt_090(uu____5, copy_of_decrypted, pseudorandomness,
+  encrypt_b40(uu____5, copy_of_decrypted, pseudorandomness,
               expected_ciphertext);
   uint8_t implicit_rejection_shared_secret[32U];
-  kdf_af_04(Eurydice_array_to_slice((size_t)32U,
+  kdf_d8_3d(Eurydice_array_to_slice((size_t)32U,
                                     implicit_rejection_shared_secret0, uint8_t),
             implicit_rejection_shared_secret);
   uint8_t shared_secret[32U];
-  kdf_af_04(shared_secret0, shared_secret);
+  kdf_d8_3d(shared_secret0, shared_secret);
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_compare_ciphertexts_select_shared_secret_in_constant_time(
-      libcrux_ml_kem_types_as_ref_00_b4(ciphertext),
+      libcrux_ml_kem_types_as_ref_00_fd(ciphertext),
       Eurydice_array_to_slice((size_t)768U, expected_ciphertext, uint8_t),
       Eurydice_array_to_slice((size_t)32U, shared_secret, uint8_t),
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret,
@@ -8039,7 +8089,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - PUBLIC_KEY_SIZE= 1184
 - K= 3
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d0(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_b70(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[3U];
@@ -8056,7 +8106,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d0(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        deserialize_to_reduced_ring_element_e1(ring_element);
+        deserialize_to_reduced_ring_element_b0(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -8135,9 +8185,9 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-bool libcrux_ml_kem_ind_cca_validate_public_key_c2(uint8_t *public_key) {
+bool libcrux_ml_kem_ind_cca_validate_public_key_6d(uint8_t *public_key) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[3U];
-  deserialize_ring_elements_reduced_9d0(
+  deserialize_ring_elements_reduced_b70(
       Eurydice_array_to_subslice_to((size_t)1184U, public_key, (size_t)1152U,
                                     uint8_t, size_t),
       deserialized_pk);
@@ -8176,6 +8226,31 @@ with const generics
 */
 static KRML_MUSTINLINE void G_f1_e4(Eurydice_slice input, uint8_t ret[64U]) {
   libcrux_ml_kem_hash_functions_portable_G(input, ret);
+}
+
+/**
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.variant.cpa_keygen_seed_d8
+with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
+with const generics
+- K= 3
+*/
+static KRML_MUSTINLINE void cpa_keygen_seed_d8_68(
+    Eurydice_slice key_generation_seed, uint8_t ret[64U]) {
+  uint8_t seed[33U] = {0U};
+  Eurydice_slice_copy(
+      Eurydice_array_to_subslice2(
+          seed, (size_t)0U,
+          LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t),
+      key_generation_seed, uint8_t);
+  seed[LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE] =
+      (uint8_t)(size_t)3U;
+  uint8_t ret0[64U];
+  G_f1_e4(Eurydice_array_to_slice((size_t)33U, seed, uint8_t), ret0);
+  memcpy(ret, ret0, (size_t)64U * sizeof(uint8_t));
 }
 
 /**
@@ -8799,10 +8874,10 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static tuple_9b generate_keypair_unpacked_42(
+static tuple_9b generate_keypair_unpacked_c1(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_f1_e4(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_68(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -8886,7 +8961,7 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static void closure_88(
+static void closure_e7(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[3U]) {
   KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U,
                   ret[i] = ZERO_89_8d(););
@@ -8919,7 +8994,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c8(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_2c(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -8927,18 +9002,18 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c8(uint8_t randomness[64U]) {
       (size_t)64U, randomness,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
-  tuple_9b uu____0 = generate_keypair_unpacked_42(ind_cpa_keypair_randomness);
+  tuple_9b uu____0 = generate_keypair_unpacked_c1(ind_cpa_keypair_randomness);
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_f8
       ind_cpa_private_key = uu____0.fst;
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_f8
       ind_cpa_public_key = uu____0.snd;
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 A[3U][3U];
-  KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U, closure_88(A[i]););
+  KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U, closure_e7(A[i]););
   KRML_MAYBE_FOR3(
       i0, (size_t)0U, (size_t)3U, (size_t)1U, size_t i1 = i0; KRML_MAYBE_FOR3(
           i, (size_t)0U, (size_t)3U, (size_t)1U, size_t j = i;
           libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____1 =
-              clone_d5_84(&ind_cpa_public_key.A[j][i1]);
+              clone_d5_51(&ind_cpa_public_key.A[j][i1]);
           A[i1][j] = uu____1;););
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____2[3U][3U];
   memcpy(uu____2, A,
@@ -8988,8 +9063,8 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_c8(uint8_t randomness[64U]) {
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cpa.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - PRIVATE_KEY_SIZE= 1152
 - PUBLIC_KEY_SIZE= 1184
@@ -8997,10 +9072,10 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair768 generate_keypair_6e(
+static libcrux_ml_kem_utils_extraction_helper_Keypair768 generate_keypair_d5(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  G_f1_e4(key_generation_seed, hashed);
+  cpa_keygen_seed_d8_68(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -9068,7 +9143,7 @@ with const generics
 - K= 3
 - SERIALIZED_KEY_LEN= 2400
 */
-static KRML_MUSTINLINE void serialize_kem_secret_key_4c(
+static KRML_MUSTINLINE void serialize_kem_secret_key_de(
     Eurydice_slice private_key, Eurydice_slice public_key,
     Eurydice_slice implicit_rejection_value, uint8_t ret[2400U]) {
   uint8_t out[2400U] = {0U};
@@ -9121,8 +9196,8 @@ static KRML_MUSTINLINE void serialize_kem_secret_key_4c(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - CPA_PRIVATE_KEY_SIZE= 1152
 - PRIVATE_KEY_SIZE= 2400
@@ -9132,7 +9207,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 libcrux_ml_kem_mlkem768_MlKem768KeyPair
-libcrux_ml_kem_ind_cca_generate_keypair_f9(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_95(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -9141,13 +9216,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_f9(uint8_t randomness[64U]) {
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
   libcrux_ml_kem_utils_extraction_helper_Keypair768 uu____0 =
-      generate_keypair_6e(ind_cpa_keypair_randomness);
+      generate_keypair_d5(ind_cpa_keypair_randomness);
   uint8_t ind_cpa_private_key[1152U];
   memcpy(ind_cpa_private_key, uu____0.fst, (size_t)1152U * sizeof(uint8_t));
   uint8_t public_key[1184U];
   memcpy(public_key, uu____0.snd, (size_t)1184U * sizeof(uint8_t));
   uint8_t secret_key_serialized[2400U];
-  serialize_kem_secret_key_4c(
+  serialize_kem_secret_key_de(
       Eurydice_array_to_slice((size_t)1152U, ind_cpa_private_key, uint8_t),
       Eurydice_array_to_slice((size_t)1184U, public_key, uint8_t),
       implicit_rejection_value, secret_key_serialized);
@@ -9156,13 +9231,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_f9(uint8_t randomness[64U]) {
   memcpy(copy_of_secret_key_serialized, secret_key_serialized,
          (size_t)2400U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemPrivateKey_55 private_key =
-      libcrux_ml_kem_types_from_05_db0(copy_of_secret_key_serialized);
+      libcrux_ml_kem_types_from_05_0b0(copy_of_secret_key_serialized);
   libcrux_ml_kem_types_MlKemPrivateKey_55 uu____2 = private_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_public_key[1184U];
   memcpy(copy_of_public_key, public_key, (size_t)1184U * sizeof(uint8_t));
-  return libcrux_ml_kem_types_from_17_120(
-      uu____2, libcrux_ml_kem_types_from_b6_8e0(copy_of_public_key));
+  return libcrux_ml_kem_types_from_17_9c0(
+      uu____2, libcrux_ml_kem_types_from_b6_b00(copy_of_public_key));
 }
 
 /**
@@ -9178,7 +9253,7 @@ generics
 - ETA2= 2
 */
 static KRML_MUSTINLINE tuple_b0
-sample_ring_element_cbd_38(uint8_t prf_input[33U], uint8_t domain_separator) {
+sample_ring_element_cbd_f1(uint8_t prf_input[33U], uint8_t domain_separator) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[3U];
   KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U,
                   error_1[i] = ZERO_89_8d(););
@@ -9234,17 +9309,17 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void invert_ntt_montgomery_95(
+static KRML_MUSTINLINE void invert_ntt_montgomery_b5(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re) {
   size_t zeta_i =
       LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT / (size_t)2U;
-  invert_ntt_at_layer_1_46(&zeta_i, re);
-  invert_ntt_at_layer_2_53(&zeta_i, re);
-  invert_ntt_at_layer_3_17(&zeta_i, re);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)4U);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)5U);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)6U);
-  invert_ntt_at_layer_4_plus_1a(&zeta_i, re, (size_t)7U);
+  invert_ntt_at_layer_1_6e(&zeta_i, re);
+  invert_ntt_at_layer_2_63(&zeta_i, re);
+  invert_ntt_at_layer_3_23(&zeta_i, re);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)4U);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)5U);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)6U);
+  invert_ntt_at_layer_4_plus_3b(&zeta_i, re, (size_t)7U);
   poly_barrett_reduce_89_61(re);
 }
 
@@ -9257,7 +9332,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void compute_vector_u_22(
+static KRML_MUSTINLINE void compute_vector_u_e4(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 (*a_as_ntt)[3U],
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *error_1,
@@ -9287,8 +9362,8 @@ static KRML_MUSTINLINE void compute_vector_u_22(
           ntt_multiply_89_17(a_element, &r_as_ntt[j]);
       add_to_ring_element_89_e8(&result[i1], &product);
     }
-    invert_ntt_montgomery_95(&result[i1]);
-    add_error_reduce_89_c3(&result[i1], &error_1[i1]);
+    invert_ntt_montgomery_b5(&result[i1]);
+    add_error_reduce_89_7a(&result[i1], &error_1[i1]);
   }
   memcpy(
       ret, result,
@@ -9305,7 +9380,7 @@ with const generics
 - K= 3
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-compute_ring_element_v_ba(
+compute_ring_element_v_69(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *t_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *error_2,
@@ -9315,8 +9390,8 @@ compute_ring_element_v_ba(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 product =
                       ntt_multiply_89_17(&t_as_ntt[i0], &r_as_ntt[i0]);
                   add_to_ring_element_89_e8(&result, &product););
-  invert_ntt_montgomery_95(&result);
-  result = add_message_error_reduce_89_a1(error_2, message, result);
+  invert_ntt_montgomery_b5(&result);
+  result = add_message_error_reduce_89_e6(error_2, message, result);
   return result;
 }
 
@@ -9332,7 +9407,7 @@ with const generics
 - COMPRESSION_FACTOR= 10
 - BLOCK_LEN= 320
 */
-static void compress_then_serialize_u_62(
+static void compress_then_serialize_u_6e(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 input[3U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -9348,7 +9423,7 @@ static void compress_then_serialize_u_62(
         out, i0 * ((size_t)960U / (size_t)3U),
         (i0 + (size_t)1U) * ((size_t)960U / (size_t)3U), uint8_t);
     uint8_t ret[320U];
-    compress_then_serialize_ring_element_u_54(&re, ret);
+    compress_then_serialize_ring_element_u_96(&re, ret);
     Eurydice_slice_copy(
         uu____0, Eurydice_array_to_slice((size_t)320U, ret, uint8_t), uint8_t);
   }
@@ -9413,7 +9488,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_c5(
+static void encrypt_unpacked_78(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_f8 *public_key,
     uint8_t message[32U], Eurydice_slice randomness, uint8_t ret[1088U]) {
   uint8_t prf_input[33U];
@@ -9431,7 +9506,7 @@ static void encrypt_unpacked_c5(
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_b0 uu____3 =
-      sample_ring_element_cbd_38(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_f1(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[3U];
   memcpy(
       error_1, uu____3.fst,
@@ -9445,25 +9520,25 @@ static void encrypt_unpacked_c5(
       sample_from_binomial_distribution_34(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u[3U];
-  compute_vector_u_22(public_key->A, r_as_ntt, error_1, u);
+  compute_vector_u_e4(public_key->A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message_as_ring_element =
-      deserialize_then_decompress_message_6c(copy_of_message);
+      deserialize_then_decompress_message_5e(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      compute_ring_element_v_ba(public_key->t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_69(public_key->t_as_ntt, r_as_ntt, &error_2,
                                 &message_as_ring_element);
   uint8_t ciphertext[1088U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____5[3U];
   memcpy(
       uu____5, u,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
-  compress_then_serialize_u_62(
+  compress_then_serialize_u_6e(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)960U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____6 = v;
-  compress_then_serialize_ring_element_v_20(
+  compress_then_serialize_ring_element_v_bc(
       uu____6, Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                                (size_t)960U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1088U * sizeof(uint8_t));
@@ -9488,7 +9563,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_de(
+tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_51(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_f8 *public_key,
     uint8_t randomness[32U]) {
   uint8_t to_hash[64U];
@@ -9515,7 +9590,7 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_de(
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1088U];
-  encrypt_unpacked_c5(uu____2, copy_of_randomness, pseudorandomness,
+  encrypt_unpacked_78(uu____2, copy_of_randomness, pseudorandomness,
                       ciphertext);
   uint8_t shared_secret_array[32U] = {0U};
   Eurydice_slice_copy(
@@ -9525,7 +9600,7 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_de(
   uint8_t copy_of_ciphertext[1088U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1088U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext uu____5 =
-      libcrux_ml_kem_types_from_01_ec0(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d0(copy_of_ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
   memcpy(copy_of_shared_secret_array, shared_secret_array,
@@ -9537,16 +9612,16 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_de(
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.entropy_preprocess_af
+A monomorphic instance of libcrux_ml_kem.variant.entropy_preprocess_d8
 with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void entropy_preprocess_af_75(Eurydice_slice randomness,
+static KRML_MUSTINLINE void entropy_preprocess_d8_f0(Eurydice_slice randomness,
                                                      uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -9567,7 +9642,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - PUBLIC_KEY_SIZE= 1152
 - K= 3
 */
-static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d(
+static KRML_MUSTINLINE void deserialize_ring_elements_reduced_b7(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[3U];
@@ -9584,7 +9659,7 @@ static KRML_MUSTINLINE void deserialize_ring_elements_reduced_9d(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        deserialize_to_reduced_ring_element_e1(ring_element);
+        deserialize_to_reduced_ring_element_b0(ring_element);
     deserialized_pk[i0] = uu____0;
   }
   memcpy(
@@ -9610,10 +9685,10 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_09(Eurydice_slice public_key, uint8_t message[32U],
+static void encrypt_b4(Eurydice_slice public_key, uint8_t message[32U],
                        Eurydice_slice randomness, uint8_t ret[1088U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 t_as_ntt[3U];
-  deserialize_ring_elements_reduced_9d(
+  deserialize_ring_elements_reduced_b7(
       Eurydice_slice_subslice_to(public_key, (size_t)1152U, uint8_t, size_t),
       t_as_ntt);
   Eurydice_slice seed =
@@ -9637,7 +9712,7 @@ static void encrypt_09(Eurydice_slice public_key, uint8_t message[32U],
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
   tuple_b0 uu____3 =
-      sample_ring_element_cbd_38(copy_of_prf_input, domain_separator0);
+      sample_ring_element_cbd_f1(copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[3U];
   memcpy(
       error_1, uu____3.fst,
@@ -9651,42 +9726,42 @@ static void encrypt_09(Eurydice_slice public_key, uint8_t message[32U],
       sample_from_binomial_distribution_34(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u[3U];
-  compute_vector_u_22(A, r_as_ntt, error_1, u);
+  compute_vector_u_e4(A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message_as_ring_element =
-      deserialize_then_decompress_message_6c(copy_of_message);
+      deserialize_then_decompress_message_5e(copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      compute_ring_element_v_ba(t_as_ntt, r_as_ntt, &error_2,
+      compute_ring_element_v_69(t_as_ntt, r_as_ntt, &error_2,
                                 &message_as_ring_element);
   uint8_t ciphertext[1088U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____5[3U];
   memcpy(
       uu____5, u,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
-  compress_then_serialize_u_62(
+  compress_then_serialize_u_6e(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)960U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____6 = v;
-  compress_then_serialize_ring_element_v_20(
+  compress_then_serialize_ring_element_v_bc(
       uu____6, Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                                (size_t)960U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1088U * sizeof(uint8_t));
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.kdf_af
+A monomorphic instance of libcrux_ml_kem.variant.kdf_d8
 with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
 with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
 */
-static KRML_MUSTINLINE void kdf_af_73(Eurydice_slice shared_secret,
+static KRML_MUSTINLINE void kdf_d8_86(Eurydice_slice shared_secret,
                                       uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -9698,7 +9773,7 @@ static KRML_MUSTINLINE void kdf_af_73(Eurydice_slice shared_secret,
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
 - PUBLIC_KEY_SIZE= 1184
@@ -9713,11 +9788,11 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-tuple_3c libcrux_ml_kem_ind_cca_encapsulate_8f(
+tuple_3c libcrux_ml_kem_ind_cca_encapsulate_51(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
-  entropy_preprocess_af_75(
+  entropy_preprocess_d8_f0(
       Eurydice_array_to_slice((size_t)32U, randomness, uint8_t), randomness0);
   uint8_t to_hash[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -9727,7 +9802,7 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_8f(
       size_t);
   uint8_t ret[32U];
   H_f1_1a(Eurydice_array_to_slice(
-              (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_6f0(public_key),
+              (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_330(public_key),
               uint8_t),
           ret);
   Eurydice_slice_copy(
@@ -9741,19 +9816,19 @@ tuple_3c libcrux_ml_kem_ind_cca_encapsulate_8f(
   Eurydice_slice shared_secret = uu____1.fst;
   Eurydice_slice pseudorandomness = uu____1.snd;
   Eurydice_slice uu____2 = Eurydice_array_to_slice(
-      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_6f0(public_key), uint8_t);
+      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_330(public_key), uint8_t);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness0, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1088U];
-  encrypt_09(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
+  encrypt_b4(uu____2, copy_of_randomness, pseudorandomness, ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_ciphertext[1088U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1088U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext ciphertext0 =
-      libcrux_ml_kem_types_from_01_ec0(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_2d0(copy_of_ciphertext);
   uint8_t shared_secret_array[32U];
-  kdf_af_73(shared_secret, shared_secret_array);
+  kdf_d8_86(shared_secret, shared_secret_array);
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext uu____5 = ciphertext0;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
@@ -9777,7 +9852,7 @@ with const generics
 - CIPHERTEXT_SIZE= 1088
 - U_COMPRESSION_FACTOR= 10
 */
-static KRML_MUSTINLINE void deserialize_then_decompress_u_d7(
+static KRML_MUSTINLINE void deserialize_then_decompress_u_1e(
     uint8_t *ciphertext,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u_as_ntt[3U];
@@ -9800,8 +9875,8 @@ static KRML_MUSTINLINE void deserialize_then_decompress_u_d7(
             LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT *
                 (size_t)10U / (size_t)8U,
         uint8_t);
-    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_a0(u_bytes);
-    ntt_vector_u_50(&u_as_ntt[i0]);
+    u_as_ntt[i0] = deserialize_then_decompress_ring_element_u_42(u_bytes);
+    ntt_vector_u_c8(&u_as_ntt[i0]);
   }
   memcpy(
       ret, u_as_ntt,
@@ -9821,7 +9896,7 @@ with const generics
 - K= 3
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-compute_message_60(
+compute_message_3f(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *v,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *secret_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *u_as_ntt) {
@@ -9830,8 +9905,8 @@ compute_message_60(
                   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 product =
                       ntt_multiply_89_17(&secret_as_ntt[i0], &u_as_ntt[i0]);
                   add_to_ring_element_89_e8(&result, &product););
-  invert_ntt_montgomery_95(&result);
-  result = subtract_reduce_89_7e(v, result);
+  invert_ntt_montgomery_b5(&result);
+  result = subtract_reduce_89_84(v, result);
   return result;
 }
 
@@ -9869,19 +9944,19 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_unpacked_82(
+static void decrypt_unpacked_fe(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_f8 *secret_key,
     uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u_as_ntt[3U];
-  deserialize_then_decompress_u_d7(ciphertext, u_as_ntt);
+  deserialize_then_decompress_u_1e(ciphertext, u_as_ntt);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      deserialize_then_decompress_ring_element_v_8e(
+      deserialize_then_decompress_ring_element_v_22(
           Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                           (size_t)960U, uint8_t, size_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message =
-      compute_message_60(&v, secret_key->secret_as_ntt, u_as_ntt);
+      compute_message_3f(&v, secret_key->secret_as_ntt, u_as_ntt);
   uint8_t ret0[32U];
-  compress_then_serialize_message_15(message, ret0);
+  compress_then_serialize_message_a9(message, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -9921,11 +9996,11 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c(
+void libcrux_ml_kem_ind_cca_decapsulate_unpacked_88(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8 *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   uint8_t decrypted[32U];
-  decrypt_unpacked_82(&key_pair->private_key.ind_cpa_private_key,
+  decrypt_unpacked_fe(&key_pair->private_key.ind_cpa_private_key,
                       ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -9954,7 +10029,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c(
   Eurydice_slice uu____2 = Eurydice_array_to_subslice_from(
       (size_t)1120U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_b40(ciphertext),
+  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_fd0(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret[32U];
   PRF_f1_ee(Eurydice_array_to_slice((size_t)1120U, to_hash, uint8_t),
@@ -9965,11 +10040,11 @@ void libcrux_ml_kem_ind_cca_decapsulate_unpacked_2c(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1088U];
-  encrypt_unpacked_c5(uu____3, copy_of_decrypted, pseudorandomness,
+  encrypt_unpacked_78(uu____3, copy_of_decrypted, pseudorandomness,
                       expected_ciphertext);
   uint8_t selector =
       libcrux_ml_kem_constant_time_ops_compare_ciphertexts_in_constant_time(
-          libcrux_ml_kem_types_as_ref_00_b40(ciphertext),
+          libcrux_ml_kem_types_as_ref_00_fd0(ciphertext),
           Eurydice_array_to_slice((size_t)1088U, expected_ciphertext, uint8_t));
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_select_shared_secret_in_constant_time(
@@ -9989,7 +10064,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void deserialize_secret_key_bb(
+static KRML_MUSTINLINE void deserialize_secret_key_d2(
     Eurydice_slice secret_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 secret_as_ntt[3U];
@@ -10006,7 +10081,7 @@ static KRML_MUSTINLINE void deserialize_secret_key_bb(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        deserialize_to_uncompressed_ring_element_22(secret_bytes);
+        deserialize_to_uncompressed_ring_element_ff(secret_bytes);
     secret_as_ntt[i0] = uu____0;
   }
   memcpy(
@@ -10024,10 +10099,10 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_50(Eurydice_slice secret_key, uint8_t *ciphertext,
+static void decrypt_86(Eurydice_slice secret_key, uint8_t *ciphertext,
                        uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 secret_as_ntt[3U];
-  deserialize_secret_key_bb(secret_key, secret_as_ntt);
+  deserialize_secret_key_d2(secret_key, secret_as_ntt);
   /* Passing arrays by value in Rust generates a copy in C */
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 copy_of_secret_as_ntt[3U];
   memcpy(
@@ -10039,7 +10114,7 @@ static void decrypt_50(Eurydice_slice secret_key, uint8_t *ciphertext,
       secret_key_unpacked.secret_as_ntt, copy_of_secret_as_ntt,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
   uint8_t ret0[32U];
-  decrypt_unpacked_82(&secret_key_unpacked, ciphertext, ret0);
+  decrypt_unpacked_fe(&secret_key_unpacked, ciphertext, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -10047,7 +10122,7 @@ static void decrypt_50(Eurydice_slice secret_key, uint8_t *ciphertext,
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - SECRET_KEY_SIZE= 2400
 - CPA_SECRET_KEY_SIZE= 1152
@@ -10065,7 +10140,7 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-void libcrux_ml_kem_ind_cca_decapsulate_81(
+void libcrux_ml_kem_ind_cca_decapsulate_46(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -10083,7 +10158,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_81(
   Eurydice_slice ind_cpa_public_key_hash = uu____2.fst;
   Eurydice_slice implicit_rejection_value = uu____2.snd;
   uint8_t decrypted[32U];
-  decrypt_50(ind_cpa_secret_key, ciphertext->value, decrypted);
+  decrypt_86(ind_cpa_secret_key, ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
       Eurydice_array_to_slice((size_t)32U, decrypted, uint8_t), to_hash0);
@@ -10105,7 +10180,7 @@ void libcrux_ml_kem_ind_cca_decapsulate_81(
   Eurydice_slice uu____4 = Eurydice_array_to_subslice_from(
       (size_t)1120U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_b40(ciphertext),
+  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_fd0(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret0[32U];
   PRF_f1_ee(Eurydice_array_to_slice((size_t)1120U, to_hash, uint8_t),
@@ -10115,16 +10190,16 @@ void libcrux_ml_kem_ind_cca_decapsulate_81(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1088U];
-  encrypt_09(uu____5, copy_of_decrypted, pseudorandomness, expected_ciphertext);
+  encrypt_b4(uu____5, copy_of_decrypted, pseudorandomness, expected_ciphertext);
   uint8_t implicit_rejection_shared_secret[32U];
-  kdf_af_73(Eurydice_array_to_slice((size_t)32U,
+  kdf_d8_86(Eurydice_array_to_slice((size_t)32U,
                                     implicit_rejection_shared_secret0, uint8_t),
             implicit_rejection_shared_secret);
   uint8_t shared_secret[32U];
-  kdf_af_73(shared_secret0, shared_secret);
+  kdf_d8_86(shared_secret0, shared_secret);
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_compare_ciphertexts_select_shared_secret_in_constant_time(
-      libcrux_ml_kem_types_as_ref_00_b40(ciphertext),
+      libcrux_ml_kem_types_as_ref_00_fd0(ciphertext),
       Eurydice_array_to_slice((size_t)1088U, expected_ciphertext, uint8_t),
       Eurydice_array_to_slice((size_t)32U, shared_secret, uint8_t),
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret,

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem_portable_H

--- a/libcrux-ml-kem/c/libcrux_sha3.h
+++ b/libcrux-ml-kem/c/libcrux_sha3.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_sha3_H

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "internal/libcrux_sha3_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/c/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_internal.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_sha3_internal_H

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.c
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #include "libcrux_sha3_neon.h"

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 322297aa4545eea6f5ba5d5fdd1565a790e5f726
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_sha3_neon_H

--- a/libcrux-ml-kem/c/tests/mlkem768_nistkats.json
+++ b/libcrux-ml-kem/c/tests/mlkem768_nistkats.json
@@ -1,802 +1,802 @@
 [
     {
         "key_generation_seed": "7c9935a0b07694aa0c6d10e4db6b1add2fd81a25ccb148032dcd739936737f2d8626ed79d451140800e03b59b956f8210e556067407d13dc90fa9e8b872bfb8f",
-        "sha3_256_hash_of_public_key": "d4ec143b50f01423b177895edee22bb739f647ecf85f50bc25ef7b5a725dee86",
-        "sha3_256_hash_of_secret_key": "245bc1d8cdd4893e4c471e8fccfa7019df0fd10f2d5375f36b4af5f4222aca6a",
+        "sha3_256_hash_of_public_key": "f57262661358cde8d3ebf990e5fd1d5b896c992ccfaadb5256b68bbf5943b132",
+        "sha3_256_hash_of_secret_key": "7deef44965b03d76de543ad6ef9e74a2772fa5a9fa0e761120dac767cf0152ef",
         "encapsulation_seed": "147c03f7a5bebba406c8fae1874d7f13c80efe79a3a9a874cc09fe76f6997615",
-        "sha3_256_hash_of_ciphertext": "bb62281b4aacc5a90a5ccdc5cd3dbe3867c502e8e6ec963ab329a9da0a20a75a",
-        "shared_secret": "729fa06ac93c5efdfbf1272a96cef167a393947ab7dc2d11ed7de8ac3c947fa8"
+        "sha3_256_hash_of_ciphertext": "6e777e2cf8054659136a971d9e70252f301226930c19c470ee0688163a63c15b",
+        "shared_secret": "e7184a0975ee3470878d2d159ec83129c8aec253d4ee17b4810311d198cd0368"
     },
     {
         "key_generation_seed": "d60b93492a1d8c1c7ba6fc0b733137f3406cee8110a93f170e7a78658af326d9003271531cf27285b8721ed5cb46853043b346a66cba6cf765f1b0eaa40bf672",
-        "sha3_256_hash_of_public_key": "2cedad700b675e98641bea57b936bd8befce2d5161e0ef4ef8406e70f1e2c27c",
-        "sha3_256_hash_of_secret_key": "0a84cc895da138b944accbef3ff1a0004b8a0d8af5d426d2b82ea4c0e585cc6a",
+        "sha3_256_hash_of_public_key": "7b00751eb9b1253231213f8a14f06f0fe1b7a4fdb7d1cfe44c161e577e5e8f0a",
+        "sha3_256_hash_of_secret_key": "3a8c009e8e648ac572d5592e4a92907fae0c1767be41c544b59dc3ffe61f7ded",
         "encapsulation_seed": "cde797df8ce67231f6c5d15811843e01eb2ab84c7490931240822adbddd72046",
-        "sha3_256_hash_of_ciphertext": "c15158a536d89bf3bafaea44cd442827a82f6eb772849015f3fec68a29d589dc",
-        "shared_secret": "c00e4ede0a4fa212980e6736686bf73585a0adf8d38fec212c860a0d3d055d1c"
+        "sha3_256_hash_of_ciphertext": "bce1bf3450f574130b9561ee11565fa41d599d05d2136f10ad2c013eb5d13ca9",
+        "shared_secret": "5f0c5d9f39d3e724b5a2bd54e69e360f72ffab5d4d6cc5e572fecba80acd4796"
     },
     {
         "key_generation_seed": "4b622de1350119c45a9f2e2ef3dc5df50a759d138cdfbd64c81cc7cc2f513345e82fcc97ca60ccb27bf6938c975658aeb8b4d37cffbde25d97e561f36c219ade",
-        "sha3_256_hash_of_public_key": "3dbc65b722a8982d058e27d409f04f744551ecde9015b62607cf67bb8ececbb8",
-        "sha3_256_hash_of_secret_key": "0ffced333b5d13fff22b81e66d57b6e2a6dba0285fe2a82d5537df51a8d3eac3",
+        "sha3_256_hash_of_public_key": "9bda55b63cffa9bf953993918b18cd6595ea6433b479e89b5cd3c9339e4468cb",
+        "sha3_256_hash_of_secret_key": "d5fc96564df6e53622b2db8295a80a44e3bad7147696e2ad1f728639c98791b1",
         "encapsulation_seed": "f43f68fbd694f0a6d307297110ecd4739876489fdf07eb9b03364e2ed0ff96e9",
-        "sha3_256_hash_of_ciphertext": "aec80e6fe21e2616352b4c148f9fa0e30986541fb0969df7873b1336b23a8de0",
-        "shared_secret": "8f50401bc9b1f857fd870902d4065f6cec8cb825db3eb22573c6167442b6e19b"
+        "sha3_256_hash_of_ciphertext": "2a8b5d9bdcac1b7ffb6d655368e15148308eee98ae34f4105eaae87f24a008a2",
+        "shared_secret": "7f3bcc03a35a0030255264914e5d88a0c93611c7ca21f0609678a88ca42ce1c9"
     },
     {
         "key_generation_seed": "050d58f9f757edc1e8180e3808b806f5bbb3586db3470b069826d1bb9a4efc2cde950541fd53a8a47aaa8cdfe80d928262a5ef7f8129ec3ef92f78d7cc32ef60",
-        "sha3_256_hash_of_public_key": "94391b7a41175a41c15cd995ebc69c83b29e4bcea6c186611dc4a79578e37f4c",
-        "sha3_256_hash_of_secret_key": "e3904266e186b34a397014c95f6d314cd6e1c813348b02e977d0fd21d9bb681b",
+        "sha3_256_hash_of_public_key": "647a81f0f1b3e3dacb6e73e900f7c078cdfaa7119a5ede48c7685fdb7e0fe2f5",
+        "sha3_256_hash_of_secret_key": "1cf686cb8732c73a38b35d73b0b28fb120bc89cda1554d9f12adedc057862081",
         "encapsulation_seed": "ea74fbc3c546500ed684bed6fe3c496d3b86d2d6dfaf223969b942e9a8c95e85",
-        "sha3_256_hash_of_ciphertext": "39fa8e1d0a5e4bb987618734ee4903771886030b2d8bea4b5a9b0cb672ebb279",
-        "shared_secret": "3221d7b046caccbded38e369625f69bac60c2d7efacad8f24170b10c5d222830"
+        "sha3_256_hash_of_ciphertext": "1c51c85ce66d80c1f9bb138e5bce84dd75cee4260c8817e06c6f2bd920601530",
+        "shared_secret": "c630736985fdb7830d7446e18b6b81fa4a707a6058964b99190120de85e7559c"
     },
     {
         "key_generation_seed": "66b79b844e0c2adad694e0478661ac46fe6b6001f6a71ff8e2f034b1fd8833d3be2d3c64d38269a1ee8660b9a2beaeb9f5ac022e8f0a357feebfd13b06813854",
-        "sha3_256_hash_of_public_key": "c5dbd68b3a8c148b2e7ac049bb986e14dd1cebfa1cbf3edd6bae85a4d2dda082",
-        "sha3_256_hash_of_secret_key": "b3fa7958f4b7ccb68712ae948c3f08740c8b89a69e53ad4e9959234e6869d8fe",
+        "sha3_256_hash_of_public_key": "811aea11a24a4b09e428415f82ee836e930c3b77867aafc5e6728149e3f2bd1b",
+        "sha3_256_hash_of_secret_key": "6a1ff1351c538a5661fc3576c29408c19f42da3688fa16f9ec5ead6a84420db5",
         "encapsulation_seed": "64efa87a12cb96f98b9b81a7e5128a959c74e5332aaab0444fca7b4a5e5e0216",
-        "sha3_256_hash_of_ciphertext": "ca9f95c38dc95f51b6b62ec709539f0d1e9fa64e49ce4ad10bbe62868f35cfc5",
-        "shared_secret": "1d746afc4160c75aaa6c6967f4eee941e09546a039027f05f0f8a483710ac334"
+        "sha3_256_hash_of_ciphertext": "db4dedc1e4d383acaf974fb50ffbf881bd3938ad196fb9aebeeb1bf1ddc94e10",
+        "shared_secret": "41e078d0d0c4fe5df5c6683171d5c1c3f1ef152c4945f9cb299f74278ce4cc4f"
     },
     {
         "key_generation_seed": "7ec408f52c9aa723d0c41d9987682a5f4ce6c9da7cd0215af60bbaf5484ab353a08ccf451b049fd51d7a9ad77ae14a81569df8c9bd3a8f1ebea86fdcfb823082",
-        "sha3_256_hash_of_public_key": "62e0447f7b5ae8a806b741ca5c302230b555c3786c11f3eb43894a8f45e3f7b1",
-        "sha3_256_hash_of_secret_key": "1a3249c268754c86d2e02ba9d87c2b60b220bf2406b71037cfaf6b089477ffb4",
+        "sha3_256_hash_of_public_key": "76c64235d8bd63438f13dcd038f286b9f4242070a5bec4d8990075008667aad3",
+        "sha3_256_hash_of_secret_key": "fb19a847c01b5bb4bc607ce0c65e50ca6869946a97625baea129c2ba07e00c01",
         "encapsulation_seed": "8a95d71228acaa5f9ae6f9d9ca8ae55fde296463b41083a39e833e37c4c90f88",
-        "sha3_256_hash_of_ciphertext": "ec7bb1327a69aeaf626a76d344be1156eac160262128a64477a194805b926233",
-        "shared_secret": "722fccef7142c46f74eb57a10b13e420d6554e9d18507f660bd1be96d3cebbcc"
+        "sha3_256_hash_of_ciphertext": "c8c63c879a7a803db4e5779ca5acb1f16f5c86c38258f583a9f1e43303ff36d0",
+        "shared_secret": "7da491b5623a43ae17160a54e45e8328453cfe1acc692a1e300906ebd2a1d9b2"
     },
     {
         "key_generation_seed": "c121915bfef6abdfc177dae2f5a24218f9abda2559afc6741b08e0e61ab433eb84ef52db5eaa6df8ec3a0bc5ffa730db0dde8c5f38f266d5c680a78d264a7b96",
-        "sha3_256_hash_of_public_key": "0c1d832af7b7282d8bd81a2237107ee60d81e28eb64d6a153ae0eaa1a25797c2",
-        "sha3_256_hash_of_secret_key": "fd6b5d3f120ca009871ca24552a6118917ea882f12f30dc8097f6614d9d36080",
+        "sha3_256_hash_of_public_key": "ae654e4412fd220548280b7a6ace9f2f0bc7b059fc103060346e53bc3c3161d8",
+        "sha3_256_hash_of_secret_key": "9088118150f9137e8ed76eb5e3a706f66f31c570fa7f0dfe75c0e81c4540878e",
         "encapsulation_seed": "90d79d75d0bbb8921cf70d46bab497022a8e750efdc99e5f1bae653275441c7b",
-        "sha3_256_hash_of_ciphertext": "da36cb6137a777acb4afbc0932811f75ef1d6732031309ae7e2de1543aaf5c2c",
-        "shared_secret": "ee7c5fb6a63ace944e1eae1bd4b182263d918754c33753b904853551b2b46cb8"
+        "sha3_256_hash_of_ciphertext": "2ce235a49669184efdbff64176f93017127735170c2e1c1b159fc746ef30d18e",
+        "shared_secret": "eeba3c0571fa453fcd9f7f0d6baeb75d59ec9854c12846089d65bd8dadf9f6b0"
     },
     {
         "key_generation_seed": "d86634ecf96cc2603761e284c0e36734cedec64e7ff486469e38539c71141c5a99daf37400cfe59841afc412ec97f2929dc84a6f3c36f378ee84ce3e46cd1209",
-        "sha3_256_hash_of_public_key": "2b757ac0425152bef72ed852ab1eb44f4359499407bb6a020ff843a31657c5fe",
-        "sha3_256_hash_of_secret_key": "27dbbc7918c31e9ab57808f439c4f4189cc318a62422457f4fed733be959c816",
+        "sha3_256_hash_of_public_key": "6ecea55c3d5c042d2dca3a3925faaa9112561827dceb0754580814a84be19b87",
+        "sha3_256_hash_of_secret_key": "33448769334ee9aa43d7ac22a003d9ae89a1ef5a9765deef2946c91fea0a1a5e",
         "encapsulation_seed": "be8a32f97b9a8d596382c02fa2a0eeebc15c083e970ddaa4f2622b91d6718663",
-        "sha3_256_hash_of_ciphertext": "85efbfd0b096fa921711ea66b17bcf7c9a6240711b38a88830dbd9d716f07195",
-        "shared_secret": "77cfbdae47854e9e10765cf397eca9ab2bf2b7522817152b22e18b6e09795016"
+        "sha3_256_hash_of_ciphertext": "14540bfc038f3eb76f418a8851513054a998e16a06f97c117417ae0a35f90e4f",
+        "shared_secret": "8bf57e5d1ce24e9942b1b3f456d184d4c0937b9b699e69c6524e93e140f39c90"
     },
     {
         "key_generation_seed": "0610678ff4dc3128e1619f915dc192c220f8fad94da1943b90aaec401683a492da1804ddb5aa9b1c6a47a98f8505a49bae2affde5fe75e69e828e546a6771004",
-        "sha3_256_hash_of_public_key": "53b9d62e64f9069d9fb94ea2c0806459b201531f4fddd708d162981cc1fb3757",
-        "sha3_256_hash_of_secret_key": "f4b964b7ab3e09fdf3d91527da06a4d29ef28344709a41739ef56f18bd5b984b",
+        "sha3_256_hash_of_public_key": "576cb9d31e5146967756cf7356926f2e20fc7c1fde9954cb2f593d96a80ab860",
+        "sha3_256_hash_of_secret_key": "2031c133d7d85e616d932c6204d7ec0f3bd0303ec609e3c7c08092e1ea443972",
         "encapsulation_seed": "da2cfaf69e25b2a89ff2557bbb6f69e01d8e2e7bb27a7a1ce7e40fead16f33b2",
-        "sha3_256_hash_of_ciphertext": "379a57a8f19110d5e0d747a2c184877d71f00fea95cd815b4c0e8782b12bec6f",
-        "shared_secret": "8be7a417efbdd3587c6f82ddd1d29956789d28c2413b8383590c5b80cc53e04a"
+        "sha3_256_hash_of_ciphertext": "20e06ce25d864f8e7a80a19e23cee6830575a072476504fd10e37b296ef8de73",
+        "shared_secret": "2f714d31bbc778518e2b67d264065d9731c12149cf931211e649addd6daf0b92"
     },
     {
         "key_generation_seed": "d322d56d8ef067ba1f24c92492b9c56df3a6ef54a304adc1b69913766a1ce69756047447b810cc094d400ab204cf9ae71e3afa68b88586ecb6498c68ac0e51b9",
-        "sha3_256_hash_of_public_key": "9cfeca12dfe978bf0b7ad7271487cf61b2b8f7c60f389f33fc18439a95bcbb63",
-        "sha3_256_hash_of_secret_key": "a2e37a55c9b80fb423f40585180b011f32402d0320259285b6e278df6c20ba60",
+        "sha3_256_hash_of_public_key": "3e9976d61a687df88a8abcc6651446b81b7d136df42bfa03473c84dfd64fdb3b",
+        "sha3_256_hash_of_secret_key": "5da40cacace6fa3712e49ef6700cd819aeea88264e6dc996681fff43d98c9830",
         "encapsulation_seed": "511c2ab40782322c06111e144e505328c4e5bfc890a5980a2bbc44aeda4c738b",
-        "sha3_256_hash_of_ciphertext": "44053f01ecb88811b9ee7a9ddd4234f94507c7cf64b6803b28c54bc605ec4e31",
-        "shared_secret": "79fcd201101e7e277c1b6cdc4475d63ea1dbc42ab94cf873bf0163c2aab0b5ff"
+        "sha3_256_hash_of_ciphertext": "48ddf3c7cf3f02af111c71607e93922176d0173ec63e890235fe981412824edd",
+        "shared_secret": "f2c29a0a4782d83f2073c7c37d90556b1a005f072f94063d2db8114430f36c8d"
     },
     {
         "key_generation_seed": "2f1d8a3bebb34540324b9485fdf3d5be3b858f544abc3fc641b5728cafab03ba8d6c42e7270ee2b77b6045385f3d175984a0e260363166c73b0c70c971644363",
-        "sha3_256_hash_of_public_key": "9aa64a30bed5aa8300772066ef577f79bf4813e3315a15f2c28b2665e4dc7e2f",
-        "sha3_256_hash_of_secret_key": "837eb6ce037f235273d7686fd9d01bea14026e0a0f5f943884f18409cc4bc70a",
+        "sha3_256_hash_of_public_key": "c0cfd4113c5edd408adcd03d38b12f0b6ac17525c618d6d151a761a9eebc2635",
+        "sha3_256_hash_of_secret_key": "2c6ec490ffd55e0a744f3c506a497cf4af575cce6368bdc3b3bdbbae733fe7b4",
         "encapsulation_seed": "dca92dbec9b260dd97e8886f876862d6effc3b91fcf3fbc986cf56ab93ae79a2",
-        "sha3_256_hash_of_ciphertext": "02798b5af1a76a2b478ee05c630e62618e5e2d7ee0c411a82ed2bf888706fe28",
-        "shared_secret": "6c4484b6d7b0a376f52abb1811c712368a9f34bd108ffe7ca31c36a6ec8140f3"
+        "sha3_256_hash_of_ciphertext": "b6ba4dfdae02842f96b915ea0ebd1c97972c170cae975c89c5fbf26cbe9a52d0",
+        "shared_secret": "13c99ded4db3e6618f5927d58c89afbe83c86a86ac2073421b2560b3f8be5aa3"
     },
     {
         "key_generation_seed": "31beda3462627f601cbc56f3ddf4424e1529c04737ef0ef2af6d7401f653b8a1812083bfa3b670e3eaf9b443702fb6db16ac1197656bbd61a8e25ed523b8d1e5",
-        "sha3_256_hash_of_public_key": "241e5c7b836862d7482d507973ae3fd8dae96eec4ecebcedb68fbda75e04b401",
-        "sha3_256_hash_of_secret_key": "95c79c2a867b3e8a4e4e545ff626cd49893b8e87eb188ed1516b159a24736c97",
+        "sha3_256_hash_of_public_key": "71c5534bb819e61a9d8a257ff2eb29598ae92eccfad38abbfc9bccde5ff95a1c",
+        "sha3_256_hash_of_secret_key": "107c5ef0842d1dfda257138d681ad7e1390e12c697111a2c804d8f014361cb4f",
         "encapsulation_seed": "57c170e691d7a914a901b9a11c62b8b569b3806427557a9dbac9faa720ec3641",
-        "sha3_256_hash_of_ciphertext": "cf3b2e2dc822949eb13638299fc2d5102c7132aa6cd54dd7834b13f05a4dece2",
-        "shared_secret": "8554d6af350f13471cfd45c23882e43dc81d8a094f6299e2ad33ef4c01a32058"
+        "sha3_256_hash_of_ciphertext": "671e3c316d4d8411237db4383fca82f76692867e9f6d15a2b82b17d934392341",
+        "shared_secret": "83302cab48eb0832bd8df0db3fce81595754772e4c951c444a1b2ee9f58c48c1"
     },
     {
         "key_generation_seed": "cbdff028766d558af4466ef14043a1a9cf765f7748c63cc09dceb59ab39a4e4d8e9a30597e4b52ffa87a54b83c91d12a5e9c2cd90fcac2c11b3a348240411a4c",
-        "sha3_256_hash_of_public_key": "6ad1d739f1598a16c608a240cd13dfaf8263d74866315e2898a3431cf19e4685",
-        "sha3_256_hash_of_secret_key": "1ef733faa4f2cb53cb5d8975aa6797b5f37fd918aeda02178a40584475cdf667",
+        "sha3_256_hash_of_public_key": "4b53b4aec0d9f86a6377c63ff80150e40fc5347714c07591dc71c6beb8daaafc",
+        "sha3_256_hash_of_secret_key": "ed13d2a9ae5541b3fbfa19891b8c8a9f4f0957d940eb5d08ee0cd18cfb28e7a4",
         "encapsulation_seed": "6b5a14e1473abf5a33d44975ca2088bd8fa6fddcb3f80e8fd5c45b9d90c24a5c",
-        "sha3_256_hash_of_ciphertext": "1706e6983032950b47cb6c8586178b42d515ce929c1434c1a8c9e36d8b4db7a3",
-        "shared_secret": "f9646f73de3d93d8e5dc5beeaa65a30d8f3a1f8d6392190ee66ff28693fbadfa"
+        "sha3_256_hash_of_ciphertext": "b83f6022179a08cdadda2660f8cd7cb70df4be0be3ad85bebb090d086079b1d1",
+        "shared_secret": "93ce6d06568d795c2a28d1196f53cbaa2cb05df1427ac76f44df09d479e14241"
     },
     {
         "key_generation_seed": "4c04310bea66305c6ca8ba6b8f61ca96257a67663afc11761f13fb5c7b324b6b8aec87a9a79204cee2986867a2906eb851b734b8b22b91d6749b1a5f07c44e3b",
-        "sha3_256_hash_of_public_key": "9510a2a0b4fcbd414fc61aff04a8df579660d14b13c40ec0470c45f639b65a58",
-        "sha3_256_hash_of_secret_key": "0bcfa8078582f60e218047d0016437601da8431f34ae6da12921f53958f32819",
+        "sha3_256_hash_of_public_key": "c2d52d0c837eb40dac0653a5e862d9fb8b832629cece9eaeb6d5feb48b6ef5da",
+        "sha3_256_hash_of_secret_key": "73ee0632229d740dd746e3ef7f0f1c29944dbc2d8f39b7860807c41c18bbb3af",
         "encapsulation_seed": "40e593754e6eddb7f9cf176ba2d5fd1087c90ad377556d0b0f686537b1a3165e",
-        "sha3_256_hash_of_ciphertext": "f9341d26e39b38a88ddef1708c96ee2068f569a59a4010745730d8290d637718",
-        "shared_secret": "1ee252e97b69445f7f109187645cd2879f55e10eb8361ab43b3492ff51f01815"
+        "sha3_256_hash_of_ciphertext": "3685126e86797a881f3bbee0eb85b76d755ff03858735c326731b8d802f023b5",
+        "shared_secret": "071db527a2ee8ce982527cb19355793859bb8557e7cc99dec58a53153eceddf4"
     },
     {
         "key_generation_seed": "38a0d5f41d7dc1896efd1b45b0485634cef149828751b96087a0a6dd81b4d58aa2acf359556df4a2abaeb9dcee945829beb71185b4d6bd18b76e5668f253383a",
-        "sha3_256_hash_of_public_key": "cfbe9649d9d1c384baad67b91b2f3e21f2fadd6bb582a0b9cb016051dd82c75a",
-        "sha3_256_hash_of_secret_key": "09b118f7c4d059baf27284d127d4e85d55b84e4c92bf3127eeb318d2f5765401",
+        "sha3_256_hash_of_public_key": "4ff02338c9bb711d263140c471409f3c42813f38424698563d9550f85a168f2d",
+        "sha3_256_hash_of_secret_key": "3c89443dab5ce46f82f6b8260af0293ea52a680f1c4fe5e042f0aefb707526f3",
         "encapsulation_seed": "c152523abd8248bed40c3827bcf0f8e8127037a55c780695e2c28ea3e041a44c",
-        "sha3_256_hash_of_ciphertext": "94a8c287238191a107e74e31ec099086d83f198e6b0f3321da4d8f46ce01a0b2",
-        "shared_secret": "1e1ea5d6a18873c5c7fc8da79093f6d3db5b28fdd0aaa42726ad130c78e9bb88"
+        "sha3_256_hash_of_ciphertext": "b20e28f42ee5cf5569f1833af90334952074dd0ea0c2520f03fdf0fb24c17a64",
+        "shared_secret": "598bd66a4a063652b2a6b25b8d1c3bab0251682ce6c362a8c680295f47f3d6d9"
     },
     {
         "key_generation_seed": "97b5665676e59e3538ebadaa8cd50df1f9fda1502d9894c616a946078e56b621df05318b5f655efe36f1b678cf4b875108a18db2fa312261caf839f84bd956c5",
-        "sha3_256_hash_of_public_key": "a19c2c9c907b129d01cc44a95949121c39534cc98b6d105e60fe519a000cc2ae",
-        "sha3_256_hash_of_secret_key": "f1c00070780a7a2ac5b57ff3ff765ca75278bb661d1635cac92792f9454fe8ba",
+        "sha3_256_hash_of_public_key": "bbccdbce67cf49fea044df5c767996681dd2714937d31c822f3c58cc34785aa7",
+        "sha3_256_hash_of_secret_key": "64fde53d297945ef2a0af6ddd044520cff8ec1388aa471e47ba4299c2cd46da4",
         "encapsulation_seed": "ad6466dd59f26b762fb02b19eedf5f79964da68bce0459b91c3a6ee5a7e01183",
-        "sha3_256_hash_of_ciphertext": "56e0b8ab3b302fae682938a45d9931e092d78877d1f8834bb43cd5c85582a205",
-        "shared_secret": "24619bb17c912fc992bd8272969cd5b6fd6b030122ee5af9365cac8b38e569fc"
+        "sha3_256_hash_of_ciphertext": "6f4cde00d3775858761742957833fe632e3d3082a9a6180477291bc23b682674",
+        "shared_secret": "92bd980f79cbb34c67594c6922549b99962e54d388034ea61f892fe250581c4e"
     },
     {
         "key_generation_seed": "ef99224a03a85a46ef115474ec5b5d620da6795d6efcca4c9135d19958a9de62df7d92dda83e6b2ef4cce08c9134563063068a196d7b1a1a13623e48ae12528e",
-        "sha3_256_hash_of_public_key": "e4174b6e7542fbe80ab2bc06dfb802f691aff147ff90332d5ea739216c18d872",
-        "sha3_256_hash_of_secret_key": "f3f3a292f5cf01d6f7266461c9e8cd44bfc8f17e16035ab8d10af8177f389b86",
+        "sha3_256_hash_of_public_key": "3ef3581d438af7dec621304e0091f797346ca18a41f39401e9d03200ef48beb6",
+        "sha3_256_hash_of_secret_key": "299a76e97511d90f7925100db418472a9c3c12d6d48acf03618a6960998ee733",
         "encapsulation_seed": "1a4d5dff5847cfb48333e33bb00ca7301b144aa89dcd412ff5a3b1081d775b7f",
-        "sha3_256_hash_of_ciphertext": "5f878ca21c8c27ae9c41c43aaf1f3a2af62c73296e165c08b88c5b22592867be",
-        "shared_secret": "a990af801ddcf2009c82fe657fe3f068bae7e6bfc661e3e588354ba7d1b176e6"
+        "sha3_256_hash_of_ciphertext": "4ede793372276800e22c1893ae554ce0b53e413fbbc3595e69feadb2e1f6d57a",
+        "shared_secret": "b7325a08fa617e19260264bb02ed6b8ab2081589fd5dcc1e92b9d0d4ebfdb6b6"
     },
     {
         "key_generation_seed": "b12f6fd965ea9c5b947db80fc60c83d5e232dca82e7263027c19bd62e5a6ff550f6aa3e88f7fa8a96067f8cdaeceeac90c2d0b5e277e56e9c405ec9420c30252",
-        "sha3_256_hash_of_public_key": "2006a70fa33ff4a65b00553734c5bd8cca0a65eb3a115d96b8aa90f8fdc5f8f4",
-        "sha3_256_hash_of_secret_key": "7334d4a1755e1e639b3e9eadb5996cd910b55d1de5790469f229231d3bfb1528",
+        "sha3_256_hash_of_public_key": "fa06bb0ff42f4d610a7b3df7544d66b97a486967cd9b62ba0142ebb10b8ee4ee",
+        "sha3_256_hash_of_secret_key": "4dcfc0ce12c4e87f02c616a8fb18c359cae017a2f8d339623a174dfaebfad98f",
         "encapsulation_seed": "34f44ec2092eeaf686f2ea170591a98527cbb03a4fa9477a7aef6b41a54feeb2",
-        "sha3_256_hash_of_ciphertext": "c2079637916c089b2afb9d6e9c6fa51308ab7720d5c2fca484c34ce614a14fc0",
-        "shared_secret": "11a2ceaa0c77f0602c4b2be3499e6df6b0339d9de90d04b2b12829f4758afaa5"
+        "sha3_256_hash_of_ciphertext": "591bf77f74463c50a4ffbe97c892e11f3cf7601813b7ad83b17038a173e21442",
+        "shared_secret": "b400082a764291666c080ae9ea9f22c383f3c1e87b4cc56775a19c8ec29a4157"
     },
     {
         "key_generation_seed": "9f52af92ca165fdc38788f2b59ba02e01c8281ff7c1e60504688043a5fe814b04f3029e1be4e1c0258c3a22ff5b50b2674cc094ba7018da2a61569845c17d26f",
-        "sha3_256_hash_of_public_key": "631e1de2556ae65d57e600c21e8e355a4ed586d667177ca0b7545cb5a23d669f",
-        "sha3_256_hash_of_secret_key": "3d4d2c680a1e6aa83861ad95043ded260e720ae80060320feffa309b4281ba3d",
+        "sha3_256_hash_of_public_key": "86538ecdf65b7a485b73a34a72193af1ea3f884d820463601c7f843672bbec7d",
+        "sha3_256_hash_of_secret_key": "70e91b44585ed93e802868e0bfe88f68995f3c85d25c2a36b0b7d8de7c5e2f8d",
         "encapsulation_seed": "6250c81126572eec2da330271db36ee591f060fc7e53eeefe2e1c476c675fa33",
-        "sha3_256_hash_of_ciphertext": "2e9d6551050e32e204d7c062a4c18b8abdb91346e9f2c2708776827e0be4c514",
-        "shared_secret": "7571990ef1ef7e15cc920318fb75fd38c4ceb9abf7a4b1adc2175f99d1a0a275"
+        "sha3_256_hash_of_ciphertext": "83754e315ef22788354c1ec632429566929f9bd53e77d1d2cb52005274f64e1e",
+        "shared_secret": "03c7470224ba22fde280005d9a8f8354c49459e9a168cc282f9d41f4f0d2da2b"
     },
     {
         "key_generation_seed": "851ea90fd3854cbf28fe39fb81f68e4b14345cf0d6eee7ec4ce772513df8410d1c0ec046899a777655233e4e1b5ca44e9afbdc67964bfd5d5e3dbb45e60d03cf",
-        "sha3_256_hash_of_public_key": "87f3829eff562789b3e19fafec92e4b5f95b45f3786f12d9c24915ca484a49ce",
-        "sha3_256_hash_of_secret_key": "9aa6c0546cf02085e2b3af65a7d7fd32d0f6d8080e1e7fbff6c39bcf3086ece4",
+        "sha3_256_hash_of_public_key": "27757389a4a68c898dab92d0f63c3340dfba51e00312a05e721932b95b11f6da",
+        "sha3_256_hash_of_secret_key": "b43f88e419ae589b85bb0ec6c9712d4870dbaf35d4c96d06ef0f8b9753b60034",
         "encapsulation_seed": "35d470bcc5880872754810dfb3f2796da2fd7f397537146f6488c27804072b34",
-        "sha3_256_hash_of_ciphertext": "14da42e207477f4383faf4004e58675f0380e7d621421b3c36b877acf3a45d5a",
-        "shared_secret": "27ba4cb50ae44cd938585e0a4905d76053dd851e5b6af4fd787446079aa5a4ab"
+        "sha3_256_hash_of_ciphertext": "0eb3d2bc103f7801dd8e002c6cc81bbcf11e070f465aba9b0b725fa9454acda7",
+        "shared_secret": "c31f7372e8c194a9589042477f34da3a60d591ea65e13bcccc07ba59402ede6d"
     },
     {
         "key_generation_seed": "d304c9389cc973477f169788abcb9d511f843219d246a9b587822f422a70c2386590a2e5c7ed86cf2c5c2a898662bc9a81418720bbb632ef9cf0b845ed052d73",
-        "sha3_256_hash_of_public_key": "699fb2f061a75f111f4a7a60195d9045dc01716b6502cc107cbcedf122e8f619",
-        "sha3_256_hash_of_secret_key": "421f16805b1ceffcd64128b1296521ef812d3a8f4c5e3875a049f8de456b021a",
+        "sha3_256_hash_of_public_key": "efe6e93d8e755292fa875609f2f63bd194c87e6f04db7c83d8bb1b9d868bb779",
+        "sha3_256_hash_of_secret_key": "f54233dfd4679cbd6eb6f18c0615745d5b4fc2fefade52d966bffab6f0cc259f",
         "encapsulation_seed": "8d667921c5db401a86fe1c35dfcf164a6bb2ab7400fd6a0b67eafd4a0ed11940",
-        "sha3_256_hash_of_ciphertext": "b2485ef56c39d468193e387e72794e0ddc9b5404c1a6d90c3b94a5f3e13ba7b4",
-        "shared_secret": "d17b2738213a98f29ee46747c93308ee7000fa404b9a0c1acf3f89654ca2446e"
+        "sha3_256_hash_of_ciphertext": "942f3cd64ed1b2675f9f9823c068d59b2e007e66d38e06a2e4558dcba7f11efd",
+        "shared_secret": "9dfd08dbf59350ae2308096f935c6767daeddeb2c6997992d4a02c14b0e58c60"
     },
     {
         "key_generation_seed": "89a6e3be304a3518fb82b18ca730f0b359cd6ba90664a493fb4f8edaf965b9c3b6591121e25d64010c25a18676033e1d7278ac5f2d0b43a31f3a4156ae710465",
-        "sha3_256_hash_of_public_key": "d3413880d082f26986fcf452a84a8da934ed06198b290ada1789e74d9081a9e7",
-        "sha3_256_hash_of_secret_key": "7b546a42ffe6b65cd9c5b8857c2518f4f8e0bf835c894a68d1743691fc9aad9d",
+        "sha3_256_hash_of_public_key": "87ada29bf78a689417b645fe127d124339422be80a993e623d13bc59f3406a6f",
+        "sha3_256_hash_of_secret_key": "6b8d44a2a71f2901b7ea97bd24df8d46041cd9ad4f0bc5d42ca27ee44981f740",
         "encapsulation_seed": "ec750b3939385a3f8df868119dc76f77ca845567ef068de6ada5478a56bc78b6",
-        "sha3_256_hash_of_ciphertext": "8290f3c4bec7c3b93f3d26e0be3b3fbfdd9c3f5806188fcf0fa1339133f29c7d",
-        "shared_secret": "954af53b4add522514b34cd2ab96669a76ca13f82aa2fd70826bc8ee790ccefb"
+        "sha3_256_hash_of_ciphertext": "aa86248e7e906ff3072a00647cbd3f6e5d0f3a4ec40efa6deb94b2df901d0097",
+        "shared_secret": "03952e1a4915d112b87569d1f79a39f5d69a8dc11c96d70c529d2162a6024dd7"
     },
     {
         "key_generation_seed": "d569b935ce015c85f792f8f7fb0d83c4f53b492959361dd4f75fb764d656450176eae84d11c4528382828f7a689a0d5cff87b8ca0bba97feacb39b935a8788cb",
-        "sha3_256_hash_of_public_key": "e6eec2929feac2a86c9dacfa6214e2e353fda2d547c3829f5678025ff8418a1a",
-        "sha3_256_hash_of_secret_key": "5fac243c82807d7357a61023226a7c270525d96932162ca5c09fc8f7b9ec6cb3",
+        "sha3_256_hash_of_public_key": "0c87bedd5c16c32cc3867910f734bdcf09869c7604a59ce36660074f561e12da",
+        "sha3_256_hash_of_secret_key": "a72b7d93adcbfc6d89485fa923a4b1095e3d593916496e521187224efa42ffa5",
         "encapsulation_seed": "74f1d52af09b12c36eb062ea7528550cb4c18a3ce8e4f4ea9fac43ae383bc925",
-        "sha3_256_hash_of_ciphertext": "f1b10c800a42ae606c72eaad76accf059cccc02299fbd78a5d091f183f6c3f0e",
-        "shared_secret": "d0bbc576fb1aa43b6e76db0e87bc4ee3fa057c31642b37f3339217a1b041b521"
+        "sha3_256_hash_of_ciphertext": "7a75e486cc2dd3ffab4b1072b4056de9a56b55cf324e58d3f6cfd031a0dda594",
+        "shared_secret": "6d2e1f456c87d5a3c79456a6d35fda52f3e9cb858f85a5f7931f532fffe26dee"
     },
     {
         "key_generation_seed": "5cbb141c2763425c274f7404fe530d9116e08c33f9f200a20b011cf563a28990fc9ebbe336dc464489861db8253606971bd0a9008a433ed17752d04023781552",
-        "sha3_256_hash_of_public_key": "c74f3b7fa6e2ef8ce99508c89cf3c71d666ab065a262581a5fb01b2c9b9444fa",
-        "sha3_256_hash_of_secret_key": "5c6998a20960109a4c9808f8f8575697b2b8d18c44c7e9dff97585ae43e6004c",
+        "sha3_256_hash_of_public_key": "9a9a59f83fc58d7194ccc92bd78a45f97f721a1eb554499d0e4d5b37aefc23a8",
+        "sha3_256_hash_of_secret_key": "ea5ce3a271f5e46f925259832d187a3c893e8088b76c19c93e0e798e4320d2fd",
         "encapsulation_seed": "4b3a70d85f640d1a2a852fb6fe96704af56a7415a8ee4282e9207bc3a2dc116a",
-        "sha3_256_hash_of_ciphertext": "e9ef0852ee47744b8c3e12cd728d9017465014eef51edf83a4502cb5218cee20",
-        "shared_secret": "91fbc37d4749ec6175c12f0d8eb6b6a8621e693c79f85f5cd2f557cafec5e7e9"
+        "sha3_256_hash_of_ciphertext": "d71fc29140e8725a4c4e8779d0ad3007990e08b1eb38856cc56f522e3079f601",
+        "shared_secret": "5c7c5cafe1fd7f3d12431ae93815c03419ff95b132caf568671ec23bdc74381c"
     },
     {
         "key_generation_seed": "293abb6d1c207927945417cf84883ef010823e11b487ed55239e466e83696d0cff8563038aad865a817cab9ce98846ba75be9363718ecf5fea538aea90b2a558",
-        "sha3_256_hash_of_public_key": "7378ef967195c977d43a50d03205044006715a6a8a8263d717f40170b49e6bd0",
-        "sha3_256_hash_of_secret_key": "30bd5f16c3f242248a4c4cddc43508bf54535958657bda4dcf105216ddf47eb0",
+        "sha3_256_hash_of_public_key": "bda0815dd53b263afcc1f71d2501128c41fb3606af71c5e68f0752c6d3a479c5",
+        "sha3_256_hash_of_secret_key": "d502e7e6df2d84e46cef88a84c53f1fddd5488accd5e1e43aed5f4f08e16a8a7",
         "encapsulation_seed": "26e38ac804fb5b4d59ddf747715e7e6041d875f99c7b638024b4af82d622da60",
-        "sha3_256_hash_of_ciphertext": "37843616c8a4f7ea9480740b6624f41650da2bb1664cf228d85d6d71a0624528",
-        "shared_secret": "d586b441b8eaf7d053cc96b6835f093426677a7c3acc51aaa3ddbb66dd14a623"
+        "sha3_256_hash_of_ciphertext": "8d4b1f3ee23ceecf073d6576609767401286da5189a1b267bff30a710a69e67a",
+        "shared_secret": "1427c322f72898a0fffd13f674719c9288d524bdd19e6a362533c1108e3a6d2c"
     },
     {
         "key_generation_seed": "74d87c7556f2671f2d666854a4d6e073e69f35421e6e1a428cccea49c37f972ce1fb7456ac0aa1b97068f452cba64ebdc138bcf5d36b0a0fada2a3b374141eb9",
-        "sha3_256_hash_of_public_key": "16fe956be4601573d72306a251f69bc2181253e2417e178341fd6553303ac189",
-        "sha3_256_hash_of_secret_key": "873c94f8bee9fe37265d5dc0c5d3bc1c706057c7efb3cd2cd5ca9ba45498d0d1",
+        "sha3_256_hash_of_public_key": "e3e96e658787ba3f6ffb47de56322541a2c81f68e2825c74cb75ab01d4b719d6",
+        "sha3_256_hash_of_secret_key": "17f821aae147fa517cf35169f9d0b59a30ffdd0ff8f46c1c9bfffe6791392f18",
         "encapsulation_seed": "a319d2b8f114f1acd866478bcdeba6fd164dc4e37b0adfa8d8034afb3e197376",
-        "sha3_256_hash_of_ciphertext": "cc677a81c73ea5139eed8d85782978d06192715933bc5aef560e737f6d57d0a7",
-        "shared_secret": "409bfd9102bd4632c6b5d3610eb349fe3e3bc51e73acc78a8e994a070e20e10c"
+        "sha3_256_hash_of_ciphertext": "7638e455aa855489cedd385a58cad62c49ee25f60be02bbcca6d7c3c383d27af",
+        "shared_secret": "d399b5ff0756707f8d1a1c2a683465c9ad4899788420643d59edf78f79b28dc1"
     },
     {
         "key_generation_seed": "013bab0212d04ecd54b478daf72748003a25e2cb060ba6cc50bf95c292b8206b9da0c5da5f195b80fbb99c2e8b06926074f3f604b3f6195b5a5b9737876bba72",
-        "sha3_256_hash_of_public_key": "633bee89571e8fc16151491ea71234ab83289426559f90c67903a36e4afaa6f4",
-        "sha3_256_hash_of_secret_key": "3c3cff5f49a802cec693efbfc264f6a385210b1eed20f7bc5b07b51839961d14",
+        "sha3_256_hash_of_public_key": "eb3fdfcc0b171aa975028f96cd47fdba421ac08e29a0044cedc29fce35eb8510",
+        "sha3_256_hash_of_secret_key": "d1266b01cdbc6774ff0edbe64a593a110c462d07071077faa86faa9a0aa2365d",
         "encapsulation_seed": "ff646071b2509e6b75790917e08e4f0b0d9f0116ec6291c0b59eaa4b583ad830",
-        "sha3_256_hash_of_ciphertext": "6d94a31cff4761e3993308cb3e812a4a7f04f64d02ed3b46b418c2fc16189dfa",
-        "shared_secret": "5dd151a8015c0b16d79822832ff4cc0da7fd38eb73b7da59bc519d4d2374b808"
+        "sha3_256_hash_of_ciphertext": "0ed3b8be821742190f88bce0d86f834dec2a829496c5eb5bf51bab1a8419064c",
+        "shared_secret": "1a0ad65924728c415ee9c92d0dcd91396665a24c59cba878050390acf2eb44dd"
     },
     {
         "key_generation_seed": "ccb073c4b90be0ad746e26fb093b60c70110bd1dcbcddb566a8cffb7b3caf80e71600a8982c350df524cde514431ded7aec23576530894bcbf0ec0bfef0bb64f",
-        "sha3_256_hash_of_public_key": "3217d034b472a846cd317681c0f36feea187bd40e546dc4ad69c2e67fd9d8303",
-        "sha3_256_hash_of_secret_key": "1503bc141825d523c9505d34f50dc0a01d7bc91cdaee6b99f4a85a24ce800496",
+        "sha3_256_hash_of_public_key": "d046d93317dc6d0ff28990721c3f94a93024ce01b01c0ca55d634c191c4280fa",
+        "sha3_256_hash_of_secret_key": "bdf5539c63b463c3dfefb7978bc44a46803117ccf066475bd17d5c82fcb49c0b",
         "encapsulation_seed": "0584270ec26f3b9818e4af074d17b2d51037cc8dfdcbe3b140fa4fed5deebc54",
-        "sha3_256_hash_of_ciphertext": "a63613ccfd2ecf8aa3adf0103ddd9eeedbde3282443bcf02513b4ab87360cabb",
-        "shared_secret": "1c729b8e580e124e715f19ea6f2409fc6de741afa3d9919b2b8bf3e54c053b51"
+        "sha3_256_hash_of_ciphertext": "b0cd3d31583e15ee8a55d85cd770cc6d64ab83429aebefdb55674f382b605c80",
+        "shared_secret": "9104061d3dbfac187f3a9eed801545a52f1fb0c3979ca8315aa31f67775d1036"
     },
     {
         "key_generation_seed": "2e889f44e28901e9ac7ca6b2fffcb124c8979401b17064d7e1d51a7e3c3adbfa0e145e44aae52cfc609e6f47fd7a6f6af877190ff52256d0ac5b05b89c3f449f",
-        "sha3_256_hash_of_public_key": "d1756ecfaeb695001ac490f36c4638151bee98d367fb7adf0e06a470844068af",
-        "sha3_256_hash_of_secret_key": "a21acea0fd4354eb0c78d47caaf93c9f2434f1cf2d6b2194871ccd98f9522ced",
+        "sha3_256_hash_of_public_key": "21b12640bf755e94ba06204982458a9be11e1da542ece4f3d284886800fc8e8e",
+        "sha3_256_hash_of_secret_key": "4e3947282ebe9f8cd652343c30dfec9a5123c237af2fbb25aca522b6bb6bc4a9",
         "encapsulation_seed": "51e05c7b4ca3079781e8293f4eccebeeb2f8c8b4c59468eddb62a21bcb4ab8a3",
-        "sha3_256_hash_of_ciphertext": "3b322134b37fe8f5d7268fb74d1634ab8b35d456a973f7b0b427fb40a93b6db2",
-        "shared_secret": "b95ac8b73c703ab1154152b3ac73f054596ed23d3be328fbe20f936ea95fa926"
+        "sha3_256_hash_of_ciphertext": "43c21d2fc350a9682e8105ed680b36a04d02579ebab292d0a05db185021dcb44",
+        "shared_secret": "ca249f10d39267ec3725f56b90eb2e22cf8b577116af350f3d3c1e2cf090ff73"
     },
     {
         "key_generation_seed": "174aaa36410566dc15a5e62874218d7abdde0b2c0f30d877bb80b1abd5f5a0a450a7a2354f7e5cefa6f4a4e9a1c411eb9364506e9e1204a8acb3cb77fbd2c4ed",
-        "sha3_256_hash_of_public_key": "1b1b0a8682caf72df2e0a48513a7358edbc77a615d6be6fe2a7145be66b7c509",
-        "sha3_256_hash_of_secret_key": "3e214f25fbf4d1bb670a87367399e1b2a9da3491cac5a22a2c18dcc44f3f1bae",
+        "sha3_256_hash_of_public_key": "95d9e5b9151d87fed52e287992acb897a07b10ada1dd83409a5ccddabf9d7cfa",
+        "sha3_256_hash_of_secret_key": "79e973da94d9166321c476a28a98a8d03ce079c9a99d6e4f55d2e2b4de936123",
         "encapsulation_seed": "9eca0fe36c80fc5eba171c3ae66a5b1c923faa50b4521bb055e7bf51005c93df",
-        "sha3_256_hash_of_ciphertext": "a2cd589c24c4c75bc0a3864dc84a85a7f0f3ac11c8578757f8e94054a7c186aa",
-        "shared_secret": "8c3851393e5c5997cc95f06da96300f6dd85c041343c98db2e742aaa5f78b298"
+        "sha3_256_hash_of_ciphertext": "18ccc37804b42db21ae4d7e238fedf4594f3d55303dc80c0e51c748ff4906ac0",
+        "shared_secret": "82a3856ca48c5dc582ac25605ab0c675ad646ee19acbaaab4ccb5350a3881b49"
     },
     {
         "key_generation_seed": "351fe4313e2da7fac83d509f3103caf7b4c64a4d458fefdf636785ac361a1390f072d9b5a99f9c7a0a011e4dc10f6b600d611f40bba75071e7bee61d23fd5eda",
-        "sha3_256_hash_of_public_key": "2c54df6e9020e1e44b11b471dea97a382a2fe8d1042565bcd51ef21cc0884d68",
-        "sha3_256_hash_of_secret_key": "c6bc9c9e797a02684d3ad8de47919b8d8fdbee09258d084c7a9dc963c80401ac",
+        "sha3_256_hash_of_public_key": "3a7acfc3d283541d985e0abd85eba5315a17d6c4a7e4f248673da60c341c29fe",
+        "sha3_256_hash_of_secret_key": "2fda122953c3d9db88caa36cb8d5621663fec1dd0e19a274a5d85bea7a126076",
         "encapsulation_seed": "0c5719261caab51ae66b8c32e21c34e6d86ee4aa127d1b0195663c066497b2e9",
-        "sha3_256_hash_of_ciphertext": "0cd687f1c3e0d67c46cebf93c1217ddc972ad8662dd05830db350e1292542c1c",
-        "shared_secret": "4b681fff6a755e1dda908d070f0d9ac610d85c73079c1022fc67d255e36f1f71"
+        "sha3_256_hash_of_ciphertext": "024ade86d89c33d9d38face3b92986e72c699467402fe9c5aaca0904c5f5737a",
+        "shared_secret": "f1e13731a14d39f474806b8c177e23e4e2301a3b839539fef9591a71e4f67d29"
     },
     {
         "key_generation_seed": "9bc5315580207c6c16dcf3a30c48daf278de12e8c27df6733e62f799068ad23d5a4d0a8a41c4f666854e9b13673071ceb2fd61def9a850c211e7c50071b1ddad",
-        "sha3_256_hash_of_public_key": "bdcaf7b417da8b8933279b33068f6fda313826c2eec500b224cbe046abeb37a7",
-        "sha3_256_hash_of_secret_key": "c96e176b19f4135add434d0dd219024587d49fdb649bf470e84d9518bbfa2879",
+        "sha3_256_hash_of_public_key": "21916dfe025b78fc6d4dd1d1541b51cd3eecca90ae52177431b33c708faf17b5",
+        "sha3_256_hash_of_secret_key": "c98bada554f301506c532ec774ee112106358d0b320407fb34051a604777f030",
         "encapsulation_seed": "0e59f6f9047c784c1f00b24454aa4f1bd32c92ae7e626549972f86fab90e7e89",
-        "sha3_256_hash_of_ciphertext": "b38711e358893a864b475f35328b2450fffd5087d631844f7ab0995de2b8310d",
-        "shared_secret": "bbaa67f1dad879f2fb33bd4ead45aec354bc8f05c7cbea1e433509faac022edf"
+        "sha3_256_hash_of_ciphertext": "b2737a0bd104c46a5f861914855f498287a33076c32a4241a46cf9690181ee98",
+        "shared_secret": "79c5817a4ba25295cfdc817cd303f3465852b93c0c908fc4a79e88c45f3b81f6"
     },
     {
         "key_generation_seed": "d8b907b34d152ff8603b73051f772daa71eb902c47b7e2f070508269d757e02e36b817736cbc5f7b1dd6eef5fe6332fb1a598f3871e5470d440fd2ea631da28a",
-        "sha3_256_hash_of_public_key": "61e27e954728e2e2e230c94ff009417d7372938e2c29c38af22184eed530fa1f",
-        "sha3_256_hash_of_secret_key": "8baa58b1d3fab8ec5cee8841c9012506cad40bf58a677adac88f1a6400506d40",
+        "sha3_256_hash_of_public_key": "8f62011fbd5a1c10713d42a00a79ae7672e5e321872971f24ff71ed754178d63",
+        "sha3_256_hash_of_secret_key": "57d13f22524022911276023bff4af90abdf04885e2a598b04fa789123295835a",
         "encapsulation_seed": "a3963ade17d69debbc358dda82c7bebe2c39d25b36813058e7a161542e3f8c2b",
-        "sha3_256_hash_of_ciphertext": "7d47a21d95483a5845a4fddbb07b3435c29a56b5cf26f5d0abfa21bc39a2f2e6",
-        "shared_secret": "2c7b983d66978be80250c12bf723eb0300a744e80ad075c903fce95fae9e41a2"
+        "sha3_256_hash_of_ciphertext": "70dfcd3fb0d525cde1e38e158f6a4234006821031941efe3f9b4fa1e70c8bb36",
+        "shared_secret": "d92f866a744d0af51c8c2ba7b1fdf816e0334bff45182cabdfc722d75f8140c4"
     },
     {
         "key_generation_seed": "684a29e4e5480a5f2533e1526b5fac8cdf5927f3d85087c71f928c59690eb56575d12195ec32a8686d0600e45d4a7f54219b0d7a3826d193a51b9156ecf2edd6",
-        "sha3_256_hash_of_public_key": "672e53b28d579974d268132187e7bd72238639c6f2ca154d50d98c74096ec330",
-        "sha3_256_hash_of_secret_key": "4c72f0a7ef5c3274c49365cca5e6770bc709ef12bdbd4fd7c2eb5faa296cdfe8",
+        "sha3_256_hash_of_public_key": "ed3d1dd05854a6542b24090a680b9aa9d6c65ef31cf1f4f5708affafeb2e3989",
+        "sha3_256_hash_of_secret_key": "d5bbcdd1c2fd57524e7926d071f71114a62b95f0579b62ac0f92ccaaac4e9dad",
         "encapsulation_seed": "97beafabf2c8575586487c7a80e8af5fc50f94b6051c1bc66a5ae9f66be3cea7",
-        "sha3_256_hash_of_ciphertext": "167b4e8b7517cad82ae0f49795918c4d33c79137a9c3e16000c4c55b30b1d382",
-        "shared_secret": "bbc58d06cc14f9e96a10acb1789d93b93933f1429cc53a1735b3cd995f086ce7"
+        "sha3_256_hash_of_ciphertext": "c54e484b3b05c6bb40bef10662de29ecda288b9374dcef8f89220d1bff2d09cd",
+        "shared_secret": "53b3b4ce1e75cfe52d22450bfa763d07985dbc585166b4781a7e6542f9bc03e3"
     },
     {
         "key_generation_seed": "d76b3573f596eb286ab5231feec7499686b13021be36cb126c7ebeb9d7030daf248c0a21ea0bb6d6f56f12300e8584d8e9a34e0e6f52227281151ae4c305fb8f",
-        "sha3_256_hash_of_public_key": "b86d5b13bb8b72a9fb81245ab712f0d10f0e2e09b222143c420e3f2c3acea27b",
-        "sha3_256_hash_of_secret_key": "c25f2e16a0e6fbf0729e5ee89fbbdd71f00ff9a1abbb00cb47f26e9989eaf678",
+        "sha3_256_hash_of_public_key": "6fe12a1e2d742dcaf56c585651ed6edce4f410aca0fc83275b5acb19daeb149d",
+        "sha3_256_hash_of_secret_key": "b9e5eb23d136e49d2b5b7964430a1f98c78cd3526f97b1fa0ffb8fb0ea9ffd79",
         "encapsulation_seed": "75461decd34c50d6a094b4a64fb75e5e9479f8f9250d82bb7d729dedeb2d4b65",
-        "sha3_256_hash_of_ciphertext": "8919940aeb732930c496fa9832b0c09382663accda45be1ee22930c545eb3a37",
-        "shared_secret": "e045e0391e15a66d6208467078f2ba5e429cc586c410ca6c5f3c032c21761955"
+        "sha3_256_hash_of_ciphertext": "763f4d04f8eb62a3599d9d095c77861f122e90a0113fa290b17d500766fe333e",
+        "shared_secret": "e7165b66834d919f8c8737c7b4df17a0668c57a87b821af78fe68cbea325aab6"
     },
     {
         "key_generation_seed": "b87439fde81c9e39eebe7cf741c685785532c1dd23e8ef868b9ce7a541010f3d1646460817a0fce5836bdfe124a7448e7adf7b8ecc2652ac6d280e986682df71",
-        "sha3_256_hash_of_public_key": "85441cbd71c18717e9de7359b920a9a3bb7f32e619806f4e4718c585085be624",
-        "sha3_256_hash_of_secret_key": "93b65d2df33d3e3ab0d53c1d0a21f3752e2c5962f7d960b888b2a8c495b1b133",
+        "sha3_256_hash_of_public_key": "30c784bb2ca3538979b24246c2644907484719c531ea39f13c5a34046f8e5cc3",
+        "sha3_256_hash_of_secret_key": "ff96c20a150142ec36186277a6f7b15e4fb93e9648385ef23186fbef674f1600",
         "encapsulation_seed": "2607dcf4fd6ca1c614c21b5e37c24981c32b91c8c3e6955777da8a3f5d9c9335",
-        "sha3_256_hash_of_ciphertext": "422509b01b8fff9468e867a2b5ebe5d3e27314de5c058b2c79a61ccf464f4df7",
-        "shared_secret": "0b8584b75838e084839d58c89cb1749e82ec06a0e85464c7546dd96870547d29"
+        "sha3_256_hash_of_ciphertext": "edee28e97f72a1798809668a1b9b9b3dc05d794d69af6cb476f524e6acad3d8d",
+        "shared_secret": "19599e218264837d06839b6cb9a09af3bc4cdc78f7d9c00fe030ee92ba3bd54c"
     },
     {
         "key_generation_seed": "056661b38038da4fdd7426f32a81576c73ed84843b305168a374f934e27a4e1b79238a80dcfd7c992d84b2dffa67493e669243d4fa38c46b090bdf86bc548411",
-        "sha3_256_hash_of_public_key": "065fb6156acaac591f1bf3ce71c4a046be8c6c55eb9a84d29569bd2b144c73e2",
-        "sha3_256_hash_of_secret_key": "0121afcc6aeb8be9f1c5b06d5b65cc1c03e9366ed7b85fc511d853c5eee230cc",
+        "sha3_256_hash_of_public_key": "b30fe432c2e9744430805aef6b75cf3011ff387e323558212b9d71ed71f044f7",
+        "sha3_256_hash_of_secret_key": "2c4c6d6ed6fd6cf8b53a352a038b9fea6648a9521604140f54268381dfaa1144",
         "encapsulation_seed": "38c89bbe7145c29e9a831c11431eb9929cb24fb4992db20737e4687d397fd732",
-        "sha3_256_hash_of_ciphertext": "f1d3b745d86f860e508ad8b6d5c8a72ef833c280ec11e99516f4ead3c42509be",
-        "shared_secret": "3547a15b5748990a5436bdc4db283738eb7d64bdb6ff566c96f7edec607ccc9b"
+        "sha3_256_hash_of_ciphertext": "b536c56ac5b187bf7372e726bef28c7a46b51e2bb3bbbcb3cab014c6f5999061",
+        "shared_secret": "dc5f3931026bcedd2f57b65601f683895c365862d28a65356e94049773de2ae0"
     },
     {
         "key_generation_seed": "a1b52d871612a1c611ae0944f9e71858f35d3bd14f20e96a931720668bdf0a6b1f135cf64b6403e103afae34da038613e2853bbfc36baafa3c6a95347193f37c",
-        "sha3_256_hash_of_public_key": "ced77d358342759291c2bd225b0bd82d659d28a24bbc5eda8f47975b780cd129",
-        "sha3_256_hash_of_secret_key": "16e06287bd8d71c78f1657bbd6d5d12c22f6bad7658e68dd849d7751da950860",
+        "sha3_256_hash_of_public_key": "ab02b962b6350a9e1314baaa272b6b13db3d1edc9f09d3addf07f6826a3556bf",
+        "sha3_256_hash_of_secret_key": "abf4653476aae658e4603990ddddad56c09da5fab6b9a3e328b9fcd670547652",
         "encapsulation_seed": "b2c35e33c72d90182791f0e12a0324f5b216efcab2c8da1bee025dfbe13f4152",
-        "sha3_256_hash_of_ciphertext": "fdfd351fbb15c92843b44489fee162d40ce2eea4856059731490afda1268b985",
-        "shared_secret": "852ba9be42763c5a74a75778eb839a3738a8ceed1520b0588f9dccdd91907228"
+        "sha3_256_hash_of_ciphertext": "fc2394d4ed9b1e2b073d73d02eb4ef8ab3633932e58641a58507d7c977b62c04",
+        "shared_secret": "7dbfce1fc7d937884e7b3fa7c8eaadb37e1663f77d7c8659b8f43abadf16cba8"
     },
     {
         "key_generation_seed": "952b49c803d6d6fba69f4375adce8594847a00bcae2179da49af2aed0423250262d7033947ae42ca53522a65fbafe18d3bc3e0cb66164e9a094fe4b44d8977ed",
-        "sha3_256_hash_of_public_key": "2fdb7c7e39ce1625c20a13a1c91aa5909d8b03b064d00877dce2415020370c72",
-        "sha3_256_hash_of_secret_key": "ffdb52b23a9ca4b71ec882031ebcb33a0ecc6731c13c817b24f3a06e48273778",
+        "sha3_256_hash_of_public_key": "c153354b0187e658306a0c860b1fe6ed14686ca77d37b7c82d66ff62149406b7",
+        "sha3_256_hash_of_secret_key": "bc48868d03fb12ad5a98d35a739388b66e17b589aeb6ad4335d2d2e0c933910f",
         "encapsulation_seed": "afb7d6dc2b7eb6d84acc080c1be63c98afe7b07786b5801f716444a3e8e64800",
-        "sha3_256_hash_of_ciphertext": "215d83f872221c5fd4ee4da557e17299dc102c52dba1fc4bc3f8c16805da7f1e",
-        "shared_secret": "618a8496b8850609c09dd1d18798ee2bfff3ed7ef6f8b8034fffcec98f291d69"
+        "sha3_256_hash_of_ciphertext": "0fdc0a9a35e5cdcdea8d39e95086e35db8f4ec92f13a7d9afad49adb5faf1e70",
+        "shared_secret": "09f64cee1af4d8738ab149d34a106ea7b19ac43e5a2536defe689824409050ba"
     },
     {
         "key_generation_seed": "3c815e57e9233e975fa1630208aab206b71ae0db37a7a8789ac683d9f9b2d29801c8e376fdb140ee343106c093af7cb149b316ba79446ceb4e5e0cedb9b164f9",
-        "sha3_256_hash_of_public_key": "86bb11e7d9c1368fbba34ce3a2f169c2464ef5fbc11f73843c456467b6cdbd4e",
-        "sha3_256_hash_of_secret_key": "5d46659798d268f1314ad1e7c1735c480301f5877773403966e928bc3fd33d1b",
+        "sha3_256_hash_of_public_key": "2ab47ca9355ece6cc643c3274c46efbd6e927b8b4d11ae8f80b5345b487a5c71",
+        "sha3_256_hash_of_secret_key": "9f65505a34f12eee3e5f6ba1cc622dc0024c4be87dc0648ff9e1edf9ffca943a",
         "encapsulation_seed": "28f5e9dbda122b2cf8f3754fe9e0c73a84ad4b0c093522e0b62cf815d60bbc3c",
-        "sha3_256_hash_of_ciphertext": "5ff5d6bdb110bac57e58a4e288d056a1384f9823606a42daef2ae82e0b7574b2",
-        "shared_secret": "cbb8b7a05f48b47d163cf8c2fad32bc586f47f2c2e0911da349f29b1e3286c22"
+        "sha3_256_hash_of_ciphertext": "5c7bfaf193010937498fafd5f4eb4665996c6a963ba25368439dbe05c56bd99c",
+        "shared_secret": "7104fe381d6d7995b4d550278a66a719b9e79d9bdc38fb0bb60212c4355cc520"
     },
     {
         "key_generation_seed": "588760826dcfbd36d9abe6ae44a669bb3ebba6a218eab69e30f18a3bd536576e0e860576285483bb5fd36e2f944d32c4317bebc1e441470c1372046a790d79d4",
-        "sha3_256_hash_of_public_key": "29253478090cb4d580bc2a912645bc685061e5d4437b3811eda69c865ea9923c",
-        "sha3_256_hash_of_secret_key": "aadce411f3708e9727e4a7e4e198781e1ef5e8f4c4c14add1e25f5758649e265",
+        "sha3_256_hash_of_public_key": "3ab27768ce397a94bb7d29f5dad97d54054915eb66be41023e5d7052a10ed1e6",
+        "sha3_256_hash_of_secret_key": "2b091ca0237c155627226a58c1ea9a049127e7e30e397307ae20343e21408dbe",
         "encapsulation_seed": "b0d713cbef0bb1df70cbb425d1e9373e9f7790fdc7980cc96a240dfc53f1e8e2",
-        "sha3_256_hash_of_ciphertext": "675039d66fcb631a050a8b24415b50f331350bd6697f9c977eef15c15d4cacca",
-        "shared_secret": "1eef87404f318351413d52ba8a07cfa5e72f235d6f91afd7fb8ad3e683ce0a55"
+        "sha3_256_hash_of_ciphertext": "1987dbb44cd3fcd1b3fded283f54d82a2dd146508124282d59a8f862be82a2a0",
+        "shared_secret": "79b1ce19715dd0a74ada36d31f63f3242716890a66d6348232c914c8e5c4c499"
     },
     {
         "key_generation_seed": "47550e9edacb6ddce3d9ab81f6b61080dd4f2693854acb05e0ccc7a4fb6390fbf89d7d99d5c3e0d10d6ef9af054d842375f695abb28e3b8eb495100f04306e92",
-        "sha3_256_hash_of_public_key": "286de7dc142efe935e84b0aeebbd32d050fd9d8b008a94e59454b19ea401611d",
-        "sha3_256_hash_of_secret_key": "a6b53edf9efd7fa67a478456a5b6a379876c248f623ea45f4b541a8db00c524e",
+        "sha3_256_hash_of_public_key": "4c20aa5a85b2e43c56e051698c75bfc27bb9b1722501a6502d1c0dac0aa7f1b0",
+        "sha3_256_hash_of_secret_key": "684968be82e153d8eafea3ad507544b512bc1b0768775fa5732a12ec2b3b22c6",
         "encapsulation_seed": "32bdcdb7059fe27f6409901980c080308951ffd90deffa8317b4d213a5f04495",
-        "sha3_256_hash_of_ciphertext": "f03d44bd9bdf3bfd486919fec2177b8b685a9981de4cbc2a9e98b7e9b0a528fd",
-        "shared_secret": "ca2c0bba56645e4fce4b7e38a7bb4b839e754bf2834a302a2614377eddd6ae60"
+        "sha3_256_hash_of_ciphertext": "5a1273ac88362d6933e9f8e203af5df0ce809b23e125abfbea3f72bc386f17b6",
+        "shared_secret": "66e872a4b3baa42bc3e8e4ee787ebe070a094f05d2a0792ae2ae60f8bd0ee0e7"
     },
     {
         "key_generation_seed": "610afb64be8cc1df288cfb016ee2f44c6c07113de7f6fee071fe0c3fe31c6215cd292e4c5f9e1a55e0489bceffb204d672a6215f4f3980a646d9f880817c52dd",
-        "sha3_256_hash_of_public_key": "029a2e12c3e6aa668afb5be8a82576813fac7b8e61c5a88aff94ecc2770c585e",
-        "sha3_256_hash_of_secret_key": "413ae41ee83e17b74ac654c2aca57abe8f8ed0409acf7cc8b301e3d6bb049cfe",
+        "sha3_256_hash_of_public_key": "72c30933b8e50425fefbf58d711f58cbf9fd8ebd2835a1b55469a2a1b993eace",
+        "sha3_256_hash_of_secret_key": "f156a8742efc92c7a7c5e07116d139872ec520aad1fdb146cbcff70c350a45a6",
         "encapsulation_seed": "4ed7c92d83bd03b2a25b567f17ae55542e2f6a4308ec0f3fe69f8ba5ae24331b",
-        "sha3_256_hash_of_ciphertext": "e8992f7b7b619c03cb9f0c991e3a9c20f91beb707c177ad4e02a5808d10d8769",
-        "shared_secret": "9155619e28de6cc0670ce70e0ad270f0e885e5f5f8d6d38426938ae1036d6ffa"
+        "sha3_256_hash_of_ciphertext": "c3c80130ce1ccb69036c753567b55e2e93df33496228735300b7640f2993c09b",
+        "shared_secret": "56551e57abc7b80a842db9ee65aaf6e65b7c4ca10fc297e9bb0a6364e6255bdb"
     },
     {
         "key_generation_seed": "e1953800acaa85ac02a906c72cb8e8d704e8d27820345f88f71e89c1f549afcc8c64c049c6dfc0f1476cffd520b055756162f7ec94243de6b14ac0b9e5fb366c",
-        "sha3_256_hash_of_public_key": "e3ec3671cc7675a321af8584a0961101c04a432772431e77f5740ba3b2ef488d",
-        "sha3_256_hash_of_secret_key": "93bf696bf0671c3845c4b246f29701a0978eec5b49de81589009e235903061e0",
+        "sha3_256_hash_of_public_key": "bce58a5d05a4840f835b8ce39703f77bb31f20b9ee4fd3795c2e326244208b28",
+        "sha3_256_hash_of_secret_key": "abc33aecf69474343f3848633db85e595a465bcbd408472257e00be338664ecc",
         "encapsulation_seed": "060ea5d2ed1dd88144a9885e79278590821c22917b55a48920f96b53ebe0e689",
-        "sha3_256_hash_of_ciphertext": "6634bd840d2dbb01463cfe5b4e3e54d1eabc081cfbdc14d0bc118911ed8d3cce",
-        "shared_secret": "d1f24383d5b8d0c3c0a6a5f8f7d38ccce13ec179a84b0b09bcda4c9988f3eb4e"
+        "sha3_256_hash_of_ciphertext": "a500aa79a567933c2cb80ea580fff3298a345398243052f2ac292591810328b4",
+        "shared_secret": "30abe054c82a82299e7edd52870f461ff6048daab627b6c848a9d4f1c4641a0f"
     },
     {
         "key_generation_seed": "c719f9b2d16399b7326ce4eca30dabefe8fdaab18e9f6df888b0a134ef355570e40771856eb77e4633504899fcb86c6a3d433d0b8d60e26f07bd61f1d4ed69bd",
-        "sha3_256_hash_of_public_key": "79836213a513bd4cfd42ed281304e3ee4560e4e0c60fa53781f83d5bd2bbea52",
-        "sha3_256_hash_of_secret_key": "65deb55fea451375ef335e7faac73917d32220fc70c95f371fdb16e712beeb26",
+        "sha3_256_hash_of_public_key": "0293675aaefa1219f8794d114bbb004463f9c631729734cb430f26f38886537e",
+        "sha3_256_hash_of_secret_key": "b25401df9f852f7383fc87fa7cbd267b9de2e80bb37946e9fa8d040134a9e31d",
         "encapsulation_seed": "10ef9426f8c4a13b52325c5bb4ead4596ecf2c6b5bd2d37d8350e90d4164fdd9",
-        "sha3_256_hash_of_ciphertext": "ba79883ad64a6f2b256004233d87809a8c390327a23c739334f773507e003aa7",
-        "shared_secret": "d2dab0b39b7f62de3ca9826f9dd15a4201191a0e0c690d3e52b305a9d3af2d0f"
+        "sha3_256_hash_of_ciphertext": "3e0e87ded530c595b63064109c6d64c78253f3bbac5f3bcba552539fa7daa004",
+        "shared_secret": "4b525f467ee0d96c1f4b899a114936343ec21c74738b05555b2bab9a5d0b5513"
     },
     {
         "key_generation_seed": "e9acbb774be970206c3a738e243b420805a509fa59fa902044be2f0d013650d2ded5edaec5de3bf5b4d7c2f2e18e87f499c1968993eff196753db8045e2c8ba8",
-        "sha3_256_hash_of_public_key": "0c2e803c2872400c49e1bb10232946ab939319e84ff32cd354dc15d082cde5a3",
-        "sha3_256_hash_of_secret_key": "d37f172803739d074d71a2be32125eb1ba4250128342e34b882fcba38b259248",
+        "sha3_256_hash_of_public_key": "cadbc64e263f1afdcddf2ad63f2fcd19799a0a8f43ec867477e249ed5fe716f8",
+        "sha3_256_hash_of_secret_key": "ae483cd66ace708eb15d06b55b1414e1ca1cd440d8867932261fe16a41eab8dd",
         "encapsulation_seed": "a4bd30a64cbf29a4e290fa1cc1dfb99e68348713041e4409a1af23c5d80c15c4",
-        "sha3_256_hash_of_ciphertext": "13d437b2fd9d67ca0699a3dacd977fba5d072fa6b482043d63e8a9548ba6a3fb",
-        "shared_secret": "6869ca370a496af2dbaa866265d91ba6be54b9686b1b8dd5714f6ba861b0d1e8"
+        "sha3_256_hash_of_ciphertext": "b4c90f9d9595c242112c963a6f24b6023083a0751e341522eb4460a0eed65f25",
+        "shared_secret": "6cba1b31809b333ea40f2f67bad438226d91bd61b08860357a840cbcc8fabfc5"
     },
     {
         "key_generation_seed": "c1b3cbffad4b306f9af0cdd3028876486dbe858875c9b6497fe20172a986c82b1c96249919cedc2369d8d739ab125e0d2ccb82dfebcd90240a545cdfe07511f2",
-        "sha3_256_hash_of_public_key": "5818ac8d7a38c781e3a0bc43d088e6d391d1d67d9639b260bb6f58a19a57150d",
-        "sha3_256_hash_of_secret_key": "280e4774d1b2401580216fa70fb24c2c214ac5dc7f3841710a42e14d6aa09663",
+        "sha3_256_hash_of_public_key": "5ca1708c7c6e354b69720b4b4a0c358fe9a6ad3febe78bb2a71691658acae21a",
+        "sha3_256_hash_of_secret_key": "eb002a4709c8b95bf166e0942d47453c32b93e32e4273aef846c296d1590d58a",
         "encapsulation_seed": "f4b66a7d3b65b896dfe100b2cad24b175a1168cfd2ae11fd704b835f6bcd311a",
-        "sha3_256_hash_of_ciphertext": "51eb70249a1abebd5159f1069b1acda2304f25fc9cbd9f4a625b58df448b47dc",
-        "shared_secret": "502d92b2a7e1804892ffb8ff009987a58f35baa30c0392c83859fde82105a9aa"
+        "sha3_256_hash_of_ciphertext": "3d21fa1e7c4b9e5b3f68f956afe6fac216d42fd9a3707b7a61932c8ebb5103b3",
+        "shared_secret": "8087b456d37e6aff785a0ca104cb03ef71fa2d6652c52dcd86220cacf878afeb"
     },
     {
         "key_generation_seed": "ff7495b8575b5a98e4fd21fb4c3e58cbb60f14bef21aa74cf8802e3153f14807bdc370460375a778d1a31d01c42b66367ed8d9e8f84551002f552f0e52102b5d",
-        "sha3_256_hash_of_public_key": "172cf4f8dace8a96b8f70da966080a5e3f132873ca7544343377a99b65e8147f",
-        "sha3_256_hash_of_secret_key": "31136804b6c14f3a0a00a3295a5fed8d606369e64d272d432c59d7fe0ccc3e47",
+        "sha3_256_hash_of_public_key": "04f0066489947b572f76e1dfc2e24297b210ed0aaf228788a0b349d11689e064",
+        "sha3_256_hash_of_secret_key": "656696013b36db5535aa376104d5e2beb2c9a708282aa6a5f0ed42cbeefcf98c",
         "encapsulation_seed": "1d7b03d3c5eefb8ae5799dc569aa668f1bcb8c86607b089d3530cf61d6380147",
-        "sha3_256_hash_of_ciphertext": "9b38b66fdfe80acab82bf9577676f6566b4429f78a14f7486b07c96ae7be921b",
-        "shared_secret": "48eb4b840c0d957f28808e434786c02a8f99d3464ccb3caf91cef4a0f8e70c4f"
+        "sha3_256_hash_of_ciphertext": "a29dc0e0107aed03c698c2448cba21940bf9923c2098225ea3421bdb474a8ecd",
+        "shared_secret": "6799d393f4000857868049c19a102e5c04c55a6bfe3a41abeb4fb6d5228cda97"
     },
     {
         "key_generation_seed": "bdc3fba1c32751139fc45bacffb3ea97f26573d804a5f27a459293d95190ed8efd5a08f656a6eb8cd20679930a31caa6a6331c4b133a6838c223ef9f769f6246",
-        "sha3_256_hash_of_public_key": "268b6356f92c57da6dd34494b927e8764adf0ad519612ef0d1b8951e50966c2f",
-        "sha3_256_hash_of_secret_key": "3bf02cee24670ca40b7280d8047fa147b24c5e286dcae9c24bace9465bb19f61",
+        "sha3_256_hash_of_public_key": "67ce6c8abcf3ec4d93505d3be02c039e5a12538e5e59adb5a5d709b9b342938d",
+        "sha3_256_hash_of_secret_key": "b68d06399932cb2d32b2a2aaf12e68568f160092efac36ade3536cfe6fc88d45",
         "encapsulation_seed": "554f3385b382f4a46314de37ee3885addfc5332bd4038785094e0a832e9e8c2c",
-        "sha3_256_hash_of_ciphertext": "fe8c3fcee4be152aff29e55f42f2fb1354ae55ccbe38400bc901ca032ede1ef6",
-        "shared_secret": "f9507f70421be90f21138a1e135329ee8228682cc948a6914ea58624d396df0b"
+        "sha3_256_hash_of_ciphertext": "93a08f27c7cd6ba3d5e6c8b6c833d8c65f05edb2cfd7eaf5bd392cd1563552ca",
+        "shared_secret": "dbbe6f3b6f5a35789697792e209428ba1f53d1b98ac2c0d1893cfee641e40375"
     },
     {
         "key_generation_seed": "447f6076a627bbc5ad7773fbfeb14b4ba9ac43a0f8b99fb6dcd5e452aa3c47ec20a7237801f470fcc2bd9fd7bea8322859b850f7882d362947432913dd068c01",
-        "sha3_256_hash_of_public_key": "4c6d304e0494d88d83b5e3aa5761df3b299551a24f28994d2747b2b08945bead",
-        "sha3_256_hash_of_secret_key": "5de91ca73756eee74da3cac78a1fb329a02f8587f212bb9bc0b29e0e654a5795",
+        "sha3_256_hash_of_public_key": "7fe853da745a27a1462668bb66c4348b7f4bf25c70527b360b2fd104cda48fe5",
+        "sha3_256_hash_of_secret_key": "85a7c0a52f7898df5e3ba9ee378057b9e354dc2108c5f8c60a10fc20c9eda749",
         "encapsulation_seed": "38bf0033b779edf5367d9ebc01c988af90904c560970815837380650e4749eea",
-        "sha3_256_hash_of_ciphertext": "805ce0ab06c568b614cacbfa4cce5e65929e2846932a90e9418513dd48cf3358",
-        "shared_secret": "24caabaafe2063f812eaf57c58b6c0376ed8ff778cec1980ee9c3228801a75a5"
+        "sha3_256_hash_of_ciphertext": "23e8b844258ff739aceecb17073a7f2be2f89030ba7ca699470e4add6f55321b",
+        "shared_secret": "494550faf270431de90c96d2ddcb7c19249d5e85305b3b43626386c30b7aba5f"
     },
     {
         "key_generation_seed": "2d5df64d62cb07fe630310bb801c658dbf3d97993e68626745de39d37fbfc2b27b534537addaba4ecf14f02ab317d36cb9f0f50222ced7cf029dff8a0d3d2fd9",
-        "sha3_256_hash_of_public_key": "72be2f5cd569e6229f00014854633f7b278e90af4ea593411909467a03e29cfb",
-        "sha3_256_hash_of_secret_key": "a68ca31b91491a129af9f280cb4c60c046e7a7ccddf41c9bd98663f8512ca34b",
+        "sha3_256_hash_of_public_key": "65297f711f12a5ff123e6de59d1f16878e93a31612015fb961bc572f3e999cea",
+        "sha3_256_hash_of_secret_key": "f80261900b053c4d1c5e3b445588f1aca6a9959b969b6a60df08f1a12da1b661",
         "encapsulation_seed": "048ea516d0ebbd9f709b47eaac66f344c571cf50f0d01c9466aa061a50b66a24",
-        "sha3_256_hash_of_ciphertext": "d27a36808f09d6165aefc5d253090027eeff0653268c55a0b3de2a751ec765be",
-        "shared_secret": "9f734b15fc7dd99bc10d6cc7de5d2c93ac789a5665e508a95d075dffbad25abb"
+        "sha3_256_hash_of_ciphertext": "7c4f753d71b67d7a6691db0e7d9bf2c2a13f9f48a0d9602be60e080262bf50f1",
+        "shared_secret": "eec9e658edcad5a8a705644ccd35aa3d785cc258666ff749bdbbafae6700f1b9"
     },
     {
         "key_generation_seed": "25056d1b8113bb362dd979d98643d7a7ac9c4f95994c0ba060609b6d07002ff3f48a9254dd40b117941fa35a66bb50296327b725525deef70e128ca8045ec451",
-        "sha3_256_hash_of_public_key": "0831c75b153fa17d336a79ff6e88ddf485daf7b1b0bcf39d8df15319d52ac67e",
-        "sha3_256_hash_of_secret_key": "2b983d7cb50880cff761441b6a2c66b7a41642cfd2a8cc297a5df53f0ed1947f",
+        "sha3_256_hash_of_public_key": "51634cb33a2bc3fc22ff47b58d7879d703bdd661ad3c290a6d812485ef0ce8ff",
+        "sha3_256_hash_of_secret_key": "e9d2895dabc85514f2f1a543440ac0de41d49cf21686327bcc6066d21a2b93a0",
         "encapsulation_seed": "686c921c9db1263e78ae753b1c9c2e7936b8229dca48c0942c56c6bca4f10917",
-        "sha3_256_hash_of_ciphertext": "0892527da24957468b1b8fab49ad2d7dd6d238eca54624fce6a3c2dbbbe8d194",
-        "shared_secret": "d27e55f2a1f9ef336c8537f11da9875e03cc7dde8951d81b0740457609654107"
+        "sha3_256_hash_of_ciphertext": "8d971865b1ec760640db6e480ed27fcac239bb1c36e72054afc530d957672c27",
+        "shared_secret": "d5c5e6657d310b0ccef250c9664a02c846ecb241f2404ca851d8219f93cb0d27"
     },
     {
         "key_generation_seed": "e4d34e12982aeeb1d62fd488d9b9e28557ed3429292239fb4f76fa9098009acae6c45c7fc62329b13c8d29844405db8ff6860de474bf727ecd19e54e6e1a141b",
-        "sha3_256_hash_of_public_key": "b30cedc4316b63d75b641fbad2f33241a3fc47ab8b3ee1a3ed597e5b04f77c68",
-        "sha3_256_hash_of_secret_key": "a49a7533c671e533deec55af218ee511c57014070e138c7059853e08c34b0a78",
+        "sha3_256_hash_of_public_key": "45cccc2997b502ed631257065214ab9afed11f00ca5c18c92c4d6b917165fd1c",
+        "sha3_256_hash_of_secret_key": "3a0f0c13760dfc8bf1bf79bdb1b4f94aa33989529be306bb826b07e089105b47",
         "encapsulation_seed": "2387772e50059cabda53cb93ba24b19ae529496c03b36584169451525c4a0e7e",
-        "sha3_256_hash_of_ciphertext": "390b3b6f9a0f9d97ccd452c83bf47416b22fd06b4d8968c44ee6effa7980e68c",
-        "shared_secret": "ed5903d1cf02861444cad7fc3793b4e1b9b6d0324bf6babfb768bb2f84300086"
+        "sha3_256_hash_of_ciphertext": "c60ba523dc75a1c9f8dd617f1cc775f6d1cee0fd7614da1a5366eee5950b6f10",
+        "shared_secret": "f62460025ebbb273f00207758a1215c3a8053d2ac66cee11c6760aeef7e35d24"
     },
     {
         "key_generation_seed": "cd6a99396eb3539ca663a51e42063a3a262cc1c5a5fce1566f0597b52ad9fa325a3407f591791a5db4578b5972093a95bec3b8e70c1d542c9b5c9789729f8922",
-        "sha3_256_hash_of_public_key": "ee044dbdf6787ff038dbf9c133557169c62fc1ce2580739369aa87df00b49648",
-        "sha3_256_hash_of_secret_key": "9e865967f0d1e7d3f6a49f2bb623ced2a7b1408a945e02adbdca35846b70e7b9",
+        "sha3_256_hash_of_public_key": "89560d4e598328f6302a9762bda2b0f29fa8ee34fe48dc4847810fc6f44cc198",
+        "sha3_256_hash_of_secret_key": "30f40a1a6f4adda2a9e73f3a881f3d10414031a0f5fc0f70ffa4966b29bb1a7f",
         "encapsulation_seed": "155c29c5f0378df0cd0e847a80a07143cf7522fcd880c9229eb9feb1ce340cd2",
-        "sha3_256_hash_of_ciphertext": "6858db6eafd97259e6d775d881f7a877010179d4f827680426946b9ac4571261",
-        "shared_secret": "0d301028c1cb31dedc8a702a9e95b7d3589f68a6a1f600af84ae0f543e625361"
+        "sha3_256_hash_of_ciphertext": "932a09da1c6de03fddf0b45ca31f2446c5c2a3d47af171cde29149167e735cd6",
+        "shared_secret": "74efee46e7b26f5022416ae9bf4a52a3940966b37fab0c3ee2e8fbb24ded6bf8"
     },
     {
         "key_generation_seed": "6c8c53ed6f65e6b2e324b84364e10de42d1c26a106d4d1c99eee79c78586fb55b9402bf02481ce4b27a52e87feb92c4399c7f2988d40e942e7496ad15ad2aa88",
-        "sha3_256_hash_of_public_key": "e965ac6995d525e324e8252d8e2c2da909a29b24baca8b68daa5122cb539a474",
-        "sha3_256_hash_of_secret_key": "91051a381626e9465fc7ab20a1944eca64be461330bda53e7d1838a74597392d",
+        "sha3_256_hash_of_public_key": "878025deeed7dab8e62d43c3d2096e4682692537c70ebab9e1561cba88b05ec0",
+        "sha3_256_hash_of_secret_key": "5469881eca81b37faa66f4d9f63c20ecf61fa8337a095410fc19eeacd774b863",
         "encapsulation_seed": "a9cb9a61a3324b1ea5afe693b32784e2871096b2ca14a11acc9577c52359a241",
-        "sha3_256_hash_of_ciphertext": "42bfb5584610497fbc8080a664139afa534b39a417cb69ab0d2a16c8737eb1cb",
-        "shared_secret": "354d86b389021a3196b75c6582927b3a005fbfee0951f34d9cd5c8f415fa50f9"
+        "sha3_256_hash_of_ciphertext": "0407bedaefe91d921a6442f34fe88c04e62389fc63dafe78a1a2b93723786a10",
+        "shared_secret": "92fd1bb6ea9f1a0a195b3ca29e457f4b3f401fb4521842196d9471f50f5c7249"
     },
     {
         "key_generation_seed": "2107204cd995f1df14314d5381f8c5440f09a347502e161cffc0a2ec3dcfbc7324c3da70fe850e80aa818301d60c70f3038153866dcd5d179e22db59b8991bb4",
-        "sha3_256_hash_of_public_key": "a3d8a85f38cfda38c66ae39b2f9186ef7bc1e0c98e8976a6cbc6c4875d73d7fb",
-        "sha3_256_hash_of_secret_key": "cf7e797f8f7229a08206034737e54fe46645ab2fabdbfc8662b45a2604876b65",
+        "sha3_256_hash_of_public_key": "7d30385f988dc748b843b7b7f569e58ccc9215503e1bc2f28f5019fc72fe6d33",
+        "sha3_256_hash_of_secret_key": "5b425d514afec91db185ec5e84bfd545453da4f3acfef398e7b3548c63f713f9",
         "encapsulation_seed": "e99fbae8a024ebbbdcef32ce213f6aa942e3eca925e5da4c09975d773b33a175",
-        "sha3_256_hash_of_ciphertext": "ce7b65856502b280e02a36d906e018c6a23cae99f27ef6d65762c87ddfedff56",
-        "shared_secret": "3afcfdc446f93a8169024a24fc0383692843cfd6b4854a8e490892fc35aad4cb"
+        "sha3_256_hash_of_ciphertext": "886a86759ae6a21a6dabe37a4b4443bdd358502f0719b5b9178dbb6b9f7e27e6",
+        "shared_secret": "e1a195eb1093af69edf107980f94adb3058378cb79dc807684c26c4ee1308533"
     },
     {
         "key_generation_seed": "63a925685a8ac5bbd918faa33ac397d1ffbcf99135d9da7c3d6ff7aa4c50af3d3afdb8a246a56ee71465591831c371f2eb87467b0559dedd776ba063ee6d2f93",
-        "sha3_256_hash_of_public_key": "aa73b40dedd61e6fdaac86971965c03ab14ae69e8130426fdf830bd57d0974ce",
-        "sha3_256_hash_of_secret_key": "1e7f3f1e5632d1df538b564304f56689742d1f652d8d32f019b45183af68a20e",
+        "sha3_256_hash_of_public_key": "0697d2f9e047e603b8845c9ecb168576f9d8bc7f3c831b6ec15c5fa4f744315d",
+        "sha3_256_hash_of_secret_key": "8b634d3c1e118577cc095a8bc53d05bc8c869f2001f3ef591dffd8cffffea969",
         "encapsulation_seed": "67a216f37d67f5e74f782f1badbce1cc8c80a6130aec305b421899a4faa0a6c3",
-        "sha3_256_hash_of_ciphertext": "b6c40fd53bcd9ee1e70bc6783b402ae34c24dec724e63262d8583c90cd10256b",
-        "shared_secret": "ebba9a8bae936c829c1445c68595da96919041ee3d9b0fe27ca93db691146874"
+        "sha3_256_hash_of_ciphertext": "a9c68747a9697af9d9442e3d5341161afcd1977777bb40dfd8642807d96f3ccb",
+        "shared_secret": "fa8721164f599caeb949141b24a124f2d576b3b58c1914af2b05da26b09bee30"
     },
     {
         "key_generation_seed": "6a1aee5e708c1b47f02bdacce4f56c860f74fc7cfec1ef3b58285b1c8ad7fec2230e05b7114ff0395cc6634db1eae8258072d09c09f291e92d6620b177dc50d7",
-        "sha3_256_hash_of_public_key": "cf754f2ee43694865a09ca7beb0deda9b1328fd0abdf30ca5c338e27e8be04b5",
-        "sha3_256_hash_of_secret_key": "928592604aa44df8f2072f26e9511129f61da0b7f57acb3f6896635a9764ea87",
+        "sha3_256_hash_of_public_key": "d49e426ae85eaa6c911c4dca80caba6e28e5f645a54d8c016de51a2b98241a29",
+        "sha3_256_hash_of_secret_key": "cb272fd45a2a27a517bbe1d77d99c027b8664d596bd77d18c4e861ab9900b0fe",
         "encapsulation_seed": "52b19fea232c9154a3e431e9d69cda40013cf2d485c3cd027ad24e645420420b",
-        "sha3_256_hash_of_ciphertext": "a4b50ad169b436877652a6c64dbbffdd63f53274ddcf58f3c96c3929215aa956",
-        "shared_secret": "f063c0908deb2e61faa0c4c0f5051b2c8af7265060681df14bacb30f0228b3b3"
+        "sha3_256_hash_of_ciphertext": "a569fc93ed9b0342e4090782e82b576632dfef108ece59234c783f80e1862de8",
+        "shared_secret": "d479c2f5e622cf848d921a7155cbbade062d0fb3ce7535d1859eb03e18ac64f1"
     },
     {
         "key_generation_seed": "6396b328b100e4c7f4bcae69875edea1a1982421558c608c13c592bf7b5d0fef1100ced48add211a5c937b8d6079d8e271af3f949edc61f70e60453aef20dea9",
-        "sha3_256_hash_of_public_key": "3a842153dee9e035299d7e268c9492d71188f9fb24bdc2dd20c1ddca647a1523",
-        "sha3_256_hash_of_secret_key": "28ee987bc4ae5a321d2669950dbf87596fc4b35c29f192836005064aa3dadee1",
+        "sha3_256_hash_of_public_key": "903d69da169d8f3f65eec290acf30078fe51bcbd1aeaf412dfe2d31c7b10157c",
+        "sha3_256_hash_of_secret_key": "87b236ca8da0c7a9d38d7714e7ac16e6dad2fb5282a04b846afedbbc0449b395",
         "encapsulation_seed": "64440adb05db3308b189bf999f9ee16e8ee3a6ccbe11eebf0d3ae4b172da7d2f",
-        "sha3_256_hash_of_ciphertext": "126b64a28d82d06ca81f7e86d33f4949634924e04528d1142061320eaadcb841",
-        "shared_secret": "02d2e466e170bf45d3e9d357e2f04c34cda408cf147e9ff7a6e8c715f2c88ace"
+        "sha3_256_hash_of_ciphertext": "d74122c64015ba74b20c9a675bf688952d42ea421aa5c7b6c82eb6dcf0cdc092",
+        "shared_secret": "0dc813eb106eb0d4864ffc38432937a1db0d27745788775a8299e93d1c808f18"
     },
     {
         "key_generation_seed": "a453bcacdd2b0d4646009e5ed451c3c45f08fb827ef733db3c517a9dc1af93e67a3cc8aa3239d4c52ce4c95afdeff6efbfacac10d294edc0e7cf4535059bfdba",
-        "sha3_256_hash_of_public_key": "da43cae3c4da51d69a57eb87094a03cd3a9c3e6b4ed864cc691a60f0509cc646",
-        "sha3_256_hash_of_secret_key": "b204cd1c3122b29a3d99cb77e11427fc102375699928c5a6fe816f96bb212627",
+        "sha3_256_hash_of_public_key": "08cff1967030a528e748b708b0fb783577f249c04ea5536d2da034fd0d15fbac",
+        "sha3_256_hash_of_secret_key": "de3ea809c8eaa873e0aaef44d481d8ae72799a0b746c5847f3d412865871bf63",
         "encapsulation_seed": "c8bb46b3a7344ad170c2052fb042b5a3b62e0590562ee82577b1081f6f114d16",
-        "sha3_256_hash_of_ciphertext": "228dfe300e3fabe4d4e550754ebcbbf72a796209c1d24e7ae93abb79e1cf17dd",
-        "shared_secret": "6a5b0842c122ab6ee251399492b061d2ab3e40843f4dc01c12fbd5bd545c600c"
+        "sha3_256_hash_of_ciphertext": "f0cbdd82f5731bf4177a14a3abfdaaef5fbe94a71ff3f1b7852a010b1d4d7eff",
+        "shared_secret": "c71d65ecbae83e06c622e28a4eff43c10041539d851149dbdf295eb121550d5e"
     },
     {
         "key_generation_seed": "47ca2b77c5b717f423222c2730ca5cb9c856bc951d01b2b2c80bd76ccb5539b78f1481d7cab000e33fa07de8dc9627a85e76fabb4428a3376e66300cf12a0787",
-        "sha3_256_hash_of_public_key": "6533c524a32345eefdadc74a3c6ad7e981832797faf1068955b79f118dff9358",
-        "sha3_256_hash_of_secret_key": "b9dee52055b1f9a2b25a0c1be4d9f30d2ecd7c5a09f0f5294de2d49a55ac9fe0",
+        "sha3_256_hash_of_public_key": "b5ed4c3fb678a44d92486cf091333c7f035541614729496d5dd45ce580f0d263",
+        "sha3_256_hash_of_secret_key": "c313fdffb08de4e928bf32e08a8d0310ea94f9713381f81cdd494a3d4af09553",
         "encapsulation_seed": "2e2b70609f3fe029a14d09d5d659871ac776ce2797a0355f16e2eb68f5613fd1",
-        "sha3_256_hash_of_ciphertext": "2d7e8fbd6f2257b05eaaa2ca1643c452b4e0b623c9ad72027cca8dd8b7b5b91d",
-        "shared_secret": "2486c0a6cf17d9635dbca1f8395784cde54dccb7df10fced92183f983478fac1"
+        "sha3_256_hash_of_ciphertext": "5c266d232b038abc42ac484a721f63094ce50740008e0be68571018d8355099f",
+        "shared_secret": "82360ffb5455f6dfdfc6bfc1a3999eb7453365ca311a0077c9d74968ed27b7a1"
     },
     {
         "key_generation_seed": "aaf6eb40e596a5e3e8218871e708b089240dcbe7fd3641f0e5e41e071ce49107e2f8d320ac3cb0c52efdc753282f092bc39baf4a18783a48ea031a191865eb78",
-        "sha3_256_hash_of_public_key": "e2f60f27da7f318eb94a74b437f8e0bc9513e9bcc38dad99c174c1d75e0145f1",
-        "sha3_256_hash_of_secret_key": "68eaa8143a71bd5f6df29b128781e3f2a5fbc5d20534afb223ddcc64bc767f5a",
+        "sha3_256_hash_of_public_key": "e9037042553968ff3007cdb135e368ecf440e4187e554af9d0ff272911ced339",
+        "sha3_256_hash_of_secret_key": "21dc6c39559081b2ca594cee9e9825ff973158cce0d11b38a51b503952daa372",
         "encapsulation_seed": "4725dd8fb314bfd8ee23731c2341dbe114606d9abe6434c471b5573e7df193bb",
-        "sha3_256_hash_of_ciphertext": "b5b2de55cfaea8fe543f67c4f45a69780c3e2d932e56e0b574d9b40b56ddc1f1",
-        "shared_secret": "85690ee044e4d8e0540ff984775b59bb5134383c4e229e79e37d7d77632fadaa"
+        "sha3_256_hash_of_ciphertext": "525a66ef29f0c8a0f989dae8592e9e00cb7f347915217d53f08a7699c2b912ed",
+        "shared_secret": "77ef6dc5a6c8ff657070e418fdb3eb272c8784a9c38bbef950c8ac1de5ec5578"
     },
     {
         "key_generation_seed": "6500f32c93415cfdbc0bd31d78d5be95cb9060c8cfa2013955b56f8b6868b322393308641a9a4647f230201e1389624a296b55192a9819fcb19ab77c25f95445",
-        "sha3_256_hash_of_public_key": "d4bf608793939ecba27dff5889d4d921c583999a57e20a48085ac549573e6abf",
-        "sha3_256_hash_of_secret_key": "5f9a14a9c41fc228306d79417015408f31bc9c3d97579616bd68a3d3444f9bd2",
+        "sha3_256_hash_of_public_key": "806aea6700e293f433a97e4b2c8485e6b4ac19ad493c4c16a10a2a884d58f5ee",
+        "sha3_256_hash_of_secret_key": "f446ecefbf4c63e8897a89123ff38bee2aece076fc7b268b6379c996999085ac",
         "encapsulation_seed": "818d3bb8ebfb32bf464775f7139bac0a5bddce80ec5798595992f9403002cd5d",
-        "sha3_256_hash_of_ciphertext": "99fb7b7767fa94e74936a6678acfd5a2306b156f90f4608d507768a25403a16f",
-        "shared_secret": "d179d901a0570bd23aa52570c5c233a2240d4724e81d98c9ceedb74187eb75a6"
+        "sha3_256_hash_of_ciphertext": "c7c82e2b3d0d3bcb73c5d9203ca3acc94ae8818794afc7610cf48a21e830c450",
+        "shared_secret": "b0978add3085e1c972bfaf86655a287946f3853cfb372f6fa5813a11b6c4e103"
     },
     {
         "key_generation_seed": "7643cef2d62cc5aaeecf754653ea62294cd2208e5bf3ddeea209e3dc45373d49eac9d531a532770837a854b4f5531f6e0c8d6c10183b30d3435498c2dd142951",
-        "sha3_256_hash_of_public_key": "65f03add3941d22c80d50659f501f8cca1b448d84462ccb93d5f065889484bc0",
-        "sha3_256_hash_of_secret_key": "e4513cfd1dd2153d30d15b023421cb8e8456e6a40e612847e1713e915a29a87c",
+        "sha3_256_hash_of_public_key": "33df23b37987c6b557e4c0f8fa9e466312f19e7e90cd0a67abe6a145cbca9d44",
+        "sha3_256_hash_of_secret_key": "039031ac6171ad5fa8734fa3d60cc5b6590574c09ae0c02564c1907ebc772d3c",
         "encapsulation_seed": "c92aa5fb91c980d9cade9ce99d4c75b2ffa7d6a6ff9bd59def1aa701f2a0992b",
-        "sha3_256_hash_of_ciphertext": "4cd7f0af86623b34c0b137a0516b876daa73ffd65d75871ddc828f86a7e9b224",
-        "shared_secret": "6d574af7fcb241fed8763b2d0a352870baf85ef686e90eea31f8500c35945ef7"
+        "sha3_256_hash_of_ciphertext": "6fc3012eab242c5a3dcf99b82c5e5230fb8a4d45902afc7bb82648298d8a00b3",
+        "shared_secret": "b888ef3a969e162edab17c3d3de9ca682de60a0fd6ac97e1b5a54171dba12a3f"
     },
     {
         "key_generation_seed": "f8ee95521060c03bb8dacc79f7eb7db640f545f315613a35d447a09e504cb4e13fc3d8392cb53f36ed647364a04e37278a0e0a45b720f4a75c580c9920eba98d",
-        "sha3_256_hash_of_public_key": "b8a3b8cf4709204a2fdb19889b0022ea655dfd58ff27e17d530510e1eef45793",
-        "sha3_256_hash_of_secret_key": "1f7cdadf3d4707efe1b7a6173d8f7b8a9f864ab388c3271d79ec424d9da3e896",
+        "sha3_256_hash_of_public_key": "30a5771b76066feb7f606a82cce122964da1be0b6872ee319832214ec677738c",
+        "sha3_256_hash_of_secret_key": "644983542c87680786b41fb07f959451f1507165353080a3789810fdf557f961",
         "encapsulation_seed": "7e8086a01dc5b3bb9eda25bcc45d27f99874841b97237968495800e007696ac5",
-        "sha3_256_hash_of_ciphertext": "1ca889a71a087ccee4ee1a178c3c55ce3649583f3db924e5c1003ccabc44091d",
-        "shared_secret": "b1090cf26276a81c22ef0e4479a4c705fe294d3b892051ddce7eab16495e0783"
+        "sha3_256_hash_of_ciphertext": "6d468584c0336dad723a1c3ea970d53837373372287371eeed8e08ca06e010cc",
+        "shared_secret": "2fc09a1852f458bc7afb58baea4d6e318bf6801e7804b98cfc250b0a1470c598"
     },
     {
         "key_generation_seed": "b8bd0493a882e3a49b4e0f6256fb1fea0912562fd9ba26ec3d6c9cc12c8973abd7e4b5d8021c486b9c3114d7cbbeb7cd49eba8a61bc2bcae1f1bef30a1daf76d",
-        "sha3_256_hash_of_public_key": "46fe6c37136273736ccb11df5b6d55debbc087de802404b72a003c5e8c809719",
-        "sha3_256_hash_of_secret_key": "3177ed170e84ff15fa1e744adc9ce806e431a68f15a7a026c6092bf593dec6a1",
+        "sha3_256_hash_of_public_key": "31fcd120f19fe976236711e58b4ad172d25ce01eb88bc9d6d051c56564a0db11",
+        "sha3_256_hash_of_secret_key": "1502619da09b1bb5e418004fb0263c8f067cb9317053ed502c501c5b5ba4d331",
         "encapsulation_seed": "bb321ef14d44d8698df879fd52450567657f52a2df8d111185dcd7d4f30a72d4",
-        "sha3_256_hash_of_ciphertext": "aa9a0ea1823a84bc84649d26e249899437844827fe7c63d4828a5144929fa00a",
-        "shared_secret": "2fda9fa72321be3a0946d6d914c7ae714b9cc175619ab8abfd1f1fd499e0dc27"
+        "sha3_256_hash_of_ciphertext": "369203e0da6ebef7ae651a3111e67303f89f568b9897ae4c24497b3180e0bcf2",
+        "shared_secret": "930131d3145d5485f06c16a9420a612330843e6524dd74654a85c383e28f2cc1"
     },
     {
         "key_generation_seed": "c0407e41ddf48d333978b89bcf2db01e4613425b456249e76a6f25b8a2827bf5b2dca81e3f5f748d23c9d356a2209f6b2d60247b2e45c9808de497f64f124643",
-        "sha3_256_hash_of_public_key": "a074ed1f76e97d68434ba4af2af0e549204222679e9e643580c35af3cdd247ce",
-        "sha3_256_hash_of_secret_key": "8f9b3f631d0fb04477846ae09aea725f1cc65b2cdefe2108cdb399c36db9b487",
+        "sha3_256_hash_of_public_key": "42f75d6e3755c28f3081ecc9db44f6cc7cec9891756d74093716697781fc8cb5",
+        "sha3_256_hash_of_secret_key": "21b9bc0035097cb2b892a3f4ad5660b160b18973b735181beec815eaf5ba5286",
         "encapsulation_seed": "210a423dadd899b810f011794b79aa7f860823ac1962370e791287d3a1afa384",
-        "sha3_256_hash_of_ciphertext": "a4fb01f55eb2986c1f90cece43330bee1b16d7bda48d617fc94aa14fc540ec4e",
-        "shared_secret": "23798e8b9eaa0b369842cad83a2bc32206f791229c830d7593b9150161168011"
+        "sha3_256_hash_of_ciphertext": "c6d1d905150eb6586eea72b13f7210d9830e8e689f9da7d9c04fa7705f21cf01",
+        "shared_secret": "b276a4fb4cf77eab502dfdf56eae9f8a8ff5e7f5df3f6cfc80614b193c87f08d"
     },
     {
         "key_generation_seed": "334382d39164d1989696a2ff77b25a28af8bead9883b5365eb6fcca7c1781cc9aba5068af837be962f439f233593d193ce5e08f7d66efb3389885927b89d2523",
-        "sha3_256_hash_of_public_key": "26659f74fc9ec372fe18be4ed6aa28b7cd84ad1c0f0115dad011a11d20fda9ed",
-        "sha3_256_hash_of_secret_key": "5e3f83cb08ff80183879af9ade3631bed2a468e429ad027a5afeafd9a6f66362",
+        "sha3_256_hash_of_public_key": "43d6c8562cdec0e87d00c8ca8060da3f031ab663ddb43148eebd67969b7fd490",
+        "sha3_256_hash_of_secret_key": "d3c172cde1f249c0a7fdb003ecc0a189776b616378b188744e407ccc601fea7f",
         "encapsulation_seed": "bc856afe24213e3d14c3d6f9b89223bbcfb2c890722d770fa3492c1e46d1c302",
-        "sha3_256_hash_of_ciphertext": "6a4204db4803d26d7b8a769033e047f3b4cb616bf5451b88a1fb3ff219bba9cd",
-        "shared_secret": "d5c63d2bd297e2d8beb6755d6aefe7234dea8ecfba9acda48e643d89a4b95869"
+        "sha3_256_hash_of_ciphertext": "353cdb064a37df87524874d3f60afdf4077be0ad96e1ab61a9ff1745d1e6e5a3",
+        "shared_secret": "f4924920e64013fae72cfdd1e94b217eebd55a011f6b7542958abb297e4fd180"
     },
     {
         "key_generation_seed": "6995143e8eb8a6e93840f76eec844f67d2b5f75b1839a5040337e61f9806764a0f4dff8e56f68440836a072412a30d851ace2c7c6f02d60e7a8420001a63e6c6",
-        "sha3_256_hash_of_public_key": "2ca3d8ad2dab1dd8a2f4320658fe6eacabf70d907920593919119cf374516336",
-        "sha3_256_hash_of_secret_key": "2798448395f6ae3223550e7d5255e6a605b430229f5809b6efd0683a6b9ca402",
+        "sha3_256_hash_of_public_key": "3cabf1c47e7aaada59ded4fa8ce378ce1d9eba621ebfe8cc96a111aaedc4b6cf",
+        "sha3_256_hash_of_secret_key": "225563503590841152fcf47d4665b7cfc76e2b9de23c0e24b527395549f9f7ff",
         "encapsulation_seed": "5fc00f89563e44b24cd67d0ce684effe5731619fd08e7d72e2406eb016afb66b",
-        "sha3_256_hash_of_ciphertext": "dbd5fc0e1df33ff8af9efd5e281a2b98160f98653803cbd54e3a07292b37fcc7",
-        "shared_secret": "29d6a229adf49a1139794209307b0ca24be5825b2771809232fb718660162475"
+        "sha3_256_hash_of_ciphertext": "f11aa37ffca654d11cb5f9aa294ab734302851b434b57e0f5bb811bb5bafc177",
+        "shared_secret": "412bafc716efe4ff928d9a86ea4665dd841e2f102a8363b994a0faad63251eda"
     },
     {
         "key_generation_seed": "995eff7e0d195c6d0533f3dc194d47e60f9ad14696144cde694d60a95f3e96b4b28f7e7a15a005f92400ce33db073d49b53871594a88fc45e0f94207b5f0f2dc",
-        "sha3_256_hash_of_public_key": "de62eff56f6b49a156d065d85eaf0aa21ca229a20fa4e1372a410ab1c4ab6e7e",
-        "sha3_256_hash_of_secret_key": "6766cef3fe644a233caddf208074b58e6e83f8a78aecd00911c29a08f6f0b0f3",
+        "sha3_256_hash_of_public_key": "2853cbbda86e7039b635d4cc850f494d42b240acb54ab2316791e9ef5b45f1d2",
+        "sha3_256_hash_of_secret_key": "87ffcfe7a504e0dca284d8cf509a92a24f82ed7c46a8c1604d9a2d6d14b1cd11",
         "encapsulation_seed": "ea22a76065db4b565ee1807fbd813b43bde72b0e08407fb867c6a18995025e50",
-        "sha3_256_hash_of_ciphertext": "4c669e33b0227c9c2040cdacdbcb7d22b9984372587985ed8f860ffc8d037e79",
-        "shared_secret": "2a56a7a6d5b4c0500ec00a92e322e69be9e93006240889552072482966c54f56"
+        "sha3_256_hash_of_ciphertext": "ae8fb4bcfc08f8daa486b185540b501680e511f46fe8a628b8fe449d5a51590a",
+        "shared_secret": "c514d4086428200e118c1c297ce5ed865d7452cd7770363961bbb834f56c564a"
     },
     {
         "key_generation_seed": "3e809ec8dd0fec0d911a4e3fac20f70fbb128c5de94dc7184ca7310ae9157a98d8128601c28b1def8d393a0db283229f7c7383152a814e7cefe8ef9d9768c473",
-        "sha3_256_hash_of_public_key": "66f161d27dc34e1a2f4b98b14a2b221d7eae26a593bfe432487d9994cb480656",
-        "sha3_256_hash_of_secret_key": "2237f6cbb452d375878b82c474a7c948ff587a5f3ed02bbba1459fa7ff8ef802",
+        "sha3_256_hash_of_public_key": "2d5680b483287bbd3e61a91839cca9e761429186176b7bc64034ad43f16f65e9",
+        "sha3_256_hash_of_secret_key": "bed74aff196e7ec7bbb4dcaac39ee1a79cfb35140cf4c400b6ef2fdfc53afc6f",
         "encapsulation_seed": "e9602b34fe73ad57f4bf6ead99743d645641553a5b9b9bf2e7016629e3e9bd76",
-        "sha3_256_hash_of_ciphertext": "8a2453a21a031cb8966924607a28882426fab2018826192e9bf833bdd38e0631",
-        "shared_secret": "ecb62b03f640ae4a9d89685fa0070efa93c24dfcff0d555142f9de25b62f861c"
+        "sha3_256_hash_of_ciphertext": "d46f403ce5a0dd92937acc508501305da6bcd32b56ff5d986fd6a07e713ab92c",
+        "shared_secret": "a175feba4c1bab576085bb12683d2bc44e98c75f543cee714c75391c559450ce"
     },
     {
         "key_generation_seed": "dbf1c465fff3d9f783bd9ee61a573715e45691147b8904439b5ffaa64f94ff7bb6d75eac6c76ced1b0a025b40a55440712ad8424672e761e9bc400d63812006f",
-        "sha3_256_hash_of_public_key": "7537e68ccf14e8b7e57090d8f648529dc461ca3950288879e88116acaf57b4a2",
-        "sha3_256_hash_of_secret_key": "bd8e44337eef01251217c4702c99232c001b33870953473d83a7486fd25484cf",
+        "sha3_256_hash_of_public_key": "38635cec71b814aaac223f748d13158dbe8eb902d9125fdc22202c4d59251cbc",
+        "sha3_256_hash_of_secret_key": "f3b87926951408dbb27fc2a4a6c14c40fedc8a1cf5c34ab398d91d554eae344f",
         "encapsulation_seed": "f72b9080a6c051bbdb9b0abc1949034be0f89a9f73fe277ec4d4740c78d04a83",
-        "sha3_256_hash_of_ciphertext": "6077c60641c03aa8b36213dddf938311ce6b7b8801f967d42713e73249fe7c55",
-        "shared_secret": "6cc30699701927e07b559d708f93126ed70af254cf37e9056ec9a8d72bfbfc79"
+        "sha3_256_hash_of_ciphertext": "50350977c400c1318bac5e32925d0f575dd3559587f42d025f4e71648e697218",
+        "shared_secret": "9781578191ebf49b162aa768d093a332b9c849c11e240187cec2ee969d4b3860"
     },
     {
         "key_generation_seed": "1f7cfd2b70863154e8a69d1758532e86c20cfc763d67c758bd10a13b24e759b5273b38bddc18488024ec90e62a4110129a42a16d2a93c45439888e76008604c6",
-        "sha3_256_hash_of_public_key": "82f68b15681cca5c2852c18d6e88bcb102a059c1d21936582adb71790cc0a335",
-        "sha3_256_hash_of_secret_key": "fd483ddc211c5c27f453bca56158e1f8084f075a7b06f5098cc3204427bf8197",
+        "sha3_256_hash_of_public_key": "af97825a77f2f4b6a45ec1a579f9f83e89c025d8d6876db26874f38348604293",
+        "sha3_256_hash_of_secret_key": "b2f08250a2681bbbd3c355e2dc61bda33cfe39f3dbbd2a3f3c41ee2266084cc8",
         "encapsulation_seed": "f1e5542190db8ecf4b8d617a04fd3783ad0df78bf8dab749afb57db8321d151b",
-        "sha3_256_hash_of_ciphertext": "5c6cfa16f63b1aa93a2b5edc2f4b14c9782f286f53deedf3153f329a2ae2d57a",
-        "shared_secret": "250e7f67bb34dd5477471e3a701fb71a8138a1920eb807824380f88a944a6fa3"
+        "sha3_256_hash_of_ciphertext": "33acafd1de1d8d8c7a9ff9a6cd69fd013b46b79e74a9180e99d5fa87805dc0de",
+        "shared_secret": "515dc87c21e6b134a577e4eeccf43a982ba7eac1224d701cf099ad07fee77cb7"
     },
     {
         "key_generation_seed": "3a19577908efd37697b8edc7fdaf47d1bd3ad01a1b77faf794bee5b9c3192a6fa3729672816f3eba84c9638a79676eeac0f22c8a48e0c5d50a26ff0844c66b99",
-        "sha3_256_hash_of_public_key": "104fbf09445794c0ea0654f5caf70ee09d51c8386d4e1f467b10633c710ac2a4",
-        "sha3_256_hash_of_secret_key": "73fb93953ae666a9df1bf933ba56b8655ea9e319c0110c78d49f8480ae1aa3fd",
+        "sha3_256_hash_of_public_key": "8517ab7585926764ec7acff3c747479e837831429b97b7cf49ac3763bd9ebbe0",
+        "sha3_256_hash_of_secret_key": "7e5684a04d59f9166f6b408dbc8ae5daf3ec6678cf5eec1e5a9016392cd6c8db",
         "encapsulation_seed": "74efa414ae171bf60b6f884cb7e5ce12028f49365daccfa23e845d551711660b",
-        "sha3_256_hash_of_ciphertext": "e51772e769f778067916e81a561ba6f64fae6096a2b4d4b945d9117e7c36e2b1",
-        "shared_secret": "0210935a18f1add5ebc2e1107bf40a628ef9cf8f6e7cdac81dc0291bb50a5a3f"
+        "sha3_256_hash_of_ciphertext": "0515c19fb395ed94194a60a6f7883d6351fa61ff18060be4cfe2eb9f81ec0024",
+        "shared_secret": "edc2c0314c7c5b2b071b85e373c06b31fa54dc499168d4b43b15f1d05b8b7ea9"
     },
     {
         "key_generation_seed": "ae0f65e29f38804a6759f70f4d01e2aaff7fe1c91ebc4f892dd0de3ab2e68ea5e03ff73e02a217659f53d8c47556bf3d8c94040f630d63605e2d0f923579370c",
-        "sha3_256_hash_of_public_key": "0f353d6a29813d354471eb8b4c38df93939eb3b1db80ddd1cdd6558a9f2687a3",
-        "sha3_256_hash_of_secret_key": "8a9edd6278707108652f3a5bc244592cb7a82c24634583ed2d3eb6a176b216b8",
+        "sha3_256_hash_of_public_key": "1bb014bb0d6489c14f5411051f9667aabce54da7a8deb73b627e3873d9390a35",
+        "sha3_256_hash_of_secret_key": "b890e330079934f2aac63e5f8d236054fabc8d6a6e057672a7a20150ae08a9a0",
         "encapsulation_seed": "0b4c3cffb2ba4380ead13dc0d8acad2356b448a810da1df29f264c44aab6d24f",
-        "sha3_256_hash_of_ciphertext": "a00c37bd326205575fcbbc100ed54630aa0f2d6dd9e69807d49151ac9a81c429",
-        "shared_secret": "34169fc520e944f94ff1fa3799db802a4c1b26cb2971bf196259a937ab8362ca"
+        "sha3_256_hash_of_ciphertext": "79018c9e998deaec058d73d702b669e10c89dd8285f431aa6e422a948a39cce2",
+        "shared_secret": "b3363e6e6dba3e41ac2c63895c461765bc8a0250880d3dd6e8a4479a7fd3921c"
     },
     {
         "key_generation_seed": "6084a235f79dd093ef6d185b54e69df33dacee73a9bf2f379004421a10e3a79d9f684fb055ece19459eb464e91e126a7a6e3ed11ccee0046da234d964c985110",
-        "sha3_256_hash_of_public_key": "12e89c47142418c26396ef0174c02f69dc00022d56494d31af935490edee6385",
-        "sha3_256_hash_of_secret_key": "bc13b19f01d4cab36dac2154e0fd8fb7d2fa012596363942847f1b0bb3715f90",
+        "sha3_256_hash_of_public_key": "c9a546b5c0a567855039f6c1bca60414684e7bd1f8eeb7913f3a1795ba4bad4c",
+        "sha3_256_hash_of_secret_key": "be5fc57b3efd80d7e82b23f62123814ce04e83ce5c998ba42e7bb978dc70469a",
         "encapsulation_seed": "1c82471dcdfca3a6942061ab4f3d5bf0d197321437c706d9cccccce449447002",
-        "sha3_256_hash_of_ciphertext": "aed1a4ee810b81cb8ee49ee00e94ff4553f0ad2176fe4d27a09f4e68157fcc3b",
-        "shared_secret": "b5901e97eb656a09d2dd132528148ad07a0a89f638717eb53516a9ad19aa36bf"
+        "sha3_256_hash_of_ciphertext": "6c1b69d56c493f6f313d3c996336b8f84b76fac2d5ab5a3d795613b27eb10912",
+        "shared_secret": "8e648593c8f6f6f7a97ce7a2d151ada30fbbc7f3c4fc517d8cbadd71e6a17476"
     },
     {
         "key_generation_seed": "acd1c0217fad5caa4235544dd9de153ab1880ccf4c76f16f236fae4e4bfda04cf03a8abb0a5010f400ae5722a75bdf5a2f6d5b546b34d73857cb1bfc7e587aa7",
-        "sha3_256_hash_of_public_key": "2fac52ca60594e514333ead02cb1bfa5cd1d9ecda4a0b25ccdfc47ad3f632a85",
-        "sha3_256_hash_of_secret_key": "2743b7a9dd83a6b9bb5c2685f28b5629b2e31132ac64788a0929557d3449dfc0",
+        "sha3_256_hash_of_public_key": "8f7bfdde2a7116ff4010cf829cbb18512f7cf44237c02241a1f75fe3ba8d22bf",
+        "sha3_256_hash_of_secret_key": "3f53a0acb384db89ca83d031bf210b072860adcaceecd79c36b4669407c1c227",
         "encapsulation_seed": "46fe60a18124125ab93e0c578f1c02f1bd1301595013001c7f3c2fa56cde294e",
-        "sha3_256_hash_of_ciphertext": "7a039d19c45cc557036189cbbc63445b3504a689db56845ece99d593f165c6af",
-        "shared_secret": "df5117706beedfb521f0f021069fe9650d0844194339033de6997dced05268c8"
+        "sha3_256_hash_of_ciphertext": "cc25f35631396f01cc366e019a7f15034cb2341d6c00924b538d25a227ed181b",
+        "shared_secret": "bcdd6f0d744d2a35147323a4a0451fbfb7d60d73c161c1f8c6a2b5e9f4239c65"
     },
     {
         "key_generation_seed": "241191401a63afa750f05662e354dddbc683c776ce3222beb83e3cf913d7ed7ca59b3bd23b49a95bc1fad20070fec930b6060bd827d742b077092e422268e15d",
-        "sha3_256_hash_of_public_key": "3eb856043b822df9d60b55fccb537afa3cacca9ef50433bde1dd9831e534d192",
-        "sha3_256_hash_of_secret_key": "398ae3423ba5c6bb05920e83e8939a104c3e4ad91647edc7db1667efe438cbfa",
+        "sha3_256_hash_of_public_key": "27b1b921723cedf55fe756ff5fb67d555296c6185d171ed8ba01393d1a735018",
+        "sha3_256_hash_of_secret_key": "40db89fcd941566546d554db0342237611e5ef6fdf8c790f03357091af0648ee",
         "encapsulation_seed": "52fb7cb6a633fd2e83f2892bd9441b48fe59ecee6d026f5246fa7f2a5e55ee3b",
-        "sha3_256_hash_of_ciphertext": "05c9617befed785811fcc44d0fce5ae3a1ec66c4d1217ab42e4b754d0ef6207e",
-        "shared_secret": "eed6ecb831c881508f99ea115745448a7b312a4fa97f65044ebcede172dee2fa"
+        "sha3_256_hash_of_ciphertext": "c5b4844dd10ecf508ea6ed2d96d2328d3f14df6a2a16093bf88ca1283e30f41f",
+        "shared_secret": "072551e254959ce9f2c67657b41122d8a98cde044bb2f60955bdc6e5dbe55277"
     },
     {
         "key_generation_seed": "b9a6b0c05677e957d41a34ba03bd06f2a9092e31f63389397d7e70fde6409d18e99c0e7b82be89bc3c1eaee6680aa4efd394e40c2b3f30523c8117f7c26a8969",
-        "sha3_256_hash_of_public_key": "306aed2a804a1c9bad4ab9e59f6126ad7c8633cdd0c2dd9d4c6f639d312ed47b",
-        "sha3_256_hash_of_secret_key": "88b28cf6fe19424ff82fc2bb096423b71f0cb8cf985af31bc15ceb4ed18a5e62",
+        "sha3_256_hash_of_public_key": "32a2a1197d78798bbeb13ce2e92cd7ed94b410adc37b1b31dc060af11fec8a8b",
+        "sha3_256_hash_of_secret_key": "602bedde695713681a96c94a9a6d35308102ae18d3f3beb92a981e4a3b7704f3",
         "encapsulation_seed": "0f81a5f97082121244403da3feeb734f6084b314b8d94beb11627aa6ad1914e9",
-        "sha3_256_hash_of_ciphertext": "315ef84926802ecbbb437f8f50927d3a391b55ee6e47dbd19aa9adeebb808008",
-        "shared_secret": "d6cb77dc96f9ae4bf8b2fc0e277935b3b7b7a59f749ff2c08ad42659dbce386b"
+        "sha3_256_hash_of_ciphertext": "e4631748f7cba566889ca2c5d90c47bba17000a0d934c4242a9a3d6dfac039e8",
+        "shared_secret": "88c0c1e22b68cd65e1eedd6d6208c36492fb674e26ba4e0d4e55f831a1affc96"
     },
     {
         "key_generation_seed": "28a96c71577ba00c94f99fe965bc595a26db2b3ca6ab5cf8e443cdd8462b17929c35d165453e5fcdc6f9df64526d9de698f2bd3e6bac6c7fdd86601b9ba5f4a5",
-        "sha3_256_hash_of_public_key": "9bb3963cc1c5cf2b2d1c6ca76226328ab765a79999ccc71fe98d5bf3b34f51b1",
-        "sha3_256_hash_of_secret_key": "d8c2492023fb1175a84c19b3ce20f03dd12b1c26b65176d5582c319124bc0e24",
+        "sha3_256_hash_of_public_key": "7cc3f47f319f88da508f841e536a056625f206fe499387d27307257682237f96",
+        "sha3_256_hash_of_secret_key": "064bf50ddc823a97adfc93d52ecbff03a0fd5d94ab38874a5abaedbdaba67309",
         "encapsulation_seed": "31af9345365549ea0360169ed57daf98cc5444799d4c75d9f1f5d615e9df8a91",
-        "sha3_256_hash_of_ciphertext": "ae36e333ece7ca60c9bc2c4ddd01ca88443fd73bab08502656873b703af8925d",
-        "shared_secret": "1592f1413331f1871b41ff298bfa669bca667241790370d81163c9050b8ac365"
+        "sha3_256_hash_of_ciphertext": "b34a0a91afbc9599ae00e67ba4ebf0d8308b3e06efcfa148aed519b0f073ddc8",
+        "shared_secret": "56f717e4baddc2250873d667f73a442b05ca2f8714d4dc4d295f899217c92c9e"
     },
     {
         "key_generation_seed": "c08ba2ef8c3a0a043afad931652d7a19e6e8cb670f840de5f1fa03309b2ca9ec5fe6141a25f7ab9f875f79e0a82d6ea5cde5a017ab637d5fdb7c42646a1d71df",
-        "sha3_256_hash_of_public_key": "6d029bb2121c788b5b6ead7226df664490dae362c4befb615717d81c656b3273",
-        "sha3_256_hash_of_secret_key": "0f2c7bd16d9289c3c27136df0cb6ebc624e80144cb92e6f0c897f58a53617ac3",
+        "sha3_256_hash_of_public_key": "beaeb6ff178f3228defdd117e6ba75a34abb70e86f31fdb16d74d91e6c1b47a7",
+        "sha3_256_hash_of_secret_key": "9cf056be85f240e1ae5b73656c07bfe83ba8ec7212973bac19cffbb80dae7249",
         "encapsulation_seed": "774ae54093d694ef40b63b62c73e6c98295f606feb8699807eda1d030ffb996d",
-        "sha3_256_hash_of_ciphertext": "f8a85f106c6144edf1c7906ec26e292f0390aa9d45a22e67ba2ea018ff565c4d",
-        "shared_secret": "966f35c6bc47b4525d9af1ba350e8f44ea448cd1d90cf4e9c55ae5878920b7cd"
+        "sha3_256_hash_of_ciphertext": "89243e04aa17615c309cae73fbfe985e0716c7fe3b8283b5e84c3caa67b5ad3f",
+        "shared_secret": "35f5517999e15ed842904d53d5b4747639d1165014ab77474c0dbc310e586186"
     },
     {
         "key_generation_seed": "0e3b30e102d707538c2671060f603bb0b8a014103f132d63b09ece07e4a4c75b11eafeca9e810796c34e8cfce9d59342884456007b01ddd12edce6d10ed87e4c",
-        "sha3_256_hash_of_public_key": "64c819d9bf66855f6ae70627f04da8378547e5867e2eb9759fe0971efd601c4a",
-        "sha3_256_hash_of_secret_key": "e85b62236d5c6c691a9076dc58bd5da80999eccc8df973c7d0e7e65d8465ea7d",
+        "sha3_256_hash_of_public_key": "b2b71b8aaccf14842a6d4ecb713612f801a5044147fb9e6987ad3863759de31e",
+        "sha3_256_hash_of_secret_key": "01158ea58361ef89d935c9f845711c7f581322afddaf14e255f71c1dcc9c0024",
         "encapsulation_seed": "9f27a47604ab5146caaf0aafe6d149424f8d66e39ba3baf5e6c73b19221b7e21",
-        "sha3_256_hash_of_ciphertext": "e9149359cc37143b0b565bd413a04f41a7833c5b76012a9263a086ac34071684",
-        "shared_secret": "aa333af0226492126c6985130ac7df2226a64d6d5c5314ce3f7a99add6696d49"
+        "sha3_256_hash_of_ciphertext": "ddf853fbd339780b3f571de2aefb30f760454f2cc1f0fca009bc829afb1f3f7d",
+        "shared_secret": "a7159981a68244549b96b27991e1323013c353bdd9c8d6f583897c35923e87a8"
     },
     {
         "key_generation_seed": "2478f7d3de6041e7e5cd11c5e2ef483d1aa6218eb126444091535f6ae532fa7311136e2681df2ef881b51a092a9badbe72c9772c169808521c47149578621e28",
-        "sha3_256_hash_of_public_key": "db315cafbaec2f8a0142f45affff65289e826c9244ab1cb03f9f65df3e3cbcf7",
-        "sha3_256_hash_of_secret_key": "be98d62e4724c0d960ad4839298d4571f9871033b63bdf10d3b0e589db376ffa",
+        "sha3_256_hash_of_public_key": "a13cb3f23ccbd9ca6a75823d1ba14ef03664560f397133935103ded2d7480b99",
+        "sha3_256_hash_of_secret_key": "710b3a8c8d49ee38390cd2776c42ad74a520c8d6ebd39b514f6fbf28c6c74b45",
         "encapsulation_seed": "90044031b7597b5e60a4f946b713e8996d0426d2cb013243d9b7d8f8ef159a0f",
-        "sha3_256_hash_of_ciphertext": "9f9368ba712cfee95f28a808cb2c23116a0c8da3910c0def2ef4e55947d7101b",
-        "shared_secret": "9535303e6035e30c6605c9e0f10c553dcd73828d8525cb190fea79937e093331"
+        "sha3_256_hash_of_ciphertext": "f5c4738d0ac3b25048186a2049668247c04033cb363e9d23b5d1518f8fa7e70f",
+        "shared_secret": "c4041a29c5b744e9039bf5155cb3ac0b799356829557a7aa3feb4b3585e6cf62"
     },
     {
         "key_generation_seed": "9d405d3ebdaf35fa8722de431b669722acaaea2fd10b814310b17f78b66147d16ceb14f7662be0c42779459f69a145c0e2ce9f0bd9a0cd1bf32ed5694cc9ae32",
-        "sha3_256_hash_of_public_key": "c8d853e65b5b118e28b7cb6f0d5d6f282e0ea20fd72f3690a6b232b20a8a55ec",
-        "sha3_256_hash_of_secret_key": "7a5e854bad628be7b99f524f52a97b0959c0ee67a7a10ad24b970e6e3aeeeb80",
+        "sha3_256_hash_of_public_key": "68302cc5af214ceda67ff8161b29bc300c4be8e1a4139437aead8a9ede3cd4ca",
+        "sha3_256_hash_of_secret_key": "5d6904a6478f0632ec56477321a6d6ec5ccdf299bed0b6ee9f4b32c6b5effec3",
         "encapsulation_seed": "a7a31e140891ea37d2b6424b59b1f84f89220f32dcb73e037eb912b389d34a48",
-        "sha3_256_hash_of_ciphertext": "31b04a4127558df57844413928b29b11547de5afc088d568a962fe080c97f190",
-        "shared_secret": "0caa79e0054182c15e54159fbe36d9fb09481331a560ccd9714fff81db5615c4"
+        "sha3_256_hash_of_ciphertext": "b4ddaeac7b4080e5e9bccdd2cbec4395a1393e61e038bedae9542db78769b923",
+        "shared_secret": "b8441852349193321f466ccbd3afa48bafe903288108312de26e9bf0de9f680c"
     },
     {
         "key_generation_seed": "9a86490f0615f3edf789cb0654066e9ee339cc59f968281f3b89213f83c692edfaeb2ef44d2f608621e831187ce79b2d2f4a20f1568bbe76b0d3d5af36111714",
-        "sha3_256_hash_of_public_key": "f69bd52cb1d071f1cc7720f949d44f66f40c917eb30f3a4b0eb519ecad2d03dc",
-        "sha3_256_hash_of_secret_key": "b6ef04e6acbcd1bb072d1cd28412cdb00ee40d04ce5b39442a2efd6756292167",
+        "sha3_256_hash_of_public_key": "149ca4d94813f81c792060502e09a88ea694c5de863ce6a50516cacb1c3f44bc",
+        "sha3_256_hash_of_secret_key": "8e69c68f8a7a0ad82b033a0bdc94d253d3e7e8516d67e86bb95d219a1090529c",
         "encapsulation_seed": "70eb3f791faa91f1f982fa477dbcddeb2c55691c07f93b04cd31b37544c94b42",
-        "sha3_256_hash_of_ciphertext": "d8fac8ffc3d8dfebe66c219f4189b780d5ba8fe28d5ab79264345639740913b0",
-        "shared_secret": "744ce1aa5a9c515c6571ad6e2f5985df8434e35e9f714cf3659f184b5db4086f"
+        "sha3_256_hash_of_ciphertext": "5fbbb17b2c8ecbb8c74f2cf6259404cb9e0cadd393174e49e88298c6b7a34a22",
+        "shared_secret": "9d0d9ba501da1b46775258f5c0904721906b237c3461da6c31d70da8575fac37"
     },
     {
         "key_generation_seed": "6dfd9b575872560c7bdc2732c4a28dac4db04e535eb8e402c3dffd145c09ce47a2985c1c4d203778597947d710dec806e36b0cd949fe460ef141213bfc525e5b",
-        "sha3_256_hash_of_public_key": "10e01965f9c196d2f5f90ce3ce8f552f8a0d76ba8f5345365392febc50560012",
-        "sha3_256_hash_of_secret_key": "2b5c6d5fe9b09ab5a027522e699401223ae9d304ac912f1b15f0f647dd9a0a7f",
+        "sha3_256_hash_of_public_key": "e5c52e639e5acd0fb97c7eb44df56df5250c6de7d171c467ce6887eaa4ee3d61",
+        "sha3_256_hash_of_secret_key": "6b452ca57379b09ea36746b5b55be3b73df4faf809d7899c5368a51eb4b18cab",
         "encapsulation_seed": "30f4095015ba88b6d969672ca3f438c395dacf7d476ea7a9e805ce932d270a13",
-        "sha3_256_hash_of_ciphertext": "e8b01628c7d63f16c59e67352399a760581f341ed41535013490502e884733be",
-        "shared_secret": "726f7d790df4c860a0b2c40de9d62c85d0ff70c704ce5a1b3f6bf1b3e3f66cd8"
+        "sha3_256_hash_of_ciphertext": "9ec7acd421fd05aeb4440720890cb1ebfba0f0ba3d9b57268b583ea10720a32d",
+        "shared_secret": "188aa07faa2b7a19b6b7bfbd4cbb1ad829a7415d601fdc3b635528db136cac52"
     },
     {
         "key_generation_seed": "6fca9f4e384d8418075cc064c70730801bdb8249899d456a77130d5beeb3662cce7683f8a03d3cf04e46970ff7d6a12494ae12558346dfc8fd9370bf944a0102",
-        "sha3_256_hash_of_public_key": "7c3991fa7983d0dd6e7157cfb152538466e9d5c3998a2b8ed862162b91ca851c",
-        "sha3_256_hash_of_secret_key": "72e786018ae9ab8293fa51cb7ca3ff0435e7cccbd5ae02b4680b92c148590265",
+        "sha3_256_hash_of_public_key": "9a350302631bd506be010a3f42112ae4ea731d515d80c3a21fcce60cc4d945ab",
+        "sha3_256_hash_of_secret_key": "985f528fdd675f3efdbe95a03e071f28e2dd16b425c51651a1e645f6b87eb25e",
         "encapsulation_seed": "cf31220f44de862e1719570e1b26e897790159366a385452334fe24cdcae28ba",
-        "sha3_256_hash_of_ciphertext": "5b2e8a3e38c13b53393c8654e92eeb6251ddbe50de4b3c5203a06977491f2fbc",
-        "shared_secret": "68f3e22d1b2d8c57bff32160e550becfce535fdcb327394aabeb60eede263213"
+        "sha3_256_hash_of_ciphertext": "df8cc2e78b5df8a43e7ae87566452a5df656f13f93a22566116a84c30b786f8c",
+        "shared_secret": "70df7eeecb6ad19b54498071e0840f4957e935a62feba82fe29531f79c2c1651"
     },
     {
         "key_generation_seed": "e58f71bf175c0550a67e00e0f7b3b7fc36bc2707bf0c93044a492626de36301a7f7054814869cf7625e45647bc1547aff288dbb90699b2ad84893f3b755d9722",
-        "sha3_256_hash_of_public_key": "8aacd8940ff6fc27f175342be74d48075f8ae9320cae20a41c879c27c1bf815d",
-        "sha3_256_hash_of_secret_key": "f7399dbf35fcc57a9bff87b0087755faa75267788cd0921b9ebc5cde8b656271",
+        "sha3_256_hash_of_public_key": "866573e536b4017c02e31c8ed7455c841a5ccdb795fc200acaf1da2fb936bb59",
+        "sha3_256_hash_of_secret_key": "e8a4ede82799c3a425b82912df460d5d1e78757b4a917177489839abb92029f2",
         "encapsulation_seed": "bb5e65669a44e5d5c709bafa98c16ccba6ac2c4ae923334f69a11543eda64f5d",
-        "sha3_256_hash_of_ciphertext": "aac868f2299bcd272afacf50f1ab0db3d092d33565cffb5645d8b92271e7e893",
-        "shared_secret": "7f6085840a30c6b1fb9dca782e0c78a2264d54726c04c3127956f131165426c8"
+        "sha3_256_hash_of_ciphertext": "99d967e7c92a7d7e2ed54b1339472d8780e0a7671aa9afb8fa2f19cf96353821",
+        "shared_secret": "8baaf439867c9761e78a64652a383e21682969d18f84dbae0d3a63095948863d"
     },
     {
         "key_generation_seed": "e3fc575ed51513e62aba655d24cd9c8f1c6c848aaffa946c49a53ac3ea59e474d82c2f1bf2e6aebde5660fa73356982e12999d8fdafbb3cb186341d0386dead0",
-        "sha3_256_hash_of_public_key": "149e0b6b49fe8adba1217c2c57c83f2b8c5f1d92f319e502b184a65869214f75",
-        "sha3_256_hash_of_secret_key": "6dfa4d29af6a0e8413d5591339c15d2e2cfac3f502f49acca3efb53b53624666",
+        "sha3_256_hash_of_public_key": "b33387825115cba8b0ae7da0d1aada1ce4ab05bc2479b360b6c56dfa870ca825",
+        "sha3_256_hash_of_secret_key": "7c35640775e31eaba8a119a8e89e1e2180177a55e54391c3fa6675829d721b01",
         "encapsulation_seed": "9ddb3aa9c7905d1a438c93bcf78e3e321813580371ab4e1289e2dbf3701972c2",
-        "sha3_256_hash_of_ciphertext": "ced7a64ce643faebac8ffd39c6a4594732b35f1d6899978ba192b87003d3ad27",
-        "shared_secret": "96e30641ea4280168da37291a3063342ced8e77b33b5415819938c0bd7264ffc"
+        "sha3_256_hash_of_ciphertext": "d42759ad66725175d4d8d3cb6519e9074d6c13d4d183863f1695f0e3b831a10a",
+        "shared_secret": "60b466221ec831f91a91b76ec6bbc29726f65ebcacc96f9e191f57a1399be186"
     },
     {
         "key_generation_seed": "470b4943f0fe7fd0d8ec5185aba0d1db09d112934e4fb4787e2bbc6b88466e7b8b2809fd40008be70a6b184981101724bc3d5ec5e1956b510b82fd5ad0668a5a",
-        "sha3_256_hash_of_public_key": "29b1bff7f12eda28dfedfbf0ac16e27008c9fdc62c35e53b28a312bdc91c40bf",
-        "sha3_256_hash_of_secret_key": "762a61eb847c017ece920f51d5da7a9036ed8b835bfd7793527321ec635e2fd0",
+        "sha3_256_hash_of_public_key": "720fd4f96ab2cac1be382907e8cba0702018ca27b28ea8f93cc19c4809885a3b",
+        "sha3_256_hash_of_secret_key": "c1ec32b739485e2437a6b4dbed289f0cb7dea0ed3b2add99d4c49a3eeda1b0fe",
         "encapsulation_seed": "26d90b190a6c3d0d9a86cf66005154e7086749e966e7187c249ccb9329fd3b8b",
-        "sha3_256_hash_of_ciphertext": "bf49310a35f9ba7994645f12949e658b0dd43d3de76386dc20d08c650522f86c",
-        "shared_secret": "47e54c85cc0e2503629a8bfdcfe038c3cf692d723d462bab733c7c8e0aa37b02"
+        "sha3_256_hash_of_ciphertext": "5fae7a10471d5303e5f6ee5d1e34013528af4945de811ffa1828648986607299",
+        "shared_secret": "6a302778f406082fa285c5ee299d78b048e837c5012f42f9a80e8659b10defda"
     },
     {
         "key_generation_seed": "6df4385db978d27b27d2aa5e452e4152b36f097503d9581ac3390105c5727e7dc95fa08ed106ce84660e8a4c90bd2b22634e40769aa0090a101c5dddad45edc5",
-        "sha3_256_hash_of_public_key": "b990059e901097d00e0ebaf40c5d5dab009c66798489d357e760478ce884cce5",
-        "sha3_256_hash_of_secret_key": "37a044795bd330e4dc60a6d84bc6e99664d1be418b0239661d2ff16d1501573f",
+        "sha3_256_hash_of_public_key": "bfa4b55c7baf2651415d3f28d221b291b175340a07843b299a46e02e22657634",
+        "sha3_256_hash_of_secret_key": "605c4a98f3775c9678804fd5795946c1657311d123b5c7d1544192a205c043d3",
         "encapsulation_seed": "7db6d1a129d6123f1f805b79ad3b413012ea86aed42a05e98e7b1f32f9fbbdec",
-        "sha3_256_hash_of_ciphertext": "329115908d0763110a387c99778e4746861e80367ee90fd821cda9acdb93fd64",
-        "shared_secret": "8569bd042465a2c4af628425cb102b15ed4f5feee16090e2234f3a884a0fa938"
+        "sha3_256_hash_of_ciphertext": "39e07846b4ca91147a0b680f5411c75db937a6855f08939f746ea3d5f9a11d51",
+        "shared_secret": "88a46d35cf07e48c6528b95016aa0c414344e090ee897fd80f26b67bc0451c7f"
     },
     {
         "key_generation_seed": "dbacba825728444921b227cdba54446b3f6881b47be9cd02832f78b023b1bee0e15274a8e2bc08fe818b117ba28c5dfae74d54fcdf6f20052f79be333edc8dde",
-        "sha3_256_hash_of_public_key": "175eb63c3144108548720ce7ee0f43a9ff3f52a9924efe9f2f59318bb93c86b5",
-        "sha3_256_hash_of_secret_key": "1993d7639b79f5e4871a7c58a69fec50f96c1424c2c0ee030ac054ae1b88a56f",
+        "sha3_256_hash_of_public_key": "9675fc6d1e3cc4e0eb62d31b6b4f10022d373d2718f3d20ee1cc00ef6892d9a0",
+        "sha3_256_hash_of_secret_key": "c463b8ab9069814e5308cf9742c6ab6e08c355fa34c0d2e65df1962589eba56e",
         "encapsulation_seed": "1d129b27be7384c359d04311fe5c44917d1fde4bfb57314f483ac617edd5ac49",
-        "sha3_256_hash_of_ciphertext": "8f4225838f2964a986336bacddc40836a98c32cca68c6afcbcf9ef68d9a3760b",
-        "shared_secret": "c184e0b019c2db772e2c1ca6f97f47478d99cf0c4c5ae1406f51d15815022123"
+        "sha3_256_hash_of_ciphertext": "5c7ef87c49f71d3098fe3d33b22bc8191f440bcdf1d04a46f293c5e6b16af12f",
+        "shared_secret": "f3c5586476f4814a2d3728a6f0ceed7d19d076b790d3675e48611c4b8df9702e"
     },
     {
         "key_generation_seed": "690eb71fd7052b906eaec09937a8ed374e0b02afa27c2f14399932be5839fad281c38c2cb5cfafac81b96a810ab749b61806b6d54c9f8cf4bf1be0192423288f",
-        "sha3_256_hash_of_public_key": "9bc32a138a2fb5b6072464172abe0fd97e9eabf357c3fa5391d94a415b53abd3",
-        "sha3_256_hash_of_secret_key": "3db4ab1393cfc8b1c708cf8efdb1c443c975878898b60182c22af66375cba13a",
+        "sha3_256_hash_of_public_key": "9d162fce2f019205a2106acc8e3e3465b6fa3912a06c764e625cbe3b95dea6c8",
+        "sha3_256_hash_of_secret_key": "eeb3bd9d8636b55722f42b3342e415b23df96d1c9b2c5b9c1c2a3e619348ba6f",
         "encapsulation_seed": "bbc773ebd2df42c36ae05952d6a64c63a5dfb82ceb3ef4f8d4df3a30ec8c0467",
-        "sha3_256_hash_of_ciphertext": "f1c85f9530d4471eb1401fcf422a29533738c485a6be25f0b554ebf40b49d49d",
-        "shared_secret": "6d72e23c8a4cc60b2f14adc788a5c480033bbf6eb111070912bc83ad7b89280b"
+        "sha3_256_hash_of_ciphertext": "d482f25e93fd142aa009f2f2569427ebcf04b87aca2bef5e022bcbc1e5972ed1",
+        "shared_secret": "a828fc1446ff04a950e4f551e442aeba279f44de0ec5296fd981bcbe6ee90d8e"
     },
     {
         "key_generation_seed": "32e0ea9089fa928482c0770da545af1bb871a03ce38604138b0d08ea2a10ca2bc06c5bef7b6508409daf847a64c8d30d0974fd3ba7476dc76c46b458a036d884",
-        "sha3_256_hash_of_public_key": "7ef43a72ef04766f1e899d25c9a005009c788b5faf985123cfb3fb97975de26d",
-        "sha3_256_hash_of_secret_key": "77431cb18010a604d56fe5a623bed2ffd028a741f176fa09546e9a45a48caa5e",
+        "sha3_256_hash_of_public_key": "3e834e34f198ab5a3504cfa0c6af6ab78de3a3ef5667e6065e084cf5d2a5bb32",
+        "sha3_256_hash_of_secret_key": "d74767e217cfaaf75adc92927107c76d7267b1d7b3b76f2f8ae5a9044aa290f2",
         "encapsulation_seed": "5b17a6adad541efcbf5ae4b0c0452cd2ce32e4f0f8701801c5b63e197c1fcbf4",
-        "sha3_256_hash_of_ciphertext": "83ddab2e25614544649a1e497b5b21c40a3e154e8a22c270f63cb0c40aa868fd",
-        "shared_secret": "29e6b1edac0a9aa33066c113167e42c64d70215ed04963d8be2d4c2dcd0f6589"
+        "sha3_256_hash_of_ciphertext": "3a41b6054d918e9613e8d4eab83628f7c82b6ef447ecdacd0a74cc21be6b47aa",
+        "shared_secret": "d98b18f7b6717b8f6b3e331d6d8f9d3633eb70f54133a78e2345138420edf89d"
     },
     {
         "key_generation_seed": "6fb2ec719f2a0dea152bf3f64b9d148f8ab8ba88f64e61f5db53e12d59f525574f797c007e4061f95c7d56cfc7ee5c49e849dde3fea8f25e7876df2a18515c34",
-        "sha3_256_hash_of_public_key": "2c0db43f39b672b2cd912f907cf76a0f6fda925eb2d205546431be0b37b20411",
-        "sha3_256_hash_of_secret_key": "09844e203f4d8fa30728ab388b9d654847febbf5c9cd939cdc11c9c9be24ce9c",
+        "sha3_256_hash_of_public_key": "c5e157ff4357d3c26b7c4b45315f0689f135c85d952a64648b0a8cec03741fe0",
+        "sha3_256_hash_of_secret_key": "edc6b8e2036f9ce7ef87dc58d4866ad9f320ffab1aa22371b7b56ec727f77531",
         "encapsulation_seed": "61ab87659525de9656af41246f20e1dbe85c24e335e7ecf9493f46168bc14e94",
-        "sha3_256_hash_of_ciphertext": "a2108ea2c446b566a50c228928893e2e4bde5fafb2184af92eb1314113bde0d6",
-        "shared_secret": "cfd1b82181543656807880f6e2576f0b095bf84629b3367e9bdede24662ee42e"
+        "sha3_256_hash_of_ciphertext": "7324a073d06af373494ecfc7960cfb81484e9ae64bc16e13651b015cdfb73668",
+        "shared_secret": "b7d5919f0bab0e2715a97cab993656831bc8a3dc86c3bd32e64ccb4762f70499"
     },
     {
         "key_generation_seed": "527fb88c8bd9a4d6031dad15e63878abd2b559e7e08d61f69e8e78fca964ee6ae32d432b4f9f751bde0496c580a181ffed762aa35454a02d3f1f47ee0394c89c",
-        "sha3_256_hash_of_public_key": "aae8e61b905723fa092fb95b839f6de3670c39ce0498c27b87d20c24e7f64e22",
-        "sha3_256_hash_of_secret_key": "3880f7ca8fc33575a7a6d8bb46fec86a3f12e0068630507ed245d8bc278fbe5d",
+        "sha3_256_hash_of_public_key": "f5cedd022077b1a6a052f5287219393cd2e0366d0f5531b2f7ea8704d2900ce5",
+        "sha3_256_hash_of_secret_key": "882916ad7b7707feae2885f13bdf19d36931886c4bfd188fd46b6b6adeeb8d78",
         "encapsulation_seed": "eca2adc3da1fb15f34033405ec08ef2f46163df4bfcccf8842c600ce0bc2026c",
-        "sha3_256_hash_of_ciphertext": "ec48b3ec403609a0ce2d1268cadda8184ab9629cc5913135ffdecd420eed1aa9",
-        "shared_secret": "f7331b0a4674969838482b7184fa92e5246f11f5b5e284c3e179effff7eb6329"
+        "sha3_256_hash_of_ciphertext": "84e4fab74ef96f7b3ec50d7afdf69445b4326fe3ad695efcbf56426c0a6df6c8",
+        "shared_secret": "149e4e38a07d18c0b08edf9c47e425b56f7da87b2b9c855bedd29f6f0a8fe5fa"
     },
     {
         "key_generation_seed": "ac6fcfaeeef795b6ef9e062f02bf42975fa01e7d91ba832f74e05269a72684d05aeda108ea4d6c6bc0fb958286850422bc357ca67b83c986048e0d0087fa11ec",
-        "sha3_256_hash_of_public_key": "64e085f67e48f00a7a7f82963e8c67176bff839a54fa1008328c0612f98d83d3",
-        "sha3_256_hash_of_secret_key": "0bfbc25d9df751f4c30907095eb6d9a75ed07fa23218ad0fffc469f0e55553c2",
+        "sha3_256_hash_of_public_key": "a53a20ea03e400a843c8cf4d04bfe0c0a3ce63dde01045e2669f7ae5da790577",
+        "sha3_256_hash_of_secret_key": "9d1e4432908352535074efbfa7cde3e6738e073fd512e04e9601380fb40b7614",
         "encapsulation_seed": "c4f15bec2d7701339d0ade4835193bea3632edcf89e74992620d9eb623a0d0d4",
-        "sha3_256_hash_of_ciphertext": "fb74b727ad120c18915dca475f3082cd34ded7ae20a308106384ffb5caa029d3",
-        "shared_secret": "c89d62938a5caabfd5b30d82ea88aced52ef5f8ec0528e59a654e1f6aff1cc2f"
+        "sha3_256_hash_of_ciphertext": "071204e26ed00e7a1f226d4e971cfb2d9502e17da99f5479235763cb7723ac5d",
+        "shared_secret": "38a1fcaf302905e18940605e49e5f44c747b06e789acc9c395211823598ef516"
     },
     {
         "key_generation_seed": "ba2fb9318d4dbe7488057c33e95e6f054583a2800c41bb83083c330a914a12cfe63f8ffda3565c2424c89b20974b748a65a5aba75133fcb3156dfb6626a83bab",
-        "sha3_256_hash_of_public_key": "8dab879de09b58d0fc7ade140393ffb5343abbddabdc118fad519b14436a964c",
-        "sha3_256_hash_of_secret_key": "7c53072fd98ea7bd8c5e873688b1a5650fe7e11c791407ac8c118b7958cf414b",
+        "sha3_256_hash_of_public_key": "cacca228846450ebb8f04a2a5ef2d919dfa47c4aa265f4cedd10cf74eef3ecc1",
+        "sha3_256_hash_of_secret_key": "a01db77c5983b2472e616dfc04666a2112924dda5ffbf00a989cf1a48578898b",
         "encapsulation_seed": "28878249e2ac2b6263422993923a0c8bd05ce56e385ed13c943b03d226856947",
-        "sha3_256_hash_of_ciphertext": "a1f1579c4ce8eb725e697623321b3d9f55f4b1d0def10b898535ef6614e9923e",
-        "shared_secret": "204d9272682710b52fb39b1176af3ff737848978770310df0c67996f6cb596c3"
+        "sha3_256_hash_of_ciphertext": "dd0b438cb7dcda28762d06e61f1765baef8003d0d86ff48cd4f9788cae8e8618",
+        "shared_secret": "403543b0f8e519ba4ab878c40ab5aed412ea06bfeb2b864baa5ef4b81a42c454"
     },
     {
         "key_generation_seed": "aa6dd1e5799cdf7af9c4fc632b3eb9d51d66e85c8e0a21ec98664fc51ab63c7dfda268813efab5204efa60f78bf81d320d01ac09ac06244f7afbd2d80fd356d9",
-        "sha3_256_hash_of_public_key": "919a696301240cd6129f66be58e19d99b0d827d9932785cd9ea3d92f7ba54463",
-        "sha3_256_hash_of_secret_key": "cb1d7301f15951883cc3f287d4dd8fdf5c9b7022f558dff551c2ade5f5065755",
+        "sha3_256_hash_of_public_key": "4126f5151d1b086e26a88bd9f20710ef06aa0f834722b801f6b79c031f1f9213",
+        "sha3_256_hash_of_secret_key": "9a6c24b5ae556241f3e6b07a7576971173ecfe474be9c6b09fd12ddef8b5f75e",
         "encapsulation_seed": "17fc65f7fbd7c75ceec421dee84dff5a8cb22764a182db17e0ebe857f54d60eb",
-        "sha3_256_hash_of_ciphertext": "f02654803493821dd9c2ed23f9e46a36addd5fca0da706bbeeda87a2df9fec4f",
-        "shared_secret": "76e5f7623e3e867fd12f28dfda4311f7cd90a405b73e994e857f693573fd2b8a"
+        "sha3_256_hash_of_ciphertext": "7c2b9cd82c349fdc534ac30eaa18bf83afd0736b17a4320963571c109451a5b6",
+        "shared_secret": "f7a280462f93b619888b5a72da3749556e53ef4f4440df728c8db1edcc86cea4"
     },
     {
         "key_generation_seed": "195d6c86a3df4c21e3007d7f2768b43c74cb3060e0eca77f0a5d3271542b9a84ae77e0f9f21eabd8c0c6eea7767f4e10fde5c2d79b8400bf96b19014b457ec21",
-        "sha3_256_hash_of_public_key": "cb6d7232426bdbdfdacd373c9190722e7bf342825f7d829185dcc9120588fc76",
-        "sha3_256_hash_of_secret_key": "a85e24cc2eafdfe40d82f46471112e1359628b9955f3feae9955b48d563ac952",
+        "sha3_256_hash_of_public_key": "b6f12914ed31f14f79c652eed4db478de7ebd263fe27052509fee10b50f2d053",
+        "sha3_256_hash_of_secret_key": "1a4de442c4c6db97bfa12227c4423237a869c93154e2c5ca49cacbd0ef730485",
         "encapsulation_seed": "fa0489f3730100609488e951e6aaa15c0f193bc1dbcfcd013bc418d6c507b176",
-        "sha3_256_hash_of_ciphertext": "17336b9ede3a1c26abe725828a5afbe746035a73dfd4a8fbde5040fbabeb2b8d",
-        "shared_secret": "874ac966970f29935db73c231e71a3559b2504e5446151b99c199276617b3824"
+        "sha3_256_hash_of_ciphertext": "41d75dd4690637576652071cb46987cc26321a07bb47a1cfb07f30d2153920c5",
+        "shared_secret": "fef3730b905431d14aa7aa7bb1d253cd912335c590b8d7de1e7aa4e0ff76be04"
     }
 ]

--- a/libcrux-ml-kem/cg.yaml
+++ b/libcrux-ml-kem/cg.yaml
@@ -96,8 +96,8 @@ files:
     inline_static: true
     private:
       exact:
-        - [ libcrux_ml_kem, ind_cca, MlKem ]
-        - [ libcrux_ml_kem, ind_cca, Kyber ]
+        - [ libcrux_ml_kem, variant, MlKem ]
+        - [ libcrux_ml_kem, variant, Kyber ]
     api:
       patterns:
         - [libcrux_ml_kem, "*"]

--- a/libcrux-ml-kem/cg/code_gen.txt
+++ b/libcrux-ml-kem/cg/code_gen.txt
@@ -2,5 +2,5 @@ This code was generated with the following revisions:
 Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
 Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
 Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
-F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
-Libcrux: 0ca73e59afe19a3f88b8ff45d0c57b0ebe851319
+F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d

--- a/libcrux-ml-kem/cg/libcrux_core.h
+++ b/libcrux-ml-kem/cg/libcrux_core.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 0ca73e59afe19a3f88b8ff45d0c57b0ebe851319
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_core_H
@@ -236,7 +236,7 @@ with const generics
 - SIZE= 1184
 */
 static inline libcrux_ml_kem_types_MlKemPublicKey_15
-libcrux_ml_kem_types_from_b6_8e(uint8_t value[1184U]) {
+libcrux_ml_kem_types_from_b6_b0(uint8_t value[1184U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[1184U];
   memcpy(copy_of_value, value, (size_t)1184U * sizeof(uint8_t));
@@ -273,7 +273,7 @@ with const generics
 - PUBLIC_KEY_SIZE= 1184
 */
 static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
-libcrux_ml_kem_types_from_17_12(libcrux_ml_kem_types_MlKemPrivateKey_55 sk,
+libcrux_ml_kem_types_from_17_9c(libcrux_ml_kem_types_MlKemPrivateKey_55 sk,
                                 libcrux_ml_kem_types_MlKemPublicKey_15 pk) {
   return (
       CLITERAL(libcrux_ml_kem_mlkem768_MlKem768KeyPair){.sk = sk, .pk = pk});
@@ -289,7 +289,7 @@ with const generics
 - SIZE= 2400
 */
 static inline libcrux_ml_kem_types_MlKemPrivateKey_55
-libcrux_ml_kem_types_from_05_db(uint8_t value[2400U]) {
+libcrux_ml_kem_types_from_05_0b(uint8_t value[2400U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[2400U];
   memcpy(copy_of_value, value, (size_t)2400U * sizeof(uint8_t));
@@ -352,7 +352,7 @@ with const generics
 - SIZE= 1088
 */
 static inline libcrux_ml_kem_mlkem768_MlKem768Ciphertext
-libcrux_ml_kem_types_from_01_ec(uint8_t value[1088U]) {
+libcrux_ml_kem_types_from_01_1e(uint8_t value[1088U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_value[1088U];
   memcpy(copy_of_value, value, (size_t)1088U * sizeof(uint8_t));
@@ -372,7 +372,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_slice_cb
 with const generics
 - SIZE= 1184
 */
-static inline uint8_t *libcrux_ml_kem_types_as_slice_cb_6f(
+static inline uint8_t *libcrux_ml_kem_types_as_slice_cb_25(
     libcrux_ml_kem_types_MlKemPublicKey_15 *self) {
   return self->value;
 }
@@ -424,7 +424,7 @@ A monomorphic instance of libcrux_ml_kem.types.as_ref_00
 with const generics
 - SIZE= 1088
 */
-static inline Eurydice_slice libcrux_ml_kem_types_as_ref_00_e0(
+static inline Eurydice_slice libcrux_ml_kem_types_as_ref_00_ae(
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *self) {
   return Eurydice_array_to_slice((size_t)1088U, self->value, uint8_t);
 }

--- a/libcrux-ml-kem/cg/libcrux_ct_ops.h
+++ b/libcrux-ml-kem/cg/libcrux_ct_ops.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 0ca73e59afe19a3f88b8ff45d0c57b0ebe851319
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_ct_ops_H

--- a/libcrux-ml-kem/cg/libcrux_mlkem768_avx2.h
+++ b/libcrux-ml-kem/cg/libcrux_mlkem768_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 0ca73e59afe19a3f88b8ff45d0c57b0ebe851319
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem768_avx2_H
@@ -1240,7 +1240,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_ind_cpa_deserialize_secret_key_closure_29(size_t _) {
+libcrux_ml_kem_ind_cpa_deserialize_secret_key_closure_49(size_t _) {
   return libcrux_ml_kem_polynomial_ZERO_89_9b();
 }
 
@@ -1252,7 +1252,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_to_uncompressed_ring_element_fe(
+libcrux_ml_kem_serialize_deserialize_to_uncompressed_ring_element_07(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re =
       libcrux_ml_kem_polynomial_ZERO_89_9b();
@@ -1276,7 +1276,7 @@ with const generics
 - K= 3
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_deserialize_secret_key_23(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_deserialize_secret_key_62(
     Eurydice_slice secret_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 secret_as_ntt[3U];
@@ -1294,7 +1294,7 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_deserialize_secret_key_23(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        libcrux_ml_kem_serialize_deserialize_to_uncompressed_ring_element_fe(
+        libcrux_ml_kem_serialize_deserialize_to_uncompressed_ring_element_07(
             secret_bytes);
     secret_as_ntt[i0] = uu____0;
   }
@@ -1323,7 +1323,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_closure_5b(size_t _) {
+libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_closure_15(size_t _) {
   return libcrux_ml_kem_polynomial_ZERO_89_9b();
 }
 
@@ -1335,7 +1335,7 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE __m256i
-libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_84(
+libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_5a(
     __m256i vector) {
   __m256i field_modulus = libcrux_intrinsics_avx2_mm256_set1_epi32(
       (int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
@@ -1387,9 +1387,9 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline __m256i
-libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_22(
+libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_02(
     __m256i vector) {
-  return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_84(
+  return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_5a(
       vector);
 }
 
@@ -1401,7 +1401,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_then_decompress_10_2b(
+libcrux_ml_kem_serialize_deserialize_then_decompress_10_be(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re =
       libcrux_ml_kem_polynomial_ZERO_89_9b();
@@ -1412,7 +1412,7 @@ libcrux_ml_kem_serialize_deserialize_then_decompress_10_2b(
         serialized, i0 * (size_t)20U, i0 * (size_t)20U + (size_t)20U, uint8_t);
     __m256i coefficient = libcrux_ml_kem_vector_avx2_deserialize_10_ea(bytes);
     re.coefficients[i0] =
-        libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_22(
+        libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_02(
             coefficient);
   }
   return re;
@@ -1426,7 +1426,7 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE __m256i
-libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_840(
+libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_5a0(
     __m256i vector) {
   __m256i field_modulus = libcrux_intrinsics_avx2_mm256_set1_epi32(
       (int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
@@ -1478,9 +1478,9 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline __m256i
-libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_220(
+libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_020(
     __m256i vector) {
-  return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_840(
+  return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_5a0(
       vector);
 }
 
@@ -1492,7 +1492,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_then_decompress_11_4a(
+libcrux_ml_kem_serialize_deserialize_then_decompress_11_7d(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re =
       libcrux_ml_kem_polynomial_ZERO_89_9b();
@@ -1503,7 +1503,7 @@ libcrux_ml_kem_serialize_deserialize_then_decompress_11_4a(
         serialized, i0 * (size_t)22U, i0 * (size_t)22U + (size_t)22U, uint8_t);
     __m256i coefficient = libcrux_ml_kem_vector_avx2_deserialize_11_ea(bytes);
     re.coefficients[i0] =
-        libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_220(
+        libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_020(
             coefficient);
   }
   return re;
@@ -1517,9 +1517,9 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_u_5d(
+libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_u_7f(
     Eurydice_slice serialized) {
-  return libcrux_ml_kem_serialize_deserialize_then_decompress_10_2b(serialized);
+  return libcrux_ml_kem_serialize_deserialize_then_decompress_10_be(serialized);
 }
 
 typedef struct libcrux_ml_kem_vector_avx2_SIMD256Vector_x2_s {
@@ -1682,7 +1682,7 @@ with const generics
 - VECTOR_U_COMPRESSION_FACTOR= 10
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_ntt_ntt_vector_u_92(
+static KRML_MUSTINLINE void libcrux_ml_kem_ntt_ntt_vector_u_51(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re) {
   size_t zeta_i = (size_t)0U;
   libcrux_ml_kem_ntt_ntt_at_layer_4_plus_5a(&zeta_i, re, (size_t)7U,
@@ -1713,7 +1713,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_5e(
+libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_8e(
     uint8_t *ciphertext,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u_as_ntt[3U];
@@ -1738,9 +1738,9 @@ libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_5e(
                 (size_t)10U / (size_t)8U,
         uint8_t);
     u_as_ntt[i0] =
-        libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_u_5d(
+        libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_u_7f(
             u_bytes);
-    libcrux_ml_kem_ntt_ntt_vector_u_92(&u_as_ntt[i0]);
+    libcrux_ml_kem_ntt_ntt_vector_u_51(&u_as_ntt[i0]);
   }
   memcpy(
       ret, u_as_ntt,
@@ -1755,7 +1755,7 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE __m256i
-libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_841(
+libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_5a1(
     __m256i vector) {
   __m256i field_modulus = libcrux_intrinsics_avx2_mm256_set1_epi32(
       (int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
@@ -1807,9 +1807,9 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline __m256i
-libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_221(
+libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_021(
     __m256i vector) {
-  return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_841(
+  return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_5a1(
       vector);
 }
 
@@ -1821,7 +1821,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_then_decompress_4_02(
+libcrux_ml_kem_serialize_deserialize_then_decompress_4_2b(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re =
       libcrux_ml_kem_polynomial_ZERO_89_9b();
@@ -1832,7 +1832,7 @@ libcrux_ml_kem_serialize_deserialize_then_decompress_4_02(
         serialized, i0 * (size_t)8U, i0 * (size_t)8U + (size_t)8U, uint8_t);
     __m256i coefficient = libcrux_ml_kem_vector_avx2_deserialize_4_ea(bytes);
     re.coefficients[i0] =
-        libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_221(
+        libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_021(
             coefficient);
   }
   return re;
@@ -1846,7 +1846,7 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE __m256i
-libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_842(
+libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_5a2(
     __m256i vector) {
   __m256i field_modulus = libcrux_intrinsics_avx2_mm256_set1_epi32(
       (int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
@@ -1898,9 +1898,9 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline __m256i
-libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_222(
+libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_022(
     __m256i vector) {
-  return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_842(
+  return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_5a2(
       vector);
 }
 
@@ -1912,7 +1912,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_then_decompress_5_75(
+libcrux_ml_kem_serialize_deserialize_then_decompress_5_48(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re =
       libcrux_ml_kem_polynomial_ZERO_89_9b();
@@ -1923,7 +1923,7 @@ libcrux_ml_kem_serialize_deserialize_then_decompress_5_75(
         serialized, i0 * (size_t)10U, i0 * (size_t)10U + (size_t)10U, uint8_t);
     re.coefficients[i0] = libcrux_ml_kem_vector_avx2_deserialize_5_ea(bytes);
     re.coefficients[i0] =
-        libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_222(
+        libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_022(
             re.coefficients[i0]);
   }
   return re;
@@ -1937,9 +1937,9 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_v_69(
+libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_v_e1(
     Eurydice_slice serialized) {
-  return libcrux_ml_kem_serialize_deserialize_then_decompress_4_02(serialized);
+  return libcrux_ml_kem_serialize_deserialize_then_decompress_4_2b(serialized);
 }
 
 /**
@@ -2042,7 +2042,7 @@ with const generics
 
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_1_3d(
+static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_1_fb(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re,
     size_t _layer) {
   for (size_t i = (size_t)0U; i < (size_t)16U; i++) {
@@ -2069,7 +2069,7 @@ with const generics
 
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_2_64(
+static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_2_ad(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re,
     size_t _layer) {
   for (size_t i = (size_t)0U; i < (size_t)16U; i++) {
@@ -2092,7 +2092,7 @@ with const generics
 
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_3_fb(
+static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_3_b7(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re,
     size_t _layer) {
   for (size_t i = (size_t)0U; i < (size_t)16U; i++) {
@@ -2113,7 +2113,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_vector_avx2_SIMD256Vector_x2
-libcrux_ml_kem_invert_ntt_inv_ntt_layer_int_vec_step_reduce_eb(__m256i a,
+libcrux_ml_kem_invert_ntt_inv_ntt_layer_int_vec_step_reduce_26(__m256i a,
                                                                __m256i b,
                                                                int16_t zeta_r) {
   __m256i a_minus_b = libcrux_ml_kem_vector_avx2_sub_ea(b, &a);
@@ -2132,7 +2132,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_39(
+libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_9c(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re,
     size_t layer) {
   size_t step = (size_t)1U << (uint32_t)layer;
@@ -2147,7 +2147,7 @@ libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_39(
     for (size_t i = offset_vec; i < offset_vec + step_vec; i++) {
       size_t j = i;
       libcrux_ml_kem_vector_avx2_SIMD256Vector_x2 uu____0 =
-          libcrux_ml_kem_invert_ntt_inv_ntt_layer_int_vec_step_reduce_eb(
+          libcrux_ml_kem_invert_ntt_inv_ntt_layer_int_vec_step_reduce_26(
               re->coefficients[j], re->coefficients[j + step_vec],
               libcrux_ml_kem_polynomial_ZETAS_TIMES_MONTGOMERY_R[zeta_i[0U]]);
       __m256i x = uu____0.fst;
@@ -2165,20 +2165,20 @@ with const generics
 - K= 3
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_e6(
+static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_de(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re) {
   size_t zeta_i =
       LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT / (size_t)2U;
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_1_3d(&zeta_i, re, (size_t)1U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_2_64(&zeta_i, re, (size_t)2U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_3_fb(&zeta_i, re, (size_t)3U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_39(&zeta_i, re,
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_1_fb(&zeta_i, re, (size_t)1U);
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_2_ad(&zeta_i, re, (size_t)2U);
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_3_b7(&zeta_i, re, (size_t)3U);
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_9c(&zeta_i, re,
                                                           (size_t)4U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_39(&zeta_i, re,
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_9c(&zeta_i, re,
                                                           (size_t)5U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_39(&zeta_i, re,
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_9c(&zeta_i, re,
                                                           (size_t)6U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_39(&zeta_i, re,
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_9c(&zeta_i, re,
                                                           (size_t)7U);
   libcrux_ml_kem_polynomial_poly_barrett_reduce_89_e6(re);
 }
@@ -2195,7 +2195,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_polynomial_subtract_reduce_89_d9(
+libcrux_ml_kem_polynomial_subtract_reduce_89_0b(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *self,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 b) {
   for (size_t i = (size_t)0U;
@@ -2225,7 +2225,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_matrix_compute_message_a7(
+libcrux_ml_kem_matrix_compute_message_2e(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *v,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *secret_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *u_as_ntt) {
@@ -2238,8 +2238,8 @@ libcrux_ml_kem_matrix_compute_message_a7(
                                                      &u_as_ntt[i0]);
     libcrux_ml_kem_polynomial_add_to_ring_element_89_ce(&result, &product);
   }
-  libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_e6(&result);
-  result = libcrux_ml_kem_polynomial_subtract_reduce_89_d9(v, result);
+  libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_de(&result);
+  result = libcrux_ml_kem_polynomial_subtract_reduce_89_0b(v, result);
   return result;
 }
 
@@ -2250,7 +2250,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE __m256i
-libcrux_ml_kem_vector_avx2_arithmetic_shift_right_5b(__m256i vector) {
+libcrux_ml_kem_vector_avx2_arithmetic_shift_right_23(__m256i vector) {
   return libcrux_intrinsics_avx2_mm256_srai_epi16((int32_t)15, vector, __m256i);
 }
 
@@ -2264,9 +2264,9 @@ with const generics
 - SHIFT_BY= 15
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_shift_right_ea_36(
+static inline __m256i libcrux_ml_kem_vector_avx2_shift_right_ea_80(
     __m256i vector) {
-  return libcrux_ml_kem_vector_avx2_arithmetic_shift_right_5b(vector);
+  return libcrux_ml_kem_vector_avx2_arithmetic_shift_right_23(vector);
 }
 
 /**
@@ -2278,7 +2278,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline __m256i
 libcrux_ml_kem_vector_traits_to_unsigned_representative_14(__m256i a) {
-  __m256i t = libcrux_ml_kem_vector_avx2_shift_right_ea_36(a);
+  __m256i t = libcrux_ml_kem_vector_avx2_shift_right_ea_80(a);
   __m256i fm = libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
       t, LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
   return libcrux_ml_kem_vector_avx2_add_ea(a, &fm);
@@ -2292,7 +2292,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_message_ef(
+libcrux_ml_kem_serialize_compress_then_serialize_message_a2(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re, uint8_t ret[32U]) {
   uint8_t serialized[32U] = {0U};
   for (size_t i = (size_t)0U; i < (size_t)16U; i++) {
@@ -2347,20 +2347,20 @@ with const generics
 - V_COMPRESSION_FACTOR= 4
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_decrypt_unpacked_ff(
+static inline void libcrux_ml_kem_ind_cpa_decrypt_unpacked_1e(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_a0 *secret_key,
     uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u_as_ntt[3U];
-  libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_5e(ciphertext, u_as_ntt);
+  libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_8e(ciphertext, u_as_ntt);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_v_69(
+      libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_v_e1(
           Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                           (size_t)960U, uint8_t, size_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message =
-      libcrux_ml_kem_matrix_compute_message_a7(&v, secret_key->secret_as_ntt,
+      libcrux_ml_kem_matrix_compute_message_2e(&v, secret_key->secret_as_ntt,
                                                u_as_ntt);
   uint8_t ret0[32U];
-  libcrux_ml_kem_serialize_compress_then_serialize_message_ef(message, ret0);
+  libcrux_ml_kem_serialize_compress_then_serialize_message_a2(message, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -2375,11 +2375,11 @@ with const generics
 - V_COMPRESSION_FACTOR= 4
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_decrypt_8e(Eurydice_slice secret_key,
+static inline void libcrux_ml_kem_ind_cpa_decrypt_c4(Eurydice_slice secret_key,
                                                      uint8_t *ciphertext,
                                                      uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 secret_as_ntt[3U];
-  libcrux_ml_kem_ind_cpa_deserialize_secret_key_23(secret_key, secret_as_ntt);
+  libcrux_ml_kem_ind_cpa_deserialize_secret_key_62(secret_key, secret_as_ntt);
   /* Passing arrays by value in Rust generates a copy in C */
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 copy_of_secret_as_ntt[3U];
   memcpy(
@@ -2391,7 +2391,7 @@ static inline void libcrux_ml_kem_ind_cpa_decrypt_8e(Eurydice_slice secret_key,
       secret_key_unpacked.secret_as_ntt, copy_of_secret_as_ntt,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
   uint8_t ret0[32U];
-  libcrux_ml_kem_ind_cpa_decrypt_unpacked_ff(&secret_key_unpacked, ciphertext,
+  libcrux_ml_kem_ind_cpa_decrypt_unpacked_1e(&secret_key_unpacked, ciphertext,
                                              ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
@@ -2450,7 +2450,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_closure_c1(
+libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_closure_47(
     size_t _i) {
   return libcrux_ml_kem_polynomial_ZERO_89_9b();
 }
@@ -2469,7 +2469,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_71(
+libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_e6(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re =
       libcrux_ml_kem_polynomial_ZERO_89_9b();
@@ -2500,7 +2500,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_a8(
+libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_09(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[3U];
@@ -2518,7 +2518,7 @@ libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_a8(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_71(
+        libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_e6(
             ring_element);
     deserialized_pk[i0] = uu____0;
   }
@@ -3350,7 +3350,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_closure_24(size_t _i) {
+libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_closure_8a(size_t _i) {
   return libcrux_ml_kem_polynomial_ZERO_89_9b();
 }
 
@@ -3367,7 +3367,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE tuple_b00
-libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_58(uint8_t prf_input[33U],
+libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_71(uint8_t prf_input[33U],
                                                   uint8_t domain_separator) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[3U];
   for (size_t i = (size_t)0U; i < (size_t)3U; i++) {
@@ -3445,7 +3445,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_matrix_compute_vector_u_closure_ae(size_t _i) {
+libcrux_ml_kem_matrix_compute_vector_u_closure_c1(size_t _i) {
   return libcrux_ml_kem_polynomial_ZERO_89_9b();
 }
 
@@ -3460,7 +3460,7 @@ with const generics
 
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_polynomial_add_error_reduce_89_c7(
+static KRML_MUSTINLINE void libcrux_ml_kem_polynomial_add_error_reduce_89_6d(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *self,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *error) {
   for (size_t i = (size_t)0U;
@@ -3485,7 +3485,7 @@ with const generics
 - K= 3
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_matrix_compute_vector_u_54(
+static KRML_MUSTINLINE void libcrux_ml_kem_matrix_compute_vector_u_58(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 (*a_as_ntt)[3U],
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *error_1,
@@ -3517,8 +3517,8 @@ static KRML_MUSTINLINE void libcrux_ml_kem_matrix_compute_vector_u_54(
       libcrux_ml_kem_polynomial_add_to_ring_element_89_ce(&result[i1],
                                                           &product);
     }
-    libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_e6(&result[i1]);
-    libcrux_ml_kem_polynomial_add_error_reduce_89_c7(&result[i1], &error_1[i1]);
+    libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_de(&result[i1]);
+    libcrux_ml_kem_polynomial_add_error_reduce_89_6d(&result[i1], &error_1[i1]);
   }
   memcpy(
       ret, result,
@@ -3532,7 +3532,7 @@ with const generics
 
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_traits_decompress_1_d7(__m256i v) {
+static inline __m256i libcrux_ml_kem_vector_traits_decompress_1_2e(__m256i v) {
   return libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
       libcrux_ml_kem_vector_avx2_sub_ea(libcrux_ml_kem_vector_avx2_ZERO_ea(),
                                         &v),
@@ -3547,7 +3547,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_then_decompress_message_d3(
+libcrux_ml_kem_serialize_deserialize_then_decompress_message_bd(
     uint8_t serialized[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re =
       libcrux_ml_kem_polynomial_ZERO_89_9b();
@@ -3558,7 +3558,7 @@ libcrux_ml_kem_serialize_deserialize_then_decompress_message_d3(
             Eurydice_array_to_subslice2(serialized, (size_t)2U * i0,
                                         (size_t)2U * i0 + (size_t)2U, uint8_t));
     re.coefficients[i0] =
-        libcrux_ml_kem_vector_traits_decompress_1_d7(coefficient_compressed);
+        libcrux_ml_kem_vector_traits_decompress_1_2e(coefficient_compressed);
   }
   return re;
 }
@@ -3575,7 +3575,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_polynomial_add_message_error_reduce_89_6a(
+libcrux_ml_kem_polynomial_add_message_error_reduce_89_d2(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *self,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *message,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 result) {
@@ -3606,7 +3606,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_matrix_compute_ring_element_v_f9(
+libcrux_ml_kem_matrix_compute_ring_element_v_73(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *t_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *error_2,
@@ -3620,8 +3620,8 @@ libcrux_ml_kem_matrix_compute_ring_element_v_f9(
                                                      &r_as_ntt[i0]);
     libcrux_ml_kem_polynomial_add_to_ring_element_89_ce(&result, &product);
   }
-  libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_e6(&result);
-  result = libcrux_ml_kem_polynomial_add_message_error_reduce_89_6a(
+  libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_de(&result);
+  result = libcrux_ml_kem_polynomial_add_message_error_reduce_89_d2(
       error_2, message, result);
   return result;
 }
@@ -3634,7 +3634,7 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE __m256i
-libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_94(
+libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_25(
     __m256i vector) {
   __m256i field_modulus_halved = libcrux_intrinsics_avx2_mm256_set1_epi32(
       ((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS - (int32_t)1) /
@@ -3689,9 +3689,9 @@ with const generics
 - COEFFICIENT_BITS= 10
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_85(
+static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_8c(
     __m256i vector) {
-  return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_94(
+  return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_25(
       vector);
 }
 
@@ -3703,13 +3703,13 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_10_d0(
+libcrux_ml_kem_serialize_compress_then_serialize_10_fe(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re, uint8_t ret[320U]) {
   uint8_t serialized[320U] = {0U};
   for (size_t i = (size_t)0U;
        i < LIBCRUX_ML_KEM_POLYNOMIAL_VECTORS_IN_RING_ELEMENT; i++) {
     size_t i0 = i;
-    __m256i coefficient = libcrux_ml_kem_vector_avx2_compress_ea_85(
+    __m256i coefficient = libcrux_ml_kem_vector_avx2_compress_ea_8c(
         libcrux_ml_kem_vector_traits_to_unsigned_representative_14(
             re->coefficients[i0]));
     uint8_t bytes[20U];
@@ -3730,7 +3730,7 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE __m256i
-libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_940(
+libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_250(
     __m256i vector) {
   __m256i field_modulus_halved = libcrux_intrinsics_avx2_mm256_set1_epi32(
       ((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS - (int32_t)1) /
@@ -3785,9 +3785,9 @@ with const generics
 - COEFFICIENT_BITS= 11
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_850(
+static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_8c0(
     __m256i vector) {
-  return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_940(
+  return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_250(
       vector);
 }
 
@@ -3799,13 +3799,13 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_11_28(
+libcrux_ml_kem_serialize_compress_then_serialize_11_c6(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re, uint8_t ret[320U]) {
   uint8_t serialized[320U] = {0U};
   for (size_t i = (size_t)0U;
        i < LIBCRUX_ML_KEM_POLYNOMIAL_VECTORS_IN_RING_ELEMENT; i++) {
     size_t i0 = i;
-    __m256i coefficient = libcrux_ml_kem_vector_avx2_compress_ea_850(
+    __m256i coefficient = libcrux_ml_kem_vector_avx2_compress_ea_8c0(
         libcrux_ml_kem_vector_traits_to_unsigned_representative_14(
             re->coefficients[i0]));
     uint8_t bytes[22U];
@@ -3827,10 +3827,10 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_ring_element_u_56(
+libcrux_ml_kem_serialize_compress_then_serialize_ring_element_u_61(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *re, uint8_t ret[320U]) {
   uint8_t uu____0[320U];
-  libcrux_ml_kem_serialize_compress_then_serialize_10_d0(re, uu____0);
+  libcrux_ml_kem_serialize_compress_then_serialize_10_fe(re, uu____0);
   memcpy(ret, uu____0, (size_t)320U * sizeof(uint8_t));
 }
 
@@ -3847,7 +3847,7 @@ with const generics
 - BLOCK_LEN= 320
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_compress_then_serialize_u_9b(
+static inline void libcrux_ml_kem_ind_cpa_compress_then_serialize_u_e6(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 input[3U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -3863,7 +3863,7 @@ static inline void libcrux_ml_kem_ind_cpa_compress_then_serialize_u_9b(
         out, i0 * ((size_t)960U / (size_t)3U),
         (i0 + (size_t)1U) * ((size_t)960U / (size_t)3U), uint8_t);
     uint8_t ret[320U];
-    libcrux_ml_kem_serialize_compress_then_serialize_ring_element_u_56(&re,
+    libcrux_ml_kem_serialize_compress_then_serialize_ring_element_u_61(&re,
                                                                        ret);
     Eurydice_slice_copy(
         uu____0, Eurydice_array_to_slice((size_t)320U, ret, uint8_t), uint8_t);
@@ -3878,7 +3878,7 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE __m256i
-libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_941(
+libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_251(
     __m256i vector) {
   __m256i field_modulus_halved = libcrux_intrinsics_avx2_mm256_set1_epi32(
       ((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS - (int32_t)1) /
@@ -3933,9 +3933,9 @@ with const generics
 - COEFFICIENT_BITS= 4
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_851(
+static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_8c1(
     __m256i vector) {
-  return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_941(
+  return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_251(
       vector);
 }
 
@@ -3947,13 +3947,13 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_4_fb(
+libcrux_ml_kem_serialize_compress_then_serialize_4_54(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re,
     Eurydice_slice serialized) {
   for (size_t i = (size_t)0U;
        i < LIBCRUX_ML_KEM_POLYNOMIAL_VECTORS_IN_RING_ELEMENT; i++) {
     size_t i0 = i;
-    __m256i coefficient = libcrux_ml_kem_vector_avx2_compress_ea_851(
+    __m256i coefficient = libcrux_ml_kem_vector_avx2_compress_ea_8c1(
         libcrux_ml_kem_vector_traits_to_unsigned_representative_14(
             re.coefficients[i0]));
     uint8_t bytes[8U];
@@ -3973,7 +3973,7 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE __m256i
-libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_942(
+libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_252(
     __m256i vector) {
   __m256i field_modulus_halved = libcrux_intrinsics_avx2_mm256_set1_epi32(
       ((int32_t)LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS - (int32_t)1) /
@@ -4028,9 +4028,9 @@ with const generics
 - COEFFICIENT_BITS= 5
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_852(
+static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_8c2(
     __m256i vector) {
-  return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_942(
+  return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_252(
       vector);
 }
 
@@ -4042,13 +4042,13 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_5_8e(
+libcrux_ml_kem_serialize_compress_then_serialize_5_9f(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re,
     Eurydice_slice serialized) {
   for (size_t i = (size_t)0U;
        i < LIBCRUX_ML_KEM_POLYNOMIAL_VECTORS_IN_RING_ELEMENT; i++) {
     size_t i0 = i;
-    __m256i coefficients = libcrux_ml_kem_vector_avx2_compress_ea_852(
+    __m256i coefficients = libcrux_ml_kem_vector_avx2_compress_ea_8c2(
         libcrux_ml_kem_vector_traits_to_unsigned_representative_14(
             re.coefficients[i0]));
     uint8_t bytes[10U];
@@ -4069,9 +4069,9 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_6d(
+libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_6b(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 re, Eurydice_slice out) {
-  libcrux_ml_kem_serialize_compress_then_serialize_4_fb(re, out);
+  libcrux_ml_kem_serialize_compress_then_serialize_4_54(re, out);
 }
 
 /**
@@ -4092,12 +4092,12 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_encrypt_a3(Eurydice_slice public_key,
+static inline void libcrux_ml_kem_ind_cpa_encrypt_c1(Eurydice_slice public_key,
                                                      uint8_t message[32U],
                                                      Eurydice_slice randomness,
                                                      uint8_t ret[1088U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 t_as_ntt[3U];
-  libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_a8(
+  libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_09(
       Eurydice_slice_subslice_to(public_key, (size_t)1152U, uint8_t, size_t),
       t_as_ntt);
   Eurydice_slice seed =
@@ -4121,7 +4121,7 @@ static inline void libcrux_ml_kem_ind_cpa_encrypt_a3(Eurydice_slice public_key,
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
-  tuple_b00 uu____3 = libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_58(
+  tuple_b00 uu____3 = libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_71(
       copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[3U];
   memcpy(
@@ -4136,44 +4136,44 @@ static inline void libcrux_ml_kem_ind_cpa_encrypt_a3(Eurydice_slice public_key,
       libcrux_ml_kem_sampling_sample_from_binomial_distribution_73(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u[3U];
-  libcrux_ml_kem_matrix_compute_vector_u_54(A, r_as_ntt, error_1, u);
+  libcrux_ml_kem_matrix_compute_vector_u_58(A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message_as_ring_element =
-      libcrux_ml_kem_serialize_deserialize_then_decompress_message_d3(
+      libcrux_ml_kem_serialize_deserialize_then_decompress_message_bd(
           copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      libcrux_ml_kem_matrix_compute_ring_element_v_f9(
+      libcrux_ml_kem_matrix_compute_ring_element_v_73(
           t_as_ntt, r_as_ntt, &error_2, &message_as_ring_element);
   uint8_t ciphertext[1088U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____5[3U];
   memcpy(
       uu____5, u,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
-  libcrux_ml_kem_ind_cpa_compress_then_serialize_u_9b(
+  libcrux_ml_kem_ind_cpa_compress_then_serialize_u_e6(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)960U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____6 = v;
-  libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_6d(
+  libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_6b(
       uu____6, Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                                (size_t)960U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1088U * sizeof(uint8_t));
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)#1}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)#1}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.kdf_43
+A monomorphic instance of libcrux_ml_kem.variant.kdf_d8
 with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_kdf_43_73(
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_kdf_d8_aa(
     Eurydice_slice shared_secret, libcrux_ml_kem_mlkem768_MlKem768Ciphertext *_,
     uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
@@ -4185,7 +4185,7 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_kdf_43_73(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 3
 - SECRET_KEY_SIZE= 2400
@@ -4205,7 +4205,7 @@ with const generics
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cca_decapsulate_e7(
+static inline void libcrux_ml_kem_ind_cca_decapsulate_13(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -4223,7 +4223,7 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_e7(
   Eurydice_slice ind_cpa_public_key_hash = uu____2.fst;
   Eurydice_slice implicit_rejection_value = uu____2.snd;
   uint8_t decrypted[32U];
-  libcrux_ml_kem_ind_cpa_decrypt_8e(ind_cpa_secret_key, ciphertext->value,
+  libcrux_ml_kem_ind_cpa_decrypt_c4(ind_cpa_secret_key, ciphertext->value,
                                     decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -4247,7 +4247,7 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_e7(
   Eurydice_slice uu____4 = Eurydice_array_to_subslice_from(
       (size_t)1120U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret0[32U];
   libcrux_ml_kem_hash_functions_avx2_PRF_a9_dd(
@@ -4258,18 +4258,18 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_e7(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_a3(uu____5, copy_of_decrypted,
+  libcrux_ml_kem_ind_cpa_encrypt_c1(uu____5, copy_of_decrypted,
                                     pseudorandomness, expected_ciphertext);
   uint8_t implicit_rejection_shared_secret[32U];
-  libcrux_ml_kem_ind_cca_kdf_43_73(
+  libcrux_ml_kem_variant_kdf_d8_aa(
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret0,
                               uint8_t),
       ciphertext, implicit_rejection_shared_secret);
   uint8_t shared_secret[32U];
-  libcrux_ml_kem_ind_cca_kdf_43_73(shared_secret0, ciphertext, shared_secret);
+  libcrux_ml_kem_variant_kdf_d8_aa(shared_secret0, ciphertext, shared_secret);
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_compare_ciphertexts_select_shared_secret_in_constant_time(
-      libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+      libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
       Eurydice_array_to_slice((size_t)1088U, expected_ciphertext, uint8_t),
       Eurydice_array_to_slice((size_t)32U, shared_secret, uint8_t),
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret,
@@ -4302,10 +4302,10 @@ with const generics
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_5f(
+static inline void libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_1c(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_e7(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_13(private_key, ciphertext, ret);
 }
 
 /**
@@ -4319,7 +4319,7 @@ KRML_ATTRIBUTE_TARGET("avx2")
 static inline void libcrux_ml_kem_mlkem768_avx2_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_5f(private_key,
+  libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_1c(private_key,
                                                             ciphertext, ret);
 }
 
@@ -4428,7 +4428,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_encrypt_unpacked_3b(
+static inline void libcrux_ml_kem_ind_cpa_encrypt_unpacked_ad(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_a0 *public_key,
     uint8_t message[32U], Eurydice_slice randomness, uint8_t ret[1088U]) {
   uint8_t prf_input[33U];
@@ -4446,7 +4446,7 @@ static inline void libcrux_ml_kem_ind_cpa_encrypt_unpacked_3b(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
-  tuple_b00 uu____3 = libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_58(
+  tuple_b00 uu____3 = libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_71(
       copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_1[3U];
   memcpy(
@@ -4461,27 +4461,27 @@ static inline void libcrux_ml_kem_ind_cpa_encrypt_unpacked_3b(
       libcrux_ml_kem_sampling_sample_from_binomial_distribution_73(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 u[3U];
-  libcrux_ml_kem_matrix_compute_vector_u_54(public_key->A, r_as_ntt, error_1,
+  libcrux_ml_kem_matrix_compute_vector_u_58(public_key->A, r_as_ntt, error_1,
                                             u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 message_as_ring_element =
-      libcrux_ml_kem_serialize_deserialize_then_decompress_message_d3(
+      libcrux_ml_kem_serialize_deserialize_then_decompress_message_bd(
           copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 v =
-      libcrux_ml_kem_matrix_compute_ring_element_v_f9(
+      libcrux_ml_kem_matrix_compute_ring_element_v_73(
           public_key->t_as_ntt, r_as_ntt, &error_2, &message_as_ring_element);
   uint8_t ciphertext[1088U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____5[3U];
   memcpy(
       uu____5, u,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
-  libcrux_ml_kem_ind_cpa_compress_then_serialize_u_9b(
+  libcrux_ml_kem_ind_cpa_compress_then_serialize_u_e6(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)960U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____6 = v;
-  libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_6d(
+  libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_6b(
       uu____6, Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                                (size_t)960U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1088U * sizeof(uint8_t));
@@ -4509,11 +4509,11 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cca_decapsulate_unpacked_4a(
+static inline void libcrux_ml_kem_ind_cca_decapsulate_unpacked_d9(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0 *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   uint8_t decrypted[32U];
-  libcrux_ml_kem_ind_cpa_decrypt_unpacked_ff(
+  libcrux_ml_kem_ind_cpa_decrypt_unpacked_1e(
       &key_pair->private_key.ind_cpa_private_key, ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -4543,7 +4543,7 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_unpacked_4a(
   Eurydice_slice uu____2 = Eurydice_array_to_subslice_from(
       (size_t)1120U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret[32U];
   libcrux_ml_kem_hash_functions_avx2_PRF_a9_dd(
@@ -4555,11 +4555,11 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_unpacked_4a(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_unpacked_3b(
+  libcrux_ml_kem_ind_cpa_encrypt_unpacked_ad(
       uu____3, copy_of_decrypted, pseudorandomness, expected_ciphertext);
   uint8_t selector =
       libcrux_ml_kem_constant_time_ops_compare_ciphertexts_in_constant_time(
-          libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+          libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
           Eurydice_array_to_slice((size_t)1088U, expected_ciphertext, uint8_t));
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_select_shared_secret_in_constant_time(
@@ -4596,10 +4596,10 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline void
-libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_unpacked_20(
+libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_unpacked_bd(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0 *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_unpacked_4a(key_pair, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_unpacked_d9(key_pair, ciphertext, ret);
 }
 
 /**
@@ -4613,22 +4613,22 @@ KRML_ATTRIBUTE_TARGET("avx2")
 static inline void libcrux_ml_kem_mlkem768_avx2_decapsulate_unpacked(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_unpacked_20(
+  libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_unpacked_bd(
       private_key, ciphertext, ret);
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)#1}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)#1}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.entropy_preprocess_43
+A monomorphic instance of libcrux_ml_kem.variant.entropy_preprocess_d8
 with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
 - K= 3
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_entropy_preprocess_43_9b(
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_entropy_preprocess_d8_f4(
     Eurydice_slice randomness, uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -4654,7 +4654,7 @@ static KRML_MUSTINLINE void libcrux_ml_kem_hash_functions_avx2_H_a9_a1(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_MlKem
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
 with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
@@ -4671,11 +4671,11 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_41(
+static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_db(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
-  libcrux_ml_kem_ind_cca_entropy_preprocess_43_9b(
+  libcrux_ml_kem_variant_entropy_preprocess_d8_f4(
       Eurydice_array_to_slice((size_t)32U, randomness, uint8_t), randomness0);
   uint8_t to_hash[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -4686,7 +4686,7 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_41(
   uint8_t ret[32U];
   libcrux_ml_kem_hash_functions_avx2_H_a9_a1(
       Eurydice_array_to_slice((size_t)1184U,
-                              libcrux_ml_kem_types_as_slice_cb_6f(public_key),
+                              libcrux_ml_kem_types_as_slice_cb_25(public_key),
                               uint8_t),
       ret);
   Eurydice_slice_copy(
@@ -4701,20 +4701,20 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_41(
   Eurydice_slice shared_secret = uu____1.fst;
   Eurydice_slice pseudorandomness = uu____1.snd;
   Eurydice_slice uu____2 = Eurydice_array_to_slice(
-      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_6f(public_key), uint8_t);
+      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_25(public_key), uint8_t);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness0, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_a3(uu____2, copy_of_randomness,
+  libcrux_ml_kem_ind_cpa_encrypt_c1(uu____2, copy_of_randomness,
                                     pseudorandomness, ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_ciphertext[1088U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1088U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext ciphertext0 =
-      libcrux_ml_kem_types_from_01_ec(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_1e(copy_of_ciphertext);
   uint8_t shared_secret_array[32U];
-  libcrux_ml_kem_ind_cca_kdf_43_73(shared_secret, &ciphertext0,
+  libcrux_ml_kem_variant_kdf_d8_aa(shared_secret, &ciphertext0,
                                    shared_secret_array);
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext uu____5 = ciphertext0;
   /* Passing arrays by value in Rust generates a copy in C */
@@ -4746,14 +4746,14 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline tuple_3c
-libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_67(
+libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_0a(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_15 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_41(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_encapsulate_db(uu____0, copy_of_randomness);
 }
 
 /**
@@ -4771,7 +4771,7 @@ static inline tuple_3c libcrux_ml_kem_mlkem768_avx2_encapsulate(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_67(
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_0a(
       uu____0, copy_of_randomness);
 }
 
@@ -4794,7 +4794,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_42(
+static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_6e(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0 *public_key,
     uint8_t randomness[32U]) {
   uint8_t to_hash[64U];
@@ -4822,7 +4822,7 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_42(
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_unpacked_3b(uu____2, copy_of_randomness,
+  libcrux_ml_kem_ind_cpa_encrypt_unpacked_ad(uu____2, copy_of_randomness,
                                              pseudorandomness, ciphertext);
   uint8_t shared_secret_array[32U] = {0U};
   Eurydice_slice_copy(
@@ -4832,7 +4832,7 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_42(
   uint8_t copy_of_ciphertext[1088U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1088U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext uu____5 =
-      libcrux_ml_kem_types_from_01_ec(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_1e(copy_of_ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
   memcpy(copy_of_shared_secret_array, shared_secret_array,
@@ -4866,7 +4866,7 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline tuple_3c
-libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_unpacked_29(
+libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_unpacked_34(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0 *uu____0 =
@@ -4874,7 +4874,7 @@ libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_unpacked_29(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_42(uu____0,
+  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_6e(uu____0,
                                                         copy_of_randomness);
 }
 
@@ -4895,8 +4895,35 @@ static inline tuple_3c libcrux_ml_kem_mlkem768_avx2_encapsulate_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_unpacked_29(
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_unpacked_34(
       uu____0, copy_of_randomness);
+}
+
+/**
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)#1}
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.variant.cpa_keygen_seed_d8
+with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
+with const generics
+- K= 3
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_cpa_keygen_seed_d8_45(
+    Eurydice_slice key_generation_seed, uint8_t ret[64U]) {
+  uint8_t seed[33U] = {0U};
+  Eurydice_slice_copy(
+      Eurydice_array_to_subslice2(
+          seed, (size_t)0U,
+          LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t),
+      key_generation_seed, uint8_t);
+  seed[LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE] =
+      (uint8_t)(size_t)3U;
+  uint8_t ret0[64U];
+  libcrux_ml_kem_hash_functions_avx2_G_a9_e1(
+      Eurydice_array_to_slice((size_t)33U, seed, uint8_t), ret0);
+  memcpy(ret, ret0, (size_t)64U * sizeof(uint8_t));
 }
 
 /**
@@ -5098,7 +5125,8 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_serialize_public_key_5a(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cpa.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 3
 - PRIVATE_KEY_SIZE= 1152
 - PUBLIC_KEY_SIZE= 1184
@@ -5108,9 +5136,9 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_utils_extraction_helper_Keypair768
-libcrux_ml_kem_ind_cpa_generate_keypair_93(Eurydice_slice key_generation_seed) {
+libcrux_ml_kem_ind_cpa_generate_keypair_b7(Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  libcrux_ml_kem_hash_functions_avx2_G_a9_e1(key_generation_seed, hashed);
+  libcrux_ml_kem_variant_cpa_keygen_seed_d8_45(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -5184,7 +5212,7 @@ with const generics
 - SERIALIZED_KEY_LEN= 2400
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_serialize_kem_secret_key_8e(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_serialize_kem_secret_key_5a(
     Eurydice_slice private_key, Eurydice_slice public_key,
     Eurydice_slice implicit_rejection_value, uint8_t ret[2400U]) {
   uint8_t out[2400U] = {0U};
@@ -5237,7 +5265,8 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_serialize_kem_secret_key_8e(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_MlKem
+with const generics
 - K= 3
 - CPA_PRIVATE_KEY_SIZE= 1152
 - PRIVATE_KEY_SIZE= 2400
@@ -5248,7 +5277,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
-libcrux_ml_kem_ind_cca_generate_keypair_0d(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_50(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -5257,13 +5286,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_0d(uint8_t randomness[64U]) {
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
   libcrux_ml_kem_utils_extraction_helper_Keypair768 uu____0 =
-      libcrux_ml_kem_ind_cpa_generate_keypair_93(ind_cpa_keypair_randomness);
+      libcrux_ml_kem_ind_cpa_generate_keypair_b7(ind_cpa_keypair_randomness);
   uint8_t ind_cpa_private_key[1152U];
   memcpy(ind_cpa_private_key, uu____0.fst, (size_t)1152U * sizeof(uint8_t));
   uint8_t public_key[1184U];
   memcpy(public_key, uu____0.snd, (size_t)1184U * sizeof(uint8_t));
   uint8_t secret_key_serialized[2400U];
-  libcrux_ml_kem_ind_cca_serialize_kem_secret_key_8e(
+  libcrux_ml_kem_ind_cca_serialize_kem_secret_key_5a(
       Eurydice_array_to_slice((size_t)1152U, ind_cpa_private_key, uint8_t),
       Eurydice_array_to_slice((size_t)1184U, public_key, uint8_t),
       implicit_rejection_value, secret_key_serialized);
@@ -5272,13 +5301,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_0d(uint8_t randomness[64U]) {
   memcpy(copy_of_secret_key_serialized, secret_key_serialized,
          (size_t)2400U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemPrivateKey_55 private_key =
-      libcrux_ml_kem_types_from_05_db(copy_of_secret_key_serialized);
+      libcrux_ml_kem_types_from_05_0b(copy_of_secret_key_serialized);
   libcrux_ml_kem_types_MlKemPrivateKey_55 uu____2 = private_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_public_key[1184U];
   memcpy(copy_of_public_key, public_key, (size_t)1184U * sizeof(uint8_t));
-  return libcrux_ml_kem_types_from_17_12(
-      uu____2, libcrux_ml_kem_types_from_b6_8e(copy_of_public_key));
+  return libcrux_ml_kem_types_from_17_9c(
+      uu____2, libcrux_ml_kem_types_from_b6_b0(copy_of_public_key));
 }
 
 /**
@@ -5297,12 +5326,12 @@ libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
-libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_98(
+libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_a5(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_0d(copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_generate_keypair_50(copy_of_randomness);
 }
 
 /**
@@ -5314,7 +5343,7 @@ libcrux_ml_kem_mlkem768_avx2_generate_key_pair(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_98(
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_a5(
       copy_of_randomness);
 }
 
@@ -5381,10 +5410,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline tuple_9b0 libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_bc(
+static inline tuple_9b0 libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_53(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  libcrux_ml_kem_hash_functions_avx2_G_a9_e1(key_generation_seed, hashed);
+  libcrux_ml_kem_variant_cpa_keygen_seed_d8_45(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -5473,7 +5502,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_closure_3d(size_t _j) {
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_closure_27(size_t _j) {
   return libcrux_ml_kem_polynomial_ZERO_89_9b();
 }
 
@@ -5491,7 +5520,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_8a(
+static inline void libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_16(
     size_t _i, libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[3U]) {
   for (size_t i = (size_t)0U; i < (size_t)3U; i++) {
     ret[i] = libcrux_ml_kem_polynomial_ZERO_89_9b();
@@ -5510,7 +5539,7 @@ with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_polynomial_clone_d5_f0(
+libcrux_ml_kem_polynomial_clone_d5_41(
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 *self) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 lit;
   __m256i ret[16U];
@@ -5534,7 +5563,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_03(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_81(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -5542,7 +5571,7 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_03(uint8_t randomness[64U]) {
       (size_t)64U, randomness,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
-  tuple_9b0 uu____0 = libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_bc(
+  tuple_9b0 uu____0 = libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_53(
       ind_cpa_keypair_randomness);
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_a0
       ind_cpa_private_key = uu____0.fst;
@@ -5550,14 +5579,14 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_03(uint8_t randomness[64U]) {
       ind_cpa_public_key = uu____0.snd;
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 A[3U][3U];
   for (size_t i = (size_t)0U; i < (size_t)3U; i++) {
-    libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_8a(i, A[i]);
+    libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_16(i, A[i]);
   }
   for (size_t i0 = (size_t)0U; i0 < (size_t)3U; i0++) {
     size_t i1 = i0;
     for (size_t i = (size_t)0U; i < (size_t)3U; i++) {
       size_t j = i;
       libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____1 =
-          libcrux_ml_kem_polynomial_clone_d5_f0(&ind_cpa_public_key.A[j][i1]);
+          libcrux_ml_kem_polynomial_clone_d5_41(&ind_cpa_public_key.A[j][i1]);
       A[i1][j] = uu____1;
     }
   }
@@ -5624,12 +5653,12 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_a0
-libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_unpacked_03(
+libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_unpacked_f3(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_03(
+  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_81(
       copy_of_randomness);
 }
 
@@ -5643,23 +5672,23 @@ libcrux_ml_kem_mlkem768_avx2_generate_key_pair_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_unpacked_03(
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_unpacked_f3(
       copy_of_randomness);
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::Kyber)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::Kyber)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.kdf_6c
+A monomorphic instance of libcrux_ml_kem.variant.kdf_33
 with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_kdf_6c_41(
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_kdf_33_e8(
     Eurydice_slice shared_secret,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   uint8_t kdf_input[64U];
@@ -5684,7 +5713,7 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_kdf_6c_41(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_Kyber
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_Kyber
 with const generics
 - K= 3
 - SECRET_KEY_SIZE= 2400
@@ -5704,7 +5733,7 @@ with const generics
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cca_decapsulate_e70(
+static inline void libcrux_ml_kem_ind_cca_decapsulate_130(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -5722,7 +5751,7 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_e70(
   Eurydice_slice ind_cpa_public_key_hash = uu____2.fst;
   Eurydice_slice implicit_rejection_value = uu____2.snd;
   uint8_t decrypted[32U];
-  libcrux_ml_kem_ind_cpa_decrypt_8e(ind_cpa_secret_key, ciphertext->value,
+  libcrux_ml_kem_ind_cpa_decrypt_c4(ind_cpa_secret_key, ciphertext->value,
                                     decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -5746,7 +5775,7 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_e70(
   Eurydice_slice uu____4 = Eurydice_array_to_subslice_from(
       (size_t)1120U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret0[32U];
   libcrux_ml_kem_hash_functions_avx2_PRF_a9_dd(
@@ -5757,18 +5786,18 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_e70(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_a3(uu____5, copy_of_decrypted,
+  libcrux_ml_kem_ind_cpa_encrypt_c1(uu____5, copy_of_decrypted,
                                     pseudorandomness, expected_ciphertext);
   uint8_t implicit_rejection_shared_secret[32U];
-  libcrux_ml_kem_ind_cca_kdf_6c_41(
+  libcrux_ml_kem_variant_kdf_33_e8(
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret0,
                               uint8_t),
       ciphertext, implicit_rejection_shared_secret);
   uint8_t shared_secret[32U];
-  libcrux_ml_kem_ind_cca_kdf_6c_41(shared_secret0, ciphertext, shared_secret);
+  libcrux_ml_kem_variant_kdf_33_e8(shared_secret0, ciphertext, shared_secret);
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_compare_ciphertexts_select_shared_secret_in_constant_time(
-      libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+      libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
       Eurydice_array_to_slice((size_t)1088U, expected_ciphertext, uint8_t),
       Eurydice_array_to_slice((size_t)32U, shared_secret, uint8_t),
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret,
@@ -5802,10 +5831,10 @@ libcrux_ml_kem.ind_cca.instantiations.avx2.kyber_decapsulate with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline void
-libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_decapsulate_67(
+libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_decapsulate_74(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_e70(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_130(private_key, ciphertext, ret);
 }
 
 /**
@@ -5819,22 +5848,22 @@ KRML_ATTRIBUTE_TARGET("avx2")
 static inline void libcrux_ml_kem_mlkem768_avx2_kyber_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_decapsulate_67(
+  libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_decapsulate_74(
       private_key, ciphertext, ret);
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::Kyber)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::Kyber)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.entropy_preprocess_6c
+A monomorphic instance of libcrux_ml_kem.variant.entropy_preprocess_33
 with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
 with const generics
 - K= 3
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_entropy_preprocess_6c_a0(
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_entropy_preprocess_33_6c(
     Eurydice_slice randomness, uint8_t ret[32U]) {
   libcrux_ml_kem_hash_functions_avx2_H_a9_a1(randomness, ret);
 }
@@ -5842,7 +5871,7 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_entropy_preprocess_6c_a0(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
-libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_ind_cca_Kyber
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_Kyber
 with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
@@ -5859,11 +5888,11 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_410(
+static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_db0(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
-  libcrux_ml_kem_ind_cca_entropy_preprocess_6c_a0(
+  libcrux_ml_kem_variant_entropy_preprocess_33_6c(
       Eurydice_array_to_slice((size_t)32U, randomness, uint8_t), randomness0);
   uint8_t to_hash[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -5874,7 +5903,7 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_410(
   uint8_t ret[32U];
   libcrux_ml_kem_hash_functions_avx2_H_a9_a1(
       Eurydice_array_to_slice((size_t)1184U,
-                              libcrux_ml_kem_types_as_slice_cb_6f(public_key),
+                              libcrux_ml_kem_types_as_slice_cb_25(public_key),
                               uint8_t),
       ret);
   Eurydice_slice_copy(
@@ -5889,20 +5918,20 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_410(
   Eurydice_slice shared_secret = uu____1.fst;
   Eurydice_slice pseudorandomness = uu____1.snd;
   Eurydice_slice uu____2 = Eurydice_array_to_slice(
-      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_6f(public_key), uint8_t);
+      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_25(public_key), uint8_t);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness0, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_a3(uu____2, copy_of_randomness,
+  libcrux_ml_kem_ind_cpa_encrypt_c1(uu____2, copy_of_randomness,
                                     pseudorandomness, ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_ciphertext[1088U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1088U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext ciphertext0 =
-      libcrux_ml_kem_types_from_01_ec(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_1e(copy_of_ciphertext);
   uint8_t shared_secret_array[32U];
-  libcrux_ml_kem_ind_cca_kdf_6c_41(shared_secret, &ciphertext0,
+  libcrux_ml_kem_variant_kdf_33_e8(shared_secret, &ciphertext0,
                                    shared_secret_array);
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext uu____5 = ciphertext0;
   /* Passing arrays by value in Rust generates a copy in C */
@@ -5937,14 +5966,14 @@ libcrux_ml_kem.ind_cca.instantiations.avx2.kyber_encapsulate with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline tuple_3c
-libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_encapsulate_ee(
+libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_encapsulate_04(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_15 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_410(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_encapsulate_db0(uu____0, copy_of_randomness);
 }
 
 /**
@@ -5962,8 +5991,195 @@ static inline tuple_3c libcrux_ml_kem_mlkem768_avx2_kyber_encapsulate(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_encapsulate_ee(
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_encapsulate_04(
       uu____0, copy_of_randomness);
+}
+
+/**
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::Kyber)}
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.variant.cpa_keygen_seed_33
+with types libcrux_ml_kem_hash_functions_avx2_Simd256Hash
+with const generics
+- K= 3
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_cpa_keygen_seed_33_2c(
+    Eurydice_slice key_generation_seed, uint8_t ret[64U]) {
+  libcrux_ml_kem_hash_functions_avx2_G_a9_e1(key_generation_seed, ret);
+}
+
+/**
+A monomorphic instance of libcrux_ml_kem.ind_cpa.generate_keypair
+with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_Kyber
+with const generics
+- K= 3
+- PRIVATE_KEY_SIZE= 1152
+- PUBLIC_KEY_SIZE= 1184
+- RANKED_BYTES_PER_RING_ELEMENT= 1152
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline libcrux_ml_kem_utils_extraction_helper_Keypair768
+libcrux_ml_kem_ind_cpa_generate_keypair_b70(
+    Eurydice_slice key_generation_seed) {
+  uint8_t hashed[64U];
+  libcrux_ml_kem_variant_cpa_keygen_seed_33_2c(key_generation_seed, hashed);
+  Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
+      Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
+      uint8_t, Eurydice_slice_uint8_t_x2);
+  Eurydice_slice seed_for_A0 = uu____0.fst;
+  Eurydice_slice seed_for_secret_and_error = uu____0.snd;
+  libcrux_ml_kem_polynomial_PolynomialRingElement_d2 A_transpose[3U][3U];
+  uint8_t ret[34U];
+  libcrux_ml_kem_utils_into_padded_array_ea1(seed_for_A0, ret);
+  libcrux_ml_kem_matrix_sample_matrix_A_ac(ret, true, A_transpose);
+  uint8_t prf_input[33U];
+  libcrux_ml_kem_utils_into_padded_array_ea2(seed_for_secret_and_error,
+                                             prf_input);
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_prf_input0[33U];
+  memcpy(copy_of_prf_input0, prf_input, (size_t)33U * sizeof(uint8_t));
+  tuple_b00 uu____2 = libcrux_ml_kem_ind_cpa_sample_vector_cbd_then_ntt_08(
+      copy_of_prf_input0, 0U);
+  libcrux_ml_kem_polynomial_PolynomialRingElement_d2 secret_as_ntt[3U];
+  memcpy(
+      secret_as_ntt, uu____2.fst,
+      (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
+  uint8_t domain_separator = uu____2.snd;
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_prf_input[33U];
+  memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
+  libcrux_ml_kem_polynomial_PolynomialRingElement_d2 error_as_ntt[3U];
+  memcpy(
+      error_as_ntt,
+      libcrux_ml_kem_ind_cpa_sample_vector_cbd_then_ntt_08(copy_of_prf_input,
+                                                           domain_separator)
+          .fst,
+      (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_d2));
+  libcrux_ml_kem_polynomial_PolynomialRingElement_d2 t_as_ntt[3U];
+  libcrux_ml_kem_matrix_compute_As_plus_e_58(A_transpose, secret_as_ntt,
+                                             error_as_ntt, t_as_ntt);
+  uint8_t seed_for_A[32U];
+  Result_00 dst;
+  Eurydice_slice_to_array2(&dst, seed_for_A0, Eurydice_slice, uint8_t[32U]);
+  unwrap_41_83(dst, seed_for_A);
+  uint8_t public_key_serialized[1184U];
+  libcrux_ml_kem_ind_cpa_serialize_public_key_5a(
+      t_as_ntt, Eurydice_array_to_slice((size_t)32U, seed_for_A, uint8_t),
+      public_key_serialized);
+  uint8_t secret_key_serialized[1152U];
+  libcrux_ml_kem_ind_cpa_serialize_secret_key_79(secret_as_ntt,
+                                                 secret_key_serialized);
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_secret_key_serialized[1152U];
+  memcpy(copy_of_secret_key_serialized, secret_key_serialized,
+         (size_t)1152U * sizeof(uint8_t));
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_public_key_serialized[1184U];
+  memcpy(copy_of_public_key_serialized, public_key_serialized,
+         (size_t)1184U * sizeof(uint8_t));
+  libcrux_ml_kem_utils_extraction_helper_Keypair768 lit;
+  memcpy(lit.fst, copy_of_secret_key_serialized,
+         (size_t)1152U * sizeof(uint8_t));
+  memcpy(lit.snd, copy_of_public_key_serialized,
+         (size_t)1184U * sizeof(uint8_t));
+  return lit;
+}
+
+/**
+ Packed API
+
+ Generate a key pair.
+
+ Depending on the `Vector` and `Hasher` used, this requires different hardware
+ features
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
+with types libcrux_ml_kem_vector_avx2_SIMD256Vector,
+libcrux_ml_kem_hash_functions_avx2_Simd256Hash, libcrux_ml_kem_variant_Kyber
+with const generics
+- K= 3
+- CPA_PRIVATE_KEY_SIZE= 1152
+- PRIVATE_KEY_SIZE= 2400
+- PUBLIC_KEY_SIZE= 1184
+- BYTES_PER_RING_ELEMENT= 1152
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+libcrux_ml_kem_ind_cca_generate_keypair_500(uint8_t randomness[64U]) {
+  Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
+      randomness, (size_t)0U,
+      LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
+  Eurydice_slice implicit_rejection_value = Eurydice_array_to_subslice_from(
+      (size_t)64U, randomness,
+      LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
+      size_t);
+  libcrux_ml_kem_utils_extraction_helper_Keypair768 uu____0 =
+      libcrux_ml_kem_ind_cpa_generate_keypair_b70(ind_cpa_keypair_randomness);
+  uint8_t ind_cpa_private_key[1152U];
+  memcpy(ind_cpa_private_key, uu____0.fst, (size_t)1152U * sizeof(uint8_t));
+  uint8_t public_key[1184U];
+  memcpy(public_key, uu____0.snd, (size_t)1184U * sizeof(uint8_t));
+  uint8_t secret_key_serialized[2400U];
+  libcrux_ml_kem_ind_cca_serialize_kem_secret_key_5a(
+      Eurydice_array_to_slice((size_t)1152U, ind_cpa_private_key, uint8_t),
+      Eurydice_array_to_slice((size_t)1184U, public_key, uint8_t),
+      implicit_rejection_value, secret_key_serialized);
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_secret_key_serialized[2400U];
+  memcpy(copy_of_secret_key_serialized, secret_key_serialized,
+         (size_t)2400U * sizeof(uint8_t));
+  libcrux_ml_kem_types_MlKemPrivateKey_55 private_key =
+      libcrux_ml_kem_types_from_05_0b(copy_of_secret_key_serialized);
+  libcrux_ml_kem_types_MlKemPrivateKey_55 uu____2 = private_key;
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_public_key[1184U];
+  memcpy(copy_of_public_key, public_key, (size_t)1184U * sizeof(uint8_t));
+  return libcrux_ml_kem_types_from_17_9c(
+      uu____2, libcrux_ml_kem_types_from_b6_b0(copy_of_public_key));
+}
+
+/**
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.kyber_generate_keypair with const
+generics
+- K= 3
+- CPA_PRIVATE_KEY_SIZE= 1152
+- PRIVATE_KEY_SIZE= 2400
+- PUBLIC_KEY_SIZE= 1184
+- BYTES_PER_RING_ELEMENT= 1152
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_generate_keypair_38(
+    uint8_t randomness[64U]) {
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[64U];
+  memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_generate_keypair_500(copy_of_randomness);
+}
+
+/**
+ Generate Kyber 768 Key Pair
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+libcrux_ml_kem_mlkem768_avx2_kyber_generate_key_pair(uint8_t randomness[64U]) {
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[64U];
+  memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_generate_keypair_38(
+      copy_of_randomness);
 }
 
 /**
@@ -5975,7 +6191,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_d2
-libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_closure_c10(
+libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_closure_470(
     size_t _i) {
   return libcrux_ml_kem_polynomial_ZERO_89_9b();
 }
@@ -5995,7 +6211,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_a80(
+libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_090(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[3U];
@@ -6013,7 +6229,7 @@ libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_a80(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_d2 uu____0 =
-        libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_71(
+        libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_e6(
             ring_element);
     deserialized_pk[i0] = uu____0;
   }
@@ -6031,10 +6247,10 @@ with const generics
 - PUBLIC_KEY_SIZE= 1184
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE bool libcrux_ml_kem_ind_cca_validate_public_key_f9(
+static KRML_MUSTINLINE bool libcrux_ml_kem_ind_cca_validate_public_key_ce(
     uint8_t *public_key) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_d2 deserialized_pk[3U];
-  libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_a80(
+  libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_090(
       Eurydice_array_to_subslice_to((size_t)1184U, public_key, (size_t)1152U,
                                     uint8_t, size_t),
       deserialized_pk);
@@ -6062,9 +6278,9 @@ generics
 */
 KRML_ATTRIBUTE_TARGET("avx2")
 static inline bool
-libcrux_ml_kem_ind_cca_instantiations_avx2_validate_public_key_ab(
+libcrux_ml_kem_ind_cca_instantiations_avx2_validate_public_key_fc(
     uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_f9(public_key);
+  return libcrux_ml_kem_ind_cca_validate_public_key_ce(public_key);
 }
 
 /**
@@ -6076,7 +6292,7 @@ KRML_ATTRIBUTE_TARGET("avx2")
 static inline Option_92 libcrux_ml_kem_mlkem768_avx2_validate_public_key(
     libcrux_ml_kem_types_MlKemPublicKey_15 public_key) {
   Option_92 uu____0;
-  if (libcrux_ml_kem_ind_cca_instantiations_avx2_validate_public_key_ab(
+  if (libcrux_ml_kem_ind_cca_instantiations_avx2_validate_public_key_fc(
           public_key.value)) {
     uu____0 = (CLITERAL(Option_92){.tag = Some, .f0 = public_key});
   } else {

--- a/libcrux-ml-kem/cg/libcrux_mlkem768_portable.h
+++ b/libcrux-ml-kem/cg/libcrux_mlkem768_portable.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 0ca73e59afe19a3f88b8ff45d0c57b0ebe851319
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_mlkem768_portable_H
@@ -2474,7 +2474,7 @@ with const generics
 - K= 3
 */
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_ind_cpa_deserialize_secret_key_closure_3a(size_t _) {
+libcrux_ml_kem_ind_cpa_deserialize_secret_key_closure_da(size_t _) {
   return libcrux_ml_kem_polynomial_ZERO_89_8d();
 }
 
@@ -2485,7 +2485,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_to_uncompressed_ring_element_18(
+libcrux_ml_kem_serialize_deserialize_to_uncompressed_ring_element_ac(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re =
       libcrux_ml_kem_polynomial_ZERO_89_8d();
@@ -2510,7 +2510,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_deserialize_secret_key_26(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_deserialize_secret_key_e8(
     Eurydice_slice secret_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 secret_as_ntt[3U];
@@ -2528,7 +2528,7 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_deserialize_secret_key_26(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        libcrux_ml_kem_serialize_deserialize_to_uncompressed_ring_element_18(
+        libcrux_ml_kem_serialize_deserialize_to_uncompressed_ring_element_ac(
             secret_bytes);
     secret_as_ntt[i0] = uu____0;
   }
@@ -2556,7 +2556,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - U_COMPRESSION_FACTOR= 10
 */
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_closure_b5(size_t _) {
+libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_closure_3e(size_t _) {
   return libcrux_ml_kem_polynomial_ZERO_89_8d();
 }
 
@@ -2605,7 +2605,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_then_decompress_10_fb(
+libcrux_ml_kem_serialize_deserialize_then_decompress_10_21(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re =
       libcrux_ml_kem_polynomial_ZERO_89_8d();
@@ -2669,7 +2669,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_then_decompress_11_fb(
+libcrux_ml_kem_serialize_deserialize_then_decompress_11_e0(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re =
       libcrux_ml_kem_polynomial_ZERO_89_8d();
@@ -2695,9 +2695,9 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - COMPRESSION_FACTOR= 10
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_u_d6(
+libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_u_b5(
     Eurydice_slice serialized) {
-  return libcrux_ml_kem_serialize_deserialize_then_decompress_10_fb(serialized);
+  return libcrux_ml_kem_serialize_deserialize_then_decompress_10_21(serialized);
 }
 
 typedef struct libcrux_ml_kem_vector_portable_vector_type_PortableVector_x2_s {
@@ -2865,7 +2865,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - VECTOR_U_COMPRESSION_FACTOR= 10
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_ntt_ntt_vector_u_8e(
+static KRML_MUSTINLINE void libcrux_ml_kem_ntt_ntt_vector_u_8b(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re) {
   size_t zeta_i = (size_t)0U;
   libcrux_ml_kem_ntt_ntt_at_layer_4_plus_39(&zeta_i, re, (size_t)7U,
@@ -2895,7 +2895,7 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_0d(
+libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_48(
     uint8_t *ciphertext,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u_as_ntt[3U];
@@ -2920,9 +2920,9 @@ libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_0d(
                 (size_t)10U / (size_t)8U,
         uint8_t);
     u_as_ntt[i0] =
-        libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_u_d6(
+        libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_u_b5(
             u_bytes);
-    libcrux_ml_kem_ntt_ntt_vector_u_8e(&u_as_ntt[i0]);
+    libcrux_ml_kem_ntt_ntt_vector_u_8b(&u_as_ntt[i0]);
   }
   memcpy(
       ret, u_as_ntt,
@@ -2974,7 +2974,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_then_decompress_4_be(
+libcrux_ml_kem_serialize_deserialize_then_decompress_4_12(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re =
       libcrux_ml_kem_polynomial_ZERO_89_8d();
@@ -3038,7 +3038,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_then_decompress_5_09(
+libcrux_ml_kem_serialize_deserialize_then_decompress_5_84(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re =
       libcrux_ml_kem_polynomial_ZERO_89_8d();
@@ -3064,9 +3064,9 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - COMPRESSION_FACTOR= 4
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_v_04(
+libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_v_c6(
     Eurydice_slice serialized) {
-  return libcrux_ml_kem_serialize_deserialize_then_decompress_4_be(serialized);
+  return libcrux_ml_kem_serialize_deserialize_then_decompress_4_12(serialized);
 }
 
 /**
@@ -3172,7 +3172,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_1_46(
+static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_1_17(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re,
     size_t _layer) {
   for (size_t i = (size_t)0U; i < (size_t)16U; i++) {
@@ -3198,7 +3198,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_2_53(
+static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_2_bb(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re,
     size_t _layer) {
   for (size_t i = (size_t)0U; i < (size_t)16U; i++) {
@@ -3220,7 +3220,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_3_17(
+static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_3_f2(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re,
     size_t _layer) {
   for (size_t i = (size_t)0U; i < (size_t)16U; i++) {
@@ -3242,7 +3242,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 */
 static KRML_MUSTINLINE
     libcrux_ml_kem_vector_portable_vector_type_PortableVector_x2
-    libcrux_ml_kem_invert_ntt_inv_ntt_layer_int_vec_step_reduce_d9(
+    libcrux_ml_kem_invert_ntt_inv_ntt_layer_int_vec_step_reduce_27(
         libcrux_ml_kem_vector_portable_vector_type_PortableVector a,
         libcrux_ml_kem_vector_portable_vector_type_PortableVector b,
         int16_t zeta_r) {
@@ -3263,7 +3263,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_1a(
+libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_8d(
     size_t *zeta_i, libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re,
     size_t layer) {
   size_t step = (size_t)1U << (uint32_t)layer;
@@ -3278,7 +3278,7 @@ libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_1a(
     for (size_t i = offset_vec; i < offset_vec + step_vec; i++) {
       size_t j = i;
       libcrux_ml_kem_vector_portable_vector_type_PortableVector_x2 uu____0 =
-          libcrux_ml_kem_invert_ntt_inv_ntt_layer_int_vec_step_reduce_d9(
+          libcrux_ml_kem_invert_ntt_inv_ntt_layer_int_vec_step_reduce_27(
               re->coefficients[j], re->coefficients[j + step_vec],
               libcrux_ml_kem_polynomial_ZETAS_TIMES_MONTGOMERY_R[zeta_i[0U]]);
       libcrux_ml_kem_vector_portable_vector_type_PortableVector x = uu____0.fst;
@@ -3295,20 +3295,20 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_95(
+static KRML_MUSTINLINE void libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_c1(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re) {
   size_t zeta_i =
       LIBCRUX_ML_KEM_CONSTANTS_COEFFICIENTS_IN_RING_ELEMENT / (size_t)2U;
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_1_46(&zeta_i, re, (size_t)1U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_2_53(&zeta_i, re, (size_t)2U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_3_17(&zeta_i, re, (size_t)3U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_1a(&zeta_i, re,
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_1_17(&zeta_i, re, (size_t)1U);
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_2_bb(&zeta_i, re, (size_t)2U);
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_3_f2(&zeta_i, re, (size_t)3U);
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_8d(&zeta_i, re,
                                                           (size_t)4U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_1a(&zeta_i, re,
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_8d(&zeta_i, re,
                                                           (size_t)5U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_1a(&zeta_i, re,
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_8d(&zeta_i, re,
                                                           (size_t)6U);
-  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_1a(&zeta_i, re,
+  libcrux_ml_kem_invert_ntt_invert_ntt_at_layer_4_plus_8d(&zeta_i, re,
                                                           (size_t)7U);
   libcrux_ml_kem_polynomial_poly_barrett_reduce_89_61(re);
 }
@@ -3324,7 +3324,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_polynomial_subtract_reduce_89_2a(
+libcrux_ml_kem_polynomial_subtract_reduce_89_b6(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *self,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 b) {
   for (size_t i = (size_t)0U;
@@ -3356,7 +3356,7 @@ with const generics
 - K= 3
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_matrix_compute_message_06(
+libcrux_ml_kem_matrix_compute_message_bc(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *v,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *secret_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *u_as_ntt) {
@@ -3369,8 +3369,8 @@ libcrux_ml_kem_matrix_compute_message_06(
                                                      &u_as_ntt[i0]);
     libcrux_ml_kem_polynomial_add_to_ring_element_89_e8(&result, &product);
   }
-  libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_95(&result);
-  result = libcrux_ml_kem_polynomial_subtract_reduce_89_2a(v, result);
+  libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_c1(&result);
+  result = libcrux_ml_kem_polynomial_subtract_reduce_89_b6(v, result);
   return result;
 }
 
@@ -3429,7 +3429,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_message_71(
+libcrux_ml_kem_serialize_compress_then_serialize_message_4c(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re, uint8_t ret[32U]) {
   uint8_t serialized[32U] = {0U};
   for (size_t i = (size_t)0U; i < (size_t)16U; i++) {
@@ -3485,20 +3485,20 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static inline void libcrux_ml_kem_ind_cpa_decrypt_unpacked_26(
+static inline void libcrux_ml_kem_ind_cpa_decrypt_unpacked_25(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_f8 *secret_key,
     uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u_as_ntt[3U];
-  libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_0d(ciphertext, u_as_ntt);
+  libcrux_ml_kem_ind_cpa_deserialize_then_decompress_u_48(ciphertext, u_as_ntt);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_v_04(
+      libcrux_ml_kem_serialize_deserialize_then_decompress_ring_element_v_c6(
           Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                           (size_t)960U, uint8_t, size_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message =
-      libcrux_ml_kem_matrix_compute_message_06(&v, secret_key->secret_as_ntt,
+      libcrux_ml_kem_matrix_compute_message_bc(&v, secret_key->secret_as_ntt,
                                                u_as_ntt);
   uint8_t ret0[32U];
-  libcrux_ml_kem_serialize_compress_then_serialize_message_71(message, ret0);
+  libcrux_ml_kem_serialize_compress_then_serialize_message_4c(message, ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
 
@@ -3512,11 +3512,11 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static inline void libcrux_ml_kem_ind_cpa_decrypt_35(Eurydice_slice secret_key,
+static inline void libcrux_ml_kem_ind_cpa_decrypt_a2(Eurydice_slice secret_key,
                                                      uint8_t *ciphertext,
                                                      uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 secret_as_ntt[3U];
-  libcrux_ml_kem_ind_cpa_deserialize_secret_key_26(secret_key, secret_as_ntt);
+  libcrux_ml_kem_ind_cpa_deserialize_secret_key_e8(secret_key, secret_as_ntt);
   /* Passing arrays by value in Rust generates a copy in C */
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 copy_of_secret_as_ntt[3U];
   memcpy(
@@ -3528,7 +3528,7 @@ static inline void libcrux_ml_kem_ind_cpa_decrypt_35(Eurydice_slice secret_key,
       secret_key_unpacked.secret_as_ntt, copy_of_secret_as_ntt,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
   uint8_t ret0[32U];
-  libcrux_ml_kem_ind_cpa_decrypt_unpacked_26(&secret_key_unpacked, ciphertext,
+  libcrux_ml_kem_ind_cpa_decrypt_unpacked_25(&secret_key_unpacked, ciphertext,
                                              ret0);
   memcpy(ret, ret0, (size_t)32U * sizeof(uint8_t));
 }
@@ -3583,7 +3583,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - K= 3
 */
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_closure_45(
+libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_closure_30(
     size_t _i) {
   return libcrux_ml_kem_polynomial_ZERO_89_8d();
 }
@@ -3601,7 +3601,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_e1(
+libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_b0(
     Eurydice_slice serialized) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re =
       libcrux_ml_kem_polynomial_ZERO_89_8d();
@@ -3633,7 +3633,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - K= 3
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_9d(
+libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_1c(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[3U];
@@ -3651,7 +3651,7 @@ libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_9d(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_e1(
+        libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_b0(
             ring_element);
     deserialized_pk[i0] = uu____0;
   }
@@ -4454,7 +4454,7 @@ generics
 - ETA2= 2
 */
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_closure_d0(size_t _i) {
+libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_closure_c7(size_t _i) {
   return libcrux_ml_kem_polynomial_ZERO_89_8d();
 }
 
@@ -4471,7 +4471,7 @@ generics
 - ETA2= 2
 */
 static KRML_MUSTINLINE tuple_b0
-libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_38(uint8_t prf_input[33U],
+libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_53(uint8_t prf_input[33U],
                                                   uint8_t domain_separator) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[3U];
   for (size_t i = (size_t)0U; i < (size_t)3U; i++) {
@@ -4546,7 +4546,7 @@ with const generics
 - K= 3
 */
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_matrix_compute_vector_u_closure_ca(size_t _i) {
+libcrux_ml_kem_matrix_compute_vector_u_closure_22(size_t _i) {
   return libcrux_ml_kem_polynomial_ZERO_89_8d();
 }
 
@@ -4560,7 +4560,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_polynomial_add_error_reduce_89_c3(
+static KRML_MUSTINLINE void libcrux_ml_kem_polynomial_add_error_reduce_89_3a(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *self,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *error) {
   for (size_t i = (size_t)0U;
@@ -4587,7 +4587,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_matrix_compute_vector_u_22(
+static KRML_MUSTINLINE void libcrux_ml_kem_matrix_compute_vector_u_3d(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 (*a_as_ntt)[3U],
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *error_1,
@@ -4619,8 +4619,8 @@ static KRML_MUSTINLINE void libcrux_ml_kem_matrix_compute_vector_u_22(
       libcrux_ml_kem_polynomial_add_to_ring_element_89_e8(&result[i1],
                                                           &product);
     }
-    libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_95(&result[i1]);
-    libcrux_ml_kem_polynomial_add_error_reduce_89_c3(&result[i1], &error_1[i1]);
+    libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_c1(&result[i1]);
+    libcrux_ml_kem_polynomial_add_error_reduce_89_3a(&result[i1], &error_1[i1]);
   }
   memcpy(
       ret, result,
@@ -4634,7 +4634,7 @@ with const generics
 
 */
 static inline libcrux_ml_kem_vector_portable_vector_type_PortableVector
-libcrux_ml_kem_vector_traits_decompress_1_b3(
+libcrux_ml_kem_vector_traits_decompress_1_7e(
     libcrux_ml_kem_vector_portable_vector_type_PortableVector v) {
   libcrux_ml_kem_vector_portable_vector_type_PortableVector uu____0 =
       libcrux_ml_kem_vector_portable_ZERO_0d();
@@ -4649,7 +4649,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_then_decompress_message_6c(
+libcrux_ml_kem_serialize_deserialize_then_decompress_message_e6(
     uint8_t serialized[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re =
       libcrux_ml_kem_polynomial_ZERO_89_8d();
@@ -4662,7 +4662,7 @@ libcrux_ml_kem_serialize_deserialize_then_decompress_message_6c(
                                             (size_t)2U * i0 + (size_t)2U,
                                             uint8_t));
     libcrux_ml_kem_vector_portable_vector_type_PortableVector uu____0 =
-        libcrux_ml_kem_vector_traits_decompress_1_b3(coefficient_compressed);
+        libcrux_ml_kem_vector_traits_decompress_1_7e(coefficient_compressed);
     re.coefficients[i0] = uu____0;
   }
   return re;
@@ -4679,7 +4679,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_polynomial_add_message_error_reduce_89_a1(
+libcrux_ml_kem_polynomial_add_message_error_reduce_89_4a(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *self,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *message,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 result) {
@@ -4712,7 +4712,7 @@ with const generics
 - K= 3
 */
 static KRML_MUSTINLINE libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_matrix_compute_ring_element_v_ba(
+libcrux_ml_kem_matrix_compute_ring_element_v_da(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *t_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *r_as_ntt,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *error_2,
@@ -4726,8 +4726,8 @@ libcrux_ml_kem_matrix_compute_ring_element_v_ba(
                                                      &r_as_ntt[i0]);
     libcrux_ml_kem_polynomial_add_to_ring_element_89_e8(&result, &product);
   }
-  libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_95(&result);
-  result = libcrux_ml_kem_polynomial_add_message_error_reduce_89_a1(
+  libcrux_ml_kem_invert_ntt_invert_ntt_montgomery_c1(&result);
+  result = libcrux_ml_kem_polynomial_add_message_error_reduce_89_4a(
       error_2, message, result);
   return result;
 }
@@ -4773,7 +4773,7 @@ with const generics
 - OUT_LEN= 320
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_10_c9(
+libcrux_ml_kem_serialize_compress_then_serialize_10_69(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re, uint8_t ret[320U]) {
   uint8_t serialized[320U] = {0U};
   for (size_t i = (size_t)0U;
@@ -4834,7 +4834,7 @@ with const generics
 - OUT_LEN= 320
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_11_f8(
+libcrux_ml_kem_serialize_compress_then_serialize_11_7b(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re, uint8_t ret[320U]) {
   uint8_t serialized[320U] = {0U};
   for (size_t i = (size_t)0U;
@@ -4862,10 +4862,10 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - OUT_LEN= 320
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_ring_element_u_54(
+libcrux_ml_kem_serialize_compress_then_serialize_ring_element_u_80(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *re, uint8_t ret[320U]) {
   uint8_t uu____0[320U];
-  libcrux_ml_kem_serialize_compress_then_serialize_10_c9(re, uu____0);
+  libcrux_ml_kem_serialize_compress_then_serialize_10_69(re, uu____0);
   memcpy(ret, uu____0, (size_t)320U * sizeof(uint8_t));
 }
 
@@ -4881,7 +4881,7 @@ with const generics
 - COMPRESSION_FACTOR= 10
 - BLOCK_LEN= 320
 */
-static inline void libcrux_ml_kem_ind_cpa_compress_then_serialize_u_62(
+static inline void libcrux_ml_kem_ind_cpa_compress_then_serialize_u_08(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 input[3U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -4897,7 +4897,7 @@ static inline void libcrux_ml_kem_ind_cpa_compress_then_serialize_u_62(
         out, i0 * ((size_t)960U / (size_t)3U),
         (i0 + (size_t)1U) * ((size_t)960U / (size_t)3U), uint8_t);
     uint8_t ret[320U];
-    libcrux_ml_kem_serialize_compress_then_serialize_ring_element_u_54(&re,
+    libcrux_ml_kem_serialize_compress_then_serialize_ring_element_u_80(&re,
                                                                        ret);
     Eurydice_slice_copy(
         uu____0, Eurydice_array_to_slice((size_t)320U, ret, uint8_t), uint8_t);
@@ -4945,7 +4945,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_4_f6(
+libcrux_ml_kem_serialize_compress_then_serialize_4_c2(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re,
     Eurydice_slice serialized) {
   for (size_t i = (size_t)0U;
@@ -5005,7 +5005,7 @@ with const generics
 
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_5_06(
+libcrux_ml_kem_serialize_compress_then_serialize_5_0a(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re,
     Eurydice_slice serialized) {
   for (size_t i = (size_t)0U;
@@ -5032,9 +5032,9 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - OUT_LEN= 128
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_20(
+libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_7f(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 re, Eurydice_slice out) {
-  libcrux_ml_kem_serialize_compress_then_serialize_4_f6(re, out);
+  libcrux_ml_kem_serialize_compress_then_serialize_4_c2(re, out);
 }
 
 /**
@@ -5055,12 +5055,12 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline void libcrux_ml_kem_ind_cpa_encrypt_09(Eurydice_slice public_key,
+static inline void libcrux_ml_kem_ind_cpa_encrypt_59(Eurydice_slice public_key,
                                                      uint8_t message[32U],
                                                      Eurydice_slice randomness,
                                                      uint8_t ret[1088U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 t_as_ntt[3U];
-  libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_9d(
+  libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_1c(
       Eurydice_slice_subslice_to(public_key, (size_t)1152U, uint8_t, size_t),
       t_as_ntt);
   Eurydice_slice seed =
@@ -5084,7 +5084,7 @@ static inline void libcrux_ml_kem_ind_cpa_encrypt_09(Eurydice_slice public_key,
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
-  tuple_b0 uu____3 = libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_38(
+  tuple_b0 uu____3 = libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_53(
       copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[3U];
   memcpy(
@@ -5099,43 +5099,43 @@ static inline void libcrux_ml_kem_ind_cpa_encrypt_09(Eurydice_slice public_key,
       libcrux_ml_kem_sampling_sample_from_binomial_distribution_34(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u[3U];
-  libcrux_ml_kem_matrix_compute_vector_u_22(A, r_as_ntt, error_1, u);
+  libcrux_ml_kem_matrix_compute_vector_u_3d(A, r_as_ntt, error_1, u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message_as_ring_element =
-      libcrux_ml_kem_serialize_deserialize_then_decompress_message_6c(
+      libcrux_ml_kem_serialize_deserialize_then_decompress_message_e6(
           copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      libcrux_ml_kem_matrix_compute_ring_element_v_ba(
+      libcrux_ml_kem_matrix_compute_ring_element_v_da(
           t_as_ntt, r_as_ntt, &error_2, &message_as_ring_element);
   uint8_t ciphertext[1088U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____5[3U];
   memcpy(
       uu____5, u,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
-  libcrux_ml_kem_ind_cpa_compress_then_serialize_u_62(
+  libcrux_ml_kem_ind_cpa_compress_then_serialize_u_08(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)960U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____6 = v;
-  libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_20(
+  libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_7f(
       uu____6, Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                                (size_t)960U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1088U * sizeof(uint8_t));
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)#1}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)#1}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.kdf_43
+A monomorphic instance of libcrux_ml_kem.variant.kdf_d8
 with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
 with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_kdf_43_b8(
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_kdf_d8_86(
     Eurydice_slice shared_secret, libcrux_ml_kem_mlkem768_MlKem768Ciphertext *_,
     uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
@@ -5148,7 +5148,7 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_kdf_43_b8(
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - SECRET_KEY_SIZE= 2400
 - CPA_SECRET_KEY_SIZE= 1152
@@ -5166,7 +5166,7 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static inline void libcrux_ml_kem_ind_cca_decapsulate_54(
+static inline void libcrux_ml_kem_ind_cca_decapsulate_1c(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -5184,7 +5184,7 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_54(
   Eurydice_slice ind_cpa_public_key_hash = uu____2.fst;
   Eurydice_slice implicit_rejection_value = uu____2.snd;
   uint8_t decrypted[32U];
-  libcrux_ml_kem_ind_cpa_decrypt_35(ind_cpa_secret_key, ciphertext->value,
+  libcrux_ml_kem_ind_cpa_decrypt_a2(ind_cpa_secret_key, ciphertext->value,
                                     decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -5208,7 +5208,7 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_54(
   Eurydice_slice uu____4 = Eurydice_array_to_subslice_from(
       (size_t)1120U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret0[32U];
   libcrux_ml_kem_hash_functions_portable_PRF_f1_ee(
@@ -5219,18 +5219,18 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_54(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_09(uu____5, copy_of_decrypted,
+  libcrux_ml_kem_ind_cpa_encrypt_59(uu____5, copy_of_decrypted,
                                     pseudorandomness, expected_ciphertext);
   uint8_t implicit_rejection_shared_secret[32U];
-  libcrux_ml_kem_ind_cca_kdf_43_b8(
+  libcrux_ml_kem_variant_kdf_d8_86(
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret0,
                               uint8_t),
       ciphertext, implicit_rejection_shared_secret);
   uint8_t shared_secret[32U];
-  libcrux_ml_kem_ind_cca_kdf_43_b8(shared_secret0, ciphertext, shared_secret);
+  libcrux_ml_kem_variant_kdf_d8_86(shared_secret0, ciphertext, shared_secret);
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_compare_ciphertexts_select_shared_secret_in_constant_time(
-      libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+      libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
       Eurydice_array_to_slice((size_t)1088U, expected_ciphertext, uint8_t),
       Eurydice_array_to_slice((size_t)32U, shared_secret, uint8_t),
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret,
@@ -5263,10 +5263,10 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
 static inline void
-libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_d4(
+libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_90(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_54(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_1c(private_key, ciphertext, ret);
 }
 
 /**
@@ -5279,7 +5279,7 @@ libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_d4(
 static inline void libcrux_ml_kem_mlkem768_portable_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_d4(
+  libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_90(
       private_key, ciphertext, ret);
 }
 
@@ -5388,7 +5388,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline void libcrux_ml_kem_ind_cpa_encrypt_unpacked_27(
+static inline void libcrux_ml_kem_ind_cpa_encrypt_unpacked_4c(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_f8 *public_key,
     uint8_t message[32U], Eurydice_slice randomness, uint8_t ret[1088U]) {
   uint8_t prf_input[33U];
@@ -5406,7 +5406,7 @@ static inline void libcrux_ml_kem_ind_cpa_encrypt_unpacked_27(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_prf_input[33U];
   memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
-  tuple_b0 uu____3 = libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_38(
+  tuple_b0 uu____3 = libcrux_ml_kem_ind_cpa_sample_ring_element_cbd_53(
       copy_of_prf_input, domain_separator0);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_1[3U];
   memcpy(
@@ -5421,27 +5421,27 @@ static inline void libcrux_ml_kem_ind_cpa_encrypt_unpacked_27(
       libcrux_ml_kem_sampling_sample_from_binomial_distribution_34(
           Eurydice_array_to_slice((size_t)128U, prf_output, uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 u[3U];
-  libcrux_ml_kem_matrix_compute_vector_u_22(public_key->A, r_as_ntt, error_1,
+  libcrux_ml_kem_matrix_compute_vector_u_3d(public_key->A, r_as_ntt, error_1,
                                             u);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_message[32U];
   memcpy(copy_of_message, message, (size_t)32U * sizeof(uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 message_as_ring_element =
-      libcrux_ml_kem_serialize_deserialize_then_decompress_message_6c(
+      libcrux_ml_kem_serialize_deserialize_then_decompress_message_e6(
           copy_of_message);
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 v =
-      libcrux_ml_kem_matrix_compute_ring_element_v_ba(
+      libcrux_ml_kem_matrix_compute_ring_element_v_da(
           public_key->t_as_ntt, r_as_ntt, &error_2, &message_as_ring_element);
   uint8_t ciphertext[1088U] = {0U};
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____5[3U];
   memcpy(
       uu____5, u,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
-  libcrux_ml_kem_ind_cpa_compress_then_serialize_u_62(
+  libcrux_ml_kem_ind_cpa_compress_then_serialize_u_08(
       uu____5, Eurydice_array_to_subslice2(ciphertext, (size_t)0U, (size_t)960U,
                                            uint8_t));
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____6 = v;
-  libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_20(
+  libcrux_ml_kem_serialize_compress_then_serialize_ring_element_v_7f(
       uu____6, Eurydice_array_to_subslice_from((size_t)1088U, ciphertext,
                                                (size_t)960U, uint8_t, size_t));
   memcpy(ret, ciphertext, (size_t)1088U * sizeof(uint8_t));
@@ -5469,11 +5469,11 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static inline void libcrux_ml_kem_ind_cca_decapsulate_unpacked_f6(
+static inline void libcrux_ml_kem_ind_cca_decapsulate_unpacked_d5(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8 *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   uint8_t decrypted[32U];
-  libcrux_ml_kem_ind_cpa_decrypt_unpacked_26(
+  libcrux_ml_kem_ind_cpa_decrypt_unpacked_25(
       &key_pair->private_key.ind_cpa_private_key, ciphertext->value, decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -5503,7 +5503,7 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_unpacked_f6(
   Eurydice_slice uu____2 = Eurydice_array_to_subslice_from(
       (size_t)1120U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+  Eurydice_slice_copy(uu____2, libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret[32U];
   libcrux_ml_kem_hash_functions_portable_PRF_f1_ee(
@@ -5515,11 +5515,11 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_unpacked_f6(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_unpacked_27(
+  libcrux_ml_kem_ind_cpa_encrypt_unpacked_4c(
       uu____3, copy_of_decrypted, pseudorandomness, expected_ciphertext);
   uint8_t selector =
       libcrux_ml_kem_constant_time_ops_compare_ciphertexts_in_constant_time(
-          libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+          libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
           Eurydice_array_to_slice((size_t)1088U, expected_ciphertext, uint8_t));
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_select_shared_secret_in_constant_time(
@@ -5555,10 +5555,10 @@ generics
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
 static inline void
-libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_unpacked_ea(
+libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_unpacked_ba(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8 *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_unpacked_f6(key_pair, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_unpacked_d5(key_pair, ciphertext, ret);
 }
 
 /**
@@ -5571,21 +5571,21 @@ libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_unpacked_ea(
 static inline void libcrux_ml_kem_mlkem768_portable_decapsulate_unpacked(
     libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_unpacked_ea(
+  libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_unpacked_ba(
       private_key, ciphertext, ret);
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::MlKem)#1}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)#1}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.entropy_preprocess_43
+A monomorphic instance of libcrux_ml_kem.variant.entropy_preprocess_d8
 with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_entropy_preprocess_43_a2(
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_entropy_preprocess_d8_f0(
     Eurydice_slice randomness, uint8_t ret[32U]) {
   uint8_t out[32U] = {0U};
   Eurydice_slice_copy(Eurydice_array_to_slice((size_t)32U, out, uint8_t),
@@ -5611,7 +5611,7 @@ static KRML_MUSTINLINE void libcrux_ml_kem_hash_functions_portable_H_f1_1a(
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
-libcrux_ml_kem_ind_cca_MlKem with const generics
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
 - PUBLIC_KEY_SIZE= 1184
@@ -5626,11 +5626,11 @@ libcrux_ml_kem_ind_cca_MlKem with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_8f(
+static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_3b(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
-  libcrux_ml_kem_ind_cca_entropy_preprocess_43_a2(
+  libcrux_ml_kem_variant_entropy_preprocess_d8_f0(
       Eurydice_array_to_slice((size_t)32U, randomness, uint8_t), randomness0);
   uint8_t to_hash[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -5641,7 +5641,7 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_8f(
   uint8_t ret[32U];
   libcrux_ml_kem_hash_functions_portable_H_f1_1a(
       Eurydice_array_to_slice((size_t)1184U,
-                              libcrux_ml_kem_types_as_slice_cb_6f(public_key),
+                              libcrux_ml_kem_types_as_slice_cb_25(public_key),
                               uint8_t),
       ret);
   Eurydice_slice_copy(
@@ -5656,20 +5656,20 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_8f(
   Eurydice_slice shared_secret = uu____1.fst;
   Eurydice_slice pseudorandomness = uu____1.snd;
   Eurydice_slice uu____2 = Eurydice_array_to_slice(
-      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_6f(public_key), uint8_t);
+      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_25(public_key), uint8_t);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness0, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_09(uu____2, copy_of_randomness,
+  libcrux_ml_kem_ind_cpa_encrypt_59(uu____2, copy_of_randomness,
                                     pseudorandomness, ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_ciphertext[1088U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1088U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext ciphertext0 =
-      libcrux_ml_kem_types_from_01_ec(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_1e(copy_of_ciphertext);
   uint8_t shared_secret_array[32U];
-  libcrux_ml_kem_ind_cca_kdf_43_b8(shared_secret, &ciphertext0,
+  libcrux_ml_kem_variant_kdf_d8_86(shared_secret, &ciphertext0,
                                    shared_secret_array);
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext uu____5 = ciphertext0;
   /* Passing arrays by value in Rust generates a copy in C */
@@ -5700,14 +5700,14 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 static inline tuple_3c
-libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_56(
+libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_31(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_15 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_8f(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_encapsulate_3b(uu____0, copy_of_randomness);
 }
 
 /**
@@ -5724,7 +5724,7 @@ static inline tuple_3c libcrux_ml_kem_mlkem768_portable_encapsulate(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_56(
+  return libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_31(
       uu____0, copy_of_randomness);
 }
 
@@ -5747,7 +5747,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_c0(
+static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_5b(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_f8 *public_key,
     uint8_t randomness[32U]) {
   uint8_t to_hash[64U];
@@ -5775,7 +5775,7 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_c0(
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_unpacked_27(uu____2, copy_of_randomness,
+  libcrux_ml_kem_ind_cpa_encrypt_unpacked_4c(uu____2, copy_of_randomness,
                                              pseudorandomness, ciphertext);
   uint8_t shared_secret_array[32U] = {0U};
   Eurydice_slice_copy(
@@ -5785,7 +5785,7 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_unpacked_c0(
   uint8_t copy_of_ciphertext[1088U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1088U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext uu____5 =
-      libcrux_ml_kem_types_from_01_ec(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_1e(copy_of_ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_shared_secret_array[32U];
   memcpy(copy_of_shared_secret_array, shared_secret_array,
@@ -5818,7 +5818,7 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 static inline tuple_3c
-libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_unpacked_6f(
+libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_unpacked_43(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_f8 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_f8 *uu____0 =
@@ -5826,7 +5826,7 @@ libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_unpacked_6f(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_c0(uu____0,
+  return libcrux_ml_kem_ind_cca_encapsulate_unpacked_5b(uu____0,
                                                         copy_of_randomness);
 }
 
@@ -5846,8 +5846,34 @@ static inline tuple_3c libcrux_ml_kem_mlkem768_portable_encapsulate_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_unpacked_6f(
+  return libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_unpacked_43(
       uu____0, copy_of_randomness);
+}
+
+/**
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::MlKem)#1}
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.variant.cpa_keygen_seed_d8
+with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
+with const generics
+- K= 3
+*/
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_cpa_keygen_seed_d8_68(
+    Eurydice_slice key_generation_seed, uint8_t ret[64U]) {
+  uint8_t seed[33U] = {0U};
+  Eurydice_slice_copy(
+      Eurydice_array_to_subslice2(
+          seed, (size_t)0U,
+          LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t),
+      key_generation_seed, uint8_t);
+  seed[LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE] =
+      (uint8_t)(size_t)3U;
+  uint8_t ret0[64U];
+  libcrux_ml_kem_hash_functions_portable_G_f1_e4(
+      Eurydice_array_to_slice((size_t)33U, seed, uint8_t), ret0);
+  memcpy(ret, ret0, (size_t)64U * sizeof(uint8_t));
 }
 
 /**
@@ -6046,8 +6072,8 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_serialize_public_key_04(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cpa.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - PRIVATE_KEY_SIZE= 1152
 - PUBLIC_KEY_SIZE= 1184
@@ -6056,9 +6082,9 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 static inline libcrux_ml_kem_utils_extraction_helper_Keypair768
-libcrux_ml_kem_ind_cpa_generate_keypair_6e(Eurydice_slice key_generation_seed) {
+libcrux_ml_kem_ind_cpa_generate_keypair_d5(Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  libcrux_ml_kem_hash_functions_portable_G_f1_e4(key_generation_seed, hashed);
+  libcrux_ml_kem_variant_cpa_keygen_seed_d8_68(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -6131,7 +6157,7 @@ with const generics
 - K= 3
 - SERIALIZED_KEY_LEN= 2400
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_serialize_kem_secret_key_4c(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_serialize_kem_secret_key_de(
     Eurydice_slice private_key, Eurydice_slice public_key,
     Eurydice_slice implicit_rejection_value, uint8_t ret[2400U]) {
   uint8_t out[2400U] = {0U};
@@ -6184,8 +6210,8 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_serialize_kem_secret_key_4c(
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
-libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]] with const
-generics
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
+libcrux_ml_kem_variant_MlKem with const generics
 - K= 3
 - CPA_PRIVATE_KEY_SIZE= 1152
 - PRIVATE_KEY_SIZE= 2400
@@ -6195,7 +6221,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
-libcrux_ml_kem_ind_cca_generate_keypair_f9(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_95(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -6204,13 +6230,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_f9(uint8_t randomness[64U]) {
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
   libcrux_ml_kem_utils_extraction_helper_Keypair768 uu____0 =
-      libcrux_ml_kem_ind_cpa_generate_keypair_6e(ind_cpa_keypair_randomness);
+      libcrux_ml_kem_ind_cpa_generate_keypair_d5(ind_cpa_keypair_randomness);
   uint8_t ind_cpa_private_key[1152U];
   memcpy(ind_cpa_private_key, uu____0.fst, (size_t)1152U * sizeof(uint8_t));
   uint8_t public_key[1184U];
   memcpy(public_key, uu____0.snd, (size_t)1184U * sizeof(uint8_t));
   uint8_t secret_key_serialized[2400U];
-  libcrux_ml_kem_ind_cca_serialize_kem_secret_key_4c(
+  libcrux_ml_kem_ind_cca_serialize_kem_secret_key_de(
       Eurydice_array_to_slice((size_t)1152U, ind_cpa_private_key, uint8_t),
       Eurydice_array_to_slice((size_t)1184U, public_key, uint8_t),
       implicit_rejection_value, secret_key_serialized);
@@ -6219,13 +6245,13 @@ libcrux_ml_kem_ind_cca_generate_keypair_f9(uint8_t randomness[64U]) {
   memcpy(copy_of_secret_key_serialized, secret_key_serialized,
          (size_t)2400U * sizeof(uint8_t));
   libcrux_ml_kem_types_MlKemPrivateKey_55 private_key =
-      libcrux_ml_kem_types_from_05_db(copy_of_secret_key_serialized);
+      libcrux_ml_kem_types_from_05_0b(copy_of_secret_key_serialized);
   libcrux_ml_kem_types_MlKemPrivateKey_55 uu____2 = private_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_public_key[1184U];
   memcpy(copy_of_public_key, public_key, (size_t)1184U * sizeof(uint8_t));
-  return libcrux_ml_kem_types_from_17_12(
-      uu____2, libcrux_ml_kem_types_from_b6_8e(copy_of_public_key));
+  return libcrux_ml_kem_types_from_17_9c(
+      uu____2, libcrux_ml_kem_types_from_b6_b0(copy_of_public_key));
 }
 
 /**
@@ -6244,12 +6270,12 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
-libcrux_ml_kem_ind_cca_instantiations_portable_generate_keypair_c1(
+libcrux_ml_kem_ind_cca_instantiations_portable_generate_keypair_19(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_f9(copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_generate_keypair_95(copy_of_randomness);
 }
 
 /**
@@ -6260,7 +6286,7 @@ libcrux_ml_kem_mlkem768_portable_generate_key_pair(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_instantiations_portable_generate_keypair_c1(
+  return libcrux_ml_kem_ind_cca_instantiations_portable_generate_keypair_19(
       copy_of_randomness);
 }
 
@@ -6327,10 +6353,10 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline tuple_9b libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_32(
+static inline tuple_9b libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_7b(
     Eurydice_slice key_generation_seed) {
   uint8_t hashed[64U];
-  libcrux_ml_kem_hash_functions_portable_G_f1_e4(key_generation_seed, hashed);
+  libcrux_ml_kem_variant_cpa_keygen_seed_d8_68(key_generation_seed, hashed);
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
       Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
       uint8_t, Eurydice_slice_uint8_t_x2);
@@ -6419,7 +6445,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_closure_b8(size_t _j) {
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_closure_c8(size_t _j) {
   return libcrux_ml_kem_polynomial_ZERO_89_8d();
 }
 
@@ -6437,7 +6463,7 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline void libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_27(
+static inline void libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_d8(
     size_t _i, libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[3U]) {
   for (size_t i = (size_t)0U; i < (size_t)3U; i++) {
     ret[i] = libcrux_ml_kem_polynomial_ZERO_89_8d();
@@ -6455,7 +6481,7 @@ with const generics
 
 */
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_polynomial_clone_d5_28(
+libcrux_ml_kem_polynomial_clone_d5_a5(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 *self) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 lit;
   libcrux_ml_kem_vector_portable_vector_type_PortableVector ret[16U];
@@ -6482,7 +6508,7 @@ generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 static inline libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8
-libcrux_ml_kem_ind_cca_generate_keypair_unpacked_34(uint8_t randomness[64U]) {
+libcrux_ml_kem_ind_cca_generate_keypair_unpacked_cb(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
@@ -6490,7 +6516,7 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_34(uint8_t randomness[64U]) {
       (size_t)64U, randomness,
       LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
       size_t);
-  tuple_9b uu____0 = libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_32(
+  tuple_9b uu____0 = libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_7b(
       ind_cpa_keypair_randomness);
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_f8
       ind_cpa_private_key = uu____0.fst;
@@ -6498,14 +6524,14 @@ libcrux_ml_kem_ind_cca_generate_keypair_unpacked_34(uint8_t randomness[64U]) {
       ind_cpa_public_key = uu____0.snd;
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 A[3U][3U];
   for (size_t i = (size_t)0U; i < (size_t)3U; i++) {
-    libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_27(i, A[i]);
+    libcrux_ml_kem_ind_cca_generate_keypair_unpacked_closure_d8(i, A[i]);
   }
   for (size_t i0 = (size_t)0U; i0 < (size_t)3U; i0++) {
     size_t i1 = i0;
     for (size_t i = (size_t)0U; i < (size_t)3U; i++) {
       size_t j = i;
       libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____1 =
-          libcrux_ml_kem_polynomial_clone_d5_28(&ind_cpa_public_key.A[j][i1]);
+          libcrux_ml_kem_polynomial_clone_d5_a5(&ind_cpa_public_key.A[j][i1]);
       A[i1][j] = uu____1;
     }
   }
@@ -6571,12 +6597,12 @@ const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 static inline libcrux_ml_kem_ind_cca_unpacked_MlKemKeyPairUnpacked_f8
-libcrux_ml_kem_ind_cca_instantiations_portable_generate_keypair_unpacked_c3(
+libcrux_ml_kem_ind_cca_instantiations_portable_generate_keypair_unpacked_20(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_34(
+  return libcrux_ml_kem_ind_cca_generate_keypair_unpacked_cb(
       copy_of_randomness);
 }
 
@@ -6589,22 +6615,22 @@ libcrux_ml_kem_mlkem768_portable_generate_key_pair_unpacked(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_instantiations_portable_generate_keypair_unpacked_c3(
+  return libcrux_ml_kem_ind_cca_instantiations_portable_generate_keypair_unpacked_20(
       copy_of_randomness);
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::Kyber)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::Kyber)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.kdf_6c
+A monomorphic instance of libcrux_ml_kem.variant.kdf_33
 with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
 with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_kdf_6c_ee(
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_kdf_33_78(
     Eurydice_slice shared_secret,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   uint8_t kdf_input[64U];
@@ -6630,7 +6656,7 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_kdf_6c_ee(
 A monomorphic instance of libcrux_ml_kem.ind_cca.decapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
-libcrux_ml_kem_ind_cca_Kyber with const generics
+libcrux_ml_kem_variant_Kyber with const generics
 - K= 3
 - SECRET_KEY_SIZE= 2400
 - CPA_SECRET_KEY_SIZE= 1152
@@ -6648,7 +6674,7 @@ libcrux_ml_kem_ind_cca_Kyber with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static inline void libcrux_ml_kem_ind_cca_decapsulate_540(
+static inline void libcrux_ml_kem_ind_cca_decapsulate_1c0(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -6666,7 +6692,7 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_540(
   Eurydice_slice ind_cpa_public_key_hash = uu____2.fst;
   Eurydice_slice implicit_rejection_value = uu____2.snd;
   uint8_t decrypted[32U];
-  libcrux_ml_kem_ind_cpa_decrypt_35(ind_cpa_secret_key, ciphertext->value,
+  libcrux_ml_kem_ind_cpa_decrypt_a2(ind_cpa_secret_key, ciphertext->value,
                                     decrypted);
   uint8_t to_hash0[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -6690,7 +6716,7 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_540(
   Eurydice_slice uu____4 = Eurydice_array_to_subslice_from(
       (size_t)1120U, to_hash, LIBCRUX_ML_KEM_CONSTANTS_SHARED_SECRET_SIZE,
       uint8_t, size_t);
-  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+  Eurydice_slice_copy(uu____4, libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
                       uint8_t);
   uint8_t implicit_rejection_shared_secret0[32U];
   libcrux_ml_kem_hash_functions_portable_PRF_f1_ee(
@@ -6701,18 +6727,18 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_540(
   uint8_t copy_of_decrypted[32U];
   memcpy(copy_of_decrypted, decrypted, (size_t)32U * sizeof(uint8_t));
   uint8_t expected_ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_09(uu____5, copy_of_decrypted,
+  libcrux_ml_kem_ind_cpa_encrypt_59(uu____5, copy_of_decrypted,
                                     pseudorandomness, expected_ciphertext);
   uint8_t implicit_rejection_shared_secret[32U];
-  libcrux_ml_kem_ind_cca_kdf_6c_ee(
+  libcrux_ml_kem_variant_kdf_33_78(
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret0,
                               uint8_t),
       ciphertext, implicit_rejection_shared_secret);
   uint8_t shared_secret[32U];
-  libcrux_ml_kem_ind_cca_kdf_6c_ee(shared_secret0, ciphertext, shared_secret);
+  libcrux_ml_kem_variant_kdf_33_78(shared_secret0, ciphertext, shared_secret);
   uint8_t ret0[32U];
   libcrux_ml_kem_constant_time_ops_compare_ciphertexts_select_shared_secret_in_constant_time(
-      libcrux_ml_kem_types_as_ref_00_e0(ciphertext),
+      libcrux_ml_kem_types_as_ref_00_ae(ciphertext),
       Eurydice_array_to_slice((size_t)1088U, expected_ciphertext, uint8_t),
       Eurydice_array_to_slice((size_t)32U, shared_secret, uint8_t),
       Eurydice_array_to_slice((size_t)32U, implicit_rejection_shared_secret,
@@ -6746,10 +6772,10 @@ generics
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
 static inline void
-libcrux_ml_kem_ind_cca_instantiations_portable_kyber_decapsulate_a6(
+libcrux_ml_kem_ind_cca_instantiations_portable_kyber_decapsulate_ee(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_540(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_decapsulate_1c0(private_key, ciphertext, ret);
 }
 
 /**
@@ -6762,21 +6788,21 @@ libcrux_ml_kem_ind_cca_instantiations_portable_kyber_decapsulate_a6(
 static inline void libcrux_ml_kem_mlkem768_portable_kyber_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_55 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_instantiations_portable_kyber_decapsulate_a6(
+  libcrux_ml_kem_ind_cca_instantiations_portable_kyber_decapsulate_ee(
       private_key, ciphertext, ret);
 }
 
 /**
-This function found in impl {(libcrux_ml_kem::ind_cca::Variant for
-libcrux_ml_kem::ind_cca::Kyber)}
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::Kyber)}
 */
 /**
-A monomorphic instance of libcrux_ml_kem.ind_cca.entropy_preprocess_6c
+A monomorphic instance of libcrux_ml_kem.variant.entropy_preprocess_33
 with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
 with const generics
 - K= 3
 */
-static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_entropy_preprocess_6c_cf(
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_entropy_preprocess_33_64(
     Eurydice_slice randomness, uint8_t ret[32U]) {
   libcrux_ml_kem_hash_functions_portable_H_f1_1a(randomness, ret);
 }
@@ -6785,7 +6811,7 @@ static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_entropy_preprocess_6c_cf(
 A monomorphic instance of libcrux_ml_kem.ind_cca.encapsulate
 with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
 libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
-libcrux_ml_kem_ind_cca_Kyber with const generics
+libcrux_ml_kem_variant_Kyber with const generics
 - K= 3
 - CIPHERTEXT_SIZE= 1088
 - PUBLIC_KEY_SIZE= 1184
@@ -6800,11 +6826,11 @@ libcrux_ml_kem_ind_cca_Kyber with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_8f0(
+static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_3b0(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
-  libcrux_ml_kem_ind_cca_entropy_preprocess_6c_cf(
+  libcrux_ml_kem_variant_entropy_preprocess_33_64(
       Eurydice_array_to_slice((size_t)32U, randomness, uint8_t), randomness0);
   uint8_t to_hash[64U];
   libcrux_ml_kem_utils_into_padded_array_ea(
@@ -6815,7 +6841,7 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_8f0(
   uint8_t ret[32U];
   libcrux_ml_kem_hash_functions_portable_H_f1_1a(
       Eurydice_array_to_slice((size_t)1184U,
-                              libcrux_ml_kem_types_as_slice_cb_6f(public_key),
+                              libcrux_ml_kem_types_as_slice_cb_25(public_key),
                               uint8_t),
       ret);
   Eurydice_slice_copy(
@@ -6830,20 +6856,20 @@ static inline tuple_3c libcrux_ml_kem_ind_cca_encapsulate_8f0(
   Eurydice_slice shared_secret = uu____1.fst;
   Eurydice_slice pseudorandomness = uu____1.snd;
   Eurydice_slice uu____2 = Eurydice_array_to_slice(
-      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_6f(public_key), uint8_t);
+      (size_t)1184U, libcrux_ml_kem_types_as_slice_cb_25(public_key), uint8_t);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness0, (size_t)32U * sizeof(uint8_t));
   uint8_t ciphertext[1088U];
-  libcrux_ml_kem_ind_cpa_encrypt_09(uu____2, copy_of_randomness,
+  libcrux_ml_kem_ind_cpa_encrypt_59(uu____2, copy_of_randomness,
                                     pseudorandomness, ciphertext);
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_ciphertext[1088U];
   memcpy(copy_of_ciphertext, ciphertext, (size_t)1088U * sizeof(uint8_t));
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext ciphertext0 =
-      libcrux_ml_kem_types_from_01_ec(copy_of_ciphertext);
+      libcrux_ml_kem_types_from_01_1e(copy_of_ciphertext);
   uint8_t shared_secret_array[32U];
-  libcrux_ml_kem_ind_cca_kdf_6c_ee(shared_secret, &ciphertext0,
+  libcrux_ml_kem_variant_kdf_33_78(shared_secret, &ciphertext0,
                                    shared_secret_array);
   libcrux_ml_kem_mlkem768_MlKem768Ciphertext uu____5 = ciphertext0;
   /* Passing arrays by value in Rust generates a copy in C */
@@ -6878,14 +6904,14 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 static inline tuple_3c
-libcrux_ml_kem_ind_cca_instantiations_portable_kyber_encapsulate_54(
+libcrux_ml_kem_ind_cca_instantiations_portable_kyber_encapsulate_03(
     libcrux_ml_kem_types_MlKemPublicKey_15 *public_key,
     uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_15 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_8f0(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_encapsulate_3b0(uu____0, copy_of_randomness);
 }
 
 /**
@@ -6902,8 +6928,191 @@ static inline tuple_3c libcrux_ml_kem_mlkem768_portable_kyber_encapsulate(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_instantiations_portable_kyber_encapsulate_54(
+  return libcrux_ml_kem_ind_cca_instantiations_portable_kyber_encapsulate_03(
       uu____0, copy_of_randomness);
+}
+
+/**
+This function found in impl {(libcrux_ml_kem::variant::Variant for
+libcrux_ml_kem::variant::Kyber)}
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.variant.cpa_keygen_seed_33
+with types libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]]
+with const generics
+- K= 3
+*/
+static KRML_MUSTINLINE void libcrux_ml_kem_variant_cpa_keygen_seed_33_d8(
+    Eurydice_slice key_generation_seed, uint8_t ret[64U]) {
+  libcrux_ml_kem_hash_functions_portable_G_f1_e4(key_generation_seed, ret);
+}
+
+/**
+A monomorphic instance of libcrux_ml_kem.ind_cpa.generate_keypair
+with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
+libcrux_ml_kem_variant_Kyber with const generics
+- K= 3
+- PRIVATE_KEY_SIZE= 1152
+- PUBLIC_KEY_SIZE= 1184
+- RANKED_BYTES_PER_RING_ELEMENT= 1152
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+static inline libcrux_ml_kem_utils_extraction_helper_Keypair768
+libcrux_ml_kem_ind_cpa_generate_keypair_d50(
+    Eurydice_slice key_generation_seed) {
+  uint8_t hashed[64U];
+  libcrux_ml_kem_variant_cpa_keygen_seed_33_d8(key_generation_seed, hashed);
+  Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
+      Eurydice_array_to_slice((size_t)64U, hashed, uint8_t), (size_t)32U,
+      uint8_t, Eurydice_slice_uint8_t_x2);
+  Eurydice_slice seed_for_A0 = uu____0.fst;
+  Eurydice_slice seed_for_secret_and_error = uu____0.snd;
+  libcrux_ml_kem_polynomial_PolynomialRingElement_f0 A_transpose[3U][3U];
+  uint8_t ret[34U];
+  libcrux_ml_kem_utils_into_padded_array_ea1(seed_for_A0, ret);
+  libcrux_ml_kem_matrix_sample_matrix_A_05(ret, true, A_transpose);
+  uint8_t prf_input[33U];
+  libcrux_ml_kem_utils_into_padded_array_ea2(seed_for_secret_and_error,
+                                             prf_input);
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_prf_input0[33U];
+  memcpy(copy_of_prf_input0, prf_input, (size_t)33U * sizeof(uint8_t));
+  tuple_b0 uu____2 = libcrux_ml_kem_ind_cpa_sample_vector_cbd_then_ntt_a7(
+      copy_of_prf_input0, 0U);
+  libcrux_ml_kem_polynomial_PolynomialRingElement_f0 secret_as_ntt[3U];
+  memcpy(
+      secret_as_ntt, uu____2.fst,
+      (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
+  uint8_t domain_separator = uu____2.snd;
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_prf_input[33U];
+  memcpy(copy_of_prf_input, prf_input, (size_t)33U * sizeof(uint8_t));
+  libcrux_ml_kem_polynomial_PolynomialRingElement_f0 error_as_ntt[3U];
+  memcpy(
+      error_as_ntt,
+      libcrux_ml_kem_ind_cpa_sample_vector_cbd_then_ntt_a7(copy_of_prf_input,
+                                                           domain_separator)
+          .fst,
+      (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f0));
+  libcrux_ml_kem_polynomial_PolynomialRingElement_f0 t_as_ntt[3U];
+  libcrux_ml_kem_matrix_compute_As_plus_e_cb(A_transpose, secret_as_ntt,
+                                             error_as_ntt, t_as_ntt);
+  uint8_t seed_for_A[32U];
+  Result_00 dst;
+  Eurydice_slice_to_array2(&dst, seed_for_A0, Eurydice_slice, uint8_t[32U]);
+  unwrap_41_83(dst, seed_for_A);
+  uint8_t public_key_serialized[1184U];
+  libcrux_ml_kem_ind_cpa_serialize_public_key_04(
+      t_as_ntt, Eurydice_array_to_slice((size_t)32U, seed_for_A, uint8_t),
+      public_key_serialized);
+  uint8_t secret_key_serialized[1152U];
+  libcrux_ml_kem_ind_cpa_serialize_secret_key_87(secret_as_ntt,
+                                                 secret_key_serialized);
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_secret_key_serialized[1152U];
+  memcpy(copy_of_secret_key_serialized, secret_key_serialized,
+         (size_t)1152U * sizeof(uint8_t));
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_public_key_serialized[1184U];
+  memcpy(copy_of_public_key_serialized, public_key_serialized,
+         (size_t)1184U * sizeof(uint8_t));
+  libcrux_ml_kem_utils_extraction_helper_Keypair768 lit;
+  memcpy(lit.fst, copy_of_secret_key_serialized,
+         (size_t)1152U * sizeof(uint8_t));
+  memcpy(lit.snd, copy_of_public_key_serialized,
+         (size_t)1184U * sizeof(uint8_t));
+  return lit;
+}
+
+/**
+ Packed API
+
+ Generate a key pair.
+
+ Depending on the `Vector` and `Hasher` used, this requires different hardware
+ features
+*/
+/**
+A monomorphic instance of libcrux_ml_kem.ind_cca.generate_keypair
+with types libcrux_ml_kem_vector_portable_vector_type_PortableVector,
+libcrux_ml_kem_hash_functions_portable_PortableHash[[$3size_t]],
+libcrux_ml_kem_variant_Kyber with const generics
+- K= 3
+- CPA_PRIVATE_KEY_SIZE= 1152
+- PRIVATE_KEY_SIZE= 2400
+- PUBLIC_KEY_SIZE= 1184
+- BYTES_PER_RING_ELEMENT= 1152
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+libcrux_ml_kem_ind_cca_generate_keypair_950(uint8_t randomness[64U]) {
+  Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
+      randomness, (size_t)0U,
+      LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t);
+  Eurydice_slice implicit_rejection_value = Eurydice_array_to_subslice_from(
+      (size_t)64U, randomness,
+      LIBCRUX_ML_KEM_CONSTANTS_CPA_PKE_KEY_GENERATION_SEED_SIZE, uint8_t,
+      size_t);
+  libcrux_ml_kem_utils_extraction_helper_Keypair768 uu____0 =
+      libcrux_ml_kem_ind_cpa_generate_keypair_d50(ind_cpa_keypair_randomness);
+  uint8_t ind_cpa_private_key[1152U];
+  memcpy(ind_cpa_private_key, uu____0.fst, (size_t)1152U * sizeof(uint8_t));
+  uint8_t public_key[1184U];
+  memcpy(public_key, uu____0.snd, (size_t)1184U * sizeof(uint8_t));
+  uint8_t secret_key_serialized[2400U];
+  libcrux_ml_kem_ind_cca_serialize_kem_secret_key_de(
+      Eurydice_array_to_slice((size_t)1152U, ind_cpa_private_key, uint8_t),
+      Eurydice_array_to_slice((size_t)1184U, public_key, uint8_t),
+      implicit_rejection_value, secret_key_serialized);
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_secret_key_serialized[2400U];
+  memcpy(copy_of_secret_key_serialized, secret_key_serialized,
+         (size_t)2400U * sizeof(uint8_t));
+  libcrux_ml_kem_types_MlKemPrivateKey_55 private_key =
+      libcrux_ml_kem_types_from_05_0b(copy_of_secret_key_serialized);
+  libcrux_ml_kem_types_MlKemPrivateKey_55 uu____2 = private_key;
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_public_key[1184U];
+  memcpy(copy_of_public_key, public_key, (size_t)1184U * sizeof(uint8_t));
+  return libcrux_ml_kem_types_from_17_9c(
+      uu____2, libcrux_ml_kem_types_from_b6_b0(copy_of_public_key));
+}
+
+/**
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.portable.kyber_generate_keypair with const
+generics
+- K= 3
+- CPA_PRIVATE_KEY_SIZE= 1152
+- PRIVATE_KEY_SIZE= 2400
+- PUBLIC_KEY_SIZE= 1184
+- BYTES_PER_RING_ELEMENT= 1152
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+libcrux_ml_kem_ind_cca_instantiations_portable_kyber_generate_keypair_b8(
+    uint8_t randomness[64U]) {
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[64U];
+  memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_generate_keypair_950(copy_of_randomness);
+}
+
+/**
+ Generate Kyber 768 Key Pair
+*/
+static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+libcrux_ml_kem_mlkem768_portable_kyber_generate_key_pair(
+    uint8_t randomness[64U]) {
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[64U];
+  memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_instantiations_portable_kyber_generate_keypair_b8(
+      copy_of_randomness);
 }
 
 /**
@@ -6914,7 +7123,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - K= 3
 */
 static inline libcrux_ml_kem_polynomial_PolynomialRingElement_f0
-libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_closure_450(
+libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_closure_300(
     size_t _i) {
   return libcrux_ml_kem_polynomial_ZERO_89_8d();
 }
@@ -6933,7 +7142,7 @@ libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 - K= 3
 */
 static KRML_MUSTINLINE void
-libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_9d0(
+libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_1c0(
     Eurydice_slice public_key,
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 ret[3U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[3U];
@@ -6951,7 +7160,7 @@ libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_9d0(
             LIBCRUX_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
         uint8_t);
     libcrux_ml_kem_polynomial_PolynomialRingElement_f0 uu____0 =
-        libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_e1(
+        libcrux_ml_kem_serialize_deserialize_to_reduced_ring_element_b0(
             ring_element);
     deserialized_pk[i0] = uu____0;
   }
@@ -6968,10 +7177,10 @@ with const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-static KRML_MUSTINLINE bool libcrux_ml_kem_ind_cca_validate_public_key_c2(
+static KRML_MUSTINLINE bool libcrux_ml_kem_ind_cca_validate_public_key_79(
     uint8_t *public_key) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f0 deserialized_pk[3U];
-  libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_9d0(
+  libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_1c0(
       Eurydice_array_to_subslice_to((size_t)1184U, public_key, (size_t)1152U,
                                     uint8_t, size_t),
       deserialized_pk);
@@ -6998,9 +7207,9 @@ generics
 - PUBLIC_KEY_SIZE= 1184
 */
 static inline bool
-libcrux_ml_kem_ind_cca_instantiations_portable_validate_public_key_9d(
+libcrux_ml_kem_ind_cca_instantiations_portable_validate_public_key_7f(
     uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_c2(public_key);
+  return libcrux_ml_kem_ind_cca_validate_public_key_79(public_key);
 }
 
 /**
@@ -7011,7 +7220,7 @@ libcrux_ml_kem_ind_cca_instantiations_portable_validate_public_key_9d(
 static inline Option_92 libcrux_ml_kem_mlkem768_portable_validate_public_key(
     libcrux_ml_kem_types_MlKemPublicKey_15 public_key) {
   Option_92 uu____0;
-  if (libcrux_ml_kem_ind_cca_instantiations_portable_validate_public_key_9d(
+  if (libcrux_ml_kem_ind_cca_instantiations_portable_validate_public_key_7f(
           public_key.value)) {
     uu____0 = (CLITERAL(Option_92){.tag = Some, .f0 = public_key});
   } else {

--- a/libcrux-ml-kem/cg/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/cg/libcrux_sha3_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 0ca73e59afe19a3f88b8ff45d0c57b0ebe851319
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/cg/libcrux_sha3_portable.h
+++ b/libcrux-ml-kem/cg/libcrux_sha3_portable.h
@@ -7,8 +7,8 @@
  * Charon: 962f26311ccdf09a6a3cfeacbccafba22bf3d405
  * Eurydice: e66abbc2119485abfafa17c1911bdbdada5b04f3
  * Karamel: 7862fdc3899b718d39ec98568f78ec40592a622a
- * F*: a32b316e521fa4f239b610ec8f1d15e78d62cbe8-dirty
- * Libcrux: 0ca73e59afe19a3f88b8ff45d0c57b0ebe851319
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: 6b71b5fae48b400c6dac49234638dd52385d111d
  */
 
 #ifndef __libcrux_sha3_portable_H

--- a/libcrux-ml-kem/cg/tests/mlkem768_nistkats.json
+++ b/libcrux-ml-kem/cg/tests/mlkem768_nistkats.json
@@ -1,802 +1,802 @@
 [
     {
         "key_generation_seed": "7c9935a0b07694aa0c6d10e4db6b1add2fd81a25ccb148032dcd739936737f2d8626ed79d451140800e03b59b956f8210e556067407d13dc90fa9e8b872bfb8f",
-        "sha3_256_hash_of_public_key": "d4ec143b50f01423b177895edee22bb739f647ecf85f50bc25ef7b5a725dee86",
-        "sha3_256_hash_of_secret_key": "245bc1d8cdd4893e4c471e8fccfa7019df0fd10f2d5375f36b4af5f4222aca6a",
+        "sha3_256_hash_of_public_key": "f57262661358cde8d3ebf990e5fd1d5b896c992ccfaadb5256b68bbf5943b132",
+        "sha3_256_hash_of_secret_key": "7deef44965b03d76de543ad6ef9e74a2772fa5a9fa0e761120dac767cf0152ef",
         "encapsulation_seed": "147c03f7a5bebba406c8fae1874d7f13c80efe79a3a9a874cc09fe76f6997615",
-        "sha3_256_hash_of_ciphertext": "bb62281b4aacc5a90a5ccdc5cd3dbe3867c502e8e6ec963ab329a9da0a20a75a",
-        "shared_secret": "729fa06ac93c5efdfbf1272a96cef167a393947ab7dc2d11ed7de8ac3c947fa8"
+        "sha3_256_hash_of_ciphertext": "6e777e2cf8054659136a971d9e70252f301226930c19c470ee0688163a63c15b",
+        "shared_secret": "e7184a0975ee3470878d2d159ec83129c8aec253d4ee17b4810311d198cd0368"
     },
     {
         "key_generation_seed": "d60b93492a1d8c1c7ba6fc0b733137f3406cee8110a93f170e7a78658af326d9003271531cf27285b8721ed5cb46853043b346a66cba6cf765f1b0eaa40bf672",
-        "sha3_256_hash_of_public_key": "2cedad700b675e98641bea57b936bd8befce2d5161e0ef4ef8406e70f1e2c27c",
-        "sha3_256_hash_of_secret_key": "0a84cc895da138b944accbef3ff1a0004b8a0d8af5d426d2b82ea4c0e585cc6a",
+        "sha3_256_hash_of_public_key": "7b00751eb9b1253231213f8a14f06f0fe1b7a4fdb7d1cfe44c161e577e5e8f0a",
+        "sha3_256_hash_of_secret_key": "3a8c009e8e648ac572d5592e4a92907fae0c1767be41c544b59dc3ffe61f7ded",
         "encapsulation_seed": "cde797df8ce67231f6c5d15811843e01eb2ab84c7490931240822adbddd72046",
-        "sha3_256_hash_of_ciphertext": "c15158a536d89bf3bafaea44cd442827a82f6eb772849015f3fec68a29d589dc",
-        "shared_secret": "c00e4ede0a4fa212980e6736686bf73585a0adf8d38fec212c860a0d3d055d1c"
+        "sha3_256_hash_of_ciphertext": "bce1bf3450f574130b9561ee11565fa41d599d05d2136f10ad2c013eb5d13ca9",
+        "shared_secret": "5f0c5d9f39d3e724b5a2bd54e69e360f72ffab5d4d6cc5e572fecba80acd4796"
     },
     {
         "key_generation_seed": "4b622de1350119c45a9f2e2ef3dc5df50a759d138cdfbd64c81cc7cc2f513345e82fcc97ca60ccb27bf6938c975658aeb8b4d37cffbde25d97e561f36c219ade",
-        "sha3_256_hash_of_public_key": "3dbc65b722a8982d058e27d409f04f744551ecde9015b62607cf67bb8ececbb8",
-        "sha3_256_hash_of_secret_key": "0ffced333b5d13fff22b81e66d57b6e2a6dba0285fe2a82d5537df51a8d3eac3",
+        "sha3_256_hash_of_public_key": "9bda55b63cffa9bf953993918b18cd6595ea6433b479e89b5cd3c9339e4468cb",
+        "sha3_256_hash_of_secret_key": "d5fc96564df6e53622b2db8295a80a44e3bad7147696e2ad1f728639c98791b1",
         "encapsulation_seed": "f43f68fbd694f0a6d307297110ecd4739876489fdf07eb9b03364e2ed0ff96e9",
-        "sha3_256_hash_of_ciphertext": "aec80e6fe21e2616352b4c148f9fa0e30986541fb0969df7873b1336b23a8de0",
-        "shared_secret": "8f50401bc9b1f857fd870902d4065f6cec8cb825db3eb22573c6167442b6e19b"
+        "sha3_256_hash_of_ciphertext": "2a8b5d9bdcac1b7ffb6d655368e15148308eee98ae34f4105eaae87f24a008a2",
+        "shared_secret": "7f3bcc03a35a0030255264914e5d88a0c93611c7ca21f0609678a88ca42ce1c9"
     },
     {
         "key_generation_seed": "050d58f9f757edc1e8180e3808b806f5bbb3586db3470b069826d1bb9a4efc2cde950541fd53a8a47aaa8cdfe80d928262a5ef7f8129ec3ef92f78d7cc32ef60",
-        "sha3_256_hash_of_public_key": "94391b7a41175a41c15cd995ebc69c83b29e4bcea6c186611dc4a79578e37f4c",
-        "sha3_256_hash_of_secret_key": "e3904266e186b34a397014c95f6d314cd6e1c813348b02e977d0fd21d9bb681b",
+        "sha3_256_hash_of_public_key": "647a81f0f1b3e3dacb6e73e900f7c078cdfaa7119a5ede48c7685fdb7e0fe2f5",
+        "sha3_256_hash_of_secret_key": "1cf686cb8732c73a38b35d73b0b28fb120bc89cda1554d9f12adedc057862081",
         "encapsulation_seed": "ea74fbc3c546500ed684bed6fe3c496d3b86d2d6dfaf223969b942e9a8c95e85",
-        "sha3_256_hash_of_ciphertext": "39fa8e1d0a5e4bb987618734ee4903771886030b2d8bea4b5a9b0cb672ebb279",
-        "shared_secret": "3221d7b046caccbded38e369625f69bac60c2d7efacad8f24170b10c5d222830"
+        "sha3_256_hash_of_ciphertext": "1c51c85ce66d80c1f9bb138e5bce84dd75cee4260c8817e06c6f2bd920601530",
+        "shared_secret": "c630736985fdb7830d7446e18b6b81fa4a707a6058964b99190120de85e7559c"
     },
     {
         "key_generation_seed": "66b79b844e0c2adad694e0478661ac46fe6b6001f6a71ff8e2f034b1fd8833d3be2d3c64d38269a1ee8660b9a2beaeb9f5ac022e8f0a357feebfd13b06813854",
-        "sha3_256_hash_of_public_key": "c5dbd68b3a8c148b2e7ac049bb986e14dd1cebfa1cbf3edd6bae85a4d2dda082",
-        "sha3_256_hash_of_secret_key": "b3fa7958f4b7ccb68712ae948c3f08740c8b89a69e53ad4e9959234e6869d8fe",
+        "sha3_256_hash_of_public_key": "811aea11a24a4b09e428415f82ee836e930c3b77867aafc5e6728149e3f2bd1b",
+        "sha3_256_hash_of_secret_key": "6a1ff1351c538a5661fc3576c29408c19f42da3688fa16f9ec5ead6a84420db5",
         "encapsulation_seed": "64efa87a12cb96f98b9b81a7e5128a959c74e5332aaab0444fca7b4a5e5e0216",
-        "sha3_256_hash_of_ciphertext": "ca9f95c38dc95f51b6b62ec709539f0d1e9fa64e49ce4ad10bbe62868f35cfc5",
-        "shared_secret": "1d746afc4160c75aaa6c6967f4eee941e09546a039027f05f0f8a483710ac334"
+        "sha3_256_hash_of_ciphertext": "db4dedc1e4d383acaf974fb50ffbf881bd3938ad196fb9aebeeb1bf1ddc94e10",
+        "shared_secret": "41e078d0d0c4fe5df5c6683171d5c1c3f1ef152c4945f9cb299f74278ce4cc4f"
     },
     {
         "key_generation_seed": "7ec408f52c9aa723d0c41d9987682a5f4ce6c9da7cd0215af60bbaf5484ab353a08ccf451b049fd51d7a9ad77ae14a81569df8c9bd3a8f1ebea86fdcfb823082",
-        "sha3_256_hash_of_public_key": "62e0447f7b5ae8a806b741ca5c302230b555c3786c11f3eb43894a8f45e3f7b1",
-        "sha3_256_hash_of_secret_key": "1a3249c268754c86d2e02ba9d87c2b60b220bf2406b71037cfaf6b089477ffb4",
+        "sha3_256_hash_of_public_key": "76c64235d8bd63438f13dcd038f286b9f4242070a5bec4d8990075008667aad3",
+        "sha3_256_hash_of_secret_key": "fb19a847c01b5bb4bc607ce0c65e50ca6869946a97625baea129c2ba07e00c01",
         "encapsulation_seed": "8a95d71228acaa5f9ae6f9d9ca8ae55fde296463b41083a39e833e37c4c90f88",
-        "sha3_256_hash_of_ciphertext": "ec7bb1327a69aeaf626a76d344be1156eac160262128a64477a194805b926233",
-        "shared_secret": "722fccef7142c46f74eb57a10b13e420d6554e9d18507f660bd1be96d3cebbcc"
+        "sha3_256_hash_of_ciphertext": "c8c63c879a7a803db4e5779ca5acb1f16f5c86c38258f583a9f1e43303ff36d0",
+        "shared_secret": "7da491b5623a43ae17160a54e45e8328453cfe1acc692a1e300906ebd2a1d9b2"
     },
     {
         "key_generation_seed": "c121915bfef6abdfc177dae2f5a24218f9abda2559afc6741b08e0e61ab433eb84ef52db5eaa6df8ec3a0bc5ffa730db0dde8c5f38f266d5c680a78d264a7b96",
-        "sha3_256_hash_of_public_key": "0c1d832af7b7282d8bd81a2237107ee60d81e28eb64d6a153ae0eaa1a25797c2",
-        "sha3_256_hash_of_secret_key": "fd6b5d3f120ca009871ca24552a6118917ea882f12f30dc8097f6614d9d36080",
+        "sha3_256_hash_of_public_key": "ae654e4412fd220548280b7a6ace9f2f0bc7b059fc103060346e53bc3c3161d8",
+        "sha3_256_hash_of_secret_key": "9088118150f9137e8ed76eb5e3a706f66f31c570fa7f0dfe75c0e81c4540878e",
         "encapsulation_seed": "90d79d75d0bbb8921cf70d46bab497022a8e750efdc99e5f1bae653275441c7b",
-        "sha3_256_hash_of_ciphertext": "da36cb6137a777acb4afbc0932811f75ef1d6732031309ae7e2de1543aaf5c2c",
-        "shared_secret": "ee7c5fb6a63ace944e1eae1bd4b182263d918754c33753b904853551b2b46cb8"
+        "sha3_256_hash_of_ciphertext": "2ce235a49669184efdbff64176f93017127735170c2e1c1b159fc746ef30d18e",
+        "shared_secret": "eeba3c0571fa453fcd9f7f0d6baeb75d59ec9854c12846089d65bd8dadf9f6b0"
     },
     {
         "key_generation_seed": "d86634ecf96cc2603761e284c0e36734cedec64e7ff486469e38539c71141c5a99daf37400cfe59841afc412ec97f2929dc84a6f3c36f378ee84ce3e46cd1209",
-        "sha3_256_hash_of_public_key": "2b757ac0425152bef72ed852ab1eb44f4359499407bb6a020ff843a31657c5fe",
-        "sha3_256_hash_of_secret_key": "27dbbc7918c31e9ab57808f439c4f4189cc318a62422457f4fed733be959c816",
+        "sha3_256_hash_of_public_key": "6ecea55c3d5c042d2dca3a3925faaa9112561827dceb0754580814a84be19b87",
+        "sha3_256_hash_of_secret_key": "33448769334ee9aa43d7ac22a003d9ae89a1ef5a9765deef2946c91fea0a1a5e",
         "encapsulation_seed": "be8a32f97b9a8d596382c02fa2a0eeebc15c083e970ddaa4f2622b91d6718663",
-        "sha3_256_hash_of_ciphertext": "85efbfd0b096fa921711ea66b17bcf7c9a6240711b38a88830dbd9d716f07195",
-        "shared_secret": "77cfbdae47854e9e10765cf397eca9ab2bf2b7522817152b22e18b6e09795016"
+        "sha3_256_hash_of_ciphertext": "14540bfc038f3eb76f418a8851513054a998e16a06f97c117417ae0a35f90e4f",
+        "shared_secret": "8bf57e5d1ce24e9942b1b3f456d184d4c0937b9b699e69c6524e93e140f39c90"
     },
     {
         "key_generation_seed": "0610678ff4dc3128e1619f915dc192c220f8fad94da1943b90aaec401683a492da1804ddb5aa9b1c6a47a98f8505a49bae2affde5fe75e69e828e546a6771004",
-        "sha3_256_hash_of_public_key": "53b9d62e64f9069d9fb94ea2c0806459b201531f4fddd708d162981cc1fb3757",
-        "sha3_256_hash_of_secret_key": "f4b964b7ab3e09fdf3d91527da06a4d29ef28344709a41739ef56f18bd5b984b",
+        "sha3_256_hash_of_public_key": "576cb9d31e5146967756cf7356926f2e20fc7c1fde9954cb2f593d96a80ab860",
+        "sha3_256_hash_of_secret_key": "2031c133d7d85e616d932c6204d7ec0f3bd0303ec609e3c7c08092e1ea443972",
         "encapsulation_seed": "da2cfaf69e25b2a89ff2557bbb6f69e01d8e2e7bb27a7a1ce7e40fead16f33b2",
-        "sha3_256_hash_of_ciphertext": "379a57a8f19110d5e0d747a2c184877d71f00fea95cd815b4c0e8782b12bec6f",
-        "shared_secret": "8be7a417efbdd3587c6f82ddd1d29956789d28c2413b8383590c5b80cc53e04a"
+        "sha3_256_hash_of_ciphertext": "20e06ce25d864f8e7a80a19e23cee6830575a072476504fd10e37b296ef8de73",
+        "shared_secret": "2f714d31bbc778518e2b67d264065d9731c12149cf931211e649addd6daf0b92"
     },
     {
         "key_generation_seed": "d322d56d8ef067ba1f24c92492b9c56df3a6ef54a304adc1b69913766a1ce69756047447b810cc094d400ab204cf9ae71e3afa68b88586ecb6498c68ac0e51b9",
-        "sha3_256_hash_of_public_key": "9cfeca12dfe978bf0b7ad7271487cf61b2b8f7c60f389f33fc18439a95bcbb63",
-        "sha3_256_hash_of_secret_key": "a2e37a55c9b80fb423f40585180b011f32402d0320259285b6e278df6c20ba60",
+        "sha3_256_hash_of_public_key": "3e9976d61a687df88a8abcc6651446b81b7d136df42bfa03473c84dfd64fdb3b",
+        "sha3_256_hash_of_secret_key": "5da40cacace6fa3712e49ef6700cd819aeea88264e6dc996681fff43d98c9830",
         "encapsulation_seed": "511c2ab40782322c06111e144e505328c4e5bfc890a5980a2bbc44aeda4c738b",
-        "sha3_256_hash_of_ciphertext": "44053f01ecb88811b9ee7a9ddd4234f94507c7cf64b6803b28c54bc605ec4e31",
-        "shared_secret": "79fcd201101e7e277c1b6cdc4475d63ea1dbc42ab94cf873bf0163c2aab0b5ff"
+        "sha3_256_hash_of_ciphertext": "48ddf3c7cf3f02af111c71607e93922176d0173ec63e890235fe981412824edd",
+        "shared_secret": "f2c29a0a4782d83f2073c7c37d90556b1a005f072f94063d2db8114430f36c8d"
     },
     {
         "key_generation_seed": "2f1d8a3bebb34540324b9485fdf3d5be3b858f544abc3fc641b5728cafab03ba8d6c42e7270ee2b77b6045385f3d175984a0e260363166c73b0c70c971644363",
-        "sha3_256_hash_of_public_key": "9aa64a30bed5aa8300772066ef577f79bf4813e3315a15f2c28b2665e4dc7e2f",
-        "sha3_256_hash_of_secret_key": "837eb6ce037f235273d7686fd9d01bea14026e0a0f5f943884f18409cc4bc70a",
+        "sha3_256_hash_of_public_key": "c0cfd4113c5edd408adcd03d38b12f0b6ac17525c618d6d151a761a9eebc2635",
+        "sha3_256_hash_of_secret_key": "2c6ec490ffd55e0a744f3c506a497cf4af575cce6368bdc3b3bdbbae733fe7b4",
         "encapsulation_seed": "dca92dbec9b260dd97e8886f876862d6effc3b91fcf3fbc986cf56ab93ae79a2",
-        "sha3_256_hash_of_ciphertext": "02798b5af1a76a2b478ee05c630e62618e5e2d7ee0c411a82ed2bf888706fe28",
-        "shared_secret": "6c4484b6d7b0a376f52abb1811c712368a9f34bd108ffe7ca31c36a6ec8140f3"
+        "sha3_256_hash_of_ciphertext": "b6ba4dfdae02842f96b915ea0ebd1c97972c170cae975c89c5fbf26cbe9a52d0",
+        "shared_secret": "13c99ded4db3e6618f5927d58c89afbe83c86a86ac2073421b2560b3f8be5aa3"
     },
     {
         "key_generation_seed": "31beda3462627f601cbc56f3ddf4424e1529c04737ef0ef2af6d7401f653b8a1812083bfa3b670e3eaf9b443702fb6db16ac1197656bbd61a8e25ed523b8d1e5",
-        "sha3_256_hash_of_public_key": "241e5c7b836862d7482d507973ae3fd8dae96eec4ecebcedb68fbda75e04b401",
-        "sha3_256_hash_of_secret_key": "95c79c2a867b3e8a4e4e545ff626cd49893b8e87eb188ed1516b159a24736c97",
+        "sha3_256_hash_of_public_key": "71c5534bb819e61a9d8a257ff2eb29598ae92eccfad38abbfc9bccde5ff95a1c",
+        "sha3_256_hash_of_secret_key": "107c5ef0842d1dfda257138d681ad7e1390e12c697111a2c804d8f014361cb4f",
         "encapsulation_seed": "57c170e691d7a914a901b9a11c62b8b569b3806427557a9dbac9faa720ec3641",
-        "sha3_256_hash_of_ciphertext": "cf3b2e2dc822949eb13638299fc2d5102c7132aa6cd54dd7834b13f05a4dece2",
-        "shared_secret": "8554d6af350f13471cfd45c23882e43dc81d8a094f6299e2ad33ef4c01a32058"
+        "sha3_256_hash_of_ciphertext": "671e3c316d4d8411237db4383fca82f76692867e9f6d15a2b82b17d934392341",
+        "shared_secret": "83302cab48eb0832bd8df0db3fce81595754772e4c951c444a1b2ee9f58c48c1"
     },
     {
         "key_generation_seed": "cbdff028766d558af4466ef14043a1a9cf765f7748c63cc09dceb59ab39a4e4d8e9a30597e4b52ffa87a54b83c91d12a5e9c2cd90fcac2c11b3a348240411a4c",
-        "sha3_256_hash_of_public_key": "6ad1d739f1598a16c608a240cd13dfaf8263d74866315e2898a3431cf19e4685",
-        "sha3_256_hash_of_secret_key": "1ef733faa4f2cb53cb5d8975aa6797b5f37fd918aeda02178a40584475cdf667",
+        "sha3_256_hash_of_public_key": "4b53b4aec0d9f86a6377c63ff80150e40fc5347714c07591dc71c6beb8daaafc",
+        "sha3_256_hash_of_secret_key": "ed13d2a9ae5541b3fbfa19891b8c8a9f4f0957d940eb5d08ee0cd18cfb28e7a4",
         "encapsulation_seed": "6b5a14e1473abf5a33d44975ca2088bd8fa6fddcb3f80e8fd5c45b9d90c24a5c",
-        "sha3_256_hash_of_ciphertext": "1706e6983032950b47cb6c8586178b42d515ce929c1434c1a8c9e36d8b4db7a3",
-        "shared_secret": "f9646f73de3d93d8e5dc5beeaa65a30d8f3a1f8d6392190ee66ff28693fbadfa"
+        "sha3_256_hash_of_ciphertext": "b83f6022179a08cdadda2660f8cd7cb70df4be0be3ad85bebb090d086079b1d1",
+        "shared_secret": "93ce6d06568d795c2a28d1196f53cbaa2cb05df1427ac76f44df09d479e14241"
     },
     {
         "key_generation_seed": "4c04310bea66305c6ca8ba6b8f61ca96257a67663afc11761f13fb5c7b324b6b8aec87a9a79204cee2986867a2906eb851b734b8b22b91d6749b1a5f07c44e3b",
-        "sha3_256_hash_of_public_key": "9510a2a0b4fcbd414fc61aff04a8df579660d14b13c40ec0470c45f639b65a58",
-        "sha3_256_hash_of_secret_key": "0bcfa8078582f60e218047d0016437601da8431f34ae6da12921f53958f32819",
+        "sha3_256_hash_of_public_key": "c2d52d0c837eb40dac0653a5e862d9fb8b832629cece9eaeb6d5feb48b6ef5da",
+        "sha3_256_hash_of_secret_key": "73ee0632229d740dd746e3ef7f0f1c29944dbc2d8f39b7860807c41c18bbb3af",
         "encapsulation_seed": "40e593754e6eddb7f9cf176ba2d5fd1087c90ad377556d0b0f686537b1a3165e",
-        "sha3_256_hash_of_ciphertext": "f9341d26e39b38a88ddef1708c96ee2068f569a59a4010745730d8290d637718",
-        "shared_secret": "1ee252e97b69445f7f109187645cd2879f55e10eb8361ab43b3492ff51f01815"
+        "sha3_256_hash_of_ciphertext": "3685126e86797a881f3bbee0eb85b76d755ff03858735c326731b8d802f023b5",
+        "shared_secret": "071db527a2ee8ce982527cb19355793859bb8557e7cc99dec58a53153eceddf4"
     },
     {
         "key_generation_seed": "38a0d5f41d7dc1896efd1b45b0485634cef149828751b96087a0a6dd81b4d58aa2acf359556df4a2abaeb9dcee945829beb71185b4d6bd18b76e5668f253383a",
-        "sha3_256_hash_of_public_key": "cfbe9649d9d1c384baad67b91b2f3e21f2fadd6bb582a0b9cb016051dd82c75a",
-        "sha3_256_hash_of_secret_key": "09b118f7c4d059baf27284d127d4e85d55b84e4c92bf3127eeb318d2f5765401",
+        "sha3_256_hash_of_public_key": "4ff02338c9bb711d263140c471409f3c42813f38424698563d9550f85a168f2d",
+        "sha3_256_hash_of_secret_key": "3c89443dab5ce46f82f6b8260af0293ea52a680f1c4fe5e042f0aefb707526f3",
         "encapsulation_seed": "c152523abd8248bed40c3827bcf0f8e8127037a55c780695e2c28ea3e041a44c",
-        "sha3_256_hash_of_ciphertext": "94a8c287238191a107e74e31ec099086d83f198e6b0f3321da4d8f46ce01a0b2",
-        "shared_secret": "1e1ea5d6a18873c5c7fc8da79093f6d3db5b28fdd0aaa42726ad130c78e9bb88"
+        "sha3_256_hash_of_ciphertext": "b20e28f42ee5cf5569f1833af90334952074dd0ea0c2520f03fdf0fb24c17a64",
+        "shared_secret": "598bd66a4a063652b2a6b25b8d1c3bab0251682ce6c362a8c680295f47f3d6d9"
     },
     {
         "key_generation_seed": "97b5665676e59e3538ebadaa8cd50df1f9fda1502d9894c616a946078e56b621df05318b5f655efe36f1b678cf4b875108a18db2fa312261caf839f84bd956c5",
-        "sha3_256_hash_of_public_key": "a19c2c9c907b129d01cc44a95949121c39534cc98b6d105e60fe519a000cc2ae",
-        "sha3_256_hash_of_secret_key": "f1c00070780a7a2ac5b57ff3ff765ca75278bb661d1635cac92792f9454fe8ba",
+        "sha3_256_hash_of_public_key": "bbccdbce67cf49fea044df5c767996681dd2714937d31c822f3c58cc34785aa7",
+        "sha3_256_hash_of_secret_key": "64fde53d297945ef2a0af6ddd044520cff8ec1388aa471e47ba4299c2cd46da4",
         "encapsulation_seed": "ad6466dd59f26b762fb02b19eedf5f79964da68bce0459b91c3a6ee5a7e01183",
-        "sha3_256_hash_of_ciphertext": "56e0b8ab3b302fae682938a45d9931e092d78877d1f8834bb43cd5c85582a205",
-        "shared_secret": "24619bb17c912fc992bd8272969cd5b6fd6b030122ee5af9365cac8b38e569fc"
+        "sha3_256_hash_of_ciphertext": "6f4cde00d3775858761742957833fe632e3d3082a9a6180477291bc23b682674",
+        "shared_secret": "92bd980f79cbb34c67594c6922549b99962e54d388034ea61f892fe250581c4e"
     },
     {
         "key_generation_seed": "ef99224a03a85a46ef115474ec5b5d620da6795d6efcca4c9135d19958a9de62df7d92dda83e6b2ef4cce08c9134563063068a196d7b1a1a13623e48ae12528e",
-        "sha3_256_hash_of_public_key": "e4174b6e7542fbe80ab2bc06dfb802f691aff147ff90332d5ea739216c18d872",
-        "sha3_256_hash_of_secret_key": "f3f3a292f5cf01d6f7266461c9e8cd44bfc8f17e16035ab8d10af8177f389b86",
+        "sha3_256_hash_of_public_key": "3ef3581d438af7dec621304e0091f797346ca18a41f39401e9d03200ef48beb6",
+        "sha3_256_hash_of_secret_key": "299a76e97511d90f7925100db418472a9c3c12d6d48acf03618a6960998ee733",
         "encapsulation_seed": "1a4d5dff5847cfb48333e33bb00ca7301b144aa89dcd412ff5a3b1081d775b7f",
-        "sha3_256_hash_of_ciphertext": "5f878ca21c8c27ae9c41c43aaf1f3a2af62c73296e165c08b88c5b22592867be",
-        "shared_secret": "a990af801ddcf2009c82fe657fe3f068bae7e6bfc661e3e588354ba7d1b176e6"
+        "sha3_256_hash_of_ciphertext": "4ede793372276800e22c1893ae554ce0b53e413fbbc3595e69feadb2e1f6d57a",
+        "shared_secret": "b7325a08fa617e19260264bb02ed6b8ab2081589fd5dcc1e92b9d0d4ebfdb6b6"
     },
     {
         "key_generation_seed": "b12f6fd965ea9c5b947db80fc60c83d5e232dca82e7263027c19bd62e5a6ff550f6aa3e88f7fa8a96067f8cdaeceeac90c2d0b5e277e56e9c405ec9420c30252",
-        "sha3_256_hash_of_public_key": "2006a70fa33ff4a65b00553734c5bd8cca0a65eb3a115d96b8aa90f8fdc5f8f4",
-        "sha3_256_hash_of_secret_key": "7334d4a1755e1e639b3e9eadb5996cd910b55d1de5790469f229231d3bfb1528",
+        "sha3_256_hash_of_public_key": "fa06bb0ff42f4d610a7b3df7544d66b97a486967cd9b62ba0142ebb10b8ee4ee",
+        "sha3_256_hash_of_secret_key": "4dcfc0ce12c4e87f02c616a8fb18c359cae017a2f8d339623a174dfaebfad98f",
         "encapsulation_seed": "34f44ec2092eeaf686f2ea170591a98527cbb03a4fa9477a7aef6b41a54feeb2",
-        "sha3_256_hash_of_ciphertext": "c2079637916c089b2afb9d6e9c6fa51308ab7720d5c2fca484c34ce614a14fc0",
-        "shared_secret": "11a2ceaa0c77f0602c4b2be3499e6df6b0339d9de90d04b2b12829f4758afaa5"
+        "sha3_256_hash_of_ciphertext": "591bf77f74463c50a4ffbe97c892e11f3cf7601813b7ad83b17038a173e21442",
+        "shared_secret": "b400082a764291666c080ae9ea9f22c383f3c1e87b4cc56775a19c8ec29a4157"
     },
     {
         "key_generation_seed": "9f52af92ca165fdc38788f2b59ba02e01c8281ff7c1e60504688043a5fe814b04f3029e1be4e1c0258c3a22ff5b50b2674cc094ba7018da2a61569845c17d26f",
-        "sha3_256_hash_of_public_key": "631e1de2556ae65d57e600c21e8e355a4ed586d667177ca0b7545cb5a23d669f",
-        "sha3_256_hash_of_secret_key": "3d4d2c680a1e6aa83861ad95043ded260e720ae80060320feffa309b4281ba3d",
+        "sha3_256_hash_of_public_key": "86538ecdf65b7a485b73a34a72193af1ea3f884d820463601c7f843672bbec7d",
+        "sha3_256_hash_of_secret_key": "70e91b44585ed93e802868e0bfe88f68995f3c85d25c2a36b0b7d8de7c5e2f8d",
         "encapsulation_seed": "6250c81126572eec2da330271db36ee591f060fc7e53eeefe2e1c476c675fa33",
-        "sha3_256_hash_of_ciphertext": "2e9d6551050e32e204d7c062a4c18b8abdb91346e9f2c2708776827e0be4c514",
-        "shared_secret": "7571990ef1ef7e15cc920318fb75fd38c4ceb9abf7a4b1adc2175f99d1a0a275"
+        "sha3_256_hash_of_ciphertext": "83754e315ef22788354c1ec632429566929f9bd53e77d1d2cb52005274f64e1e",
+        "shared_secret": "03c7470224ba22fde280005d9a8f8354c49459e9a168cc282f9d41f4f0d2da2b"
     },
     {
         "key_generation_seed": "851ea90fd3854cbf28fe39fb81f68e4b14345cf0d6eee7ec4ce772513df8410d1c0ec046899a777655233e4e1b5ca44e9afbdc67964bfd5d5e3dbb45e60d03cf",
-        "sha3_256_hash_of_public_key": "87f3829eff562789b3e19fafec92e4b5f95b45f3786f12d9c24915ca484a49ce",
-        "sha3_256_hash_of_secret_key": "9aa6c0546cf02085e2b3af65a7d7fd32d0f6d8080e1e7fbff6c39bcf3086ece4",
+        "sha3_256_hash_of_public_key": "27757389a4a68c898dab92d0f63c3340dfba51e00312a05e721932b95b11f6da",
+        "sha3_256_hash_of_secret_key": "b43f88e419ae589b85bb0ec6c9712d4870dbaf35d4c96d06ef0f8b9753b60034",
         "encapsulation_seed": "35d470bcc5880872754810dfb3f2796da2fd7f397537146f6488c27804072b34",
-        "sha3_256_hash_of_ciphertext": "14da42e207477f4383faf4004e58675f0380e7d621421b3c36b877acf3a45d5a",
-        "shared_secret": "27ba4cb50ae44cd938585e0a4905d76053dd851e5b6af4fd787446079aa5a4ab"
+        "sha3_256_hash_of_ciphertext": "0eb3d2bc103f7801dd8e002c6cc81bbcf11e070f465aba9b0b725fa9454acda7",
+        "shared_secret": "c31f7372e8c194a9589042477f34da3a60d591ea65e13bcccc07ba59402ede6d"
     },
     {
         "key_generation_seed": "d304c9389cc973477f169788abcb9d511f843219d246a9b587822f422a70c2386590a2e5c7ed86cf2c5c2a898662bc9a81418720bbb632ef9cf0b845ed052d73",
-        "sha3_256_hash_of_public_key": "699fb2f061a75f111f4a7a60195d9045dc01716b6502cc107cbcedf122e8f619",
-        "sha3_256_hash_of_secret_key": "421f16805b1ceffcd64128b1296521ef812d3a8f4c5e3875a049f8de456b021a",
+        "sha3_256_hash_of_public_key": "efe6e93d8e755292fa875609f2f63bd194c87e6f04db7c83d8bb1b9d868bb779",
+        "sha3_256_hash_of_secret_key": "f54233dfd4679cbd6eb6f18c0615745d5b4fc2fefade52d966bffab6f0cc259f",
         "encapsulation_seed": "8d667921c5db401a86fe1c35dfcf164a6bb2ab7400fd6a0b67eafd4a0ed11940",
-        "sha3_256_hash_of_ciphertext": "b2485ef56c39d468193e387e72794e0ddc9b5404c1a6d90c3b94a5f3e13ba7b4",
-        "shared_secret": "d17b2738213a98f29ee46747c93308ee7000fa404b9a0c1acf3f89654ca2446e"
+        "sha3_256_hash_of_ciphertext": "942f3cd64ed1b2675f9f9823c068d59b2e007e66d38e06a2e4558dcba7f11efd",
+        "shared_secret": "9dfd08dbf59350ae2308096f935c6767daeddeb2c6997992d4a02c14b0e58c60"
     },
     {
         "key_generation_seed": "89a6e3be304a3518fb82b18ca730f0b359cd6ba90664a493fb4f8edaf965b9c3b6591121e25d64010c25a18676033e1d7278ac5f2d0b43a31f3a4156ae710465",
-        "sha3_256_hash_of_public_key": "d3413880d082f26986fcf452a84a8da934ed06198b290ada1789e74d9081a9e7",
-        "sha3_256_hash_of_secret_key": "7b546a42ffe6b65cd9c5b8857c2518f4f8e0bf835c894a68d1743691fc9aad9d",
+        "sha3_256_hash_of_public_key": "87ada29bf78a689417b645fe127d124339422be80a993e623d13bc59f3406a6f",
+        "sha3_256_hash_of_secret_key": "6b8d44a2a71f2901b7ea97bd24df8d46041cd9ad4f0bc5d42ca27ee44981f740",
         "encapsulation_seed": "ec750b3939385a3f8df868119dc76f77ca845567ef068de6ada5478a56bc78b6",
-        "sha3_256_hash_of_ciphertext": "8290f3c4bec7c3b93f3d26e0be3b3fbfdd9c3f5806188fcf0fa1339133f29c7d",
-        "shared_secret": "954af53b4add522514b34cd2ab96669a76ca13f82aa2fd70826bc8ee790ccefb"
+        "sha3_256_hash_of_ciphertext": "aa86248e7e906ff3072a00647cbd3f6e5d0f3a4ec40efa6deb94b2df901d0097",
+        "shared_secret": "03952e1a4915d112b87569d1f79a39f5d69a8dc11c96d70c529d2162a6024dd7"
     },
     {
         "key_generation_seed": "d569b935ce015c85f792f8f7fb0d83c4f53b492959361dd4f75fb764d656450176eae84d11c4528382828f7a689a0d5cff87b8ca0bba97feacb39b935a8788cb",
-        "sha3_256_hash_of_public_key": "e6eec2929feac2a86c9dacfa6214e2e353fda2d547c3829f5678025ff8418a1a",
-        "sha3_256_hash_of_secret_key": "5fac243c82807d7357a61023226a7c270525d96932162ca5c09fc8f7b9ec6cb3",
+        "sha3_256_hash_of_public_key": "0c87bedd5c16c32cc3867910f734bdcf09869c7604a59ce36660074f561e12da",
+        "sha3_256_hash_of_secret_key": "a72b7d93adcbfc6d89485fa923a4b1095e3d593916496e521187224efa42ffa5",
         "encapsulation_seed": "74f1d52af09b12c36eb062ea7528550cb4c18a3ce8e4f4ea9fac43ae383bc925",
-        "sha3_256_hash_of_ciphertext": "f1b10c800a42ae606c72eaad76accf059cccc02299fbd78a5d091f183f6c3f0e",
-        "shared_secret": "d0bbc576fb1aa43b6e76db0e87bc4ee3fa057c31642b37f3339217a1b041b521"
+        "sha3_256_hash_of_ciphertext": "7a75e486cc2dd3ffab4b1072b4056de9a56b55cf324e58d3f6cfd031a0dda594",
+        "shared_secret": "6d2e1f456c87d5a3c79456a6d35fda52f3e9cb858f85a5f7931f532fffe26dee"
     },
     {
         "key_generation_seed": "5cbb141c2763425c274f7404fe530d9116e08c33f9f200a20b011cf563a28990fc9ebbe336dc464489861db8253606971bd0a9008a433ed17752d04023781552",
-        "sha3_256_hash_of_public_key": "c74f3b7fa6e2ef8ce99508c89cf3c71d666ab065a262581a5fb01b2c9b9444fa",
-        "sha3_256_hash_of_secret_key": "5c6998a20960109a4c9808f8f8575697b2b8d18c44c7e9dff97585ae43e6004c",
+        "sha3_256_hash_of_public_key": "9a9a59f83fc58d7194ccc92bd78a45f97f721a1eb554499d0e4d5b37aefc23a8",
+        "sha3_256_hash_of_secret_key": "ea5ce3a271f5e46f925259832d187a3c893e8088b76c19c93e0e798e4320d2fd",
         "encapsulation_seed": "4b3a70d85f640d1a2a852fb6fe96704af56a7415a8ee4282e9207bc3a2dc116a",
-        "sha3_256_hash_of_ciphertext": "e9ef0852ee47744b8c3e12cd728d9017465014eef51edf83a4502cb5218cee20",
-        "shared_secret": "91fbc37d4749ec6175c12f0d8eb6b6a8621e693c79f85f5cd2f557cafec5e7e9"
+        "sha3_256_hash_of_ciphertext": "d71fc29140e8725a4c4e8779d0ad3007990e08b1eb38856cc56f522e3079f601",
+        "shared_secret": "5c7c5cafe1fd7f3d12431ae93815c03419ff95b132caf568671ec23bdc74381c"
     },
     {
         "key_generation_seed": "293abb6d1c207927945417cf84883ef010823e11b487ed55239e466e83696d0cff8563038aad865a817cab9ce98846ba75be9363718ecf5fea538aea90b2a558",
-        "sha3_256_hash_of_public_key": "7378ef967195c977d43a50d03205044006715a6a8a8263d717f40170b49e6bd0",
-        "sha3_256_hash_of_secret_key": "30bd5f16c3f242248a4c4cddc43508bf54535958657bda4dcf105216ddf47eb0",
+        "sha3_256_hash_of_public_key": "bda0815dd53b263afcc1f71d2501128c41fb3606af71c5e68f0752c6d3a479c5",
+        "sha3_256_hash_of_secret_key": "d502e7e6df2d84e46cef88a84c53f1fddd5488accd5e1e43aed5f4f08e16a8a7",
         "encapsulation_seed": "26e38ac804fb5b4d59ddf747715e7e6041d875f99c7b638024b4af82d622da60",
-        "sha3_256_hash_of_ciphertext": "37843616c8a4f7ea9480740b6624f41650da2bb1664cf228d85d6d71a0624528",
-        "shared_secret": "d586b441b8eaf7d053cc96b6835f093426677a7c3acc51aaa3ddbb66dd14a623"
+        "sha3_256_hash_of_ciphertext": "8d4b1f3ee23ceecf073d6576609767401286da5189a1b267bff30a710a69e67a",
+        "shared_secret": "1427c322f72898a0fffd13f674719c9288d524bdd19e6a362533c1108e3a6d2c"
     },
     {
         "key_generation_seed": "74d87c7556f2671f2d666854a4d6e073e69f35421e6e1a428cccea49c37f972ce1fb7456ac0aa1b97068f452cba64ebdc138bcf5d36b0a0fada2a3b374141eb9",
-        "sha3_256_hash_of_public_key": "16fe956be4601573d72306a251f69bc2181253e2417e178341fd6553303ac189",
-        "sha3_256_hash_of_secret_key": "873c94f8bee9fe37265d5dc0c5d3bc1c706057c7efb3cd2cd5ca9ba45498d0d1",
+        "sha3_256_hash_of_public_key": "e3e96e658787ba3f6ffb47de56322541a2c81f68e2825c74cb75ab01d4b719d6",
+        "sha3_256_hash_of_secret_key": "17f821aae147fa517cf35169f9d0b59a30ffdd0ff8f46c1c9bfffe6791392f18",
         "encapsulation_seed": "a319d2b8f114f1acd866478bcdeba6fd164dc4e37b0adfa8d8034afb3e197376",
-        "sha3_256_hash_of_ciphertext": "cc677a81c73ea5139eed8d85782978d06192715933bc5aef560e737f6d57d0a7",
-        "shared_secret": "409bfd9102bd4632c6b5d3610eb349fe3e3bc51e73acc78a8e994a070e20e10c"
+        "sha3_256_hash_of_ciphertext": "7638e455aa855489cedd385a58cad62c49ee25f60be02bbcca6d7c3c383d27af",
+        "shared_secret": "d399b5ff0756707f8d1a1c2a683465c9ad4899788420643d59edf78f79b28dc1"
     },
     {
         "key_generation_seed": "013bab0212d04ecd54b478daf72748003a25e2cb060ba6cc50bf95c292b8206b9da0c5da5f195b80fbb99c2e8b06926074f3f604b3f6195b5a5b9737876bba72",
-        "sha3_256_hash_of_public_key": "633bee89571e8fc16151491ea71234ab83289426559f90c67903a36e4afaa6f4",
-        "sha3_256_hash_of_secret_key": "3c3cff5f49a802cec693efbfc264f6a385210b1eed20f7bc5b07b51839961d14",
+        "sha3_256_hash_of_public_key": "eb3fdfcc0b171aa975028f96cd47fdba421ac08e29a0044cedc29fce35eb8510",
+        "sha3_256_hash_of_secret_key": "d1266b01cdbc6774ff0edbe64a593a110c462d07071077faa86faa9a0aa2365d",
         "encapsulation_seed": "ff646071b2509e6b75790917e08e4f0b0d9f0116ec6291c0b59eaa4b583ad830",
-        "sha3_256_hash_of_ciphertext": "6d94a31cff4761e3993308cb3e812a4a7f04f64d02ed3b46b418c2fc16189dfa",
-        "shared_secret": "5dd151a8015c0b16d79822832ff4cc0da7fd38eb73b7da59bc519d4d2374b808"
+        "sha3_256_hash_of_ciphertext": "0ed3b8be821742190f88bce0d86f834dec2a829496c5eb5bf51bab1a8419064c",
+        "shared_secret": "1a0ad65924728c415ee9c92d0dcd91396665a24c59cba878050390acf2eb44dd"
     },
     {
         "key_generation_seed": "ccb073c4b90be0ad746e26fb093b60c70110bd1dcbcddb566a8cffb7b3caf80e71600a8982c350df524cde514431ded7aec23576530894bcbf0ec0bfef0bb64f",
-        "sha3_256_hash_of_public_key": "3217d034b472a846cd317681c0f36feea187bd40e546dc4ad69c2e67fd9d8303",
-        "sha3_256_hash_of_secret_key": "1503bc141825d523c9505d34f50dc0a01d7bc91cdaee6b99f4a85a24ce800496",
+        "sha3_256_hash_of_public_key": "d046d93317dc6d0ff28990721c3f94a93024ce01b01c0ca55d634c191c4280fa",
+        "sha3_256_hash_of_secret_key": "bdf5539c63b463c3dfefb7978bc44a46803117ccf066475bd17d5c82fcb49c0b",
         "encapsulation_seed": "0584270ec26f3b9818e4af074d17b2d51037cc8dfdcbe3b140fa4fed5deebc54",
-        "sha3_256_hash_of_ciphertext": "a63613ccfd2ecf8aa3adf0103ddd9eeedbde3282443bcf02513b4ab87360cabb",
-        "shared_secret": "1c729b8e580e124e715f19ea6f2409fc6de741afa3d9919b2b8bf3e54c053b51"
+        "sha3_256_hash_of_ciphertext": "b0cd3d31583e15ee8a55d85cd770cc6d64ab83429aebefdb55674f382b605c80",
+        "shared_secret": "9104061d3dbfac187f3a9eed801545a52f1fb0c3979ca8315aa31f67775d1036"
     },
     {
         "key_generation_seed": "2e889f44e28901e9ac7ca6b2fffcb124c8979401b17064d7e1d51a7e3c3adbfa0e145e44aae52cfc609e6f47fd7a6f6af877190ff52256d0ac5b05b89c3f449f",
-        "sha3_256_hash_of_public_key": "d1756ecfaeb695001ac490f36c4638151bee98d367fb7adf0e06a470844068af",
-        "sha3_256_hash_of_secret_key": "a21acea0fd4354eb0c78d47caaf93c9f2434f1cf2d6b2194871ccd98f9522ced",
+        "sha3_256_hash_of_public_key": "21b12640bf755e94ba06204982458a9be11e1da542ece4f3d284886800fc8e8e",
+        "sha3_256_hash_of_secret_key": "4e3947282ebe9f8cd652343c30dfec9a5123c237af2fbb25aca522b6bb6bc4a9",
         "encapsulation_seed": "51e05c7b4ca3079781e8293f4eccebeeb2f8c8b4c59468eddb62a21bcb4ab8a3",
-        "sha3_256_hash_of_ciphertext": "3b322134b37fe8f5d7268fb74d1634ab8b35d456a973f7b0b427fb40a93b6db2",
-        "shared_secret": "b95ac8b73c703ab1154152b3ac73f054596ed23d3be328fbe20f936ea95fa926"
+        "sha3_256_hash_of_ciphertext": "43c21d2fc350a9682e8105ed680b36a04d02579ebab292d0a05db185021dcb44",
+        "shared_secret": "ca249f10d39267ec3725f56b90eb2e22cf8b577116af350f3d3c1e2cf090ff73"
     },
     {
         "key_generation_seed": "174aaa36410566dc15a5e62874218d7abdde0b2c0f30d877bb80b1abd5f5a0a450a7a2354f7e5cefa6f4a4e9a1c411eb9364506e9e1204a8acb3cb77fbd2c4ed",
-        "sha3_256_hash_of_public_key": "1b1b0a8682caf72df2e0a48513a7358edbc77a615d6be6fe2a7145be66b7c509",
-        "sha3_256_hash_of_secret_key": "3e214f25fbf4d1bb670a87367399e1b2a9da3491cac5a22a2c18dcc44f3f1bae",
+        "sha3_256_hash_of_public_key": "95d9e5b9151d87fed52e287992acb897a07b10ada1dd83409a5ccddabf9d7cfa",
+        "sha3_256_hash_of_secret_key": "79e973da94d9166321c476a28a98a8d03ce079c9a99d6e4f55d2e2b4de936123",
         "encapsulation_seed": "9eca0fe36c80fc5eba171c3ae66a5b1c923faa50b4521bb055e7bf51005c93df",
-        "sha3_256_hash_of_ciphertext": "a2cd589c24c4c75bc0a3864dc84a85a7f0f3ac11c8578757f8e94054a7c186aa",
-        "shared_secret": "8c3851393e5c5997cc95f06da96300f6dd85c041343c98db2e742aaa5f78b298"
+        "sha3_256_hash_of_ciphertext": "18ccc37804b42db21ae4d7e238fedf4594f3d55303dc80c0e51c748ff4906ac0",
+        "shared_secret": "82a3856ca48c5dc582ac25605ab0c675ad646ee19acbaaab4ccb5350a3881b49"
     },
     {
         "key_generation_seed": "351fe4313e2da7fac83d509f3103caf7b4c64a4d458fefdf636785ac361a1390f072d9b5a99f9c7a0a011e4dc10f6b600d611f40bba75071e7bee61d23fd5eda",
-        "sha3_256_hash_of_public_key": "2c54df6e9020e1e44b11b471dea97a382a2fe8d1042565bcd51ef21cc0884d68",
-        "sha3_256_hash_of_secret_key": "c6bc9c9e797a02684d3ad8de47919b8d8fdbee09258d084c7a9dc963c80401ac",
+        "sha3_256_hash_of_public_key": "3a7acfc3d283541d985e0abd85eba5315a17d6c4a7e4f248673da60c341c29fe",
+        "sha3_256_hash_of_secret_key": "2fda122953c3d9db88caa36cb8d5621663fec1dd0e19a274a5d85bea7a126076",
         "encapsulation_seed": "0c5719261caab51ae66b8c32e21c34e6d86ee4aa127d1b0195663c066497b2e9",
-        "sha3_256_hash_of_ciphertext": "0cd687f1c3e0d67c46cebf93c1217ddc972ad8662dd05830db350e1292542c1c",
-        "shared_secret": "4b681fff6a755e1dda908d070f0d9ac610d85c73079c1022fc67d255e36f1f71"
+        "sha3_256_hash_of_ciphertext": "024ade86d89c33d9d38face3b92986e72c699467402fe9c5aaca0904c5f5737a",
+        "shared_secret": "f1e13731a14d39f474806b8c177e23e4e2301a3b839539fef9591a71e4f67d29"
     },
     {
         "key_generation_seed": "9bc5315580207c6c16dcf3a30c48daf278de12e8c27df6733e62f799068ad23d5a4d0a8a41c4f666854e9b13673071ceb2fd61def9a850c211e7c50071b1ddad",
-        "sha3_256_hash_of_public_key": "bdcaf7b417da8b8933279b33068f6fda313826c2eec500b224cbe046abeb37a7",
-        "sha3_256_hash_of_secret_key": "c96e176b19f4135add434d0dd219024587d49fdb649bf470e84d9518bbfa2879",
+        "sha3_256_hash_of_public_key": "21916dfe025b78fc6d4dd1d1541b51cd3eecca90ae52177431b33c708faf17b5",
+        "sha3_256_hash_of_secret_key": "c98bada554f301506c532ec774ee112106358d0b320407fb34051a604777f030",
         "encapsulation_seed": "0e59f6f9047c784c1f00b24454aa4f1bd32c92ae7e626549972f86fab90e7e89",
-        "sha3_256_hash_of_ciphertext": "b38711e358893a864b475f35328b2450fffd5087d631844f7ab0995de2b8310d",
-        "shared_secret": "bbaa67f1dad879f2fb33bd4ead45aec354bc8f05c7cbea1e433509faac022edf"
+        "sha3_256_hash_of_ciphertext": "b2737a0bd104c46a5f861914855f498287a33076c32a4241a46cf9690181ee98",
+        "shared_secret": "79c5817a4ba25295cfdc817cd303f3465852b93c0c908fc4a79e88c45f3b81f6"
     },
     {
         "key_generation_seed": "d8b907b34d152ff8603b73051f772daa71eb902c47b7e2f070508269d757e02e36b817736cbc5f7b1dd6eef5fe6332fb1a598f3871e5470d440fd2ea631da28a",
-        "sha3_256_hash_of_public_key": "61e27e954728e2e2e230c94ff009417d7372938e2c29c38af22184eed530fa1f",
-        "sha3_256_hash_of_secret_key": "8baa58b1d3fab8ec5cee8841c9012506cad40bf58a677adac88f1a6400506d40",
+        "sha3_256_hash_of_public_key": "8f62011fbd5a1c10713d42a00a79ae7672e5e321872971f24ff71ed754178d63",
+        "sha3_256_hash_of_secret_key": "57d13f22524022911276023bff4af90abdf04885e2a598b04fa789123295835a",
         "encapsulation_seed": "a3963ade17d69debbc358dda82c7bebe2c39d25b36813058e7a161542e3f8c2b",
-        "sha3_256_hash_of_ciphertext": "7d47a21d95483a5845a4fddbb07b3435c29a56b5cf26f5d0abfa21bc39a2f2e6",
-        "shared_secret": "2c7b983d66978be80250c12bf723eb0300a744e80ad075c903fce95fae9e41a2"
+        "sha3_256_hash_of_ciphertext": "70dfcd3fb0d525cde1e38e158f6a4234006821031941efe3f9b4fa1e70c8bb36",
+        "shared_secret": "d92f866a744d0af51c8c2ba7b1fdf816e0334bff45182cabdfc722d75f8140c4"
     },
     {
         "key_generation_seed": "684a29e4e5480a5f2533e1526b5fac8cdf5927f3d85087c71f928c59690eb56575d12195ec32a8686d0600e45d4a7f54219b0d7a3826d193a51b9156ecf2edd6",
-        "sha3_256_hash_of_public_key": "672e53b28d579974d268132187e7bd72238639c6f2ca154d50d98c74096ec330",
-        "sha3_256_hash_of_secret_key": "4c72f0a7ef5c3274c49365cca5e6770bc709ef12bdbd4fd7c2eb5faa296cdfe8",
+        "sha3_256_hash_of_public_key": "ed3d1dd05854a6542b24090a680b9aa9d6c65ef31cf1f4f5708affafeb2e3989",
+        "sha3_256_hash_of_secret_key": "d5bbcdd1c2fd57524e7926d071f71114a62b95f0579b62ac0f92ccaaac4e9dad",
         "encapsulation_seed": "97beafabf2c8575586487c7a80e8af5fc50f94b6051c1bc66a5ae9f66be3cea7",
-        "sha3_256_hash_of_ciphertext": "167b4e8b7517cad82ae0f49795918c4d33c79137a9c3e16000c4c55b30b1d382",
-        "shared_secret": "bbc58d06cc14f9e96a10acb1789d93b93933f1429cc53a1735b3cd995f086ce7"
+        "sha3_256_hash_of_ciphertext": "c54e484b3b05c6bb40bef10662de29ecda288b9374dcef8f89220d1bff2d09cd",
+        "shared_secret": "53b3b4ce1e75cfe52d22450bfa763d07985dbc585166b4781a7e6542f9bc03e3"
     },
     {
         "key_generation_seed": "d76b3573f596eb286ab5231feec7499686b13021be36cb126c7ebeb9d7030daf248c0a21ea0bb6d6f56f12300e8584d8e9a34e0e6f52227281151ae4c305fb8f",
-        "sha3_256_hash_of_public_key": "b86d5b13bb8b72a9fb81245ab712f0d10f0e2e09b222143c420e3f2c3acea27b",
-        "sha3_256_hash_of_secret_key": "c25f2e16a0e6fbf0729e5ee89fbbdd71f00ff9a1abbb00cb47f26e9989eaf678",
+        "sha3_256_hash_of_public_key": "6fe12a1e2d742dcaf56c585651ed6edce4f410aca0fc83275b5acb19daeb149d",
+        "sha3_256_hash_of_secret_key": "b9e5eb23d136e49d2b5b7964430a1f98c78cd3526f97b1fa0ffb8fb0ea9ffd79",
         "encapsulation_seed": "75461decd34c50d6a094b4a64fb75e5e9479f8f9250d82bb7d729dedeb2d4b65",
-        "sha3_256_hash_of_ciphertext": "8919940aeb732930c496fa9832b0c09382663accda45be1ee22930c545eb3a37",
-        "shared_secret": "e045e0391e15a66d6208467078f2ba5e429cc586c410ca6c5f3c032c21761955"
+        "sha3_256_hash_of_ciphertext": "763f4d04f8eb62a3599d9d095c77861f122e90a0113fa290b17d500766fe333e",
+        "shared_secret": "e7165b66834d919f8c8737c7b4df17a0668c57a87b821af78fe68cbea325aab6"
     },
     {
         "key_generation_seed": "b87439fde81c9e39eebe7cf741c685785532c1dd23e8ef868b9ce7a541010f3d1646460817a0fce5836bdfe124a7448e7adf7b8ecc2652ac6d280e986682df71",
-        "sha3_256_hash_of_public_key": "85441cbd71c18717e9de7359b920a9a3bb7f32e619806f4e4718c585085be624",
-        "sha3_256_hash_of_secret_key": "93b65d2df33d3e3ab0d53c1d0a21f3752e2c5962f7d960b888b2a8c495b1b133",
+        "sha3_256_hash_of_public_key": "30c784bb2ca3538979b24246c2644907484719c531ea39f13c5a34046f8e5cc3",
+        "sha3_256_hash_of_secret_key": "ff96c20a150142ec36186277a6f7b15e4fb93e9648385ef23186fbef674f1600",
         "encapsulation_seed": "2607dcf4fd6ca1c614c21b5e37c24981c32b91c8c3e6955777da8a3f5d9c9335",
-        "sha3_256_hash_of_ciphertext": "422509b01b8fff9468e867a2b5ebe5d3e27314de5c058b2c79a61ccf464f4df7",
-        "shared_secret": "0b8584b75838e084839d58c89cb1749e82ec06a0e85464c7546dd96870547d29"
+        "sha3_256_hash_of_ciphertext": "edee28e97f72a1798809668a1b9b9b3dc05d794d69af6cb476f524e6acad3d8d",
+        "shared_secret": "19599e218264837d06839b6cb9a09af3bc4cdc78f7d9c00fe030ee92ba3bd54c"
     },
     {
         "key_generation_seed": "056661b38038da4fdd7426f32a81576c73ed84843b305168a374f934e27a4e1b79238a80dcfd7c992d84b2dffa67493e669243d4fa38c46b090bdf86bc548411",
-        "sha3_256_hash_of_public_key": "065fb6156acaac591f1bf3ce71c4a046be8c6c55eb9a84d29569bd2b144c73e2",
-        "sha3_256_hash_of_secret_key": "0121afcc6aeb8be9f1c5b06d5b65cc1c03e9366ed7b85fc511d853c5eee230cc",
+        "sha3_256_hash_of_public_key": "b30fe432c2e9744430805aef6b75cf3011ff387e323558212b9d71ed71f044f7",
+        "sha3_256_hash_of_secret_key": "2c4c6d6ed6fd6cf8b53a352a038b9fea6648a9521604140f54268381dfaa1144",
         "encapsulation_seed": "38c89bbe7145c29e9a831c11431eb9929cb24fb4992db20737e4687d397fd732",
-        "sha3_256_hash_of_ciphertext": "f1d3b745d86f860e508ad8b6d5c8a72ef833c280ec11e99516f4ead3c42509be",
-        "shared_secret": "3547a15b5748990a5436bdc4db283738eb7d64bdb6ff566c96f7edec607ccc9b"
+        "sha3_256_hash_of_ciphertext": "b536c56ac5b187bf7372e726bef28c7a46b51e2bb3bbbcb3cab014c6f5999061",
+        "shared_secret": "dc5f3931026bcedd2f57b65601f683895c365862d28a65356e94049773de2ae0"
     },
     {
         "key_generation_seed": "a1b52d871612a1c611ae0944f9e71858f35d3bd14f20e96a931720668bdf0a6b1f135cf64b6403e103afae34da038613e2853bbfc36baafa3c6a95347193f37c",
-        "sha3_256_hash_of_public_key": "ced77d358342759291c2bd225b0bd82d659d28a24bbc5eda8f47975b780cd129",
-        "sha3_256_hash_of_secret_key": "16e06287bd8d71c78f1657bbd6d5d12c22f6bad7658e68dd849d7751da950860",
+        "sha3_256_hash_of_public_key": "ab02b962b6350a9e1314baaa272b6b13db3d1edc9f09d3addf07f6826a3556bf",
+        "sha3_256_hash_of_secret_key": "abf4653476aae658e4603990ddddad56c09da5fab6b9a3e328b9fcd670547652",
         "encapsulation_seed": "b2c35e33c72d90182791f0e12a0324f5b216efcab2c8da1bee025dfbe13f4152",
-        "sha3_256_hash_of_ciphertext": "fdfd351fbb15c92843b44489fee162d40ce2eea4856059731490afda1268b985",
-        "shared_secret": "852ba9be42763c5a74a75778eb839a3738a8ceed1520b0588f9dccdd91907228"
+        "sha3_256_hash_of_ciphertext": "fc2394d4ed9b1e2b073d73d02eb4ef8ab3633932e58641a58507d7c977b62c04",
+        "shared_secret": "7dbfce1fc7d937884e7b3fa7c8eaadb37e1663f77d7c8659b8f43abadf16cba8"
     },
     {
         "key_generation_seed": "952b49c803d6d6fba69f4375adce8594847a00bcae2179da49af2aed0423250262d7033947ae42ca53522a65fbafe18d3bc3e0cb66164e9a094fe4b44d8977ed",
-        "sha3_256_hash_of_public_key": "2fdb7c7e39ce1625c20a13a1c91aa5909d8b03b064d00877dce2415020370c72",
-        "sha3_256_hash_of_secret_key": "ffdb52b23a9ca4b71ec882031ebcb33a0ecc6731c13c817b24f3a06e48273778",
+        "sha3_256_hash_of_public_key": "c153354b0187e658306a0c860b1fe6ed14686ca77d37b7c82d66ff62149406b7",
+        "sha3_256_hash_of_secret_key": "bc48868d03fb12ad5a98d35a739388b66e17b589aeb6ad4335d2d2e0c933910f",
         "encapsulation_seed": "afb7d6dc2b7eb6d84acc080c1be63c98afe7b07786b5801f716444a3e8e64800",
-        "sha3_256_hash_of_ciphertext": "215d83f872221c5fd4ee4da557e17299dc102c52dba1fc4bc3f8c16805da7f1e",
-        "shared_secret": "618a8496b8850609c09dd1d18798ee2bfff3ed7ef6f8b8034fffcec98f291d69"
+        "sha3_256_hash_of_ciphertext": "0fdc0a9a35e5cdcdea8d39e95086e35db8f4ec92f13a7d9afad49adb5faf1e70",
+        "shared_secret": "09f64cee1af4d8738ab149d34a106ea7b19ac43e5a2536defe689824409050ba"
     },
     {
         "key_generation_seed": "3c815e57e9233e975fa1630208aab206b71ae0db37a7a8789ac683d9f9b2d29801c8e376fdb140ee343106c093af7cb149b316ba79446ceb4e5e0cedb9b164f9",
-        "sha3_256_hash_of_public_key": "86bb11e7d9c1368fbba34ce3a2f169c2464ef5fbc11f73843c456467b6cdbd4e",
-        "sha3_256_hash_of_secret_key": "5d46659798d268f1314ad1e7c1735c480301f5877773403966e928bc3fd33d1b",
+        "sha3_256_hash_of_public_key": "2ab47ca9355ece6cc643c3274c46efbd6e927b8b4d11ae8f80b5345b487a5c71",
+        "sha3_256_hash_of_secret_key": "9f65505a34f12eee3e5f6ba1cc622dc0024c4be87dc0648ff9e1edf9ffca943a",
         "encapsulation_seed": "28f5e9dbda122b2cf8f3754fe9e0c73a84ad4b0c093522e0b62cf815d60bbc3c",
-        "sha3_256_hash_of_ciphertext": "5ff5d6bdb110bac57e58a4e288d056a1384f9823606a42daef2ae82e0b7574b2",
-        "shared_secret": "cbb8b7a05f48b47d163cf8c2fad32bc586f47f2c2e0911da349f29b1e3286c22"
+        "sha3_256_hash_of_ciphertext": "5c7bfaf193010937498fafd5f4eb4665996c6a963ba25368439dbe05c56bd99c",
+        "shared_secret": "7104fe381d6d7995b4d550278a66a719b9e79d9bdc38fb0bb60212c4355cc520"
     },
     {
         "key_generation_seed": "588760826dcfbd36d9abe6ae44a669bb3ebba6a218eab69e30f18a3bd536576e0e860576285483bb5fd36e2f944d32c4317bebc1e441470c1372046a790d79d4",
-        "sha3_256_hash_of_public_key": "29253478090cb4d580bc2a912645bc685061e5d4437b3811eda69c865ea9923c",
-        "sha3_256_hash_of_secret_key": "aadce411f3708e9727e4a7e4e198781e1ef5e8f4c4c14add1e25f5758649e265",
+        "sha3_256_hash_of_public_key": "3ab27768ce397a94bb7d29f5dad97d54054915eb66be41023e5d7052a10ed1e6",
+        "sha3_256_hash_of_secret_key": "2b091ca0237c155627226a58c1ea9a049127e7e30e397307ae20343e21408dbe",
         "encapsulation_seed": "b0d713cbef0bb1df70cbb425d1e9373e9f7790fdc7980cc96a240dfc53f1e8e2",
-        "sha3_256_hash_of_ciphertext": "675039d66fcb631a050a8b24415b50f331350bd6697f9c977eef15c15d4cacca",
-        "shared_secret": "1eef87404f318351413d52ba8a07cfa5e72f235d6f91afd7fb8ad3e683ce0a55"
+        "sha3_256_hash_of_ciphertext": "1987dbb44cd3fcd1b3fded283f54d82a2dd146508124282d59a8f862be82a2a0",
+        "shared_secret": "79b1ce19715dd0a74ada36d31f63f3242716890a66d6348232c914c8e5c4c499"
     },
     {
         "key_generation_seed": "47550e9edacb6ddce3d9ab81f6b61080dd4f2693854acb05e0ccc7a4fb6390fbf89d7d99d5c3e0d10d6ef9af054d842375f695abb28e3b8eb495100f04306e92",
-        "sha3_256_hash_of_public_key": "286de7dc142efe935e84b0aeebbd32d050fd9d8b008a94e59454b19ea401611d",
-        "sha3_256_hash_of_secret_key": "a6b53edf9efd7fa67a478456a5b6a379876c248f623ea45f4b541a8db00c524e",
+        "sha3_256_hash_of_public_key": "4c20aa5a85b2e43c56e051698c75bfc27bb9b1722501a6502d1c0dac0aa7f1b0",
+        "sha3_256_hash_of_secret_key": "684968be82e153d8eafea3ad507544b512bc1b0768775fa5732a12ec2b3b22c6",
         "encapsulation_seed": "32bdcdb7059fe27f6409901980c080308951ffd90deffa8317b4d213a5f04495",
-        "sha3_256_hash_of_ciphertext": "f03d44bd9bdf3bfd486919fec2177b8b685a9981de4cbc2a9e98b7e9b0a528fd",
-        "shared_secret": "ca2c0bba56645e4fce4b7e38a7bb4b839e754bf2834a302a2614377eddd6ae60"
+        "sha3_256_hash_of_ciphertext": "5a1273ac88362d6933e9f8e203af5df0ce809b23e125abfbea3f72bc386f17b6",
+        "shared_secret": "66e872a4b3baa42bc3e8e4ee787ebe070a094f05d2a0792ae2ae60f8bd0ee0e7"
     },
     {
         "key_generation_seed": "610afb64be8cc1df288cfb016ee2f44c6c07113de7f6fee071fe0c3fe31c6215cd292e4c5f9e1a55e0489bceffb204d672a6215f4f3980a646d9f880817c52dd",
-        "sha3_256_hash_of_public_key": "029a2e12c3e6aa668afb5be8a82576813fac7b8e61c5a88aff94ecc2770c585e",
-        "sha3_256_hash_of_secret_key": "413ae41ee83e17b74ac654c2aca57abe8f8ed0409acf7cc8b301e3d6bb049cfe",
+        "sha3_256_hash_of_public_key": "72c30933b8e50425fefbf58d711f58cbf9fd8ebd2835a1b55469a2a1b993eace",
+        "sha3_256_hash_of_secret_key": "f156a8742efc92c7a7c5e07116d139872ec520aad1fdb146cbcff70c350a45a6",
         "encapsulation_seed": "4ed7c92d83bd03b2a25b567f17ae55542e2f6a4308ec0f3fe69f8ba5ae24331b",
-        "sha3_256_hash_of_ciphertext": "e8992f7b7b619c03cb9f0c991e3a9c20f91beb707c177ad4e02a5808d10d8769",
-        "shared_secret": "9155619e28de6cc0670ce70e0ad270f0e885e5f5f8d6d38426938ae1036d6ffa"
+        "sha3_256_hash_of_ciphertext": "c3c80130ce1ccb69036c753567b55e2e93df33496228735300b7640f2993c09b",
+        "shared_secret": "56551e57abc7b80a842db9ee65aaf6e65b7c4ca10fc297e9bb0a6364e6255bdb"
     },
     {
         "key_generation_seed": "e1953800acaa85ac02a906c72cb8e8d704e8d27820345f88f71e89c1f549afcc8c64c049c6dfc0f1476cffd520b055756162f7ec94243de6b14ac0b9e5fb366c",
-        "sha3_256_hash_of_public_key": "e3ec3671cc7675a321af8584a0961101c04a432772431e77f5740ba3b2ef488d",
-        "sha3_256_hash_of_secret_key": "93bf696bf0671c3845c4b246f29701a0978eec5b49de81589009e235903061e0",
+        "sha3_256_hash_of_public_key": "bce58a5d05a4840f835b8ce39703f77bb31f20b9ee4fd3795c2e326244208b28",
+        "sha3_256_hash_of_secret_key": "abc33aecf69474343f3848633db85e595a465bcbd408472257e00be338664ecc",
         "encapsulation_seed": "060ea5d2ed1dd88144a9885e79278590821c22917b55a48920f96b53ebe0e689",
-        "sha3_256_hash_of_ciphertext": "6634bd840d2dbb01463cfe5b4e3e54d1eabc081cfbdc14d0bc118911ed8d3cce",
-        "shared_secret": "d1f24383d5b8d0c3c0a6a5f8f7d38ccce13ec179a84b0b09bcda4c9988f3eb4e"
+        "sha3_256_hash_of_ciphertext": "a500aa79a567933c2cb80ea580fff3298a345398243052f2ac292591810328b4",
+        "shared_secret": "30abe054c82a82299e7edd52870f461ff6048daab627b6c848a9d4f1c4641a0f"
     },
     {
         "key_generation_seed": "c719f9b2d16399b7326ce4eca30dabefe8fdaab18e9f6df888b0a134ef355570e40771856eb77e4633504899fcb86c6a3d433d0b8d60e26f07bd61f1d4ed69bd",
-        "sha3_256_hash_of_public_key": "79836213a513bd4cfd42ed281304e3ee4560e4e0c60fa53781f83d5bd2bbea52",
-        "sha3_256_hash_of_secret_key": "65deb55fea451375ef335e7faac73917d32220fc70c95f371fdb16e712beeb26",
+        "sha3_256_hash_of_public_key": "0293675aaefa1219f8794d114bbb004463f9c631729734cb430f26f38886537e",
+        "sha3_256_hash_of_secret_key": "b25401df9f852f7383fc87fa7cbd267b9de2e80bb37946e9fa8d040134a9e31d",
         "encapsulation_seed": "10ef9426f8c4a13b52325c5bb4ead4596ecf2c6b5bd2d37d8350e90d4164fdd9",
-        "sha3_256_hash_of_ciphertext": "ba79883ad64a6f2b256004233d87809a8c390327a23c739334f773507e003aa7",
-        "shared_secret": "d2dab0b39b7f62de3ca9826f9dd15a4201191a0e0c690d3e52b305a9d3af2d0f"
+        "sha3_256_hash_of_ciphertext": "3e0e87ded530c595b63064109c6d64c78253f3bbac5f3bcba552539fa7daa004",
+        "shared_secret": "4b525f467ee0d96c1f4b899a114936343ec21c74738b05555b2bab9a5d0b5513"
     },
     {
         "key_generation_seed": "e9acbb774be970206c3a738e243b420805a509fa59fa902044be2f0d013650d2ded5edaec5de3bf5b4d7c2f2e18e87f499c1968993eff196753db8045e2c8ba8",
-        "sha3_256_hash_of_public_key": "0c2e803c2872400c49e1bb10232946ab939319e84ff32cd354dc15d082cde5a3",
-        "sha3_256_hash_of_secret_key": "d37f172803739d074d71a2be32125eb1ba4250128342e34b882fcba38b259248",
+        "sha3_256_hash_of_public_key": "cadbc64e263f1afdcddf2ad63f2fcd19799a0a8f43ec867477e249ed5fe716f8",
+        "sha3_256_hash_of_secret_key": "ae483cd66ace708eb15d06b55b1414e1ca1cd440d8867932261fe16a41eab8dd",
         "encapsulation_seed": "a4bd30a64cbf29a4e290fa1cc1dfb99e68348713041e4409a1af23c5d80c15c4",
-        "sha3_256_hash_of_ciphertext": "13d437b2fd9d67ca0699a3dacd977fba5d072fa6b482043d63e8a9548ba6a3fb",
-        "shared_secret": "6869ca370a496af2dbaa866265d91ba6be54b9686b1b8dd5714f6ba861b0d1e8"
+        "sha3_256_hash_of_ciphertext": "b4c90f9d9595c242112c963a6f24b6023083a0751e341522eb4460a0eed65f25",
+        "shared_secret": "6cba1b31809b333ea40f2f67bad438226d91bd61b08860357a840cbcc8fabfc5"
     },
     {
         "key_generation_seed": "c1b3cbffad4b306f9af0cdd3028876486dbe858875c9b6497fe20172a986c82b1c96249919cedc2369d8d739ab125e0d2ccb82dfebcd90240a545cdfe07511f2",
-        "sha3_256_hash_of_public_key": "5818ac8d7a38c781e3a0bc43d088e6d391d1d67d9639b260bb6f58a19a57150d",
-        "sha3_256_hash_of_secret_key": "280e4774d1b2401580216fa70fb24c2c214ac5dc7f3841710a42e14d6aa09663",
+        "sha3_256_hash_of_public_key": "5ca1708c7c6e354b69720b4b4a0c358fe9a6ad3febe78bb2a71691658acae21a",
+        "sha3_256_hash_of_secret_key": "eb002a4709c8b95bf166e0942d47453c32b93e32e4273aef846c296d1590d58a",
         "encapsulation_seed": "f4b66a7d3b65b896dfe100b2cad24b175a1168cfd2ae11fd704b835f6bcd311a",
-        "sha3_256_hash_of_ciphertext": "51eb70249a1abebd5159f1069b1acda2304f25fc9cbd9f4a625b58df448b47dc",
-        "shared_secret": "502d92b2a7e1804892ffb8ff009987a58f35baa30c0392c83859fde82105a9aa"
+        "sha3_256_hash_of_ciphertext": "3d21fa1e7c4b9e5b3f68f956afe6fac216d42fd9a3707b7a61932c8ebb5103b3",
+        "shared_secret": "8087b456d37e6aff785a0ca104cb03ef71fa2d6652c52dcd86220cacf878afeb"
     },
     {
         "key_generation_seed": "ff7495b8575b5a98e4fd21fb4c3e58cbb60f14bef21aa74cf8802e3153f14807bdc370460375a778d1a31d01c42b66367ed8d9e8f84551002f552f0e52102b5d",
-        "sha3_256_hash_of_public_key": "172cf4f8dace8a96b8f70da966080a5e3f132873ca7544343377a99b65e8147f",
-        "sha3_256_hash_of_secret_key": "31136804b6c14f3a0a00a3295a5fed8d606369e64d272d432c59d7fe0ccc3e47",
+        "sha3_256_hash_of_public_key": "04f0066489947b572f76e1dfc2e24297b210ed0aaf228788a0b349d11689e064",
+        "sha3_256_hash_of_secret_key": "656696013b36db5535aa376104d5e2beb2c9a708282aa6a5f0ed42cbeefcf98c",
         "encapsulation_seed": "1d7b03d3c5eefb8ae5799dc569aa668f1bcb8c86607b089d3530cf61d6380147",
-        "sha3_256_hash_of_ciphertext": "9b38b66fdfe80acab82bf9577676f6566b4429f78a14f7486b07c96ae7be921b",
-        "shared_secret": "48eb4b840c0d957f28808e434786c02a8f99d3464ccb3caf91cef4a0f8e70c4f"
+        "sha3_256_hash_of_ciphertext": "a29dc0e0107aed03c698c2448cba21940bf9923c2098225ea3421bdb474a8ecd",
+        "shared_secret": "6799d393f4000857868049c19a102e5c04c55a6bfe3a41abeb4fb6d5228cda97"
     },
     {
         "key_generation_seed": "bdc3fba1c32751139fc45bacffb3ea97f26573d804a5f27a459293d95190ed8efd5a08f656a6eb8cd20679930a31caa6a6331c4b133a6838c223ef9f769f6246",
-        "sha3_256_hash_of_public_key": "268b6356f92c57da6dd34494b927e8764adf0ad519612ef0d1b8951e50966c2f",
-        "sha3_256_hash_of_secret_key": "3bf02cee24670ca40b7280d8047fa147b24c5e286dcae9c24bace9465bb19f61",
+        "sha3_256_hash_of_public_key": "67ce6c8abcf3ec4d93505d3be02c039e5a12538e5e59adb5a5d709b9b342938d",
+        "sha3_256_hash_of_secret_key": "b68d06399932cb2d32b2a2aaf12e68568f160092efac36ade3536cfe6fc88d45",
         "encapsulation_seed": "554f3385b382f4a46314de37ee3885addfc5332bd4038785094e0a832e9e8c2c",
-        "sha3_256_hash_of_ciphertext": "fe8c3fcee4be152aff29e55f42f2fb1354ae55ccbe38400bc901ca032ede1ef6",
-        "shared_secret": "f9507f70421be90f21138a1e135329ee8228682cc948a6914ea58624d396df0b"
+        "sha3_256_hash_of_ciphertext": "93a08f27c7cd6ba3d5e6c8b6c833d8c65f05edb2cfd7eaf5bd392cd1563552ca",
+        "shared_secret": "dbbe6f3b6f5a35789697792e209428ba1f53d1b98ac2c0d1893cfee641e40375"
     },
     {
         "key_generation_seed": "447f6076a627bbc5ad7773fbfeb14b4ba9ac43a0f8b99fb6dcd5e452aa3c47ec20a7237801f470fcc2bd9fd7bea8322859b850f7882d362947432913dd068c01",
-        "sha3_256_hash_of_public_key": "4c6d304e0494d88d83b5e3aa5761df3b299551a24f28994d2747b2b08945bead",
-        "sha3_256_hash_of_secret_key": "5de91ca73756eee74da3cac78a1fb329a02f8587f212bb9bc0b29e0e654a5795",
+        "sha3_256_hash_of_public_key": "7fe853da745a27a1462668bb66c4348b7f4bf25c70527b360b2fd104cda48fe5",
+        "sha3_256_hash_of_secret_key": "85a7c0a52f7898df5e3ba9ee378057b9e354dc2108c5f8c60a10fc20c9eda749",
         "encapsulation_seed": "38bf0033b779edf5367d9ebc01c988af90904c560970815837380650e4749eea",
-        "sha3_256_hash_of_ciphertext": "805ce0ab06c568b614cacbfa4cce5e65929e2846932a90e9418513dd48cf3358",
-        "shared_secret": "24caabaafe2063f812eaf57c58b6c0376ed8ff778cec1980ee9c3228801a75a5"
+        "sha3_256_hash_of_ciphertext": "23e8b844258ff739aceecb17073a7f2be2f89030ba7ca699470e4add6f55321b",
+        "shared_secret": "494550faf270431de90c96d2ddcb7c19249d5e85305b3b43626386c30b7aba5f"
     },
     {
         "key_generation_seed": "2d5df64d62cb07fe630310bb801c658dbf3d97993e68626745de39d37fbfc2b27b534537addaba4ecf14f02ab317d36cb9f0f50222ced7cf029dff8a0d3d2fd9",
-        "sha3_256_hash_of_public_key": "72be2f5cd569e6229f00014854633f7b278e90af4ea593411909467a03e29cfb",
-        "sha3_256_hash_of_secret_key": "a68ca31b91491a129af9f280cb4c60c046e7a7ccddf41c9bd98663f8512ca34b",
+        "sha3_256_hash_of_public_key": "65297f711f12a5ff123e6de59d1f16878e93a31612015fb961bc572f3e999cea",
+        "sha3_256_hash_of_secret_key": "f80261900b053c4d1c5e3b445588f1aca6a9959b969b6a60df08f1a12da1b661",
         "encapsulation_seed": "048ea516d0ebbd9f709b47eaac66f344c571cf50f0d01c9466aa061a50b66a24",
-        "sha3_256_hash_of_ciphertext": "d27a36808f09d6165aefc5d253090027eeff0653268c55a0b3de2a751ec765be",
-        "shared_secret": "9f734b15fc7dd99bc10d6cc7de5d2c93ac789a5665e508a95d075dffbad25abb"
+        "sha3_256_hash_of_ciphertext": "7c4f753d71b67d7a6691db0e7d9bf2c2a13f9f48a0d9602be60e080262bf50f1",
+        "shared_secret": "eec9e658edcad5a8a705644ccd35aa3d785cc258666ff749bdbbafae6700f1b9"
     },
     {
         "key_generation_seed": "25056d1b8113bb362dd979d98643d7a7ac9c4f95994c0ba060609b6d07002ff3f48a9254dd40b117941fa35a66bb50296327b725525deef70e128ca8045ec451",
-        "sha3_256_hash_of_public_key": "0831c75b153fa17d336a79ff6e88ddf485daf7b1b0bcf39d8df15319d52ac67e",
-        "sha3_256_hash_of_secret_key": "2b983d7cb50880cff761441b6a2c66b7a41642cfd2a8cc297a5df53f0ed1947f",
+        "sha3_256_hash_of_public_key": "51634cb33a2bc3fc22ff47b58d7879d703bdd661ad3c290a6d812485ef0ce8ff",
+        "sha3_256_hash_of_secret_key": "e9d2895dabc85514f2f1a543440ac0de41d49cf21686327bcc6066d21a2b93a0",
         "encapsulation_seed": "686c921c9db1263e78ae753b1c9c2e7936b8229dca48c0942c56c6bca4f10917",
-        "sha3_256_hash_of_ciphertext": "0892527da24957468b1b8fab49ad2d7dd6d238eca54624fce6a3c2dbbbe8d194",
-        "shared_secret": "d27e55f2a1f9ef336c8537f11da9875e03cc7dde8951d81b0740457609654107"
+        "sha3_256_hash_of_ciphertext": "8d971865b1ec760640db6e480ed27fcac239bb1c36e72054afc530d957672c27",
+        "shared_secret": "d5c5e6657d310b0ccef250c9664a02c846ecb241f2404ca851d8219f93cb0d27"
     },
     {
         "key_generation_seed": "e4d34e12982aeeb1d62fd488d9b9e28557ed3429292239fb4f76fa9098009acae6c45c7fc62329b13c8d29844405db8ff6860de474bf727ecd19e54e6e1a141b",
-        "sha3_256_hash_of_public_key": "b30cedc4316b63d75b641fbad2f33241a3fc47ab8b3ee1a3ed597e5b04f77c68",
-        "sha3_256_hash_of_secret_key": "a49a7533c671e533deec55af218ee511c57014070e138c7059853e08c34b0a78",
+        "sha3_256_hash_of_public_key": "45cccc2997b502ed631257065214ab9afed11f00ca5c18c92c4d6b917165fd1c",
+        "sha3_256_hash_of_secret_key": "3a0f0c13760dfc8bf1bf79bdb1b4f94aa33989529be306bb826b07e089105b47",
         "encapsulation_seed": "2387772e50059cabda53cb93ba24b19ae529496c03b36584169451525c4a0e7e",
-        "sha3_256_hash_of_ciphertext": "390b3b6f9a0f9d97ccd452c83bf47416b22fd06b4d8968c44ee6effa7980e68c",
-        "shared_secret": "ed5903d1cf02861444cad7fc3793b4e1b9b6d0324bf6babfb768bb2f84300086"
+        "sha3_256_hash_of_ciphertext": "c60ba523dc75a1c9f8dd617f1cc775f6d1cee0fd7614da1a5366eee5950b6f10",
+        "shared_secret": "f62460025ebbb273f00207758a1215c3a8053d2ac66cee11c6760aeef7e35d24"
     },
     {
         "key_generation_seed": "cd6a99396eb3539ca663a51e42063a3a262cc1c5a5fce1566f0597b52ad9fa325a3407f591791a5db4578b5972093a95bec3b8e70c1d542c9b5c9789729f8922",
-        "sha3_256_hash_of_public_key": "ee044dbdf6787ff038dbf9c133557169c62fc1ce2580739369aa87df00b49648",
-        "sha3_256_hash_of_secret_key": "9e865967f0d1e7d3f6a49f2bb623ced2a7b1408a945e02adbdca35846b70e7b9",
+        "sha3_256_hash_of_public_key": "89560d4e598328f6302a9762bda2b0f29fa8ee34fe48dc4847810fc6f44cc198",
+        "sha3_256_hash_of_secret_key": "30f40a1a6f4adda2a9e73f3a881f3d10414031a0f5fc0f70ffa4966b29bb1a7f",
         "encapsulation_seed": "155c29c5f0378df0cd0e847a80a07143cf7522fcd880c9229eb9feb1ce340cd2",
-        "sha3_256_hash_of_ciphertext": "6858db6eafd97259e6d775d881f7a877010179d4f827680426946b9ac4571261",
-        "shared_secret": "0d301028c1cb31dedc8a702a9e95b7d3589f68a6a1f600af84ae0f543e625361"
+        "sha3_256_hash_of_ciphertext": "932a09da1c6de03fddf0b45ca31f2446c5c2a3d47af171cde29149167e735cd6",
+        "shared_secret": "74efee46e7b26f5022416ae9bf4a52a3940966b37fab0c3ee2e8fbb24ded6bf8"
     },
     {
         "key_generation_seed": "6c8c53ed6f65e6b2e324b84364e10de42d1c26a106d4d1c99eee79c78586fb55b9402bf02481ce4b27a52e87feb92c4399c7f2988d40e942e7496ad15ad2aa88",
-        "sha3_256_hash_of_public_key": "e965ac6995d525e324e8252d8e2c2da909a29b24baca8b68daa5122cb539a474",
-        "sha3_256_hash_of_secret_key": "91051a381626e9465fc7ab20a1944eca64be461330bda53e7d1838a74597392d",
+        "sha3_256_hash_of_public_key": "878025deeed7dab8e62d43c3d2096e4682692537c70ebab9e1561cba88b05ec0",
+        "sha3_256_hash_of_secret_key": "5469881eca81b37faa66f4d9f63c20ecf61fa8337a095410fc19eeacd774b863",
         "encapsulation_seed": "a9cb9a61a3324b1ea5afe693b32784e2871096b2ca14a11acc9577c52359a241",
-        "sha3_256_hash_of_ciphertext": "42bfb5584610497fbc8080a664139afa534b39a417cb69ab0d2a16c8737eb1cb",
-        "shared_secret": "354d86b389021a3196b75c6582927b3a005fbfee0951f34d9cd5c8f415fa50f9"
+        "sha3_256_hash_of_ciphertext": "0407bedaefe91d921a6442f34fe88c04e62389fc63dafe78a1a2b93723786a10",
+        "shared_secret": "92fd1bb6ea9f1a0a195b3ca29e457f4b3f401fb4521842196d9471f50f5c7249"
     },
     {
         "key_generation_seed": "2107204cd995f1df14314d5381f8c5440f09a347502e161cffc0a2ec3dcfbc7324c3da70fe850e80aa818301d60c70f3038153866dcd5d179e22db59b8991bb4",
-        "sha3_256_hash_of_public_key": "a3d8a85f38cfda38c66ae39b2f9186ef7bc1e0c98e8976a6cbc6c4875d73d7fb",
-        "sha3_256_hash_of_secret_key": "cf7e797f8f7229a08206034737e54fe46645ab2fabdbfc8662b45a2604876b65",
+        "sha3_256_hash_of_public_key": "7d30385f988dc748b843b7b7f569e58ccc9215503e1bc2f28f5019fc72fe6d33",
+        "sha3_256_hash_of_secret_key": "5b425d514afec91db185ec5e84bfd545453da4f3acfef398e7b3548c63f713f9",
         "encapsulation_seed": "e99fbae8a024ebbbdcef32ce213f6aa942e3eca925e5da4c09975d773b33a175",
-        "sha3_256_hash_of_ciphertext": "ce7b65856502b280e02a36d906e018c6a23cae99f27ef6d65762c87ddfedff56",
-        "shared_secret": "3afcfdc446f93a8169024a24fc0383692843cfd6b4854a8e490892fc35aad4cb"
+        "sha3_256_hash_of_ciphertext": "886a86759ae6a21a6dabe37a4b4443bdd358502f0719b5b9178dbb6b9f7e27e6",
+        "shared_secret": "e1a195eb1093af69edf107980f94adb3058378cb79dc807684c26c4ee1308533"
     },
     {
         "key_generation_seed": "63a925685a8ac5bbd918faa33ac397d1ffbcf99135d9da7c3d6ff7aa4c50af3d3afdb8a246a56ee71465591831c371f2eb87467b0559dedd776ba063ee6d2f93",
-        "sha3_256_hash_of_public_key": "aa73b40dedd61e6fdaac86971965c03ab14ae69e8130426fdf830bd57d0974ce",
-        "sha3_256_hash_of_secret_key": "1e7f3f1e5632d1df538b564304f56689742d1f652d8d32f019b45183af68a20e",
+        "sha3_256_hash_of_public_key": "0697d2f9e047e603b8845c9ecb168576f9d8bc7f3c831b6ec15c5fa4f744315d",
+        "sha3_256_hash_of_secret_key": "8b634d3c1e118577cc095a8bc53d05bc8c869f2001f3ef591dffd8cffffea969",
         "encapsulation_seed": "67a216f37d67f5e74f782f1badbce1cc8c80a6130aec305b421899a4faa0a6c3",
-        "sha3_256_hash_of_ciphertext": "b6c40fd53bcd9ee1e70bc6783b402ae34c24dec724e63262d8583c90cd10256b",
-        "shared_secret": "ebba9a8bae936c829c1445c68595da96919041ee3d9b0fe27ca93db691146874"
+        "sha3_256_hash_of_ciphertext": "a9c68747a9697af9d9442e3d5341161afcd1977777bb40dfd8642807d96f3ccb",
+        "shared_secret": "fa8721164f599caeb949141b24a124f2d576b3b58c1914af2b05da26b09bee30"
     },
     {
         "key_generation_seed": "6a1aee5e708c1b47f02bdacce4f56c860f74fc7cfec1ef3b58285b1c8ad7fec2230e05b7114ff0395cc6634db1eae8258072d09c09f291e92d6620b177dc50d7",
-        "sha3_256_hash_of_public_key": "cf754f2ee43694865a09ca7beb0deda9b1328fd0abdf30ca5c338e27e8be04b5",
-        "sha3_256_hash_of_secret_key": "928592604aa44df8f2072f26e9511129f61da0b7f57acb3f6896635a9764ea87",
+        "sha3_256_hash_of_public_key": "d49e426ae85eaa6c911c4dca80caba6e28e5f645a54d8c016de51a2b98241a29",
+        "sha3_256_hash_of_secret_key": "cb272fd45a2a27a517bbe1d77d99c027b8664d596bd77d18c4e861ab9900b0fe",
         "encapsulation_seed": "52b19fea232c9154a3e431e9d69cda40013cf2d485c3cd027ad24e645420420b",
-        "sha3_256_hash_of_ciphertext": "a4b50ad169b436877652a6c64dbbffdd63f53274ddcf58f3c96c3929215aa956",
-        "shared_secret": "f063c0908deb2e61faa0c4c0f5051b2c8af7265060681df14bacb30f0228b3b3"
+        "sha3_256_hash_of_ciphertext": "a569fc93ed9b0342e4090782e82b576632dfef108ece59234c783f80e1862de8",
+        "shared_secret": "d479c2f5e622cf848d921a7155cbbade062d0fb3ce7535d1859eb03e18ac64f1"
     },
     {
         "key_generation_seed": "6396b328b100e4c7f4bcae69875edea1a1982421558c608c13c592bf7b5d0fef1100ced48add211a5c937b8d6079d8e271af3f949edc61f70e60453aef20dea9",
-        "sha3_256_hash_of_public_key": "3a842153dee9e035299d7e268c9492d71188f9fb24bdc2dd20c1ddca647a1523",
-        "sha3_256_hash_of_secret_key": "28ee987bc4ae5a321d2669950dbf87596fc4b35c29f192836005064aa3dadee1",
+        "sha3_256_hash_of_public_key": "903d69da169d8f3f65eec290acf30078fe51bcbd1aeaf412dfe2d31c7b10157c",
+        "sha3_256_hash_of_secret_key": "87b236ca8da0c7a9d38d7714e7ac16e6dad2fb5282a04b846afedbbc0449b395",
         "encapsulation_seed": "64440adb05db3308b189bf999f9ee16e8ee3a6ccbe11eebf0d3ae4b172da7d2f",
-        "sha3_256_hash_of_ciphertext": "126b64a28d82d06ca81f7e86d33f4949634924e04528d1142061320eaadcb841",
-        "shared_secret": "02d2e466e170bf45d3e9d357e2f04c34cda408cf147e9ff7a6e8c715f2c88ace"
+        "sha3_256_hash_of_ciphertext": "d74122c64015ba74b20c9a675bf688952d42ea421aa5c7b6c82eb6dcf0cdc092",
+        "shared_secret": "0dc813eb106eb0d4864ffc38432937a1db0d27745788775a8299e93d1c808f18"
     },
     {
         "key_generation_seed": "a453bcacdd2b0d4646009e5ed451c3c45f08fb827ef733db3c517a9dc1af93e67a3cc8aa3239d4c52ce4c95afdeff6efbfacac10d294edc0e7cf4535059bfdba",
-        "sha3_256_hash_of_public_key": "da43cae3c4da51d69a57eb87094a03cd3a9c3e6b4ed864cc691a60f0509cc646",
-        "sha3_256_hash_of_secret_key": "b204cd1c3122b29a3d99cb77e11427fc102375699928c5a6fe816f96bb212627",
+        "sha3_256_hash_of_public_key": "08cff1967030a528e748b708b0fb783577f249c04ea5536d2da034fd0d15fbac",
+        "sha3_256_hash_of_secret_key": "de3ea809c8eaa873e0aaef44d481d8ae72799a0b746c5847f3d412865871bf63",
         "encapsulation_seed": "c8bb46b3a7344ad170c2052fb042b5a3b62e0590562ee82577b1081f6f114d16",
-        "sha3_256_hash_of_ciphertext": "228dfe300e3fabe4d4e550754ebcbbf72a796209c1d24e7ae93abb79e1cf17dd",
-        "shared_secret": "6a5b0842c122ab6ee251399492b061d2ab3e40843f4dc01c12fbd5bd545c600c"
+        "sha3_256_hash_of_ciphertext": "f0cbdd82f5731bf4177a14a3abfdaaef5fbe94a71ff3f1b7852a010b1d4d7eff",
+        "shared_secret": "c71d65ecbae83e06c622e28a4eff43c10041539d851149dbdf295eb121550d5e"
     },
     {
         "key_generation_seed": "47ca2b77c5b717f423222c2730ca5cb9c856bc951d01b2b2c80bd76ccb5539b78f1481d7cab000e33fa07de8dc9627a85e76fabb4428a3376e66300cf12a0787",
-        "sha3_256_hash_of_public_key": "6533c524a32345eefdadc74a3c6ad7e981832797faf1068955b79f118dff9358",
-        "sha3_256_hash_of_secret_key": "b9dee52055b1f9a2b25a0c1be4d9f30d2ecd7c5a09f0f5294de2d49a55ac9fe0",
+        "sha3_256_hash_of_public_key": "b5ed4c3fb678a44d92486cf091333c7f035541614729496d5dd45ce580f0d263",
+        "sha3_256_hash_of_secret_key": "c313fdffb08de4e928bf32e08a8d0310ea94f9713381f81cdd494a3d4af09553",
         "encapsulation_seed": "2e2b70609f3fe029a14d09d5d659871ac776ce2797a0355f16e2eb68f5613fd1",
-        "sha3_256_hash_of_ciphertext": "2d7e8fbd6f2257b05eaaa2ca1643c452b4e0b623c9ad72027cca8dd8b7b5b91d",
-        "shared_secret": "2486c0a6cf17d9635dbca1f8395784cde54dccb7df10fced92183f983478fac1"
+        "sha3_256_hash_of_ciphertext": "5c266d232b038abc42ac484a721f63094ce50740008e0be68571018d8355099f",
+        "shared_secret": "82360ffb5455f6dfdfc6bfc1a3999eb7453365ca311a0077c9d74968ed27b7a1"
     },
     {
         "key_generation_seed": "aaf6eb40e596a5e3e8218871e708b089240dcbe7fd3641f0e5e41e071ce49107e2f8d320ac3cb0c52efdc753282f092bc39baf4a18783a48ea031a191865eb78",
-        "sha3_256_hash_of_public_key": "e2f60f27da7f318eb94a74b437f8e0bc9513e9bcc38dad99c174c1d75e0145f1",
-        "sha3_256_hash_of_secret_key": "68eaa8143a71bd5f6df29b128781e3f2a5fbc5d20534afb223ddcc64bc767f5a",
+        "sha3_256_hash_of_public_key": "e9037042553968ff3007cdb135e368ecf440e4187e554af9d0ff272911ced339",
+        "sha3_256_hash_of_secret_key": "21dc6c39559081b2ca594cee9e9825ff973158cce0d11b38a51b503952daa372",
         "encapsulation_seed": "4725dd8fb314bfd8ee23731c2341dbe114606d9abe6434c471b5573e7df193bb",
-        "sha3_256_hash_of_ciphertext": "b5b2de55cfaea8fe543f67c4f45a69780c3e2d932e56e0b574d9b40b56ddc1f1",
-        "shared_secret": "85690ee044e4d8e0540ff984775b59bb5134383c4e229e79e37d7d77632fadaa"
+        "sha3_256_hash_of_ciphertext": "525a66ef29f0c8a0f989dae8592e9e00cb7f347915217d53f08a7699c2b912ed",
+        "shared_secret": "77ef6dc5a6c8ff657070e418fdb3eb272c8784a9c38bbef950c8ac1de5ec5578"
     },
     {
         "key_generation_seed": "6500f32c93415cfdbc0bd31d78d5be95cb9060c8cfa2013955b56f8b6868b322393308641a9a4647f230201e1389624a296b55192a9819fcb19ab77c25f95445",
-        "sha3_256_hash_of_public_key": "d4bf608793939ecba27dff5889d4d921c583999a57e20a48085ac549573e6abf",
-        "sha3_256_hash_of_secret_key": "5f9a14a9c41fc228306d79417015408f31bc9c3d97579616bd68a3d3444f9bd2",
+        "sha3_256_hash_of_public_key": "806aea6700e293f433a97e4b2c8485e6b4ac19ad493c4c16a10a2a884d58f5ee",
+        "sha3_256_hash_of_secret_key": "f446ecefbf4c63e8897a89123ff38bee2aece076fc7b268b6379c996999085ac",
         "encapsulation_seed": "818d3bb8ebfb32bf464775f7139bac0a5bddce80ec5798595992f9403002cd5d",
-        "sha3_256_hash_of_ciphertext": "99fb7b7767fa94e74936a6678acfd5a2306b156f90f4608d507768a25403a16f",
-        "shared_secret": "d179d901a0570bd23aa52570c5c233a2240d4724e81d98c9ceedb74187eb75a6"
+        "sha3_256_hash_of_ciphertext": "c7c82e2b3d0d3bcb73c5d9203ca3acc94ae8818794afc7610cf48a21e830c450",
+        "shared_secret": "b0978add3085e1c972bfaf86655a287946f3853cfb372f6fa5813a11b6c4e103"
     },
     {
         "key_generation_seed": "7643cef2d62cc5aaeecf754653ea62294cd2208e5bf3ddeea209e3dc45373d49eac9d531a532770837a854b4f5531f6e0c8d6c10183b30d3435498c2dd142951",
-        "sha3_256_hash_of_public_key": "65f03add3941d22c80d50659f501f8cca1b448d84462ccb93d5f065889484bc0",
-        "sha3_256_hash_of_secret_key": "e4513cfd1dd2153d30d15b023421cb8e8456e6a40e612847e1713e915a29a87c",
+        "sha3_256_hash_of_public_key": "33df23b37987c6b557e4c0f8fa9e466312f19e7e90cd0a67abe6a145cbca9d44",
+        "sha3_256_hash_of_secret_key": "039031ac6171ad5fa8734fa3d60cc5b6590574c09ae0c02564c1907ebc772d3c",
         "encapsulation_seed": "c92aa5fb91c980d9cade9ce99d4c75b2ffa7d6a6ff9bd59def1aa701f2a0992b",
-        "sha3_256_hash_of_ciphertext": "4cd7f0af86623b34c0b137a0516b876daa73ffd65d75871ddc828f86a7e9b224",
-        "shared_secret": "6d574af7fcb241fed8763b2d0a352870baf85ef686e90eea31f8500c35945ef7"
+        "sha3_256_hash_of_ciphertext": "6fc3012eab242c5a3dcf99b82c5e5230fb8a4d45902afc7bb82648298d8a00b3",
+        "shared_secret": "b888ef3a969e162edab17c3d3de9ca682de60a0fd6ac97e1b5a54171dba12a3f"
     },
     {
         "key_generation_seed": "f8ee95521060c03bb8dacc79f7eb7db640f545f315613a35d447a09e504cb4e13fc3d8392cb53f36ed647364a04e37278a0e0a45b720f4a75c580c9920eba98d",
-        "sha3_256_hash_of_public_key": "b8a3b8cf4709204a2fdb19889b0022ea655dfd58ff27e17d530510e1eef45793",
-        "sha3_256_hash_of_secret_key": "1f7cdadf3d4707efe1b7a6173d8f7b8a9f864ab388c3271d79ec424d9da3e896",
+        "sha3_256_hash_of_public_key": "30a5771b76066feb7f606a82cce122964da1be0b6872ee319832214ec677738c",
+        "sha3_256_hash_of_secret_key": "644983542c87680786b41fb07f959451f1507165353080a3789810fdf557f961",
         "encapsulation_seed": "7e8086a01dc5b3bb9eda25bcc45d27f99874841b97237968495800e007696ac5",
-        "sha3_256_hash_of_ciphertext": "1ca889a71a087ccee4ee1a178c3c55ce3649583f3db924e5c1003ccabc44091d",
-        "shared_secret": "b1090cf26276a81c22ef0e4479a4c705fe294d3b892051ddce7eab16495e0783"
+        "sha3_256_hash_of_ciphertext": "6d468584c0336dad723a1c3ea970d53837373372287371eeed8e08ca06e010cc",
+        "shared_secret": "2fc09a1852f458bc7afb58baea4d6e318bf6801e7804b98cfc250b0a1470c598"
     },
     {
         "key_generation_seed": "b8bd0493a882e3a49b4e0f6256fb1fea0912562fd9ba26ec3d6c9cc12c8973abd7e4b5d8021c486b9c3114d7cbbeb7cd49eba8a61bc2bcae1f1bef30a1daf76d",
-        "sha3_256_hash_of_public_key": "46fe6c37136273736ccb11df5b6d55debbc087de802404b72a003c5e8c809719",
-        "sha3_256_hash_of_secret_key": "3177ed170e84ff15fa1e744adc9ce806e431a68f15a7a026c6092bf593dec6a1",
+        "sha3_256_hash_of_public_key": "31fcd120f19fe976236711e58b4ad172d25ce01eb88bc9d6d051c56564a0db11",
+        "sha3_256_hash_of_secret_key": "1502619da09b1bb5e418004fb0263c8f067cb9317053ed502c501c5b5ba4d331",
         "encapsulation_seed": "bb321ef14d44d8698df879fd52450567657f52a2df8d111185dcd7d4f30a72d4",
-        "sha3_256_hash_of_ciphertext": "aa9a0ea1823a84bc84649d26e249899437844827fe7c63d4828a5144929fa00a",
-        "shared_secret": "2fda9fa72321be3a0946d6d914c7ae714b9cc175619ab8abfd1f1fd499e0dc27"
+        "sha3_256_hash_of_ciphertext": "369203e0da6ebef7ae651a3111e67303f89f568b9897ae4c24497b3180e0bcf2",
+        "shared_secret": "930131d3145d5485f06c16a9420a612330843e6524dd74654a85c383e28f2cc1"
     },
     {
         "key_generation_seed": "c0407e41ddf48d333978b89bcf2db01e4613425b456249e76a6f25b8a2827bf5b2dca81e3f5f748d23c9d356a2209f6b2d60247b2e45c9808de497f64f124643",
-        "sha3_256_hash_of_public_key": "a074ed1f76e97d68434ba4af2af0e549204222679e9e643580c35af3cdd247ce",
-        "sha3_256_hash_of_secret_key": "8f9b3f631d0fb04477846ae09aea725f1cc65b2cdefe2108cdb399c36db9b487",
+        "sha3_256_hash_of_public_key": "42f75d6e3755c28f3081ecc9db44f6cc7cec9891756d74093716697781fc8cb5",
+        "sha3_256_hash_of_secret_key": "21b9bc0035097cb2b892a3f4ad5660b160b18973b735181beec815eaf5ba5286",
         "encapsulation_seed": "210a423dadd899b810f011794b79aa7f860823ac1962370e791287d3a1afa384",
-        "sha3_256_hash_of_ciphertext": "a4fb01f55eb2986c1f90cece43330bee1b16d7bda48d617fc94aa14fc540ec4e",
-        "shared_secret": "23798e8b9eaa0b369842cad83a2bc32206f791229c830d7593b9150161168011"
+        "sha3_256_hash_of_ciphertext": "c6d1d905150eb6586eea72b13f7210d9830e8e689f9da7d9c04fa7705f21cf01",
+        "shared_secret": "b276a4fb4cf77eab502dfdf56eae9f8a8ff5e7f5df3f6cfc80614b193c87f08d"
     },
     {
         "key_generation_seed": "334382d39164d1989696a2ff77b25a28af8bead9883b5365eb6fcca7c1781cc9aba5068af837be962f439f233593d193ce5e08f7d66efb3389885927b89d2523",
-        "sha3_256_hash_of_public_key": "26659f74fc9ec372fe18be4ed6aa28b7cd84ad1c0f0115dad011a11d20fda9ed",
-        "sha3_256_hash_of_secret_key": "5e3f83cb08ff80183879af9ade3631bed2a468e429ad027a5afeafd9a6f66362",
+        "sha3_256_hash_of_public_key": "43d6c8562cdec0e87d00c8ca8060da3f031ab663ddb43148eebd67969b7fd490",
+        "sha3_256_hash_of_secret_key": "d3c172cde1f249c0a7fdb003ecc0a189776b616378b188744e407ccc601fea7f",
         "encapsulation_seed": "bc856afe24213e3d14c3d6f9b89223bbcfb2c890722d770fa3492c1e46d1c302",
-        "sha3_256_hash_of_ciphertext": "6a4204db4803d26d7b8a769033e047f3b4cb616bf5451b88a1fb3ff219bba9cd",
-        "shared_secret": "d5c63d2bd297e2d8beb6755d6aefe7234dea8ecfba9acda48e643d89a4b95869"
+        "sha3_256_hash_of_ciphertext": "353cdb064a37df87524874d3f60afdf4077be0ad96e1ab61a9ff1745d1e6e5a3",
+        "shared_secret": "f4924920e64013fae72cfdd1e94b217eebd55a011f6b7542958abb297e4fd180"
     },
     {
         "key_generation_seed": "6995143e8eb8a6e93840f76eec844f67d2b5f75b1839a5040337e61f9806764a0f4dff8e56f68440836a072412a30d851ace2c7c6f02d60e7a8420001a63e6c6",
-        "sha3_256_hash_of_public_key": "2ca3d8ad2dab1dd8a2f4320658fe6eacabf70d907920593919119cf374516336",
-        "sha3_256_hash_of_secret_key": "2798448395f6ae3223550e7d5255e6a605b430229f5809b6efd0683a6b9ca402",
+        "sha3_256_hash_of_public_key": "3cabf1c47e7aaada59ded4fa8ce378ce1d9eba621ebfe8cc96a111aaedc4b6cf",
+        "sha3_256_hash_of_secret_key": "225563503590841152fcf47d4665b7cfc76e2b9de23c0e24b527395549f9f7ff",
         "encapsulation_seed": "5fc00f89563e44b24cd67d0ce684effe5731619fd08e7d72e2406eb016afb66b",
-        "sha3_256_hash_of_ciphertext": "dbd5fc0e1df33ff8af9efd5e281a2b98160f98653803cbd54e3a07292b37fcc7",
-        "shared_secret": "29d6a229adf49a1139794209307b0ca24be5825b2771809232fb718660162475"
+        "sha3_256_hash_of_ciphertext": "f11aa37ffca654d11cb5f9aa294ab734302851b434b57e0f5bb811bb5bafc177",
+        "shared_secret": "412bafc716efe4ff928d9a86ea4665dd841e2f102a8363b994a0faad63251eda"
     },
     {
         "key_generation_seed": "995eff7e0d195c6d0533f3dc194d47e60f9ad14696144cde694d60a95f3e96b4b28f7e7a15a005f92400ce33db073d49b53871594a88fc45e0f94207b5f0f2dc",
-        "sha3_256_hash_of_public_key": "de62eff56f6b49a156d065d85eaf0aa21ca229a20fa4e1372a410ab1c4ab6e7e",
-        "sha3_256_hash_of_secret_key": "6766cef3fe644a233caddf208074b58e6e83f8a78aecd00911c29a08f6f0b0f3",
+        "sha3_256_hash_of_public_key": "2853cbbda86e7039b635d4cc850f494d42b240acb54ab2316791e9ef5b45f1d2",
+        "sha3_256_hash_of_secret_key": "87ffcfe7a504e0dca284d8cf509a92a24f82ed7c46a8c1604d9a2d6d14b1cd11",
         "encapsulation_seed": "ea22a76065db4b565ee1807fbd813b43bde72b0e08407fb867c6a18995025e50",
-        "sha3_256_hash_of_ciphertext": "4c669e33b0227c9c2040cdacdbcb7d22b9984372587985ed8f860ffc8d037e79",
-        "shared_secret": "2a56a7a6d5b4c0500ec00a92e322e69be9e93006240889552072482966c54f56"
+        "sha3_256_hash_of_ciphertext": "ae8fb4bcfc08f8daa486b185540b501680e511f46fe8a628b8fe449d5a51590a",
+        "shared_secret": "c514d4086428200e118c1c297ce5ed865d7452cd7770363961bbb834f56c564a"
     },
     {
         "key_generation_seed": "3e809ec8dd0fec0d911a4e3fac20f70fbb128c5de94dc7184ca7310ae9157a98d8128601c28b1def8d393a0db283229f7c7383152a814e7cefe8ef9d9768c473",
-        "sha3_256_hash_of_public_key": "66f161d27dc34e1a2f4b98b14a2b221d7eae26a593bfe432487d9994cb480656",
-        "sha3_256_hash_of_secret_key": "2237f6cbb452d375878b82c474a7c948ff587a5f3ed02bbba1459fa7ff8ef802",
+        "sha3_256_hash_of_public_key": "2d5680b483287bbd3e61a91839cca9e761429186176b7bc64034ad43f16f65e9",
+        "sha3_256_hash_of_secret_key": "bed74aff196e7ec7bbb4dcaac39ee1a79cfb35140cf4c400b6ef2fdfc53afc6f",
         "encapsulation_seed": "e9602b34fe73ad57f4bf6ead99743d645641553a5b9b9bf2e7016629e3e9bd76",
-        "sha3_256_hash_of_ciphertext": "8a2453a21a031cb8966924607a28882426fab2018826192e9bf833bdd38e0631",
-        "shared_secret": "ecb62b03f640ae4a9d89685fa0070efa93c24dfcff0d555142f9de25b62f861c"
+        "sha3_256_hash_of_ciphertext": "d46f403ce5a0dd92937acc508501305da6bcd32b56ff5d986fd6a07e713ab92c",
+        "shared_secret": "a175feba4c1bab576085bb12683d2bc44e98c75f543cee714c75391c559450ce"
     },
     {
         "key_generation_seed": "dbf1c465fff3d9f783bd9ee61a573715e45691147b8904439b5ffaa64f94ff7bb6d75eac6c76ced1b0a025b40a55440712ad8424672e761e9bc400d63812006f",
-        "sha3_256_hash_of_public_key": "7537e68ccf14e8b7e57090d8f648529dc461ca3950288879e88116acaf57b4a2",
-        "sha3_256_hash_of_secret_key": "bd8e44337eef01251217c4702c99232c001b33870953473d83a7486fd25484cf",
+        "sha3_256_hash_of_public_key": "38635cec71b814aaac223f748d13158dbe8eb902d9125fdc22202c4d59251cbc",
+        "sha3_256_hash_of_secret_key": "f3b87926951408dbb27fc2a4a6c14c40fedc8a1cf5c34ab398d91d554eae344f",
         "encapsulation_seed": "f72b9080a6c051bbdb9b0abc1949034be0f89a9f73fe277ec4d4740c78d04a83",
-        "sha3_256_hash_of_ciphertext": "6077c60641c03aa8b36213dddf938311ce6b7b8801f967d42713e73249fe7c55",
-        "shared_secret": "6cc30699701927e07b559d708f93126ed70af254cf37e9056ec9a8d72bfbfc79"
+        "sha3_256_hash_of_ciphertext": "50350977c400c1318bac5e32925d0f575dd3559587f42d025f4e71648e697218",
+        "shared_secret": "9781578191ebf49b162aa768d093a332b9c849c11e240187cec2ee969d4b3860"
     },
     {
         "key_generation_seed": "1f7cfd2b70863154e8a69d1758532e86c20cfc763d67c758bd10a13b24e759b5273b38bddc18488024ec90e62a4110129a42a16d2a93c45439888e76008604c6",
-        "sha3_256_hash_of_public_key": "82f68b15681cca5c2852c18d6e88bcb102a059c1d21936582adb71790cc0a335",
-        "sha3_256_hash_of_secret_key": "fd483ddc211c5c27f453bca56158e1f8084f075a7b06f5098cc3204427bf8197",
+        "sha3_256_hash_of_public_key": "af97825a77f2f4b6a45ec1a579f9f83e89c025d8d6876db26874f38348604293",
+        "sha3_256_hash_of_secret_key": "b2f08250a2681bbbd3c355e2dc61bda33cfe39f3dbbd2a3f3c41ee2266084cc8",
         "encapsulation_seed": "f1e5542190db8ecf4b8d617a04fd3783ad0df78bf8dab749afb57db8321d151b",
-        "sha3_256_hash_of_ciphertext": "5c6cfa16f63b1aa93a2b5edc2f4b14c9782f286f53deedf3153f329a2ae2d57a",
-        "shared_secret": "250e7f67bb34dd5477471e3a701fb71a8138a1920eb807824380f88a944a6fa3"
+        "sha3_256_hash_of_ciphertext": "33acafd1de1d8d8c7a9ff9a6cd69fd013b46b79e74a9180e99d5fa87805dc0de",
+        "shared_secret": "515dc87c21e6b134a577e4eeccf43a982ba7eac1224d701cf099ad07fee77cb7"
     },
     {
         "key_generation_seed": "3a19577908efd37697b8edc7fdaf47d1bd3ad01a1b77faf794bee5b9c3192a6fa3729672816f3eba84c9638a79676eeac0f22c8a48e0c5d50a26ff0844c66b99",
-        "sha3_256_hash_of_public_key": "104fbf09445794c0ea0654f5caf70ee09d51c8386d4e1f467b10633c710ac2a4",
-        "sha3_256_hash_of_secret_key": "73fb93953ae666a9df1bf933ba56b8655ea9e319c0110c78d49f8480ae1aa3fd",
+        "sha3_256_hash_of_public_key": "8517ab7585926764ec7acff3c747479e837831429b97b7cf49ac3763bd9ebbe0",
+        "sha3_256_hash_of_secret_key": "7e5684a04d59f9166f6b408dbc8ae5daf3ec6678cf5eec1e5a9016392cd6c8db",
         "encapsulation_seed": "74efa414ae171bf60b6f884cb7e5ce12028f49365daccfa23e845d551711660b",
-        "sha3_256_hash_of_ciphertext": "e51772e769f778067916e81a561ba6f64fae6096a2b4d4b945d9117e7c36e2b1",
-        "shared_secret": "0210935a18f1add5ebc2e1107bf40a628ef9cf8f6e7cdac81dc0291bb50a5a3f"
+        "sha3_256_hash_of_ciphertext": "0515c19fb395ed94194a60a6f7883d6351fa61ff18060be4cfe2eb9f81ec0024",
+        "shared_secret": "edc2c0314c7c5b2b071b85e373c06b31fa54dc499168d4b43b15f1d05b8b7ea9"
     },
     {
         "key_generation_seed": "ae0f65e29f38804a6759f70f4d01e2aaff7fe1c91ebc4f892dd0de3ab2e68ea5e03ff73e02a217659f53d8c47556bf3d8c94040f630d63605e2d0f923579370c",
-        "sha3_256_hash_of_public_key": "0f353d6a29813d354471eb8b4c38df93939eb3b1db80ddd1cdd6558a9f2687a3",
-        "sha3_256_hash_of_secret_key": "8a9edd6278707108652f3a5bc244592cb7a82c24634583ed2d3eb6a176b216b8",
+        "sha3_256_hash_of_public_key": "1bb014bb0d6489c14f5411051f9667aabce54da7a8deb73b627e3873d9390a35",
+        "sha3_256_hash_of_secret_key": "b890e330079934f2aac63e5f8d236054fabc8d6a6e057672a7a20150ae08a9a0",
         "encapsulation_seed": "0b4c3cffb2ba4380ead13dc0d8acad2356b448a810da1df29f264c44aab6d24f",
-        "sha3_256_hash_of_ciphertext": "a00c37bd326205575fcbbc100ed54630aa0f2d6dd9e69807d49151ac9a81c429",
-        "shared_secret": "34169fc520e944f94ff1fa3799db802a4c1b26cb2971bf196259a937ab8362ca"
+        "sha3_256_hash_of_ciphertext": "79018c9e998deaec058d73d702b669e10c89dd8285f431aa6e422a948a39cce2",
+        "shared_secret": "b3363e6e6dba3e41ac2c63895c461765bc8a0250880d3dd6e8a4479a7fd3921c"
     },
     {
         "key_generation_seed": "6084a235f79dd093ef6d185b54e69df33dacee73a9bf2f379004421a10e3a79d9f684fb055ece19459eb464e91e126a7a6e3ed11ccee0046da234d964c985110",
-        "sha3_256_hash_of_public_key": "12e89c47142418c26396ef0174c02f69dc00022d56494d31af935490edee6385",
-        "sha3_256_hash_of_secret_key": "bc13b19f01d4cab36dac2154e0fd8fb7d2fa012596363942847f1b0bb3715f90",
+        "sha3_256_hash_of_public_key": "c9a546b5c0a567855039f6c1bca60414684e7bd1f8eeb7913f3a1795ba4bad4c",
+        "sha3_256_hash_of_secret_key": "be5fc57b3efd80d7e82b23f62123814ce04e83ce5c998ba42e7bb978dc70469a",
         "encapsulation_seed": "1c82471dcdfca3a6942061ab4f3d5bf0d197321437c706d9cccccce449447002",
-        "sha3_256_hash_of_ciphertext": "aed1a4ee810b81cb8ee49ee00e94ff4553f0ad2176fe4d27a09f4e68157fcc3b",
-        "shared_secret": "b5901e97eb656a09d2dd132528148ad07a0a89f638717eb53516a9ad19aa36bf"
+        "sha3_256_hash_of_ciphertext": "6c1b69d56c493f6f313d3c996336b8f84b76fac2d5ab5a3d795613b27eb10912",
+        "shared_secret": "8e648593c8f6f6f7a97ce7a2d151ada30fbbc7f3c4fc517d8cbadd71e6a17476"
     },
     {
         "key_generation_seed": "acd1c0217fad5caa4235544dd9de153ab1880ccf4c76f16f236fae4e4bfda04cf03a8abb0a5010f400ae5722a75bdf5a2f6d5b546b34d73857cb1bfc7e587aa7",
-        "sha3_256_hash_of_public_key": "2fac52ca60594e514333ead02cb1bfa5cd1d9ecda4a0b25ccdfc47ad3f632a85",
-        "sha3_256_hash_of_secret_key": "2743b7a9dd83a6b9bb5c2685f28b5629b2e31132ac64788a0929557d3449dfc0",
+        "sha3_256_hash_of_public_key": "8f7bfdde2a7116ff4010cf829cbb18512f7cf44237c02241a1f75fe3ba8d22bf",
+        "sha3_256_hash_of_secret_key": "3f53a0acb384db89ca83d031bf210b072860adcaceecd79c36b4669407c1c227",
         "encapsulation_seed": "46fe60a18124125ab93e0c578f1c02f1bd1301595013001c7f3c2fa56cde294e",
-        "sha3_256_hash_of_ciphertext": "7a039d19c45cc557036189cbbc63445b3504a689db56845ece99d593f165c6af",
-        "shared_secret": "df5117706beedfb521f0f021069fe9650d0844194339033de6997dced05268c8"
+        "sha3_256_hash_of_ciphertext": "cc25f35631396f01cc366e019a7f15034cb2341d6c00924b538d25a227ed181b",
+        "shared_secret": "bcdd6f0d744d2a35147323a4a0451fbfb7d60d73c161c1f8c6a2b5e9f4239c65"
     },
     {
         "key_generation_seed": "241191401a63afa750f05662e354dddbc683c776ce3222beb83e3cf913d7ed7ca59b3bd23b49a95bc1fad20070fec930b6060bd827d742b077092e422268e15d",
-        "sha3_256_hash_of_public_key": "3eb856043b822df9d60b55fccb537afa3cacca9ef50433bde1dd9831e534d192",
-        "sha3_256_hash_of_secret_key": "398ae3423ba5c6bb05920e83e8939a104c3e4ad91647edc7db1667efe438cbfa",
+        "sha3_256_hash_of_public_key": "27b1b921723cedf55fe756ff5fb67d555296c6185d171ed8ba01393d1a735018",
+        "sha3_256_hash_of_secret_key": "40db89fcd941566546d554db0342237611e5ef6fdf8c790f03357091af0648ee",
         "encapsulation_seed": "52fb7cb6a633fd2e83f2892bd9441b48fe59ecee6d026f5246fa7f2a5e55ee3b",
-        "sha3_256_hash_of_ciphertext": "05c9617befed785811fcc44d0fce5ae3a1ec66c4d1217ab42e4b754d0ef6207e",
-        "shared_secret": "eed6ecb831c881508f99ea115745448a7b312a4fa97f65044ebcede172dee2fa"
+        "sha3_256_hash_of_ciphertext": "c5b4844dd10ecf508ea6ed2d96d2328d3f14df6a2a16093bf88ca1283e30f41f",
+        "shared_secret": "072551e254959ce9f2c67657b41122d8a98cde044bb2f60955bdc6e5dbe55277"
     },
     {
         "key_generation_seed": "b9a6b0c05677e957d41a34ba03bd06f2a9092e31f63389397d7e70fde6409d18e99c0e7b82be89bc3c1eaee6680aa4efd394e40c2b3f30523c8117f7c26a8969",
-        "sha3_256_hash_of_public_key": "306aed2a804a1c9bad4ab9e59f6126ad7c8633cdd0c2dd9d4c6f639d312ed47b",
-        "sha3_256_hash_of_secret_key": "88b28cf6fe19424ff82fc2bb096423b71f0cb8cf985af31bc15ceb4ed18a5e62",
+        "sha3_256_hash_of_public_key": "32a2a1197d78798bbeb13ce2e92cd7ed94b410adc37b1b31dc060af11fec8a8b",
+        "sha3_256_hash_of_secret_key": "602bedde695713681a96c94a9a6d35308102ae18d3f3beb92a981e4a3b7704f3",
         "encapsulation_seed": "0f81a5f97082121244403da3feeb734f6084b314b8d94beb11627aa6ad1914e9",
-        "sha3_256_hash_of_ciphertext": "315ef84926802ecbbb437f8f50927d3a391b55ee6e47dbd19aa9adeebb808008",
-        "shared_secret": "d6cb77dc96f9ae4bf8b2fc0e277935b3b7b7a59f749ff2c08ad42659dbce386b"
+        "sha3_256_hash_of_ciphertext": "e4631748f7cba566889ca2c5d90c47bba17000a0d934c4242a9a3d6dfac039e8",
+        "shared_secret": "88c0c1e22b68cd65e1eedd6d6208c36492fb674e26ba4e0d4e55f831a1affc96"
     },
     {
         "key_generation_seed": "28a96c71577ba00c94f99fe965bc595a26db2b3ca6ab5cf8e443cdd8462b17929c35d165453e5fcdc6f9df64526d9de698f2bd3e6bac6c7fdd86601b9ba5f4a5",
-        "sha3_256_hash_of_public_key": "9bb3963cc1c5cf2b2d1c6ca76226328ab765a79999ccc71fe98d5bf3b34f51b1",
-        "sha3_256_hash_of_secret_key": "d8c2492023fb1175a84c19b3ce20f03dd12b1c26b65176d5582c319124bc0e24",
+        "sha3_256_hash_of_public_key": "7cc3f47f319f88da508f841e536a056625f206fe499387d27307257682237f96",
+        "sha3_256_hash_of_secret_key": "064bf50ddc823a97adfc93d52ecbff03a0fd5d94ab38874a5abaedbdaba67309",
         "encapsulation_seed": "31af9345365549ea0360169ed57daf98cc5444799d4c75d9f1f5d615e9df8a91",
-        "sha3_256_hash_of_ciphertext": "ae36e333ece7ca60c9bc2c4ddd01ca88443fd73bab08502656873b703af8925d",
-        "shared_secret": "1592f1413331f1871b41ff298bfa669bca667241790370d81163c9050b8ac365"
+        "sha3_256_hash_of_ciphertext": "b34a0a91afbc9599ae00e67ba4ebf0d8308b3e06efcfa148aed519b0f073ddc8",
+        "shared_secret": "56f717e4baddc2250873d667f73a442b05ca2f8714d4dc4d295f899217c92c9e"
     },
     {
         "key_generation_seed": "c08ba2ef8c3a0a043afad931652d7a19e6e8cb670f840de5f1fa03309b2ca9ec5fe6141a25f7ab9f875f79e0a82d6ea5cde5a017ab637d5fdb7c42646a1d71df",
-        "sha3_256_hash_of_public_key": "6d029bb2121c788b5b6ead7226df664490dae362c4befb615717d81c656b3273",
-        "sha3_256_hash_of_secret_key": "0f2c7bd16d9289c3c27136df0cb6ebc624e80144cb92e6f0c897f58a53617ac3",
+        "sha3_256_hash_of_public_key": "beaeb6ff178f3228defdd117e6ba75a34abb70e86f31fdb16d74d91e6c1b47a7",
+        "sha3_256_hash_of_secret_key": "9cf056be85f240e1ae5b73656c07bfe83ba8ec7212973bac19cffbb80dae7249",
         "encapsulation_seed": "774ae54093d694ef40b63b62c73e6c98295f606feb8699807eda1d030ffb996d",
-        "sha3_256_hash_of_ciphertext": "f8a85f106c6144edf1c7906ec26e292f0390aa9d45a22e67ba2ea018ff565c4d",
-        "shared_secret": "966f35c6bc47b4525d9af1ba350e8f44ea448cd1d90cf4e9c55ae5878920b7cd"
+        "sha3_256_hash_of_ciphertext": "89243e04aa17615c309cae73fbfe985e0716c7fe3b8283b5e84c3caa67b5ad3f",
+        "shared_secret": "35f5517999e15ed842904d53d5b4747639d1165014ab77474c0dbc310e586186"
     },
     {
         "key_generation_seed": "0e3b30e102d707538c2671060f603bb0b8a014103f132d63b09ece07e4a4c75b11eafeca9e810796c34e8cfce9d59342884456007b01ddd12edce6d10ed87e4c",
-        "sha3_256_hash_of_public_key": "64c819d9bf66855f6ae70627f04da8378547e5867e2eb9759fe0971efd601c4a",
-        "sha3_256_hash_of_secret_key": "e85b62236d5c6c691a9076dc58bd5da80999eccc8df973c7d0e7e65d8465ea7d",
+        "sha3_256_hash_of_public_key": "b2b71b8aaccf14842a6d4ecb713612f801a5044147fb9e6987ad3863759de31e",
+        "sha3_256_hash_of_secret_key": "01158ea58361ef89d935c9f845711c7f581322afddaf14e255f71c1dcc9c0024",
         "encapsulation_seed": "9f27a47604ab5146caaf0aafe6d149424f8d66e39ba3baf5e6c73b19221b7e21",
-        "sha3_256_hash_of_ciphertext": "e9149359cc37143b0b565bd413a04f41a7833c5b76012a9263a086ac34071684",
-        "shared_secret": "aa333af0226492126c6985130ac7df2226a64d6d5c5314ce3f7a99add6696d49"
+        "sha3_256_hash_of_ciphertext": "ddf853fbd339780b3f571de2aefb30f760454f2cc1f0fca009bc829afb1f3f7d",
+        "shared_secret": "a7159981a68244549b96b27991e1323013c353bdd9c8d6f583897c35923e87a8"
     },
     {
         "key_generation_seed": "2478f7d3de6041e7e5cd11c5e2ef483d1aa6218eb126444091535f6ae532fa7311136e2681df2ef881b51a092a9badbe72c9772c169808521c47149578621e28",
-        "sha3_256_hash_of_public_key": "db315cafbaec2f8a0142f45affff65289e826c9244ab1cb03f9f65df3e3cbcf7",
-        "sha3_256_hash_of_secret_key": "be98d62e4724c0d960ad4839298d4571f9871033b63bdf10d3b0e589db376ffa",
+        "sha3_256_hash_of_public_key": "a13cb3f23ccbd9ca6a75823d1ba14ef03664560f397133935103ded2d7480b99",
+        "sha3_256_hash_of_secret_key": "710b3a8c8d49ee38390cd2776c42ad74a520c8d6ebd39b514f6fbf28c6c74b45",
         "encapsulation_seed": "90044031b7597b5e60a4f946b713e8996d0426d2cb013243d9b7d8f8ef159a0f",
-        "sha3_256_hash_of_ciphertext": "9f9368ba712cfee95f28a808cb2c23116a0c8da3910c0def2ef4e55947d7101b",
-        "shared_secret": "9535303e6035e30c6605c9e0f10c553dcd73828d8525cb190fea79937e093331"
+        "sha3_256_hash_of_ciphertext": "f5c4738d0ac3b25048186a2049668247c04033cb363e9d23b5d1518f8fa7e70f",
+        "shared_secret": "c4041a29c5b744e9039bf5155cb3ac0b799356829557a7aa3feb4b3585e6cf62"
     },
     {
         "key_generation_seed": "9d405d3ebdaf35fa8722de431b669722acaaea2fd10b814310b17f78b66147d16ceb14f7662be0c42779459f69a145c0e2ce9f0bd9a0cd1bf32ed5694cc9ae32",
-        "sha3_256_hash_of_public_key": "c8d853e65b5b118e28b7cb6f0d5d6f282e0ea20fd72f3690a6b232b20a8a55ec",
-        "sha3_256_hash_of_secret_key": "7a5e854bad628be7b99f524f52a97b0959c0ee67a7a10ad24b970e6e3aeeeb80",
+        "sha3_256_hash_of_public_key": "68302cc5af214ceda67ff8161b29bc300c4be8e1a4139437aead8a9ede3cd4ca",
+        "sha3_256_hash_of_secret_key": "5d6904a6478f0632ec56477321a6d6ec5ccdf299bed0b6ee9f4b32c6b5effec3",
         "encapsulation_seed": "a7a31e140891ea37d2b6424b59b1f84f89220f32dcb73e037eb912b389d34a48",
-        "sha3_256_hash_of_ciphertext": "31b04a4127558df57844413928b29b11547de5afc088d568a962fe080c97f190",
-        "shared_secret": "0caa79e0054182c15e54159fbe36d9fb09481331a560ccd9714fff81db5615c4"
+        "sha3_256_hash_of_ciphertext": "b4ddaeac7b4080e5e9bccdd2cbec4395a1393e61e038bedae9542db78769b923",
+        "shared_secret": "b8441852349193321f466ccbd3afa48bafe903288108312de26e9bf0de9f680c"
     },
     {
         "key_generation_seed": "9a86490f0615f3edf789cb0654066e9ee339cc59f968281f3b89213f83c692edfaeb2ef44d2f608621e831187ce79b2d2f4a20f1568bbe76b0d3d5af36111714",
-        "sha3_256_hash_of_public_key": "f69bd52cb1d071f1cc7720f949d44f66f40c917eb30f3a4b0eb519ecad2d03dc",
-        "sha3_256_hash_of_secret_key": "b6ef04e6acbcd1bb072d1cd28412cdb00ee40d04ce5b39442a2efd6756292167",
+        "sha3_256_hash_of_public_key": "149ca4d94813f81c792060502e09a88ea694c5de863ce6a50516cacb1c3f44bc",
+        "sha3_256_hash_of_secret_key": "8e69c68f8a7a0ad82b033a0bdc94d253d3e7e8516d67e86bb95d219a1090529c",
         "encapsulation_seed": "70eb3f791faa91f1f982fa477dbcddeb2c55691c07f93b04cd31b37544c94b42",
-        "sha3_256_hash_of_ciphertext": "d8fac8ffc3d8dfebe66c219f4189b780d5ba8fe28d5ab79264345639740913b0",
-        "shared_secret": "744ce1aa5a9c515c6571ad6e2f5985df8434e35e9f714cf3659f184b5db4086f"
+        "sha3_256_hash_of_ciphertext": "5fbbb17b2c8ecbb8c74f2cf6259404cb9e0cadd393174e49e88298c6b7a34a22",
+        "shared_secret": "9d0d9ba501da1b46775258f5c0904721906b237c3461da6c31d70da8575fac37"
     },
     {
         "key_generation_seed": "6dfd9b575872560c7bdc2732c4a28dac4db04e535eb8e402c3dffd145c09ce47a2985c1c4d203778597947d710dec806e36b0cd949fe460ef141213bfc525e5b",
-        "sha3_256_hash_of_public_key": "10e01965f9c196d2f5f90ce3ce8f552f8a0d76ba8f5345365392febc50560012",
-        "sha3_256_hash_of_secret_key": "2b5c6d5fe9b09ab5a027522e699401223ae9d304ac912f1b15f0f647dd9a0a7f",
+        "sha3_256_hash_of_public_key": "e5c52e639e5acd0fb97c7eb44df56df5250c6de7d171c467ce6887eaa4ee3d61",
+        "sha3_256_hash_of_secret_key": "6b452ca57379b09ea36746b5b55be3b73df4faf809d7899c5368a51eb4b18cab",
         "encapsulation_seed": "30f4095015ba88b6d969672ca3f438c395dacf7d476ea7a9e805ce932d270a13",
-        "sha3_256_hash_of_ciphertext": "e8b01628c7d63f16c59e67352399a760581f341ed41535013490502e884733be",
-        "shared_secret": "726f7d790df4c860a0b2c40de9d62c85d0ff70c704ce5a1b3f6bf1b3e3f66cd8"
+        "sha3_256_hash_of_ciphertext": "9ec7acd421fd05aeb4440720890cb1ebfba0f0ba3d9b57268b583ea10720a32d",
+        "shared_secret": "188aa07faa2b7a19b6b7bfbd4cbb1ad829a7415d601fdc3b635528db136cac52"
     },
     {
         "key_generation_seed": "6fca9f4e384d8418075cc064c70730801bdb8249899d456a77130d5beeb3662cce7683f8a03d3cf04e46970ff7d6a12494ae12558346dfc8fd9370bf944a0102",
-        "sha3_256_hash_of_public_key": "7c3991fa7983d0dd6e7157cfb152538466e9d5c3998a2b8ed862162b91ca851c",
-        "sha3_256_hash_of_secret_key": "72e786018ae9ab8293fa51cb7ca3ff0435e7cccbd5ae02b4680b92c148590265",
+        "sha3_256_hash_of_public_key": "9a350302631bd506be010a3f42112ae4ea731d515d80c3a21fcce60cc4d945ab",
+        "sha3_256_hash_of_secret_key": "985f528fdd675f3efdbe95a03e071f28e2dd16b425c51651a1e645f6b87eb25e",
         "encapsulation_seed": "cf31220f44de862e1719570e1b26e897790159366a385452334fe24cdcae28ba",
-        "sha3_256_hash_of_ciphertext": "5b2e8a3e38c13b53393c8654e92eeb6251ddbe50de4b3c5203a06977491f2fbc",
-        "shared_secret": "68f3e22d1b2d8c57bff32160e550becfce535fdcb327394aabeb60eede263213"
+        "sha3_256_hash_of_ciphertext": "df8cc2e78b5df8a43e7ae87566452a5df656f13f93a22566116a84c30b786f8c",
+        "shared_secret": "70df7eeecb6ad19b54498071e0840f4957e935a62feba82fe29531f79c2c1651"
     },
     {
         "key_generation_seed": "e58f71bf175c0550a67e00e0f7b3b7fc36bc2707bf0c93044a492626de36301a7f7054814869cf7625e45647bc1547aff288dbb90699b2ad84893f3b755d9722",
-        "sha3_256_hash_of_public_key": "8aacd8940ff6fc27f175342be74d48075f8ae9320cae20a41c879c27c1bf815d",
-        "sha3_256_hash_of_secret_key": "f7399dbf35fcc57a9bff87b0087755faa75267788cd0921b9ebc5cde8b656271",
+        "sha3_256_hash_of_public_key": "866573e536b4017c02e31c8ed7455c841a5ccdb795fc200acaf1da2fb936bb59",
+        "sha3_256_hash_of_secret_key": "e8a4ede82799c3a425b82912df460d5d1e78757b4a917177489839abb92029f2",
         "encapsulation_seed": "bb5e65669a44e5d5c709bafa98c16ccba6ac2c4ae923334f69a11543eda64f5d",
-        "sha3_256_hash_of_ciphertext": "aac868f2299bcd272afacf50f1ab0db3d092d33565cffb5645d8b92271e7e893",
-        "shared_secret": "7f6085840a30c6b1fb9dca782e0c78a2264d54726c04c3127956f131165426c8"
+        "sha3_256_hash_of_ciphertext": "99d967e7c92a7d7e2ed54b1339472d8780e0a7671aa9afb8fa2f19cf96353821",
+        "shared_secret": "8baaf439867c9761e78a64652a383e21682969d18f84dbae0d3a63095948863d"
     },
     {
         "key_generation_seed": "e3fc575ed51513e62aba655d24cd9c8f1c6c848aaffa946c49a53ac3ea59e474d82c2f1bf2e6aebde5660fa73356982e12999d8fdafbb3cb186341d0386dead0",
-        "sha3_256_hash_of_public_key": "149e0b6b49fe8adba1217c2c57c83f2b8c5f1d92f319e502b184a65869214f75",
-        "sha3_256_hash_of_secret_key": "6dfa4d29af6a0e8413d5591339c15d2e2cfac3f502f49acca3efb53b53624666",
+        "sha3_256_hash_of_public_key": "b33387825115cba8b0ae7da0d1aada1ce4ab05bc2479b360b6c56dfa870ca825",
+        "sha3_256_hash_of_secret_key": "7c35640775e31eaba8a119a8e89e1e2180177a55e54391c3fa6675829d721b01",
         "encapsulation_seed": "9ddb3aa9c7905d1a438c93bcf78e3e321813580371ab4e1289e2dbf3701972c2",
-        "sha3_256_hash_of_ciphertext": "ced7a64ce643faebac8ffd39c6a4594732b35f1d6899978ba192b87003d3ad27",
-        "shared_secret": "96e30641ea4280168da37291a3063342ced8e77b33b5415819938c0bd7264ffc"
+        "sha3_256_hash_of_ciphertext": "d42759ad66725175d4d8d3cb6519e9074d6c13d4d183863f1695f0e3b831a10a",
+        "shared_secret": "60b466221ec831f91a91b76ec6bbc29726f65ebcacc96f9e191f57a1399be186"
     },
     {
         "key_generation_seed": "470b4943f0fe7fd0d8ec5185aba0d1db09d112934e4fb4787e2bbc6b88466e7b8b2809fd40008be70a6b184981101724bc3d5ec5e1956b510b82fd5ad0668a5a",
-        "sha3_256_hash_of_public_key": "29b1bff7f12eda28dfedfbf0ac16e27008c9fdc62c35e53b28a312bdc91c40bf",
-        "sha3_256_hash_of_secret_key": "762a61eb847c017ece920f51d5da7a9036ed8b835bfd7793527321ec635e2fd0",
+        "sha3_256_hash_of_public_key": "720fd4f96ab2cac1be382907e8cba0702018ca27b28ea8f93cc19c4809885a3b",
+        "sha3_256_hash_of_secret_key": "c1ec32b739485e2437a6b4dbed289f0cb7dea0ed3b2add99d4c49a3eeda1b0fe",
         "encapsulation_seed": "26d90b190a6c3d0d9a86cf66005154e7086749e966e7187c249ccb9329fd3b8b",
-        "sha3_256_hash_of_ciphertext": "bf49310a35f9ba7994645f12949e658b0dd43d3de76386dc20d08c650522f86c",
-        "shared_secret": "47e54c85cc0e2503629a8bfdcfe038c3cf692d723d462bab733c7c8e0aa37b02"
+        "sha3_256_hash_of_ciphertext": "5fae7a10471d5303e5f6ee5d1e34013528af4945de811ffa1828648986607299",
+        "shared_secret": "6a302778f406082fa285c5ee299d78b048e837c5012f42f9a80e8659b10defda"
     },
     {
         "key_generation_seed": "6df4385db978d27b27d2aa5e452e4152b36f097503d9581ac3390105c5727e7dc95fa08ed106ce84660e8a4c90bd2b22634e40769aa0090a101c5dddad45edc5",
-        "sha3_256_hash_of_public_key": "b990059e901097d00e0ebaf40c5d5dab009c66798489d357e760478ce884cce5",
-        "sha3_256_hash_of_secret_key": "37a044795bd330e4dc60a6d84bc6e99664d1be418b0239661d2ff16d1501573f",
+        "sha3_256_hash_of_public_key": "bfa4b55c7baf2651415d3f28d221b291b175340a07843b299a46e02e22657634",
+        "sha3_256_hash_of_secret_key": "605c4a98f3775c9678804fd5795946c1657311d123b5c7d1544192a205c043d3",
         "encapsulation_seed": "7db6d1a129d6123f1f805b79ad3b413012ea86aed42a05e98e7b1f32f9fbbdec",
-        "sha3_256_hash_of_ciphertext": "329115908d0763110a387c99778e4746861e80367ee90fd821cda9acdb93fd64",
-        "shared_secret": "8569bd042465a2c4af628425cb102b15ed4f5feee16090e2234f3a884a0fa938"
+        "sha3_256_hash_of_ciphertext": "39e07846b4ca91147a0b680f5411c75db937a6855f08939f746ea3d5f9a11d51",
+        "shared_secret": "88a46d35cf07e48c6528b95016aa0c414344e090ee897fd80f26b67bc0451c7f"
     },
     {
         "key_generation_seed": "dbacba825728444921b227cdba54446b3f6881b47be9cd02832f78b023b1bee0e15274a8e2bc08fe818b117ba28c5dfae74d54fcdf6f20052f79be333edc8dde",
-        "sha3_256_hash_of_public_key": "175eb63c3144108548720ce7ee0f43a9ff3f52a9924efe9f2f59318bb93c86b5",
-        "sha3_256_hash_of_secret_key": "1993d7639b79f5e4871a7c58a69fec50f96c1424c2c0ee030ac054ae1b88a56f",
+        "sha3_256_hash_of_public_key": "9675fc6d1e3cc4e0eb62d31b6b4f10022d373d2718f3d20ee1cc00ef6892d9a0",
+        "sha3_256_hash_of_secret_key": "c463b8ab9069814e5308cf9742c6ab6e08c355fa34c0d2e65df1962589eba56e",
         "encapsulation_seed": "1d129b27be7384c359d04311fe5c44917d1fde4bfb57314f483ac617edd5ac49",
-        "sha3_256_hash_of_ciphertext": "8f4225838f2964a986336bacddc40836a98c32cca68c6afcbcf9ef68d9a3760b",
-        "shared_secret": "c184e0b019c2db772e2c1ca6f97f47478d99cf0c4c5ae1406f51d15815022123"
+        "sha3_256_hash_of_ciphertext": "5c7ef87c49f71d3098fe3d33b22bc8191f440bcdf1d04a46f293c5e6b16af12f",
+        "shared_secret": "f3c5586476f4814a2d3728a6f0ceed7d19d076b790d3675e48611c4b8df9702e"
     },
     {
         "key_generation_seed": "690eb71fd7052b906eaec09937a8ed374e0b02afa27c2f14399932be5839fad281c38c2cb5cfafac81b96a810ab749b61806b6d54c9f8cf4bf1be0192423288f",
-        "sha3_256_hash_of_public_key": "9bc32a138a2fb5b6072464172abe0fd97e9eabf357c3fa5391d94a415b53abd3",
-        "sha3_256_hash_of_secret_key": "3db4ab1393cfc8b1c708cf8efdb1c443c975878898b60182c22af66375cba13a",
+        "sha3_256_hash_of_public_key": "9d162fce2f019205a2106acc8e3e3465b6fa3912a06c764e625cbe3b95dea6c8",
+        "sha3_256_hash_of_secret_key": "eeb3bd9d8636b55722f42b3342e415b23df96d1c9b2c5b9c1c2a3e619348ba6f",
         "encapsulation_seed": "bbc773ebd2df42c36ae05952d6a64c63a5dfb82ceb3ef4f8d4df3a30ec8c0467",
-        "sha3_256_hash_of_ciphertext": "f1c85f9530d4471eb1401fcf422a29533738c485a6be25f0b554ebf40b49d49d",
-        "shared_secret": "6d72e23c8a4cc60b2f14adc788a5c480033bbf6eb111070912bc83ad7b89280b"
+        "sha3_256_hash_of_ciphertext": "d482f25e93fd142aa009f2f2569427ebcf04b87aca2bef5e022bcbc1e5972ed1",
+        "shared_secret": "a828fc1446ff04a950e4f551e442aeba279f44de0ec5296fd981bcbe6ee90d8e"
     },
     {
         "key_generation_seed": "32e0ea9089fa928482c0770da545af1bb871a03ce38604138b0d08ea2a10ca2bc06c5bef7b6508409daf847a64c8d30d0974fd3ba7476dc76c46b458a036d884",
-        "sha3_256_hash_of_public_key": "7ef43a72ef04766f1e899d25c9a005009c788b5faf985123cfb3fb97975de26d",
-        "sha3_256_hash_of_secret_key": "77431cb18010a604d56fe5a623bed2ffd028a741f176fa09546e9a45a48caa5e",
+        "sha3_256_hash_of_public_key": "3e834e34f198ab5a3504cfa0c6af6ab78de3a3ef5667e6065e084cf5d2a5bb32",
+        "sha3_256_hash_of_secret_key": "d74767e217cfaaf75adc92927107c76d7267b1d7b3b76f2f8ae5a9044aa290f2",
         "encapsulation_seed": "5b17a6adad541efcbf5ae4b0c0452cd2ce32e4f0f8701801c5b63e197c1fcbf4",
-        "sha3_256_hash_of_ciphertext": "83ddab2e25614544649a1e497b5b21c40a3e154e8a22c270f63cb0c40aa868fd",
-        "shared_secret": "29e6b1edac0a9aa33066c113167e42c64d70215ed04963d8be2d4c2dcd0f6589"
+        "sha3_256_hash_of_ciphertext": "3a41b6054d918e9613e8d4eab83628f7c82b6ef447ecdacd0a74cc21be6b47aa",
+        "shared_secret": "d98b18f7b6717b8f6b3e331d6d8f9d3633eb70f54133a78e2345138420edf89d"
     },
     {
         "key_generation_seed": "6fb2ec719f2a0dea152bf3f64b9d148f8ab8ba88f64e61f5db53e12d59f525574f797c007e4061f95c7d56cfc7ee5c49e849dde3fea8f25e7876df2a18515c34",
-        "sha3_256_hash_of_public_key": "2c0db43f39b672b2cd912f907cf76a0f6fda925eb2d205546431be0b37b20411",
-        "sha3_256_hash_of_secret_key": "09844e203f4d8fa30728ab388b9d654847febbf5c9cd939cdc11c9c9be24ce9c",
+        "sha3_256_hash_of_public_key": "c5e157ff4357d3c26b7c4b45315f0689f135c85d952a64648b0a8cec03741fe0",
+        "sha3_256_hash_of_secret_key": "edc6b8e2036f9ce7ef87dc58d4866ad9f320ffab1aa22371b7b56ec727f77531",
         "encapsulation_seed": "61ab87659525de9656af41246f20e1dbe85c24e335e7ecf9493f46168bc14e94",
-        "sha3_256_hash_of_ciphertext": "a2108ea2c446b566a50c228928893e2e4bde5fafb2184af92eb1314113bde0d6",
-        "shared_secret": "cfd1b82181543656807880f6e2576f0b095bf84629b3367e9bdede24662ee42e"
+        "sha3_256_hash_of_ciphertext": "7324a073d06af373494ecfc7960cfb81484e9ae64bc16e13651b015cdfb73668",
+        "shared_secret": "b7d5919f0bab0e2715a97cab993656831bc8a3dc86c3bd32e64ccb4762f70499"
     },
     {
         "key_generation_seed": "527fb88c8bd9a4d6031dad15e63878abd2b559e7e08d61f69e8e78fca964ee6ae32d432b4f9f751bde0496c580a181ffed762aa35454a02d3f1f47ee0394c89c",
-        "sha3_256_hash_of_public_key": "aae8e61b905723fa092fb95b839f6de3670c39ce0498c27b87d20c24e7f64e22",
-        "sha3_256_hash_of_secret_key": "3880f7ca8fc33575a7a6d8bb46fec86a3f12e0068630507ed245d8bc278fbe5d",
+        "sha3_256_hash_of_public_key": "f5cedd022077b1a6a052f5287219393cd2e0366d0f5531b2f7ea8704d2900ce5",
+        "sha3_256_hash_of_secret_key": "882916ad7b7707feae2885f13bdf19d36931886c4bfd188fd46b6b6adeeb8d78",
         "encapsulation_seed": "eca2adc3da1fb15f34033405ec08ef2f46163df4bfcccf8842c600ce0bc2026c",
-        "sha3_256_hash_of_ciphertext": "ec48b3ec403609a0ce2d1268cadda8184ab9629cc5913135ffdecd420eed1aa9",
-        "shared_secret": "f7331b0a4674969838482b7184fa92e5246f11f5b5e284c3e179effff7eb6329"
+        "sha3_256_hash_of_ciphertext": "84e4fab74ef96f7b3ec50d7afdf69445b4326fe3ad695efcbf56426c0a6df6c8",
+        "shared_secret": "149e4e38a07d18c0b08edf9c47e425b56f7da87b2b9c855bedd29f6f0a8fe5fa"
     },
     {
         "key_generation_seed": "ac6fcfaeeef795b6ef9e062f02bf42975fa01e7d91ba832f74e05269a72684d05aeda108ea4d6c6bc0fb958286850422bc357ca67b83c986048e0d0087fa11ec",
-        "sha3_256_hash_of_public_key": "64e085f67e48f00a7a7f82963e8c67176bff839a54fa1008328c0612f98d83d3",
-        "sha3_256_hash_of_secret_key": "0bfbc25d9df751f4c30907095eb6d9a75ed07fa23218ad0fffc469f0e55553c2",
+        "sha3_256_hash_of_public_key": "a53a20ea03e400a843c8cf4d04bfe0c0a3ce63dde01045e2669f7ae5da790577",
+        "sha3_256_hash_of_secret_key": "9d1e4432908352535074efbfa7cde3e6738e073fd512e04e9601380fb40b7614",
         "encapsulation_seed": "c4f15bec2d7701339d0ade4835193bea3632edcf89e74992620d9eb623a0d0d4",
-        "sha3_256_hash_of_ciphertext": "fb74b727ad120c18915dca475f3082cd34ded7ae20a308106384ffb5caa029d3",
-        "shared_secret": "c89d62938a5caabfd5b30d82ea88aced52ef5f8ec0528e59a654e1f6aff1cc2f"
+        "sha3_256_hash_of_ciphertext": "071204e26ed00e7a1f226d4e971cfb2d9502e17da99f5479235763cb7723ac5d",
+        "shared_secret": "38a1fcaf302905e18940605e49e5f44c747b06e789acc9c395211823598ef516"
     },
     {
         "key_generation_seed": "ba2fb9318d4dbe7488057c33e95e6f054583a2800c41bb83083c330a914a12cfe63f8ffda3565c2424c89b20974b748a65a5aba75133fcb3156dfb6626a83bab",
-        "sha3_256_hash_of_public_key": "8dab879de09b58d0fc7ade140393ffb5343abbddabdc118fad519b14436a964c",
-        "sha3_256_hash_of_secret_key": "7c53072fd98ea7bd8c5e873688b1a5650fe7e11c791407ac8c118b7958cf414b",
+        "sha3_256_hash_of_public_key": "cacca228846450ebb8f04a2a5ef2d919dfa47c4aa265f4cedd10cf74eef3ecc1",
+        "sha3_256_hash_of_secret_key": "a01db77c5983b2472e616dfc04666a2112924dda5ffbf00a989cf1a48578898b",
         "encapsulation_seed": "28878249e2ac2b6263422993923a0c8bd05ce56e385ed13c943b03d226856947",
-        "sha3_256_hash_of_ciphertext": "a1f1579c4ce8eb725e697623321b3d9f55f4b1d0def10b898535ef6614e9923e",
-        "shared_secret": "204d9272682710b52fb39b1176af3ff737848978770310df0c67996f6cb596c3"
+        "sha3_256_hash_of_ciphertext": "dd0b438cb7dcda28762d06e61f1765baef8003d0d86ff48cd4f9788cae8e8618",
+        "shared_secret": "403543b0f8e519ba4ab878c40ab5aed412ea06bfeb2b864baa5ef4b81a42c454"
     },
     {
         "key_generation_seed": "aa6dd1e5799cdf7af9c4fc632b3eb9d51d66e85c8e0a21ec98664fc51ab63c7dfda268813efab5204efa60f78bf81d320d01ac09ac06244f7afbd2d80fd356d9",
-        "sha3_256_hash_of_public_key": "919a696301240cd6129f66be58e19d99b0d827d9932785cd9ea3d92f7ba54463",
-        "sha3_256_hash_of_secret_key": "cb1d7301f15951883cc3f287d4dd8fdf5c9b7022f558dff551c2ade5f5065755",
+        "sha3_256_hash_of_public_key": "4126f5151d1b086e26a88bd9f20710ef06aa0f834722b801f6b79c031f1f9213",
+        "sha3_256_hash_of_secret_key": "9a6c24b5ae556241f3e6b07a7576971173ecfe474be9c6b09fd12ddef8b5f75e",
         "encapsulation_seed": "17fc65f7fbd7c75ceec421dee84dff5a8cb22764a182db17e0ebe857f54d60eb",
-        "sha3_256_hash_of_ciphertext": "f02654803493821dd9c2ed23f9e46a36addd5fca0da706bbeeda87a2df9fec4f",
-        "shared_secret": "76e5f7623e3e867fd12f28dfda4311f7cd90a405b73e994e857f693573fd2b8a"
+        "sha3_256_hash_of_ciphertext": "7c2b9cd82c349fdc534ac30eaa18bf83afd0736b17a4320963571c109451a5b6",
+        "shared_secret": "f7a280462f93b619888b5a72da3749556e53ef4f4440df728c8db1edcc86cea4"
     },
     {
         "key_generation_seed": "195d6c86a3df4c21e3007d7f2768b43c74cb3060e0eca77f0a5d3271542b9a84ae77e0f9f21eabd8c0c6eea7767f4e10fde5c2d79b8400bf96b19014b457ec21",
-        "sha3_256_hash_of_public_key": "cb6d7232426bdbdfdacd373c9190722e7bf342825f7d829185dcc9120588fc76",
-        "sha3_256_hash_of_secret_key": "a85e24cc2eafdfe40d82f46471112e1359628b9955f3feae9955b48d563ac952",
+        "sha3_256_hash_of_public_key": "b6f12914ed31f14f79c652eed4db478de7ebd263fe27052509fee10b50f2d053",
+        "sha3_256_hash_of_secret_key": "1a4de442c4c6db97bfa12227c4423237a869c93154e2c5ca49cacbd0ef730485",
         "encapsulation_seed": "fa0489f3730100609488e951e6aaa15c0f193bc1dbcfcd013bc418d6c507b176",
-        "sha3_256_hash_of_ciphertext": "17336b9ede3a1c26abe725828a5afbe746035a73dfd4a8fbde5040fbabeb2b8d",
-        "shared_secret": "874ac966970f29935db73c231e71a3559b2504e5446151b99c199276617b3824"
+        "sha3_256_hash_of_ciphertext": "41d75dd4690637576652071cb46987cc26321a07bb47a1cfb07f30d2153920c5",
+        "shared_secret": "fef3730b905431d14aa7aa7bb1d253cd912335c590b8d7de1e7aa4e0ff76be04"
     }
 ]

--- a/libcrux-ml-kem/src/ind_cca/instantiations.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations.rs
@@ -33,6 +33,33 @@ macro_rules! instantiate {
                     ETA1_RANDOMNESS_SIZE,
                     $vector,
                     $hash,
+                    crate::variant::MlKem,
+                >(randomness)
+            }
+
+            #[cfg(feature = "kyber")]
+            pub(crate) fn kyber_generate_keypair<
+                const K: usize,
+                const CPA_PRIVATE_KEY_SIZE: usize,
+                const PRIVATE_KEY_SIZE: usize,
+                const PUBLIC_KEY_SIZE: usize,
+                const BYTES_PER_RING_ELEMENT: usize,
+                const ETA1: usize,
+                const ETA1_RANDOMNESS_SIZE: usize,
+            >(
+                randomness: [u8; KEY_GENERATION_SEED_SIZE],
+            ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
+                crate::ind_cca::generate_keypair::<
+                    K,
+                    CPA_PRIVATE_KEY_SIZE,
+                    PRIVATE_KEY_SIZE,
+                    PUBLIC_KEY_SIZE,
+                    BYTES_PER_RING_ELEMENT,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                    $vector,
+                    $hash,
+                    crate::variant::Kyber,
                 >(randomness)
             }
 
@@ -88,7 +115,7 @@ macro_rules! instantiate {
                     ETA2_RANDOMNESS_SIZE,
                     $vector,
                     $hash,
-                    crate::ind_cca::Kyber,
+                    crate::variant::Kyber,
                 >(public_key, randomness)
             }
 
@@ -126,7 +153,7 @@ macro_rules! instantiate {
                     ETA2_RANDOMNESS_SIZE,
                     $vector,
                     $hash,
-                    crate::ind_cca::MlKem,
+                    crate::variant::MlKem,
                 >(public_key, randomness)
             }
 
@@ -172,7 +199,7 @@ macro_rules! instantiate {
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                     $vector,
                     $hash,
-                    crate::ind_cca::Kyber,
+                    crate::variant::Kyber,
                 >(private_key, ciphertext)
             }
 
@@ -217,7 +244,7 @@ macro_rules! instantiate {
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                     $vector,
                     $hash,
-                    crate::ind_cca::MlKem,
+                    crate::variant::MlKem,
                 >(private_key, ciphertext)
             }
 

--- a/libcrux-ml-kem/src/lib.rs
+++ b/libcrux-ml-kem/src/lib.rs
@@ -107,6 +107,7 @@ cfg_pre_verification! {
     mod hash_functions;
     mod ind_cca;
     mod ind_cpa;
+    mod variant;
     mod invert_ntt;
     mod matrix;
     mod ntt;
@@ -141,7 +142,7 @@ cfg_pre_verification! {
         pub mod kyber512 {
             //! Kyber 512 (NIST PQC Round 3)
             cfg_no_eurydice! {
-                pub use crate::mlkem512::generate_key_pair;
+                pub use crate::mlkem512::kyber::generate_key_pair;
                 pub use crate::mlkem512::kyber::decapsulate;
                 pub use crate::mlkem512::kyber::encapsulate;
                 pub use crate::mlkem512::validate_public_key;
@@ -153,7 +154,7 @@ cfg_pre_verification! {
         pub mod kyber768 {
             //! Kyber 768 (NIST PQC Round 3)
             cfg_no_eurydice! {
-                pub use crate::mlkem768::generate_key_pair;
+                pub use crate::mlkem768::kyber::generate_key_pair;
                 pub use crate::mlkem768::kyber::decapsulate;
                 pub use crate::mlkem768::kyber::encapsulate;
                 pub use crate::mlkem768::validate_public_key;
@@ -165,7 +166,7 @@ cfg_pre_verification! {
         pub mod kyber1024 {
             //! Kyber 1024 (NIST PQC Round 3)
             cfg_no_eurydice! {
-                pub use crate::mlkem1024::generate_key_pair;
+                pub use crate::mlkem1024::kyber::generate_key_pair;
                 pub use crate::mlkem1024::kyber::decapsulate;
                 pub use crate::mlkem1024::kyber::encapsulate;
                 pub use crate::mlkem1024::validate_public_key;

--- a/libcrux-ml-kem/src/mlkem1024.rs
+++ b/libcrux-ml-kem/src/mlkem1024.rs
@@ -84,6 +84,22 @@ macro_rules! instantiate {
                 }
             }
 
+            /// Generate Kyber 1024 Key Pair
+            #[cfg(feature = "kyber")]
+            pub fn kyber_generate_key_pair(
+                randomness: [u8; KEY_GENERATION_SEED_SIZE],
+            ) -> MlKem1024KeyPair {
+                p::kyber_generate_keypair::<
+                    RANK_1024,
+                    CPA_PKE_SECRET_KEY_SIZE_1024,
+                    SECRET_KEY_SIZE_1024,
+                    CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                    RANKED_BYTES_PER_RING_ELEMENT_1024,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                >(randomness)
+            }
+
             /// Generate ML-KEM 1024 Key Pair
             pub fn generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
@@ -402,6 +418,26 @@ pub fn decapsulate(
 #[cfg(all(not(eurydice), feature = "kyber"))]
 pub(crate) mod kyber {
     use super::*;
+
+    /// Generate Kyber 1024 Key Pair
+    ///
+    /// Generate an ML-KEM key pair. The input is a byte array of size
+    /// [`KEY_GENERATION_SEED_SIZE`].
+    ///
+    /// This function returns an [`MlKem1024KeyPair`].
+    pub fn generate_key_pair(
+        randomness: [u8; KEY_GENERATION_SEED_SIZE],
+    ) -> MlKemKeyPair<SECRET_KEY_SIZE_1024, CPA_PKE_PUBLIC_KEY_SIZE_1024> {
+        multiplexing::kyber_generate_keypair::<
+            RANK_1024,
+            CPA_PKE_SECRET_KEY_SIZE_1024,
+            SECRET_KEY_SIZE_1024,
+            CPA_PKE_PUBLIC_KEY_SIZE_1024,
+            RANKED_BYTES_PER_RING_ELEMENT_1024,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+        >(randomness)
+    }
 
     /// Encapsulate Kyber 1024
     ///

--- a/libcrux-ml-kem/src/mlkem512.rs
+++ b/libcrux-ml-kem/src/mlkem512.rs
@@ -94,6 +94,21 @@ macro_rules! instantiate {
                 >(randomness)
             }
 
+            /// Generate Kyber 512 Key Pair
+            #[cfg(feature = "kyber")]
+            pub fn kyber_generate_key_pair(
+                randomness: [u8; KEY_GENERATION_SEED_SIZE],
+            ) -> MlKem512KeyPair {
+                p::kyber_generate_keypair::<
+                    RANK_512,
+                    CPA_PKE_SECRET_KEY_SIZE_512,
+                    SECRET_KEY_SIZE_512,
+                    CPA_PKE_PUBLIC_KEY_SIZE_512,
+                    RANKED_BYTES_PER_RING_ELEMENT_512,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                >(randomness)
+            }
             /// Encapsulate ML-KEM 512
             ///
             /// Generates an ([`MlKem512Ciphertext`], [`MlKemSharedSecret`]) tuple.
@@ -393,12 +408,30 @@ pub fn decapsulate(
 #[cfg(all(not(eurydice), feature = "kyber"))]
 pub(crate) mod kyber {
     use super::*;
+
+    /// Generate Kyber 512 Key Pair
+    ///
+    /// The input is a byte array of size
+    /// [`KEY_GENERATION_SEED_SIZE`].
+    ///
+    /// This function returns an [`MlKem512KeyPair`].
+    pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem512KeyPair {
+        multiplexing::kyber_generate_keypair::<
+            RANK_512,
+            CPA_PKE_SECRET_KEY_SIZE_512,
+            SECRET_KEY_SIZE_512,
+            CPA_PKE_PUBLIC_KEY_SIZE_512,
+            RANKED_BYTES_PER_RING_ELEMENT_512,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+        >(randomness)
+    }
+
     /// Encapsulate Kyber 512
     ///
     /// Generates an ([`MlKem512Ciphertext`], [`MlKemSharedSecret`]) tuple.
     /// The input is a reference to an [`MlKem512PublicKey`] and [`SHARED_SECRET_SIZE`]
     /// bytes of `randomness`.
-
     pub fn encapsulate(
         public_key: &MlKem512PublicKey,
         randomness: [u8; SHARED_SECRET_SIZE],

--- a/libcrux-ml-kem/src/mlkem768.rs
+++ b/libcrux-ml-kem/src/mlkem768.rs
@@ -97,6 +97,22 @@ macro_rules! instantiate {
                 >(randomness)
             }
 
+            /// Generate Kyber 768 Key Pair
+            #[cfg(feature = "kyber")]
+            pub fn kyber_generate_key_pair(
+                randomness: [u8; KEY_GENERATION_SEED_SIZE],
+            ) -> MlKem768KeyPair {
+                p::kyber_generate_keypair::<
+                    RANK_768,
+                    CPA_PKE_SECRET_KEY_SIZE_768,
+                    SECRET_KEY_SIZE_768,
+                    CPA_PKE_PUBLIC_KEY_SIZE_768,
+                    RANKED_BYTES_PER_RING_ELEMENT_768,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                >(randomness)
+            }
+
             /// Encapsulate ML-KEM 768
             ///
             /// Generates an ([`MlKem768Ciphertext`], [`MlKemSharedSecret`]) tuple.
@@ -396,6 +412,24 @@ pub fn decapsulate(
 #[cfg(all(not(eurydice), feature = "kyber"))]
 pub(crate) mod kyber {
     use super::*;
+
+    /// Generate Kyber 768 Key Pair
+    ///
+    /// Generate a Kyber key pair. The input is a byte array of size
+    /// [`KEY_GENERATION_SEED_SIZE`].
+    ///
+    /// This function returns an [`MlKem768KeyPair`].
+    pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem768KeyPair {
+        multiplexing::kyber_generate_keypair::<
+            RANK_768,
+            CPA_PKE_SECRET_KEY_SIZE_768,
+            SECRET_KEY_SIZE_768,
+            CPA_PKE_PUBLIC_KEY_SIZE_768,
+            RANKED_BYTES_PER_RING_ELEMENT_768,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+        >(randomness)
+    }
 
     /// Encapsulate Kyber 768
     ///

--- a/libcrux-ml-kem/src/variant.rs
+++ b/libcrux-ml-kem/src/variant.rs
@@ -1,0 +1,88 @@
+//! This module defines the `Variant` trait, which captures
+//! differences between the NIST standard FIPS 203 (ML-KEM) and the
+//! Round 3 CRYSTALS-Kyber submissions in the NIST PQ competition.
+
+use crate::{
+    constants::{CPA_PKE_KEY_GENERATION_SEED_SIZE, H_DIGEST_SIZE}, hash_functions::Hash, utils::into_padded_array, MlKemCiphertext,
+};
+
+/// This trait collects differences in specification between ML-KEM
+/// (FIPS 203) and the Round 3 CRYSTALS-Kyber submission in the
+/// NIST PQ competition.
+///
+/// cf. FIPS 203, Appendix C
+pub(crate) trait Variant {
+    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash<K>>(
+        shared_secret: &[u8],
+        ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+    ) -> [u8; 32];
+    fn entropy_preprocess<const K: usize, Hasher: Hash<K>>(randomness: &[u8]) -> [u8; 32];
+    fn cpa_keygen_seed<const K: usize, Hasher: Hash<K>>(seed: &[u8]) -> [u8; 64];
+}
+
+/// Implements [`Variant`], to perform the Kyber-specific actions
+/// during encapsulation and decapsulation.
+/// Specifically,
+/// * during key generation, the seed hash is not domain separated
+/// * during encapsulation, the initial randomness is hashed before being used,
+/// * the derivation of the shared secret includes a hash of the Kyber ciphertext.
+#[cfg(feature = "kyber")]
+pub(crate) struct Kyber {}
+
+#[cfg(feature = "kyber")]
+impl Variant for Kyber {
+    #[inline(always)]
+    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash<K>>(
+        shared_secret: &[u8],
+        ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+    ) -> [u8; 32] {
+        let mut kdf_input: [u8; 2 * H_DIGEST_SIZE] = into_padded_array(&shared_secret);
+        kdf_input[H_DIGEST_SIZE..].copy_from_slice(&Hasher::H(ciphertext.as_slice()));
+        Hasher::PRF::<32>(&kdf_input)
+    }
+
+    #[inline(always)]
+    fn entropy_preprocess<const K: usize, Hasher: Hash<K>>(randomness: &[u8]) -> [u8; 32] {
+        Hasher::H(&randomness)
+    }
+
+    #[inline(always)]
+    fn cpa_keygen_seed<const K: usize, Hasher: Hash<K>>(key_generation_seed: &[u8]) -> [u8; 64] {
+        Hasher::G(key_generation_seed)
+    }
+}
+
+/// Implements [`Variant`], to perform the ML-KEM-specific actions
+/// during encapsulation and decapsulation.
+/// Specifically,
+/// * during key generation, the seed hash is domain separated (this is a difference from the FIPS 203 IPD and Kyber)
+/// * during encapsulation, the initial randomness is used without prior hashing,
+/// * the derivation of the shared secret does not include a hash of the ML-KEM ciphertext.
+pub(crate) struct MlKem {}
+
+impl Variant for MlKem {
+    #[inline(always)]
+    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash<K>>(
+        shared_secret: &[u8],
+        _: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+    ) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        out.copy_from_slice(shared_secret);
+        out
+    }
+
+    #[inline(always)]
+    fn entropy_preprocess<const K: usize, Hasher: Hash<K>>(randomness: &[u8]) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        out.copy_from_slice(randomness);
+        out
+    }
+
+    #[inline(always)]
+    fn cpa_keygen_seed<const K: usize, Hasher: Hash<K>>(key_generation_seed: &[u8]) -> [u8; 64] {
+        let mut seed = [0u8; CPA_PKE_KEY_GENERATION_SEED_SIZE + 1];
+        seed[0..CPA_PKE_KEY_GENERATION_SEED_SIZE].copy_from_slice(key_generation_seed);
+        seed[CPA_PKE_KEY_GENERATION_SEED_SIZE] = K as u8;
+        Hasher::G(&seed)
+    }
+}

--- a/libcrux-ml-kem/tests/kats/mlkem.py
+++ b/libcrux-ml-kem/tests/kats/mlkem.py
@@ -292,7 +292,7 @@ def constantTimeSelectOnEquality(a, b, ifEq, ifNeq):
 
 def InnerKeyGen(seed, params):
     assert len(seed) == 32
-    rho, sigma = G(seed)
+    rho, sigma = G(seed + bytes([params.k]))
     A = sampleMatrix(rho, params.k)
     s = sampleNoise(sigma, params.eta1, 0, params.k)
     e = sampleNoise(sigma, params.eta1, params.k, params.k)

--- a/libcrux-ml-kem/tests/kats/mlkem.py
+++ b/libcrux-ml-kem/tests/kats/mlkem.py
@@ -290,9 +290,12 @@ def constantTimeSelectOnEquality(a, b, ifEq, ifNeq):
     return ifEq if a == b else ifNeq
 
 
-def InnerKeyGen(seed, params):
+def InnerKeyGen(seed, params, ipd):
     assert len(seed) == 32
-    rho, sigma = G(seed + bytes([params.k]))
+    if ipd:
+            rho, sigma = G(seed)
+    else:
+            rho, sigma = G(seed + bytes([params.k]))
     A = sampleMatrix(rho, params.k)
     s = sampleNoise(sigma, params.eta1, 0, params.k)
     e = sampleNoise(sigma, params.eta1, params.k, params.k)
@@ -330,10 +333,10 @@ def InnerDec(sk, ct, params):
     return (v - sHat.DotNTT(u.NTT()).InvNTT()).Compress(1).Encode(1)
 
 
-def KeyGen(seed, params):
+def KeyGen(seed, params, ipd = False):
     assert len(seed) == 64
     z = seed[32:]
-    pk, sk2 = InnerKeyGen(seed[:32], params)
+    pk, sk2 = InnerKeyGen(seed[:32], params, ipd)
     h = H(pk)
     return (pk, sk2 + pk + h + z)
 

--- a/libcrux-ml-kem/tests/kats/nistkats_mlkem_1024.json
+++ b/libcrux-ml-kem/tests/kats/nistkats_mlkem_1024.json
@@ -1,802 +1,802 @@
 [
     {
         "key_generation_seed": "7c9935a0b07694aa0c6d10e4db6b1add2fd81a25ccb148032dcd739936737f2d8626ed79d451140800e03b59b956f8210e556067407d13dc90fa9e8b872bfb8f",
-        "sha3_256_hash_of_public_key": "8a39e87d531f3527c207edcc1db7faddcf9628391879b335c707839a0db051a8",
-        "sha3_256_hash_of_secret_key": "ed1f6cb687c37931ea2aa80d9c956f277a9df532649661035c6e2f9872132638",
+        "sha3_256_hash_of_public_key": "ebbe41cd4dea489dedd00e76ae0bcf54aa8550202920eb64d5892ad02b13f2e5",
+        "sha3_256_hash_of_secret_key": "ecfa369ec7e834204291fccb4d59c3fd1557b0ec3ab2ed7d50c98c01f292612e",
         "encapsulation_seed": "147c03f7a5bebba406c8fae1874d7f13c80efe79a3a9a874cc09fe76f6997615",
-        "sha3_256_hash_of_ciphertext": "5ef5d180bf8d4493ef8e8ddc23c22e428840c362a05a25fd306c6c528bd90f8c",
-        "shared_secret": "63a1039074f01f2651213ad9350d6561cb03a60400e74118bb4464d87b9db205"
+        "sha3_256_hash_of_ciphertext": "507dcdae0432f558189a09c5e79fd69896e2f830e37ae4d598b00566e55f20f5",
+        "shared_secret": "489dd1e9c2be4af3482bdb35bb26ce760e6e414da6ecbe489985748a825f1cd6"
     },
     {
         "key_generation_seed": "d60b93492a1d8c1c7ba6fc0b733137f3406cee8110a93f170e7a78658af326d9003271531cf27285b8721ed5cb46853043b346a66cba6cf765f1b0eaa40bf672",
-        "sha3_256_hash_of_public_key": "c9ede13be3dbb0edc3ab08226cae11771ff4c0b04a564b64a0d9ff10e373e986",
-        "sha3_256_hash_of_secret_key": "9b5876610793ae42f683d94f736d8d7e0e033bee588bab07a31c9cdb4ab99a5d",
+        "sha3_256_hash_of_public_key": "cfb6fc18d6419f5438a0573693f421d3793e5ddf3d846678552aaddc19265946",
+        "sha3_256_hash_of_secret_key": "af6dbb5f11b3570e9372988cb2846f7b10ffe3c19b153242e3cf70e46a4f0b39",
         "encapsulation_seed": "cde797df8ce67231f6c5d15811843e01eb2ab84c7490931240822adbddd72046",
-        "sha3_256_hash_of_ciphertext": "bef440cb5a14bfa652ff69fc431b59980147a2408df8a893f0fafded11d6cfa3",
-        "shared_secret": "856d56ee09279a13f9abdca14ecbe8ca9968495f09a0758b6d1c8376099365eb"
+        "sha3_256_hash_of_ciphertext": "e43c464573dca153ca5ee869688d9ca23313415a21e8277d690288238d1f50f3",
+        "shared_secret": "425ada67204ff5b30a9d1cb545bcb4a6dbbd923cb3ca284911a1c5fe491ffb39"
     },
     {
         "key_generation_seed": "4b622de1350119c45a9f2e2ef3dc5df50a759d138cdfbd64c81cc7cc2f513345e82fcc97ca60ccb27bf6938c975658aeb8b4d37cffbde25d97e561f36c219ade",
-        "sha3_256_hash_of_public_key": "ff2546623aee72025fb6746fba736bae0e80e257e66edbf09d8d4dc11049cda4",
-        "sha3_256_hash_of_secret_key": "57155298b53d3af5d6db214dfa91a9e16f8d5de570bbff5dba5f4cd84098f255",
+        "sha3_256_hash_of_public_key": "cb74eb00a87eb1651271050e74552291b66a29053bef5e49690d4eec7b7bd352",
+        "sha3_256_hash_of_secret_key": "1814830755e0bc59ca8763fc299b0b1503e8205eb1e24e13e22394b9cf7edc6c",
         "encapsulation_seed": "f43f68fbd694f0a6d307297110ecd4739876489fdf07eb9b03364e2ed0ff96e9",
-        "sha3_256_hash_of_ciphertext": "28e308a6f91068b01a7065b8579fcb6234ecd9bb8d3172b6dfc5a3a470050ea7",
-        "shared_secret": "c33a4432cc441b7683605c29afdecc81922cf234e02be8c2fbc4e2a7a3b4b078"
+        "sha3_256_hash_of_ciphertext": "0d8830c371bc3a02c24f2a0289a17b4dc4550d8b06ed79f7da3c909af98f00d2",
+        "shared_secret": "2bd0703c81210c5d9bdf59f8cbb7c32e30e042c20743c96c74db89545eba4fa2"
     },
     {
         "key_generation_seed": "050d58f9f757edc1e8180e3808b806f5bbb3586db3470b069826d1bb9a4efc2cde950541fd53a8a47aaa8cdfe80d928262a5ef7f8129ec3ef92f78d7cc32ef60",
-        "sha3_256_hash_of_public_key": "25b786a67de17d61b2fc0e85a13924398aab931896b6174089569f08b7260687",
-        "sha3_256_hash_of_secret_key": "d188a2637dfe80dbd0fc25165eb4898923888a82c10f6ff0b8ddb5bf251c0650",
+        "sha3_256_hash_of_public_key": "4ada82049cbac3e8c6830334021c22894085dbc8382fb43cbe318e8e6ada9955",
+        "sha3_256_hash_of_secret_key": "4886d92462e3899b347073916ff8f75fe5d406a2515715f39292d0ff8fd033f8",
         "encapsulation_seed": "ea74fbc3c546500ed684bed6fe3c496d3b86d2d6dfaf223969b942e9a8c95e85",
-        "sha3_256_hash_of_ciphertext": "8427a1684769e63ec43e97ecbe7b7e654b6e63433bccd23340849904e02767dd",
-        "shared_secret": "7c14fb353ba421705de44f2a12ddc5ad9b11e30e7b0e163cebebe2da79a7293f"
+        "sha3_256_hash_of_ciphertext": "ed64332b4a54bf40b47d189d80d1f6c8ada29779c5819e78ff386a758f364de3",
+        "shared_secret": "f6baf98028ce4f75cc14f6a75dd50502c4adc4d1377d72671c9396d4c26fac69"
     },
     {
         "key_generation_seed": "66b79b844e0c2adad694e0478661ac46fe6b6001f6a71ff8e2f034b1fd8833d3be2d3c64d38269a1ee8660b9a2beaeb9f5ac022e8f0a357feebfd13b06813854",
-        "sha3_256_hash_of_public_key": "d35e259a200d16048302df38d8e7f9e1c3352502c43f086fe166325048fdce9c",
-        "sha3_256_hash_of_secret_key": "020ba30e5832867a6db83cdb1e60ddf0b0a88fb33919edb84b246a345d11da6c",
+        "sha3_256_hash_of_public_key": "edc529d14502bab03d1b7fc370f2ede22c7190bd47cc88028adb3294029e264a",
+        "sha3_256_hash_of_secret_key": "96aeba6845ce707a752d778945ce3b93ff3b062582164a014411ab860bab1027",
         "encapsulation_seed": "64efa87a12cb96f98b9b81a7e5128a959c74e5332aaab0444fca7b4a5e5e0216",
-        "sha3_256_hash_of_ciphertext": "b52dc0a41015132b3e7a1ae6f544f12601869bf0673625964e5c4e05cbe656e0",
-        "shared_secret": "35d2a2ab0e91d365a3e2e99bbe3f5121f2eeb528305cc7730f679e10ec1c9b8a"
+        "sha3_256_hash_of_ciphertext": "04015a8aa6e50547eaafc570396c16ecb409965f2c5ad13d3829afdf330ac518",
+        "shared_secret": "52b1d99af018531b8f3b6226d7ae23843ca7b84d8f9cef28ead85ab3840906d5"
     },
     {
         "key_generation_seed": "7ec408f52c9aa723d0c41d9987682a5f4ce6c9da7cd0215af60bbaf5484ab353a08ccf451b049fd51d7a9ad77ae14a81569df8c9bd3a8f1ebea86fdcfb823082",
-        "sha3_256_hash_of_public_key": "5a5db7d619be642bd87294527b3f859372b279a1e6074824d9632b5d7f616e42",
-        "sha3_256_hash_of_secret_key": "630f093cb1ff96bff76ede70e970a009a9e5d28fed660e68127d31c3b6dbdb2a",
+        "sha3_256_hash_of_public_key": "80db50ddb1aff6498e12eac2d5dcdd68be66c7a569b0153ab4aeba37a75dc973",
+        "sha3_256_hash_of_secret_key": "8ca86fc77b1d59004ee108431292ef71e254bde4714a9f9d33b14bc1542c3104",
         "encapsulation_seed": "8a95d71228acaa5f9ae6f9d9ca8ae55fde296463b41083a39e833e37c4c90f88",
-        "sha3_256_hash_of_ciphertext": "4714a5497351399718258f490da0ce28ce8211aad6975546cb4351c8ebe61917",
-        "shared_secret": "8084cfff3d54b7680e737ed71c37e449f1f9d74bf6735696c46910b13d42d1f1"
+        "sha3_256_hash_of_ciphertext": "cebeb8cf34cc7a440e9dccc00b5699a792321abf6b16df2da3265909dcb60741",
+        "shared_secret": "392242412070b869a67b7ab071fd796e83b4e3b5af669ed7a8c4fd1d8d3ecfe2"
     },
     {
         "key_generation_seed": "c121915bfef6abdfc177dae2f5a24218f9abda2559afc6741b08e0e61ab433eb84ef52db5eaa6df8ec3a0bc5ffa730db0dde8c5f38f266d5c680a78d264a7b96",
-        "sha3_256_hash_of_public_key": "f0d1acd4fe1bd3bad938c23ec5a7f320766e01005e32769724abb4ebac578def",
-        "sha3_256_hash_of_secret_key": "664f3632f56ebc5c509931ff3b7e1845265e42a76e20550b683527d7d24e8df8",
+        "sha3_256_hash_of_public_key": "a0237f5f24fca5a18f8f98c916c3e3304d2669330c1042829573e197597d7294",
+        "sha3_256_hash_of_secret_key": "ff9be46e9cf8a703446f7563b786f9b851fea88bf0279d1cf1b949df0e46fe9d",
         "encapsulation_seed": "90d79d75d0bbb8921cf70d46bab497022a8e750efdc99e5f1bae653275441c7b",
-        "sha3_256_hash_of_ciphertext": "4ebd3e44b82b03c01ec2aa9e8805e53b8c8022e987fc9eca59c9a5cfcb1c4a84",
-        "shared_secret": "3e94b68a80291e957f9dd0a15b112ad75bfa07951ccb36c2de610e6755a4a0d6"
+        "sha3_256_hash_of_ciphertext": "4f7b8cbf2c9f28c5eb892d040ee2435eca1168bbc06236e084f559b632e79c88",
+        "shared_secret": "0472c7777196fbf335dcbec891e291c5666791991a332ea676778e01b7379e72"
     },
     {
         "key_generation_seed": "d86634ecf96cc2603761e284c0e36734cedec64e7ff486469e38539c71141c5a99daf37400cfe59841afc412ec97f2929dc84a6f3c36f378ee84ce3e46cd1209",
-        "sha3_256_hash_of_public_key": "7008db565f7ab9c362dc38dcd3e30e5da873c559e9a9222710e8d2e7f6417ce6",
-        "sha3_256_hash_of_secret_key": "9e774cb57c18575de3ec6a9677e40626c2026e47c389c7a3dc5422d8a83b747b",
+        "sha3_256_hash_of_public_key": "c266d76c52b2a849f00690ffb252699d5b3e9f66e0abd3c1362c39cedbc69850",
+        "sha3_256_hash_of_secret_key": "898b613ac0c89b5e001c9577766e44a07ab540dbe1d9a9cc76e0908cbf428abd",
         "encapsulation_seed": "be8a32f97b9a8d596382c02fa2a0eeebc15c083e970ddaa4f2622b91d6718663",
-        "sha3_256_hash_of_ciphertext": "1cb3879c49c65c184d605bc6daa22f63affd2a005e145103e6c1ac1ad683d976",
-        "shared_secret": "900649130f9c28082eab5ce3d128593eeaae89667d7fa4da23fcdfc1573995fa"
+        "sha3_256_hash_of_ciphertext": "7d2cf7c60e6b6c8c3053f676a13f9f0c799c65c1829e7bcefab59eea43c5fdf8",
+        "shared_secret": "1518e22b08f28512506461e0c46e60d73f7211cbba08f2880fe612817ce9f933"
     },
     {
         "key_generation_seed": "0610678ff4dc3128e1619f915dc192c220f8fad94da1943b90aaec401683a492da1804ddb5aa9b1c6a47a98f8505a49bae2affde5fe75e69e828e546a6771004",
-        "sha3_256_hash_of_public_key": "143b9c53320cdb1b7e8d71efd1f0a1ad5ad1e1ce84dd9fe7c92f19c926388e3c",
-        "sha3_256_hash_of_secret_key": "63707e33c30114732374ac21fd5be61e6dfa7dd85a36eef2e2bae6b3d0599a71",
+        "sha3_256_hash_of_public_key": "2bfa2721399623d76222e93d092c34792aa8308d8999aac7e17433da2166292b",
+        "sha3_256_hash_of_secret_key": "f6ceea917c60dd7bf38aa44c779156a6c293f0c3d96a2fc97d1c105ae3462a5a",
         "encapsulation_seed": "da2cfaf69e25b2a89ff2557bbb6f69e01d8e2e7bb27a7a1ce7e40fead16f33b2",
-        "sha3_256_hash_of_ciphertext": "780162548f2d85c00f0276f1db2d6566421cf718679147740d279660fb742544",
-        "shared_secret": "084aafffcc38ac80dfc02548df07f6e7809eb0644385abce0fc569821a907011"
+        "sha3_256_hash_of_ciphertext": "46b552d7bc80095052bb90c895cafb30c5d40a6d35f54fb70cc21cca03af83dd",
+        "shared_secret": "31828b1321febce31e35e6843462b302d13162eed40f0f495fef0654e67faabb"
     },
     {
         "key_generation_seed": "d322d56d8ef067ba1f24c92492b9c56df3a6ef54a304adc1b69913766a1ce69756047447b810cc094d400ab204cf9ae71e3afa68b88586ecb6498c68ac0e51b9",
-        "sha3_256_hash_of_public_key": "f2d009cde4abd55a2c7417c9341792e60eaa8e26b53a3aae805746401c4c446f",
-        "sha3_256_hash_of_secret_key": "2a53faa8053fa21b7b07a96ea259c052ef78746c5d53e2857e9f30bd20d3f2b6",
+        "sha3_256_hash_of_public_key": "517dd00566aba5f53253d778ce06e380b14c9019095028f3944a31a1aa4816d5",
+        "sha3_256_hash_of_secret_key": "9845e6e757e2badabc4409a0411c8ed01c6ace5c6ce2c6fcb9767c6b16506dc3",
         "encapsulation_seed": "511c2ab40782322c06111e144e505328c4e5bfc890a5980a2bbc44aeda4c738b",
-        "sha3_256_hash_of_ciphertext": "9b7ead45e0e00c615fce96105720d82ba431692f92e1a73e14b490219c8dda2b",
-        "shared_secret": "a7fd777a337219e1d0ad2cdb47fa18f4685ac343bc537dba6c97326340ab3ebb"
+        "sha3_256_hash_of_ciphertext": "53374df7489393e2f209c93eaabbaa8d9305d7bdcf93af7ca675ef3f155daa38",
+        "shared_secret": "3c2d5cd46985e0e37e487c51af3850c5516673fa376d128fb32e63ae84d5de70"
     },
     {
         "key_generation_seed": "2f1d8a3bebb34540324b9485fdf3d5be3b858f544abc3fc641b5728cafab03ba8d6c42e7270ee2b77b6045385f3d175984a0e260363166c73b0c70c971644363",
-        "sha3_256_hash_of_public_key": "1f06190bdfd692cf499be99bacc4beccf048c89926769f1b254cca9a9a44089a",
-        "sha3_256_hash_of_secret_key": "faa641eaff01077bd2fc261ccb91d5c3b468a940e25e8d5d794d564b663315c3",
+        "sha3_256_hash_of_public_key": "d2d4c9cfe0e22188f2bb5e538a054c904cdd0d6dd921af93591f4a37e9ea2b5c",
+        "sha3_256_hash_of_secret_key": "803fbd40cdeb06eb515bc9be1b7a8e24809bca250573bf3ab88c42728c36f0a2",
         "encapsulation_seed": "dca92dbec9b260dd97e8886f876862d6effc3b91fcf3fbc986cf56ab93ae79a2",
-        "sha3_256_hash_of_ciphertext": "3a22350624e9ffcfeaf0a68c265dc03036e7d5bdbb102474fd2aed257fce04ed",
-        "shared_secret": "17672805d3953f1f374dc8671137dabb0136de43700fea82a2ca23292bd0d562"
+        "sha3_256_hash_of_ciphertext": "8ad710fb21ff1df4705a2f648bc0be79fa0d99fb15c50f898f6878ba060f116a",
+        "shared_secret": "8916871d69a1d3eff8176775f01e75198ca74da4ef8d8f410706cadf9bfcbb91"
     },
     {
         "key_generation_seed": "31beda3462627f601cbc56f3ddf4424e1529c04737ef0ef2af6d7401f653b8a1812083bfa3b670e3eaf9b443702fb6db16ac1197656bbd61a8e25ed523b8d1e5",
-        "sha3_256_hash_of_public_key": "cc20155074cd7cbd43ec2380dc6a71b3a88c9a4bf168ab2bf426a899706fa597",
-        "sha3_256_hash_of_secret_key": "6084f1eb2fe4b9055d6004bfccadad7bd64f623595dd0b5e0c0100d647313279",
+        "sha3_256_hash_of_public_key": "ad2b1951f0dce0b0afd296d3f22bafe4f13638ee2540caf8a6bf7d0387265bf8",
+        "sha3_256_hash_of_secret_key": "69110aba50531ef8983b3d67cd553fd47137dbc1c2c73e92709256338438e296",
         "encapsulation_seed": "57c170e691d7a914a901b9a11c62b8b569b3806427557a9dbac9faa720ec3641",
-        "sha3_256_hash_of_ciphertext": "43291afa9c1a8098770d5ed9dd4cd71688c52d616e9e68798f8718e4555e0caa",
-        "shared_secret": "8813fdb7bcec5369e6238322be653d920ba26e0aa63a3c3b4e4218c48c1d6dfb"
+        "sha3_256_hash_of_ciphertext": "1c30fedca78d8cbd38d08ceb0cc0a05b89729e5815a131b893528356ee510e66",
+        "shared_secret": "3ae3603ac2c25b00d16e4db451d8e13dc77a3c0fa4f775c74e028abafab70164"
     },
     {
         "key_generation_seed": "cbdff028766d558af4466ef14043a1a9cf765f7748c63cc09dceb59ab39a4e4d8e9a30597e4b52ffa87a54b83c91d12a5e9c2cd90fcac2c11b3a348240411a4c",
-        "sha3_256_hash_of_public_key": "77fbe004761fc37fe7597638e5dae8b44bd44c8d6efa2893a0a84b104ace6ac4",
-        "sha3_256_hash_of_secret_key": "608099f3fa437094212b3aa2696d592a9ba45f697b9c1020b69ec1d6e178b76c",
+        "sha3_256_hash_of_public_key": "58672899468fc0a35e2a8c6fcbb35b2912e4aefb8c396bb9738e3c16c95ccf75",
+        "sha3_256_hash_of_secret_key": "cf6d958c589b9bd5fd9fa36ad4033035cd4b795c9a605894577fff640f8d663d",
         "encapsulation_seed": "6b5a14e1473abf5a33d44975ca2088bd8fa6fddcb3f80e8fd5c45b9d90c24a5c",
-        "sha3_256_hash_of_ciphertext": "368fcbdfa009642b3ca8fe0261d10d18db5566bc43938e193d9dae45adf2d41e",
-        "shared_secret": "b00167b499d5130ef82a91f83d1f1563185de735e74f89afea0b45ae1b90cea8"
+        "sha3_256_hash_of_ciphertext": "3ec1ad08fac922b09448e558b2ef4030cd3f34f12fec7a8022053660cd07ab01",
+        "shared_secret": "480307819049683defc30e7eb2f711a150d8c5503e52d93e95875754046004dc"
     },
     {
         "key_generation_seed": "4c04310bea66305c6ca8ba6b8f61ca96257a67663afc11761f13fb5c7b324b6b8aec87a9a79204cee2986867a2906eb851b734b8b22b91d6749b1a5f07c44e3b",
-        "sha3_256_hash_of_public_key": "49cbe8daa7dac02d7795e907b037e2ae56624fdc8d7c6320f9e1e69dd0f6286f",
-        "sha3_256_hash_of_secret_key": "de7838a99458b56d0f1de343315d1a7d460269ded85551f70335b1e002742b5f",
+        "sha3_256_hash_of_public_key": "5bfb6d44c0e7348fba37d50b05031c0489d4294be6cfdc6f4146740e54fa5d69",
+        "sha3_256_hash_of_secret_key": "a028bf71ba6a1f5ec4cf1af0cb9ad9388c037c71143b8fcde05572452a343475",
         "encapsulation_seed": "40e593754e6eddb7f9cf176ba2d5fd1087c90ad377556d0b0f686537b1a3165e",
-        "sha3_256_hash_of_ciphertext": "04c5a66da97cec8a22bca38de71927b176310004175b3496c5a2737e91b18e00",
-        "shared_secret": "c55179382eb5d4bbd91e45f4b3dcc5d1022110aa209c002600fe0d55a5b3333d"
+        "sha3_256_hash_of_ciphertext": "514b71dd5fba9c30a58582a39845195b0f19b1e15a984fabd7bef885769ddd08",
+        "shared_secret": "8d0ebe7aafeba5ef991b1647872cf097d625a671203c53a05c4dd624c087855f"
     },
     {
         "key_generation_seed": "38a0d5f41d7dc1896efd1b45b0485634cef149828751b96087a0a6dd81b4d58aa2acf359556df4a2abaeb9dcee945829beb71185b4d6bd18b76e5668f253383a",
-        "sha3_256_hash_of_public_key": "a333d474be9bacbea4c301148be2ddf13c3c25d7e4f52447a549a27b6d12710d",
-        "sha3_256_hash_of_secret_key": "731e7c1597fcea477249114301154b9fda1050e71617827da0c9cc149c1cb99b",
+        "sha3_256_hash_of_public_key": "22599b58af4bf05a9815c270046161175cfdbc167293cfd50e9d74851ef1d1df",
+        "sha3_256_hash_of_secret_key": "15a922260f11e5815f882c96786d106f029f193d6d047cbd5ac63f31692132c1",
         "encapsulation_seed": "c152523abd8248bed40c3827bcf0f8e8127037a55c780695e2c28ea3e041a44c",
-        "sha3_256_hash_of_ciphertext": "841415e768ab08549533578cdb506a9f72e8d01b472b64746322328c0c035080",
-        "shared_secret": "91c0a23c78351e8f8de8e38c5a10e41e5290ef96266f93839169c05842820e41"
+        "sha3_256_hash_of_ciphertext": "108fdcd2b41e467400feee2cda893fd5fc3844845cf6dbc07ecbce8eb10ddfd4",
+        "shared_secret": "fcd665fd50eafdf62b40f8eee25c6f38b5b4d110e329399460596d4f5c0bee30"
     },
     {
         "key_generation_seed": "97b5665676e59e3538ebadaa8cd50df1f9fda1502d9894c616a946078e56b621df05318b5f655efe36f1b678cf4b875108a18db2fa312261caf839f84bd956c5",
-        "sha3_256_hash_of_public_key": "35d109f57ea2764642ea3473a4f192cedfbe153a37f131cdf447b60e92310eea",
-        "sha3_256_hash_of_secret_key": "0420ee0853629da644872d3e2a9b0a89c9dece1a6748247d2f8f39721af21e12",
+        "sha3_256_hash_of_public_key": "4f71da07c289afd5cafba73184b9723c238da81e3ae109daca1873ae1e34d84a",
+        "sha3_256_hash_of_secret_key": "ad2b5c14ccfc67736dc7ec1697fff3fed2723c7277c8d30488c14c651cbbe080",
         "encapsulation_seed": "ad6466dd59f26b762fb02b19eedf5f79964da68bce0459b91c3a6ee5a7e01183",
-        "sha3_256_hash_of_ciphertext": "82c120326a2ab109d5c3910a95ec69dc3b1c1c05570728164791870d9c9c1a3f",
-        "shared_secret": "ffd93f9141d4b2abf600c1c258ee78e0f752513bb002677221060cca3ff1e5a6"
+        "sha3_256_hash_of_ciphertext": "8f3f0267fccbd0f302d33b25d10f9a065fb6371a1f182508c492d225962ce764",
+        "shared_secret": "b7928b922df5a82fc6217de5f086de8cfedf91cc521f1207f3d912b2274fcebb"
     },
     {
         "key_generation_seed": "ef99224a03a85a46ef115474ec5b5d620da6795d6efcca4c9135d19958a9de62df7d92dda83e6b2ef4cce08c9134563063068a196d7b1a1a13623e48ae12528e",
-        "sha3_256_hash_of_public_key": "cd65fd07a78e48c1a02e235ec76fdb509cf9903a4f5a850c51d9d3fda383cc67",
-        "sha3_256_hash_of_secret_key": "951cf21e37dcba710b581e49a6df1c75c65186e9672d647e9cd7239eb4bb975d",
+        "sha3_256_hash_of_public_key": "482c88cdc80345768e4cb54d17aebf2947b07c716dde8da26e0b7114f85dfd29",
+        "sha3_256_hash_of_secret_key": "3ff42377c65eb0b3168e7ca342599db6e3a105fdcb2f8fbd6101ddd0198cf4fe",
         "encapsulation_seed": "1a4d5dff5847cfb48333e33bb00ca7301b144aa89dcd412ff5a3b1081d775b7f",
-        "sha3_256_hash_of_ciphertext": "0217f113b6d5786c3995b366adff6984d0c8d91a388f798a9556d7d3a8252b9c",
-        "shared_secret": "550b4e8c00bb5ece74059879fd14f5a0a89073d8a54f8bf1597f1ebf198a61fc"
+        "sha3_256_hash_of_ciphertext": "af9ca3a38669b3e5f142a43e64965e6365a1f48d44b1b06a6da32dfb5331b7e5",
+        "shared_secret": "c653e05ceaae3783b2cd20961c12a4331f920ed695b6047ba6eaf5d256b8af1e"
     },
     {
         "key_generation_seed": "b12f6fd965ea9c5b947db80fc60c83d5e232dca82e7263027c19bd62e5a6ff550f6aa3e88f7fa8a96067f8cdaeceeac90c2d0b5e277e56e9c405ec9420c30252",
-        "sha3_256_hash_of_public_key": "376f022313718aba325ef4c3b720e2c3ab314ace74e983948ba2e43ee3a6ebde",
-        "sha3_256_hash_of_secret_key": "e697899409d15ce13113a2ad86448157a248ff0701b40eec11fb4afac7b9f2fe",
+        "sha3_256_hash_of_public_key": "a8f24545f5c1f2244d7712dce7596ce08146dae6a7f474daab4056da2d22c4ad",
+        "sha3_256_hash_of_secret_key": "edc603aa05fa07ce3bf2a4542a68261229444a7177f88609a4b20db24838904c",
         "encapsulation_seed": "34f44ec2092eeaf686f2ea170591a98527cbb03a4fa9477a7aef6b41a54feeb2",
-        "sha3_256_hash_of_ciphertext": "26c5a91a627899cf23122c5881bd00b0a4f76e0aaf5de60d1d273e8e635b574e",
-        "shared_secret": "e5b98a3c32a5563c49df725e661a9f44a20390cf83a9779ecf5e7d9f5aff0143"
+        "sha3_256_hash_of_ciphertext": "614c867453faf49d81bd1ca0381d5dcfb5b966341fa1dff67caf36d579221ad8",
+        "shared_secret": "9fa99f495d5ec88b908a180594ea391556d73b5043fd53e60413cbdce7512ed6"
     },
     {
         "key_generation_seed": "9f52af92ca165fdc38788f2b59ba02e01c8281ff7c1e60504688043a5fe814b04f3029e1be4e1c0258c3a22ff5b50b2674cc094ba7018da2a61569845c17d26f",
-        "sha3_256_hash_of_public_key": "7944e5d79dabf7b7259df5ced02669c81b7dc4590e0b10764729d812f6bd85d7",
-        "sha3_256_hash_of_secret_key": "301fb18a9ec0d975414abc4d41ed0c553e2b9aa2b03bf2765476e3288f760ee7",
+        "sha3_256_hash_of_public_key": "1c931f81fc67b2316f99db7f55d799363828f7de74b5e979fd7620c7449132d4",
+        "sha3_256_hash_of_secret_key": "e88eb4552ec4793dbbb3d6d95e91c8fbd8574097051968ac5ba32b4c48eef54c",
         "encapsulation_seed": "6250c81126572eec2da330271db36ee591f060fc7e53eeefe2e1c476c675fa33",
-        "sha3_256_hash_of_ciphertext": "c7474d6b8d9b3677b39b69030f40415e2234e637e200c689f90d6b37da3c4a8d",
-        "shared_secret": "169929e655f214d7ddca31eae7ecd2e01d9ee0601fd4a2c3a59eb701ed9522ab"
+        "sha3_256_hash_of_ciphertext": "1ee0d223d53a3f9578eeb5260e6827ead7749898198ff47b22485fdc327e6c36",
+        "shared_secret": "9b93f91e8134042ed4915b713269a6a3239b08ed049def076439151344e508e8"
     },
     {
         "key_generation_seed": "851ea90fd3854cbf28fe39fb81f68e4b14345cf0d6eee7ec4ce772513df8410d1c0ec046899a777655233e4e1b5ca44e9afbdc67964bfd5d5e3dbb45e60d03cf",
-        "sha3_256_hash_of_public_key": "692176b38737a053dce0551b63e3eca81884bbf95e1d8975671a2f7f1dfae251",
-        "sha3_256_hash_of_secret_key": "1ae55a55d87ea8d58b51f842c7d6990a1ae6932eccf5c39e97f56bb481a16b7d",
+        "sha3_256_hash_of_public_key": "c11d5e63a349785e242cc58bf790539d3adf4844176afb3ade1db843a9e6ae9f",
+        "sha3_256_hash_of_secret_key": "688265f913868027cbbc9dfa94448be736e2a5f0b92bbf93058fadb350030fae",
         "encapsulation_seed": "35d470bcc5880872754810dfb3f2796da2fd7f397537146f6488c27804072b34",
-        "sha3_256_hash_of_ciphertext": "7509dec8c1dd6f29855e08d61a56ade71c6bd9a47102a12b3d4c9784010bc5d0",
-        "shared_secret": "be36ca6f5e0d3da0b5c144ebccd725900a06782fae7b2707ce7c5cb6818c8991"
+        "sha3_256_hash_of_ciphertext": "7f65f239ce22eaba7c7ab316cebbfae0969cc2290cb71f440034994cf90dbbb1",
+        "shared_secret": "b616ad16ce3e737184ea0f5b25f8439ffe0bbe9647e0c2c725d23d4eb2f13464"
     },
     {
         "key_generation_seed": "d304c9389cc973477f169788abcb9d511f843219d246a9b587822f422a70c2386590a2e5c7ed86cf2c5c2a898662bc9a81418720bbb632ef9cf0b845ed052d73",
-        "sha3_256_hash_of_public_key": "2f54bedb19919171eca777186dd743b11ec9489aea09534c157faa75adf1c77c",
-        "sha3_256_hash_of_secret_key": "4bea180ffc80875ac731f18365224bd3eefc8d11fad63c7376adc1a37adc67bc",
+        "sha3_256_hash_of_public_key": "5955b9c5a4f2ca172535d5a32ef67d54f334bf726829082485a7b83d43b46b23",
+        "sha3_256_hash_of_secret_key": "7809270364124d24715bc895edf612bac243172af3b02ec93d5bfd9cff0e109f",
         "encapsulation_seed": "8d667921c5db401a86fe1c35dfcf164a6bb2ab7400fd6a0b67eafd4a0ed11940",
-        "sha3_256_hash_of_ciphertext": "def0451ac37ac39a0ef5b94406de4e313b3d12d899d6a4e92f3ee37c84869efe",
-        "shared_secret": "9769b7f3571089f1a086606f3545dcd094097befd492e3c9889f9a97c7b181a4"
+        "sha3_256_hash_of_ciphertext": "82424d5f00c6d9c6fed4e457ccf6ec1a8924d1991d069d61af6225de70265cef",
+        "shared_secret": "634ce1c824fa766f69c30548e34a772e828248e5ea4c4a7780ff38e2d7d3a4ea"
     },
     {
         "key_generation_seed": "89a6e3be304a3518fb82b18ca730f0b359cd6ba90664a493fb4f8edaf965b9c3b6591121e25d64010c25a18676033e1d7278ac5f2d0b43a31f3a4156ae710465",
-        "sha3_256_hash_of_public_key": "7a9232085a0222b9c863931ec3bdbdd51be3f16d6cab3009c138e0c8cb692563",
-        "sha3_256_hash_of_secret_key": "a01d03ab913ef4672c49664d2c95fecdd98fcfc19e8d8b839e79a8f6fb9bdf42",
+        "sha3_256_hash_of_public_key": "1f40abf556c865cd096c702d21239de7c22713d70626f1a3a4c4cfbdf3faca62",
+        "sha3_256_hash_of_secret_key": "7be795e3cf1129fd66006f863810789bcfae7b470f48dc67e56420c528fc7161",
         "encapsulation_seed": "ec750b3939385a3f8df868119dc76f77ca845567ef068de6ada5478a56bc78b6",
-        "sha3_256_hash_of_ciphertext": "45c35e22eaa9d63a6b57f60ad2e6a35290b290c01761030dea1c9aa7947c965f",
-        "shared_secret": "7a190640b245b6b4de7ac38fa6d4c50e935c0062c2089c926e4e8c31f233fbba"
+        "sha3_256_hash_of_ciphertext": "ef56de7b20b69ffaf2fa99b4e97b0c1a35c714ef33ad6bcf1a5db52825ddc57d",
+        "shared_secret": "ee1b62c612b20db1f35a37f94f3cdcf4d3c02f1a7e2ed944764ca65711cc7cdf"
     },
     {
         "key_generation_seed": "d569b935ce015c85f792f8f7fb0d83c4f53b492959361dd4f75fb764d656450176eae84d11c4528382828f7a689a0d5cff87b8ca0bba97feacb39b935a8788cb",
-        "sha3_256_hash_of_public_key": "1642d52117145ea2956bd5e446b895609be84a9344ff0f5cd1ec62af9ea9e3c0",
-        "sha3_256_hash_of_secret_key": "e2d190c6c423252af301186a3e49892da8c22e4c0fb61586d119119fb7b07447",
+        "sha3_256_hash_of_public_key": "d5d6b62e0449476f7c6f9ea3621237bce0f97b11fe0e65776f1e92da38362cb3",
+        "sha3_256_hash_of_secret_key": "4ffc1c18bf762ca3b1050d2a4f583a63a5aaa6326fcade7673d49d8a4921ff17",
         "encapsulation_seed": "74f1d52af09b12c36eb062ea7528550cb4c18a3ce8e4f4ea9fac43ae383bc925",
-        "sha3_256_hash_of_ciphertext": "0e67bf478bf93c925eee2cdfc285161c1b6dd2ba3a479dfb5fd9203ffdcd3c85",
-        "shared_secret": "5de71ca6710d2d588f53059a15e3a266eab4ed2230502b597f088014fbe9b659"
+        "sha3_256_hash_of_ciphertext": "e1328b21914b182fa2908f7ed771da784ad836a85bf341f56bd748d16c64c768",
+        "shared_secret": "1554300d6dd3d2dbb7a1647991daceaac9bd28f6bc937cc8bd3246c48e219f65"
     },
     {
         "key_generation_seed": "5cbb141c2763425c274f7404fe530d9116e08c33f9f200a20b011cf563a28990fc9ebbe336dc464489861db8253606971bd0a9008a433ed17752d04023781552",
-        "sha3_256_hash_of_public_key": "0163017a26dba83777c4c0f46f31375ba02680ffaba588a9fe91f97ccb99c445",
-        "sha3_256_hash_of_secret_key": "5d101bd4f51fad047a1161e7a95197f6307e7cb88e57fcf9fb28a2be43e9f4a0",
+        "sha3_256_hash_of_public_key": "269505d6cb8212b9dad2fa70171035fd4107ff47c02696b3489650d5ef9c6f19",
+        "sha3_256_hash_of_secret_key": "018eb767bd3dc2eab26a00ad9f83c0335711512d57932cd0261fbdea92b66da8",
         "encapsulation_seed": "4b3a70d85f640d1a2a852fb6fe96704af56a7415a8ee4282e9207bc3a2dc116a",
-        "sha3_256_hash_of_ciphertext": "7e38f78738ad21d1015a2e79860e8108e807a3e7070515185ae581345e08f6e4",
-        "shared_secret": "42ffbb3ae86b744b00f36a01f9cb34e8a08916f455c9ea0e5e6ce81bb5042cae"
+        "sha3_256_hash_of_ciphertext": "b2fe82f12289cde84395d5757b2f0cf5a3a968827d03bd7c25995052eb71798c",
+        "shared_secret": "321f4ce476ad84c9f9d3b906a733b8bbd8aa0c3301d81d9cf7587345c098157c"
     },
     {
         "key_generation_seed": "293abb6d1c207927945417cf84883ef010823e11b487ed55239e466e83696d0cff8563038aad865a817cab9ce98846ba75be9363718ecf5fea538aea90b2a558",
-        "sha3_256_hash_of_public_key": "fb21cf5cc9a8a47a07cb2a154f73676d39a98a7d12a4abbd37378595c6332f46",
-        "sha3_256_hash_of_secret_key": "3c5041ff25ab5e854e792eccf12721be4f820020ed7895d5ccb7b1ba4bb7b193",
+        "sha3_256_hash_of_public_key": "3e8ca044ed0e215c83f03eb98b6da9da137ff2433b319d9ccbd0bf054135d63b",
+        "sha3_256_hash_of_secret_key": "0082aadf73da0e894dfcf587c66f00d42c9619c48d09d5560faeb3396dfbf8f3",
         "encapsulation_seed": "26e38ac804fb5b4d59ddf747715e7e6041d875f99c7b638024b4af82d622da60",
-        "sha3_256_hash_of_ciphertext": "e2b8a6842755e5a408a47a32c2093dcf3aa0d32448ddb1f1a154315634f1b701",
-        "shared_secret": "90ca5a797490eb35c3cc24af19fca6dc71d41aa58d68e0061c1bdb8481e691d7"
+        "sha3_256_hash_of_ciphertext": "3c1dc77214aece55f05e63e8d83fc4186c445d2d2f54846b5422a362ef058d6e",
+        "shared_secret": "3f9a0a1579989654c58a2d33470a0ab5b6587419be2e9cf4c5027ed252c48494"
     },
     {
         "key_generation_seed": "74d87c7556f2671f2d666854a4d6e073e69f35421e6e1a428cccea49c37f972ce1fb7456ac0aa1b97068f452cba64ebdc138bcf5d36b0a0fada2a3b374141eb9",
-        "sha3_256_hash_of_public_key": "591aa9c81277503a34441fbd6cb59c6d1ecd5e00298fa56be9df562576250c52",
-        "sha3_256_hash_of_secret_key": "2e9c26235e0db1383671ad4ef147c1cbe3724bf800be90e356a5a381e3d9aa12",
+        "sha3_256_hash_of_public_key": "b4ecd70cf455e2195477c581fa72af1ae232e7b5efb374d9607fd958447b7c67",
+        "sha3_256_hash_of_secret_key": "d609a934cad16aedacb4af3a071387c24b0421a7747310ae045ff5da10ca337b",
         "encapsulation_seed": "a319d2b8f114f1acd866478bcdeba6fd164dc4e37b0adfa8d8034afb3e197376",
-        "sha3_256_hash_of_ciphertext": "02f85b52a3684cab8bc416b74de36ac686cf3a3a495440cd444c1fe7d84b2e07",
-        "shared_secret": "bd58345e9e19483cde256be650975b954e167bd8b0a9036a95c98ebf037e87ec"
+        "sha3_256_hash_of_ciphertext": "a54658518ce500e04544f0774dcecff4c0c17ea6170941cbf6b670fe5e9a1ed4",
+        "shared_secret": "a28945631e9d080f64dea8dc345de2a4cb95048d5b78cc573afac0fd86ce57b3"
     },
     {
         "key_generation_seed": "013bab0212d04ecd54b478daf72748003a25e2cb060ba6cc50bf95c292b8206b9da0c5da5f195b80fbb99c2e8b06926074f3f604b3f6195b5a5b9737876bba72",
-        "sha3_256_hash_of_public_key": "1c6c4009e28f6a20aad0c0b14b7cc0a01aeca507c366913ba5cadefe6656881b",
-        "sha3_256_hash_of_secret_key": "a9d3487d20af12309fb8d12b71a3fc3ad9109a9cc2720a0fa409ec5a491943b4",
+        "sha3_256_hash_of_public_key": "a97ab878370142b7b2b346179050eff0a4153943be66d9ce47c6772362ba795b",
+        "sha3_256_hash_of_secret_key": "505631cb623779f8c05817160d13c7d5bc3ab641ac31cb0eee3025a204a4a3b2",
         "encapsulation_seed": "ff646071b2509e6b75790917e08e4f0b0d9f0116ec6291c0b59eaa4b583ad830",
-        "sha3_256_hash_of_ciphertext": "7a5d4cb38e9fb2beefd925d54155ae91d60bd95696db2de45e2307658341f2e7",
-        "shared_secret": "53d22dbfb623f5282ac68ff607b69b9ce559ec3b70aae668c684d90dcbbca13d"
+        "sha3_256_hash_of_ciphertext": "1ede2d6f454578ca9d2b0c1324d9342b484eed64f6bb788a6d377b262e53d719",
+        "shared_secret": "5a2913f3ed09c2f765977781f18823602437334e5a5c210a71f4cd734fd10b07"
     },
     {
         "key_generation_seed": "ccb073c4b90be0ad746e26fb093b60c70110bd1dcbcddb566a8cffb7b3caf80e71600a8982c350df524cde514431ded7aec23576530894bcbf0ec0bfef0bb64f",
-        "sha3_256_hash_of_public_key": "4576536d1bace29aa7c31f7681222ddd15a3cf6ea6bbd3528d2ec8610d68d134",
-        "sha3_256_hash_of_secret_key": "0f1d74d5cd2fd6a9aa7022a0f06bdb6272a0bc23f115796d6e04692aa44de4ab",
+        "sha3_256_hash_of_public_key": "13035e253575fcae389887037cdbff8ea508ff9e5337e2fb607919747cc53df8",
+        "sha3_256_hash_of_secret_key": "5db526c73d60025195493b0ee21c47c762bb95107e7a9037e2bc3d15eabb08cf",
         "encapsulation_seed": "0584270ec26f3b9818e4af074d17b2d51037cc8dfdcbe3b140fa4fed5deebc54",
-        "sha3_256_hash_of_ciphertext": "8448f623dc438ea4a849544c4fbcf3dc493b18dbacb911b83ed651155a145c53",
-        "shared_secret": "cdca5387453ba0f0fe9f126702ada05c3612388b70185b6c2e69dbf98c2803ec"
+        "sha3_256_hash_of_ciphertext": "550adbedf0e28eb616e477f2ffd925575f2339b9650b5282493dbc20efaa7b0a",
+        "shared_secret": "3084c8b9e79c5eea12b89c5acd1a5cc6d9835656138a1f5d68d27fbb56988d57"
     },
     {
         "key_generation_seed": "2e889f44e28901e9ac7ca6b2fffcb124c8979401b17064d7e1d51a7e3c3adbfa0e145e44aae52cfc609e6f47fd7a6f6af877190ff52256d0ac5b05b89c3f449f",
-        "sha3_256_hash_of_public_key": "eea5db7a82254d19c0a0c552ccc92db9c3eef74cd73a9937b7b7298171313f12",
-        "sha3_256_hash_of_secret_key": "d4d3196a516686b8da051e915241f141b04af55e83effb968c52f23a19ccf79d",
+        "sha3_256_hash_of_public_key": "0409f3dfebc62eda14a11b1c03d59d46382c2c2a579009c0355da8a58440c49a",
+        "sha3_256_hash_of_secret_key": "5b1cd45db8082dff58e3242c2f37d14a682fb38843394879e95f9edd56268ad9",
         "encapsulation_seed": "51e05c7b4ca3079781e8293f4eccebeeb2f8c8b4c59468eddb62a21bcb4ab8a3",
-        "sha3_256_hash_of_ciphertext": "84e87b27235041a1815c98ca4cf9ce031d7700a48f602bc9dcc98f876ae50c62",
-        "shared_secret": "b15db77dc79f2d64e13445c4dfa997afb191e0bb2bbf6a210a5d64263b2408f5"
+        "sha3_256_hash_of_ciphertext": "b95d4e0919a1e4659fc88c49a3a5635215ce65a74f40076fb5b24e0e3499209c",
+        "shared_secret": "2c9aa133dc5aa592b7c73f23ddcb85faed4c69d249363f9cd7fdfadc7329ff86"
     },
     {
         "key_generation_seed": "174aaa36410566dc15a5e62874218d7abdde0b2c0f30d877bb80b1abd5f5a0a450a7a2354f7e5cefa6f4a4e9a1c411eb9364506e9e1204a8acb3cb77fbd2c4ed",
-        "sha3_256_hash_of_public_key": "72998cc3abc79487ca0a4db5b17514e9961916d30ab9b500430ba748c5c79226",
-        "sha3_256_hash_of_secret_key": "362b40ba4e015b703f639f4c784fa9f114f2cf65de5f6645e8f9d37fb33fd044",
+        "sha3_256_hash_of_public_key": "a964f69c975bc276b67b828d04997c8caaf20600da330ec642633f9789858f73",
+        "sha3_256_hash_of_secret_key": "43c8d52432e0cd004cb84f3ae8b6e2c4657357f3535740404189a47b9549b14e",
         "encapsulation_seed": "9eca0fe36c80fc5eba171c3ae66a5b1c923faa50b4521bb055e7bf51005c93df",
-        "sha3_256_hash_of_ciphertext": "44b60f83deff617231e92c5ece08a24243841d3df34de2517c29bdc89ff51400",
-        "shared_secret": "8ca9424860c35214636855849bb039cdcb4c722c5b81ce18ac1a1090034dafc1"
+        "sha3_256_hash_of_ciphertext": "a22b43056ca8a6a318b06142a7d1fc71c7d5b72c269f14cb86c531800b2d9862",
+        "shared_secret": "cedbcc4a7eb422e8a50f22ff47da0bd8b6f2337cb2aea98fcd80288c14da7d92"
     },
     {
         "key_generation_seed": "351fe4313e2da7fac83d509f3103caf7b4c64a4d458fefdf636785ac361a1390f072d9b5a99f9c7a0a011e4dc10f6b600d611f40bba75071e7bee61d23fd5eda",
-        "sha3_256_hash_of_public_key": "e9631b6d4237dd6884ae3647dd8622fc13d1cc689f3c8ed94ec6bcd4bbdb6980",
-        "sha3_256_hash_of_secret_key": "96736bf10a73d079e56f5812f65e3465957b8228423fdae4059feaf918fba361",
+        "sha3_256_hash_of_public_key": "2a63040993f86bda57d8006a152c436e383ae407c7d9bd7a715a2f9efa507422",
+        "sha3_256_hash_of_secret_key": "304cf25b7cb02f8ba61b73f24441c9f73076f43da697b73462d33c08e22889e7",
         "encapsulation_seed": "0c5719261caab51ae66b8c32e21c34e6d86ee4aa127d1b0195663c066497b2e9",
-        "sha3_256_hash_of_ciphertext": "eda93794649d2ba24fb277e8cb0e5788102a4796cb21388caa25eb10bafefc5f",
-        "shared_secret": "b056e2904d66c51dc817acf961f141c2de7d201ca8e52d19564d0fb4e1310aa9"
+        "sha3_256_hash_of_ciphertext": "b1fdace65d63dbde3b624bccf02ae3859209bc7597ec464c1955604b69b98247",
+        "shared_secret": "cd0a41e85f2afaabcd7f00c2a9be9bacc6d6f79e0ae6b7ef64de31dcdfa02b91"
     },
     {
         "key_generation_seed": "9bc5315580207c6c16dcf3a30c48daf278de12e8c27df6733e62f799068ad23d5a4d0a8a41c4f666854e9b13673071ceb2fd61def9a850c211e7c50071b1ddad",
-        "sha3_256_hash_of_public_key": "847db13de94d97a88d5a3deae31c246f5f04d0c7d7f337859e024764337a08f2",
-        "sha3_256_hash_of_secret_key": "7fc950abb115ea2236036c300c95c76015606539ddd2409ff1b39a99b86a179f",
+        "sha3_256_hash_of_public_key": "4016ac096bf081a60fd2726d6b275f550c50021d42608c49c93385828573f89f",
+        "sha3_256_hash_of_secret_key": "9570199a1807116c7f724a899ff769f20dff8052fa0c9c9715f0c64438884144",
         "encapsulation_seed": "0e59f6f9047c784c1f00b24454aa4f1bd32c92ae7e626549972f86fab90e7e89",
-        "sha3_256_hash_of_ciphertext": "af6d97857d131ebccf9d356e78a4fbbb66c7d5ad68fd42d356c3ef14aa756d47",
-        "shared_secret": "663bcd21601942f0ce47640325c9efcfc3eb3b022f0cfaed168893b1b6e5dcfc"
+        "sha3_256_hash_of_ciphertext": "58307716aa46e4259f8bd30ee56b62d9bdbc750dcbf454833f2d7ee8c39c4444",
+        "shared_secret": "1537e848472d0efdb11567f6ae943c8d16d37f91285fa7f77bf589ecc5e33d10"
     },
     {
         "key_generation_seed": "d8b907b34d152ff8603b73051f772daa71eb902c47b7e2f070508269d757e02e36b817736cbc5f7b1dd6eef5fe6332fb1a598f3871e5470d440fd2ea631da28a",
-        "sha3_256_hash_of_public_key": "f122b76b83c343de27054985634387fb7138f6f6f105cd4cd3f5b02698a964b0",
-        "sha3_256_hash_of_secret_key": "620b4d0dc53a26e175c69ae7a8f2d749d4adf1d0429852b84839d334e024ab06",
+        "sha3_256_hash_of_public_key": "a08c74eb9f3d9296c268dcd23c66bf0250b222854a5c31830b7431ccd3ed53fd",
+        "sha3_256_hash_of_secret_key": "47a4e26c07937e29c94d64ffd1819bfb707ef600869f58407c21d7c259ca5490",
         "encapsulation_seed": "a3963ade17d69debbc358dda82c7bebe2c39d25b36813058e7a161542e3f8c2b",
-        "sha3_256_hash_of_ciphertext": "51f8a50f2dbcb1255619a7a9868eece507b55d2138707a0550a4113a7e162d5c",
-        "shared_secret": "cad5816f1b2057a410cf917f52040aad9cdef2122ce59211ccef77c4a7c23a6b"
+        "sha3_256_hash_of_ciphertext": "cc98832ef8d034a40761d82fbca633cc1534bf5cdfe2326b68ad088222e04221",
+        "shared_secret": "5aad40b5528d175e52ceeeb0e70f31d8eaebb691d69f87029c966f191c6e5a59"
     },
     {
         "key_generation_seed": "684a29e4e5480a5f2533e1526b5fac8cdf5927f3d85087c71f928c59690eb56575d12195ec32a8686d0600e45d4a7f54219b0d7a3826d193a51b9156ecf2edd6",
-        "sha3_256_hash_of_public_key": "4c3182ca7a48afe60eb85790dcb50b8005b568921dbc724130b0ce83f1278454",
-        "sha3_256_hash_of_secret_key": "44b1c2b3487cdda8a8e9205d95dca710093e981e7bf2ea30d1d2502b164375fd",
+        "sha3_256_hash_of_public_key": "37e94def940045d3fd9ddec0289680ae2f96d9d43f5d774a81b86ae7a4761ab2",
+        "sha3_256_hash_of_secret_key": "0164daef54c215fcd310fea777ace0a20ed964a64ce6fab3c5816da5bf11fd1d",
         "encapsulation_seed": "97beafabf2c8575586487c7a80e8af5fc50f94b6051c1bc66a5ae9f66be3cea7",
-        "sha3_256_hash_of_ciphertext": "f231d9b8e3cb86e9daddae8d4555779a9125a16a6d2984ef55914a27d7912fbb",
-        "shared_secret": "e8f4dd3d2bb2c2f110bd410b2c37beee6d3bc7c7c4dc477c358234c54bbbd4ca"
+        "sha3_256_hash_of_ciphertext": "135ef47f41dbc48f35afdca64081e9185c69c63740ef27b107e0b0bebc8add69",
+        "shared_secret": "fdf3ed80a2b98a72be0cc079b8e1af0ee6491fee10520a1fa694fd692d70787e"
     },
     {
         "key_generation_seed": "d76b3573f596eb286ab5231feec7499686b13021be36cb126c7ebeb9d7030daf248c0a21ea0bb6d6f56f12300e8584d8e9a34e0e6f52227281151ae4c305fb8f",
-        "sha3_256_hash_of_public_key": "4359601c371b50b50b5306de33cfd476d3b5f811700dc4918beb345840244e3a",
-        "sha3_256_hash_of_secret_key": "6f2d2c913b4a19bb07b531d74edb549659a35d1330b1ddd62c74dac4bc5f061c",
+        "sha3_256_hash_of_public_key": "ee3fad17b073dded30b6531f854523002db21673437ae275e8a4d702ef311619",
+        "sha3_256_hash_of_secret_key": "092c1cde9a894c7ac542397cd7ad5c147055259fed7a91db55d761b01e0d5dba",
         "encapsulation_seed": "75461decd34c50d6a094b4a64fb75e5e9479f8f9250d82bb7d729dedeb2d4b65",
-        "sha3_256_hash_of_ciphertext": "a6130d387a04846c8b920f94f59d6c65b4954b6ced0f0d6a8566a0110c198a08",
-        "shared_secret": "249855eb724db68f7367385c45a3206fa19c521644f8841b7a73f536ca47c26c"
+        "sha3_256_hash_of_ciphertext": "28692f010feb0f736aa9c04aba9200857d9aa9dac6efe22dacf9b4c1d3d53163",
+        "shared_secret": "fa205e16b79ab208250601b4ec37f6a13f6851b94d93a0899a395d623f543836"
     },
     {
         "key_generation_seed": "b87439fde81c9e39eebe7cf741c685785532c1dd23e8ef868b9ce7a541010f3d1646460817a0fce5836bdfe124a7448e7adf7b8ecc2652ac6d280e986682df71",
-        "sha3_256_hash_of_public_key": "e1f6c5a99a49d6b1b4aa18089439bb4c56ca465785bb36594ef2ebd3af20d564",
-        "sha3_256_hash_of_secret_key": "fcc14cdacdcebc6d1933f1ec9d430c643ff5fdbd78d2fe053a8880e6ee8ef129",
+        "sha3_256_hash_of_public_key": "71c37cff80f992f3359ded64b566956adfa3266cb05f171eb644711d3a2cb4b4",
+        "sha3_256_hash_of_secret_key": "9a8f61cf678f26d95f894db02b0954989bb3371a63846951e5cc7a80cc876d27",
         "encapsulation_seed": "2607dcf4fd6ca1c614c21b5e37c24981c32b91c8c3e6955777da8a3f5d9c9335",
-        "sha3_256_hash_of_ciphertext": "73a09eadd34a8be74772db44187ab49a2bc086b91848c6ff09f1306c264f6fe4",
-        "shared_secret": "f1be516b31ed89cb70bcf428a2ba2c22b3919f8a9824a59b875ff1e697095ae2"
+        "sha3_256_hash_of_ciphertext": "be65e0ed279809360ad843946e4d130197990be0a3c5fcd1abdec60d5657a62d",
+        "shared_secret": "11e27d94d4dd5a8e8088e281608ed424a9384bfe96ffee3b6305d17cddf698fa"
     },
     {
         "key_generation_seed": "056661b38038da4fdd7426f32a81576c73ed84843b305168a374f934e27a4e1b79238a80dcfd7c992d84b2dffa67493e669243d4fa38c46b090bdf86bc548411",
-        "sha3_256_hash_of_public_key": "b8aa8568431ffc4681caacecd4475c838cf7348402a06413e7a9590ba405ea5e",
-        "sha3_256_hash_of_secret_key": "f1e4bb0178d949637c06e252493235480d3ed16687e9a1c36df0721b29a7573c",
+        "sha3_256_hash_of_public_key": "6af202d9ad3f2c7ca61993e238140ce8550a5f0c39147130a5313c8c02d68de7",
+        "sha3_256_hash_of_secret_key": "2c29ab0dce04a8f397880e3439e36d03be54ced504f1cf632e42fcde3dd4e1f7",
         "encapsulation_seed": "38c89bbe7145c29e9a831c11431eb9929cb24fb4992db20737e4687d397fd732",
-        "sha3_256_hash_of_ciphertext": "24392701d3f5204f5cad5662bd6526a178567186cc070d951e03593e5722eb46",
-        "shared_secret": "6ec4f71386c0f0c16294e4d76966c69c512d4e5e00a6e05c5aa544e542454225"
+        "sha3_256_hash_of_ciphertext": "775897e9e4f79c835ebd2199d71a9749fe0dec91377e6d95e4027fd91cb468d4",
+        "shared_secret": "86d765b2917cb98458fc5f5d26cc9a28426655a73109ea65f61377532c83c280"
     },
     {
         "key_generation_seed": "a1b52d871612a1c611ae0944f9e71858f35d3bd14f20e96a931720668bdf0a6b1f135cf64b6403e103afae34da038613e2853bbfc36baafa3c6a95347193f37c",
-        "sha3_256_hash_of_public_key": "984f4c4ef2371654067ce0f22bbe4648dc9d87eee23842f31affcdc36328e8db",
-        "sha3_256_hash_of_secret_key": "240fe3ab98047b1985b22240622da9669f7ecec81801861ea0859704f3263f6c",
+        "sha3_256_hash_of_public_key": "eba48a8a50609e70baaf4c552f680f0b02afab2da76d8833a2cbc3b6f782b36a",
+        "sha3_256_hash_of_secret_key": "1c5f35b107f7681236d5d4ec8bd88a20f5788ac034394fe92b5b3c43fd77c03a",
         "encapsulation_seed": "b2c35e33c72d90182791f0e12a0324f5b216efcab2c8da1bee025dfbe13f4152",
-        "sha3_256_hash_of_ciphertext": "f190fb70fe762db7125e3ba3b459e32bf99775c3c1efb84ae1776b50206db7df",
-        "shared_secret": "464274dd39f2862a97833631ac446642b3c3dd6467c7d2404aaa46a8f5f65b3f"
+        "sha3_256_hash_of_ciphertext": "76f10ecdf3391c19c9485c6e4057a3bb4c942bda9498e552a9b4d653e031ab29",
+        "shared_secret": "5f83d8b07d320694b387d4ac6084fea240a41f02e66a12a7280e5078ae0ce208"
     },
     {
         "key_generation_seed": "952b49c803d6d6fba69f4375adce8594847a00bcae2179da49af2aed0423250262d7033947ae42ca53522a65fbafe18d3bc3e0cb66164e9a094fe4b44d8977ed",
-        "sha3_256_hash_of_public_key": "74841a59db1202eb2e3744bb36b9c5a229a33cf9eeafca4b3d02d155d870b6bf",
-        "sha3_256_hash_of_secret_key": "e808e7b999c5bedc14a1763428a3f2b3eb9c3f90743f8a1922c87b5874acd79a",
+        "sha3_256_hash_of_public_key": "69835f3a1f1d9511e257abfead77d365076a5c423ebf1554cecc7b29c0a61b67",
+        "sha3_256_hash_of_secret_key": "94e39fcd2bb008cfae04f152dda76e80fa77b4c0f38d736e873d4fefeb09cd60",
         "encapsulation_seed": "afb7d6dc2b7eb6d84acc080c1be63c98afe7b07786b5801f716444a3e8e64800",
-        "sha3_256_hash_of_ciphertext": "675ff34f87383d52203c979d1502e2fd35d9da09cc095b44caa073cf58562ba1",
-        "shared_secret": "99dd968e1f5c94c6c4d92e7eee393c802d8ea4a34d39de2048eebfb21a0a4b9c"
+        "sha3_256_hash_of_ciphertext": "969609353a83a8073e72f1e2f3b2f3e618bb4199fbc3bd1fb884cef8ca6f3c37",
+        "shared_secret": "070da4db5d59e004607fef8f49379692999d0d4cb63dab350cf8c546fd954ee1"
     },
     {
         "key_generation_seed": "3c815e57e9233e975fa1630208aab206b71ae0db37a7a8789ac683d9f9b2d29801c8e376fdb140ee343106c093af7cb149b316ba79446ceb4e5e0cedb9b164f9",
-        "sha3_256_hash_of_public_key": "f7243d71bcbb46b9a423431b3b30947eda5fd81b526cce79a36730d8ee1be42c",
-        "sha3_256_hash_of_secret_key": "b1e6993caef04e00ffcf42c81ae97c6d89c5c19bc3b3e1235c48829151f8b4cd",
+        "sha3_256_hash_of_public_key": "3649c5c2f1142a51eafdc3edbdcb3c5150c608d828b7e1b9c1ace00f9a548fce",
+        "sha3_256_hash_of_secret_key": "636e040204dd2c953f1178927d44462d7f58fd2da80f35dc4a86b82abe1c0a00",
         "encapsulation_seed": "28f5e9dbda122b2cf8f3754fe9e0c73a84ad4b0c093522e0b62cf815d60bbc3c",
-        "sha3_256_hash_of_ciphertext": "319744b03f01b7676b3975b70d20698972d5492a2b0c8e0833837de36945c699",
-        "shared_secret": "0642533fe87a2913a37847843f7336a0e4c47f778afe5cc95433948a76ee7ecb"
+        "sha3_256_hash_of_ciphertext": "4fd78ed5eeaa3692fcccd2d876499203ac064c46955839c3f8c3cd0d96114647",
+        "shared_secret": "16d4d64c78114b5fecbb99dfeb59623cc33725e9fde5fbfe1f805c05ea7c6c4c"
     },
     {
         "key_generation_seed": "588760826dcfbd36d9abe6ae44a669bb3ebba6a218eab69e30f18a3bd536576e0e860576285483bb5fd36e2f944d32c4317bebc1e441470c1372046a790d79d4",
-        "sha3_256_hash_of_public_key": "4092d5afa2f038f879184f7344800ea49a63543be9600bdc2b18420744588290",
-        "sha3_256_hash_of_secret_key": "18b8bfec268d6e1d6edd376689f2bc5ffbcdc859cee0a26ccf550fb42863d57d",
+        "sha3_256_hash_of_public_key": "f651c0028e1e5653a53302082d4e89b76b6b6a939a2f2f5b6b7d5931ff3ed6c5",
+        "sha3_256_hash_of_secret_key": "bea5f349a7d0d1b43888db9ffb786c53a2cdc44b9ee3609a761d54e2cc0967ae",
         "encapsulation_seed": "b0d713cbef0bb1df70cbb425d1e9373e9f7790fdc7980cc96a240dfc53f1e8e2",
-        "sha3_256_hash_of_ciphertext": "4fb1c5f9a918a9077f822c79ec0697dd6dd7b23ff3cfffafaa272dfb1233bf8a",
-        "shared_secret": "a226b83601ae0e6f76f9f08b0a2f6eb30a3afaa39ecf5c5671e988a354fde9a7"
+        "sha3_256_hash_of_ciphertext": "f1cd1b7442fe0ecc78a1367ef6e8312ca049acca88defb0b8f2a8c41c30b7fa6",
+        "shared_secret": "7822319b0d51be73985bf8e42d01dba870be788b62f9fe8bac94a109cf202111"
     },
     {
         "key_generation_seed": "47550e9edacb6ddce3d9ab81f6b61080dd4f2693854acb05e0ccc7a4fb6390fbf89d7d99d5c3e0d10d6ef9af054d842375f695abb28e3b8eb495100f04306e92",
-        "sha3_256_hash_of_public_key": "ad7166f31b2650d125c8ef23b5825fe11afe25d0cda306fa6c7a824b4c2d31d4",
-        "sha3_256_hash_of_secret_key": "0124d8202fcb0c40d7a6cbc1570df65602f376854abd55ea664f66e3923b3d56",
+        "sha3_256_hash_of_public_key": "63a647d85d1d66436cdf42ca198a44b31aa9f9d28b0311fb858cb5ecf74eb770",
+        "sha3_256_hash_of_secret_key": "c1b16c7d12d066bb93a9cd540a3d0867571946feef80ea31d2dfa91d612332de",
         "encapsulation_seed": "32bdcdb7059fe27f6409901980c080308951ffd90deffa8317b4d213a5f04495",
-        "sha3_256_hash_of_ciphertext": "74501710705cbe8837e88dc8986d78310ea57196185e3ee3ecc8d17d8cafa7ac",
-        "shared_secret": "3040e7e4eeb844c1385a78dc3c8a6375880ce8fab92827460de1825a4915c3b6"
+        "sha3_256_hash_of_ciphertext": "4cd20e03ec01cc4b675248b92afec87e56abe0550059302686c82e3ee40c7021",
+        "shared_secret": "3f338dfaa091406b88dc39f5e82ec7582b90e4066882aca5ec4be352d4cff72d"
     },
     {
         "key_generation_seed": "610afb64be8cc1df288cfb016ee2f44c6c07113de7f6fee071fe0c3fe31c6215cd292e4c5f9e1a55e0489bceffb204d672a6215f4f3980a646d9f880817c52dd",
-        "sha3_256_hash_of_public_key": "37933cfd8c0e61085f2ae264d85c4ae05f8bd40bf29976c6d52e4f1c7ff709cc",
-        "sha3_256_hash_of_secret_key": "e9a6c0af326ca00c7f8ee0b6ef5661be3a84c39165ff60fea5510cb219b8f788",
+        "sha3_256_hash_of_public_key": "53729573ce2f4f51da212385808ef436eecdb8fb9f3c8346800beb4b9e537d1d",
+        "sha3_256_hash_of_secret_key": "fa421cb5d87cab0678d9a45a0c195d97cbe2441d2d15b6dc5c7a3342c74bc87b",
         "encapsulation_seed": "4ed7c92d83bd03b2a25b567f17ae55542e2f6a4308ec0f3fe69f8ba5ae24331b",
-        "sha3_256_hash_of_ciphertext": "3fc676cfc433cccd2d248824c4f51406491cfd99bd05f863cb4200155ac471c0",
-        "shared_secret": "d990008c5eceab7097524d6755c663ba04599eda80560d59088b21cd73243462"
+        "sha3_256_hash_of_ciphertext": "3bb045c0ebb24dc551fdb039d5148b92c54bb8fcc2d0ff0db51dc458b271ebfb",
+        "shared_secret": "59c094e831e466b4329ecc5f2f627c2bff4d0a1f1f3454f5b052fd1be7d6358e"
     },
     {
         "key_generation_seed": "e1953800acaa85ac02a906c72cb8e8d704e8d27820345f88f71e89c1f549afcc8c64c049c6dfc0f1476cffd520b055756162f7ec94243de6b14ac0b9e5fb366c",
-        "sha3_256_hash_of_public_key": "ae96ec4edc7ee08108fe6c0411a96f48731066ae4be12edeb7fc667039c9c1de",
-        "sha3_256_hash_of_secret_key": "7110c8c6d14a3cf5dba3e5f2ecda1ed1490e62b032f798139b779054da20985b",
+        "sha3_256_hash_of_public_key": "60166dfba8564a4a16e7f53e467431528a6e2d8b62b614d427846b701fbff5f4",
+        "sha3_256_hash_of_secret_key": "fa278d498d445abcaef069f687508dee4f48a676739bf3cc1330216df98930d4",
         "encapsulation_seed": "060ea5d2ed1dd88144a9885e79278590821c22917b55a48920f96b53ebe0e689",
-        "sha3_256_hash_of_ciphertext": "9b33f0f26252a0e1b92f55f4c0f979efd5ef68ef1ed6f23bf23e5eab1c732ba2",
-        "shared_secret": "bd50423b4ef27559d67532abbfad2a3a388e3dbf4d7b6488c2b48f19cee07ad4"
+        "sha3_256_hash_of_ciphertext": "32171c5243f2acfa4801076b43263d7d0db72262638e39f149afdc488026dece",
+        "shared_secret": "b2420d66a17633b60ca68b5c7adcf36ce7b39ea418b39e63bf68288a5af09112"
     },
     {
         "key_generation_seed": "c719f9b2d16399b7326ce4eca30dabefe8fdaab18e9f6df888b0a134ef355570e40771856eb77e4633504899fcb86c6a3d433d0b8d60e26f07bd61f1d4ed69bd",
-        "sha3_256_hash_of_public_key": "4e23909b028699d6677eabe6bac4bc4e8437acbc52b0b17f1df5760c0455c2b5",
-        "sha3_256_hash_of_secret_key": "63ace19297953d106cbc1df1a25143a15772197c05aefb070825ef568eafcf23",
+        "sha3_256_hash_of_public_key": "a96998e3f52b93dc875dbbd503bc67beeee7f1e46083868f96edb9ec3601dad0",
+        "sha3_256_hash_of_secret_key": "963ad136496def586d9fedfa3897bfa4a59ef153bd7aa0578dd6fa773d1b141c",
         "encapsulation_seed": "10ef9426f8c4a13b52325c5bb4ead4596ecf2c6b5bd2d37d8350e90d4164fdd9",
-        "sha3_256_hash_of_ciphertext": "7747110bc34f1a35fea13d10fffb950a85bd6d9247c89b2071afce7544b312bf",
-        "shared_secret": "38e3d97b0547e648b2b722c4844f59ed43dcc4b40fa7dcfe6184c2fe62ab3530"
+        "sha3_256_hash_of_ciphertext": "7957941bc3aca55fa93fbe56e95e52e6ab9a47011849892a933d0db1d6e2874f",
+        "shared_secret": "a108c039dd241e403afae065b37d609b13afe12380471f5b398f5a66ccc78f66"
     },
     {
         "key_generation_seed": "e9acbb774be970206c3a738e243b420805a509fa59fa902044be2f0d013650d2ded5edaec5de3bf5b4d7c2f2e18e87f499c1968993eff196753db8045e2c8ba8",
-        "sha3_256_hash_of_public_key": "513906f5bef81445bd210d63fc4c9b9ef0b61c17b0cd5b229a45908fcbaddcec",
-        "sha3_256_hash_of_secret_key": "11added546dd697edc51e8ed16ca3ccc9da9629c4ce0c8404d04de1aa8b8114c",
+        "sha3_256_hash_of_public_key": "087881ddff4095efebaea305138bf83f0e3071f5494c3ea5bec8f775128ce60a",
+        "sha3_256_hash_of_secret_key": "4c80c1ce1f92782a34fc9f5d6c87e345abaf8a04e09106b5b6add9661db03246",
         "encapsulation_seed": "a4bd30a64cbf29a4e290fa1cc1dfb99e68348713041e4409a1af23c5d80c15c4",
-        "sha3_256_hash_of_ciphertext": "569f8e9da2051bde67bd3ff8e81e3b4e749b198586e2ec8d0544e6a8793aa782",
-        "shared_secret": "cca4f1d172212f8c23eb5da77144640d821d2671f66f0b3015d0b46e274e193c"
+        "sha3_256_hash_of_ciphertext": "5147c831bab955521767f2e664b5670b04e7771b253e70f3190673fd7fc61fa3",
+        "shared_secret": "f37800ef70ba18d14be289229810194a8f3f6f8c3a8e71d85afc29d133663964"
     },
     {
         "key_generation_seed": "c1b3cbffad4b306f9af0cdd3028876486dbe858875c9b6497fe20172a986c82b1c96249919cedc2369d8d739ab125e0d2ccb82dfebcd90240a545cdfe07511f2",
-        "sha3_256_hash_of_public_key": "4f8b3e9ae47d3b5b95c080d4f18440c24b0691c19f06f5547554697bdfe97b01",
-        "sha3_256_hash_of_secret_key": "cf4be19205cf0c2bd0eb0c1e7aabd40e265792bfc302bb0f28716c406585ca37",
+        "sha3_256_hash_of_public_key": "367bf894b2bffe5be757d54623b972fdb9093b0f54568b4f6f2e688f86ab2eab",
+        "sha3_256_hash_of_secret_key": "a5e2e3699996d1bbafc7cd22c8208d1290d5f102546c8d29049e467417c33485",
         "encapsulation_seed": "f4b66a7d3b65b896dfe100b2cad24b175a1168cfd2ae11fd704b835f6bcd311a",
-        "sha3_256_hash_of_ciphertext": "ce6e0b8523fc48a54f1b10be23b1e990a390e4e823d4483681ffbd2ad09f4977",
-        "shared_secret": "dd7816a8a015b2001258e665dc0e576ae19b10dba9704be9c484e4c8ba645522"
+        "sha3_256_hash_of_ciphertext": "d8298025f586761a680a382d3fdb421ad479864fd433ae2a3f3521d697dfb0c9",
+        "shared_secret": "cfab6ccf400c22dd43b0094cf8161fb453e5291fefb299719ac2e7000325d1b8"
     },
     {
         "key_generation_seed": "ff7495b8575b5a98e4fd21fb4c3e58cbb60f14bef21aa74cf8802e3153f14807bdc370460375a778d1a31d01c42b66367ed8d9e8f84551002f552f0e52102b5d",
-        "sha3_256_hash_of_public_key": "c1b4fdc4929c2c7e4501ba7a9feb0be571e27c43fa96f9a7f934636ed9a86110",
-        "sha3_256_hash_of_secret_key": "5b475ff0aeb273c017d1e7d7cd380e41d50e634840e443a762608c09282f3007",
+        "sha3_256_hash_of_public_key": "fcda92e6bdb853f01617133d65b67c0d6cc83710c053a18263aa91dbdbef7b85",
+        "sha3_256_hash_of_secret_key": "a74fafd6744f0b25c1a5bac19526cbf0c233a56259a9dceecc8289762f188464",
         "encapsulation_seed": "1d7b03d3c5eefb8ae5799dc569aa668f1bcb8c86607b089d3530cf61d6380147",
-        "sha3_256_hash_of_ciphertext": "556aebca384b3876ec2c00d446239855602625800bd1ecf1b7eb3411d101d442",
-        "shared_secret": "e911f73a4c23637a2708739bd5ef842ccc57d32993f30d6ee1f88acf5093ebcc"
+        "sha3_256_hash_of_ciphertext": "156bd98a0b0cf3609f8b746a77e2e5ccb3f91b3c7a99490c4bcb79703717e946",
+        "shared_secret": "abdf30bf8e4ed92c05241b6f00895dc0d56759ac668245a88c7ffa59cdb48fdb"
     },
     {
         "key_generation_seed": "bdc3fba1c32751139fc45bacffb3ea97f26573d804a5f27a459293d95190ed8efd5a08f656a6eb8cd20679930a31caa6a6331c4b133a6838c223ef9f769f6246",
-        "sha3_256_hash_of_public_key": "df4f164c11041dbe981d8ff2008757b7e694f564a298b92cd182129ade5e72bc",
-        "sha3_256_hash_of_secret_key": "1f836ed803ea8abe63224c016dc15468719599e06564c11e9f641eeb3634350c",
+        "sha3_256_hash_of_public_key": "2b8799c6382723886f5b8371ee58a35fbb48022d9c107ba6fb6dc5fdbd4ff573",
+        "sha3_256_hash_of_secret_key": "80a7112e497073a71d6dd3b94d017ae9fc091495ef66895f74016f80dbce65aa",
         "encapsulation_seed": "554f3385b382f4a46314de37ee3885addfc5332bd4038785094e0a832e9e8c2c",
-        "sha3_256_hash_of_ciphertext": "5dec68120c8c2182ac2b2995eac56b91df2ee9c9bce8e801853e2cee14c0d8a2",
-        "shared_secret": "572994fb967815fe8bf36cf41560dc69aeba8e32b13e1d25128585dbb0e71068"
+        "sha3_256_hash_of_ciphertext": "1f247b6e0f744630d3e273532f0cfda8dd904327558fbce528f9a0b3c02981aa",
+        "shared_secret": "9ac4dcbe2ce4c1b26961fd95fbdc719296829c8107260b8a21cf3dedb292eb7c"
     },
     {
         "key_generation_seed": "447f6076a627bbc5ad7773fbfeb14b4ba9ac43a0f8b99fb6dcd5e452aa3c47ec20a7237801f470fcc2bd9fd7bea8322859b850f7882d362947432913dd068c01",
-        "sha3_256_hash_of_public_key": "ed722667caf175df48a3a346ec7cb1bcc37d67d3137ff7b7c70a07f202893a33",
-        "sha3_256_hash_of_secret_key": "272df80631771996565e673a4dd92318e87e625097f74fae14c688a24b558216",
+        "sha3_256_hash_of_public_key": "9590cca5e4b82099b66c7175c5f858851eaca730fd0c55edf9ae451e07bd366d",
+        "sha3_256_hash_of_secret_key": "7513342267898e9672039730d70ee926361527f5e705fc8b0c94326720f5e380",
         "encapsulation_seed": "38bf0033b779edf5367d9ebc01c988af90904c560970815837380650e4749eea",
-        "sha3_256_hash_of_ciphertext": "4214ca50c6c732d34dab0b460d7cd9e0ae97346fa50a67386fc35ca0ac8223fe",
-        "shared_secret": "92c63dee4666bfb34fe3095f65cd458654df578f6eac0ec75f5235e5da6a926a"
+        "sha3_256_hash_of_ciphertext": "2d17aaa231a31829d5dfeeca3ab60c761ab95204e63471448deffef21a3140c7",
+        "shared_secret": "d1e8a626ea8c5fa1b89ae3c05f745517eae6a8710dc1173083209de32cc685b4"
     },
     {
         "key_generation_seed": "2d5df64d62cb07fe630310bb801c658dbf3d97993e68626745de39d37fbfc2b27b534537addaba4ecf14f02ab317d36cb9f0f50222ced7cf029dff8a0d3d2fd9",
-        "sha3_256_hash_of_public_key": "0c4dc82d723965476a518ea0915c1554bcc61c814c80ff120c37e7e8ed6d5c40",
-        "sha3_256_hash_of_secret_key": "d9e7fabffb14d620ccf618a1e25375d4cf58875c38ecc73587cd09b17621ade4",
+        "sha3_256_hash_of_public_key": "9b3999082be47443720bf6b573a95207d1eee1b3be613a1985b3d6f48dc64878",
+        "sha3_256_hash_of_secret_key": "28d72f885c3273e7ec5b3da2a7d91192b132785a6255456c1ab72bcb0af52847",
         "encapsulation_seed": "048ea516d0ebbd9f709b47eaac66f344c571cf50f0d01c9466aa061a50b66a24",
-        "sha3_256_hash_of_ciphertext": "651834fb53362a4c4af0b141885056f9db913c4be968c1aed3d7d3f5bd1048ec",
-        "shared_secret": "0e2179fc3d310aca496244699b05da9b7bbb7891ed41b675e5dd48355a586360"
+        "sha3_256_hash_of_ciphertext": "b1fdeaf6ba53b2ca81b68ff49a4f2e702b8748a517c607c91586a14091cb9e30",
+        "shared_secret": "a74e04b62bad015f2346f2d44395cf5e7c380cb5228c55e843ba8189ac2fd7be"
     },
     {
         "key_generation_seed": "25056d1b8113bb362dd979d98643d7a7ac9c4f95994c0ba060609b6d07002ff3f48a9254dd40b117941fa35a66bb50296327b725525deef70e128ca8045ec451",
-        "sha3_256_hash_of_public_key": "c934c11e2eaa7c3c4e764863e436ff12fc9f517c79df6344ab98611f57fe7296",
-        "sha3_256_hash_of_secret_key": "4f502a9abdfece85347362ac4c7e2beedb137e29a4b638c9bfd710de432b5e5a",
+        "sha3_256_hash_of_public_key": "4e145d000a02fc34e2891d2047f787ad49b9adede43fc52fba6803172487e191",
+        "sha3_256_hash_of_secret_key": "8d78809d1756fa21b22e6db736cb753a61532c70e7bcacf09955295cc8ad5a7c",
         "encapsulation_seed": "686c921c9db1263e78ae753b1c9c2e7936b8229dca48c0942c56c6bca4f10917",
-        "sha3_256_hash_of_ciphertext": "06786544f2ea24bcbb677092f4602d59f9cc9d2d8211614dbb5b87edc6edc46f",
-        "shared_secret": "573a8fd5e5935badcf974c50cc36e191f0ae2c1458fb00d4117e675424d4e37d"
+        "sha3_256_hash_of_ciphertext": "5d33db9d704951852874c1d3054ff941eb9232fd5ae2b2891294b441c11b783f",
+        "shared_secret": "8feaaacfb4827cfb8e45729780e72705d15cad0e7754231fc4c47260a740b051"
     },
     {
         "key_generation_seed": "e4d34e12982aeeb1d62fd488d9b9e28557ed3429292239fb4f76fa9098009acae6c45c7fc62329b13c8d29844405db8ff6860de474bf727ecd19e54e6e1a141b",
-        "sha3_256_hash_of_public_key": "5b07c8359e6ec4989c34b31293f4df965b5d95802afa5836beabb001d5cd4dae",
-        "sha3_256_hash_of_secret_key": "73973aaa43538874f8b16d44faefbd26dee5389a05fad2d4f966662ea9eb1df3",
+        "sha3_256_hash_of_public_key": "706781da8dd5f11267492109ea905a77270a67315eea1f5c223aa9378bfb8116",
+        "sha3_256_hash_of_secret_key": "02f2395283c2d9937477dadfeaecea41a59efe8cadb002f812fb248a527f25d1",
         "encapsulation_seed": "2387772e50059cabda53cb93ba24b19ae529496c03b36584169451525c4a0e7e",
-        "sha3_256_hash_of_ciphertext": "2d6085e31726d74e2ce2a28088ef3247b68b39d0d51c225df2521ba327bb3154",
-        "shared_secret": "c8d5e0dd64b4f3c6450fd24ed2918887d3ea2806479d3fcd5a19894f4fe401ea"
+        "sha3_256_hash_of_ciphertext": "d6e2df0b49a1d2fc1c71e6e03a6ad9c8e1fb4b8e4bdeeac89f442e9b4a010b89",
+        "shared_secret": "7837d532d751ebb2d4e8debc55c324f951e2128559c9f7db17fdea6e39bda6eb"
     },
     {
         "key_generation_seed": "cd6a99396eb3539ca663a51e42063a3a262cc1c5a5fce1566f0597b52ad9fa325a3407f591791a5db4578b5972093a95bec3b8e70c1d542c9b5c9789729f8922",
-        "sha3_256_hash_of_public_key": "37f1d7e636b4ab366dd5725957b9e5d2498e4ee1929f2213f9d05c882d96a106",
-        "sha3_256_hash_of_secret_key": "1b150644ef3edff5c406fc9a85e16fbc87cfcf8a6ac726284483947cc2fffd63",
+        "sha3_256_hash_of_public_key": "243a93c5dc84bb3afe84c380645fad6886c5614a8735a6f718acc565905e3532",
+        "sha3_256_hash_of_secret_key": "552d49d03205b7fbbefca77e9e30a6c0f89a51aaac9893789b3d76d1f6830941",
         "encapsulation_seed": "155c29c5f0378df0cd0e847a80a07143cf7522fcd880c9229eb9feb1ce340cd2",
-        "sha3_256_hash_of_ciphertext": "37d80e33f5bde211a9a3f634f8505a816e46195616c34a51d62b031822201337",
-        "shared_secret": "f0691ad2fe875e3f0993f25452c70f0c40891b998deb6a7f7aa3c0bacc59bfce"
+        "sha3_256_hash_of_ciphertext": "f603f82a97b445df63577e653e487e40df91d9a46d5557e3b837ac509b558670",
+        "shared_secret": "5354347e316b6122fc62202a775657e779e82f6b292a11ffa2b9bb7dacc4f1f6"
     },
     {
         "key_generation_seed": "6c8c53ed6f65e6b2e324b84364e10de42d1c26a106d4d1c99eee79c78586fb55b9402bf02481ce4b27a52e87feb92c4399c7f2988d40e942e7496ad15ad2aa88",
-        "sha3_256_hash_of_public_key": "a5383897314d60ae0ab1a8b50d6f5de454a2eb8b0502d57001e6e19223a82ef2",
-        "sha3_256_hash_of_secret_key": "38e8404120bbd346e0483ff7eeb758bd655ed94f6c02e427468f0c5fdbd957f5",
+        "sha3_256_hash_of_public_key": "ec53d050d5a81c049eab8f93e7768c39323dd805f12c6553c204d58cbc47d8e8",
+        "sha3_256_hash_of_secret_key": "7ee3dc7d16a5f35b1e7b95aa5b366d610f1ec652479b05b32a817cd38e917b6d",
         "encapsulation_seed": "a9cb9a61a3324b1ea5afe693b32784e2871096b2ca14a11acc9577c52359a241",
-        "sha3_256_hash_of_ciphertext": "3e819dc1fbc939e49bf5935fc8ac8c36d8c16da057091442df74a76fc3125fa0",
-        "shared_secret": "bec215c6bb33e83574319c839db1ca6793931d35a7239bf4ad3c4a493fe5c5ea"
+        "sha3_256_hash_of_ciphertext": "df6e515f367db5d67a94e591da79d2174eb697bb98cce0cf2d3b4730d1432da7",
+        "shared_secret": "634c1076627a11c878cb3a75e7026f50656e2a90614b6d76985998f51791ec27"
     },
     {
         "key_generation_seed": "2107204cd995f1df14314d5381f8c5440f09a347502e161cffc0a2ec3dcfbc7324c3da70fe850e80aa818301d60c70f3038153866dcd5d179e22db59b8991bb4",
-        "sha3_256_hash_of_public_key": "500dd7b94b28b5b650d90962962bb9a3ae96e70d35723217f3f178cbe5659051",
-        "sha3_256_hash_of_secret_key": "5930b10cb88d66ad1ec117d2b134f921fe4ec980ed9c351951d47d33510585bf",
+        "sha3_256_hash_of_public_key": "fbeea6f8085943992ed8b051cf758a8b8166c1a1e5f818f0deb30fa1fa061904",
+        "sha3_256_hash_of_secret_key": "aff138640fd116a363a7872e6b9555546b8292cab1d873d09fe46584f95e1415",
         "encapsulation_seed": "e99fbae8a024ebbbdcef32ce213f6aa942e3eca925e5da4c09975d773b33a175",
-        "sha3_256_hash_of_ciphertext": "cb20903e6ba3a41f594cd09056c0a7af4dea86039677761e88dd6818db0d0e88",
-        "shared_secret": "18a505a0543800a93ab6e2fc1d866e22337fc8387d32541008ff82a73ce7dd31"
+        "sha3_256_hash_of_ciphertext": "4880cc1686aa2f0c4a867fd6172a668dc2ef70c08be6d7e4686294d43eb8059c",
+        "shared_secret": "39be6e85e7c17bd9e17a0ecdeb3e60f75cd5fe7913e7556ccf166d24049b6abe"
     },
     {
         "key_generation_seed": "63a925685a8ac5bbd918faa33ac397d1ffbcf99135d9da7c3d6ff7aa4c50af3d3afdb8a246a56ee71465591831c371f2eb87467b0559dedd776ba063ee6d2f93",
-        "sha3_256_hash_of_public_key": "3c4467b507971523509bf97d2bdd733ad9eb94f312e4226d036e8fe827a20533",
-        "sha3_256_hash_of_secret_key": "76e696d5d7ebb4e2035507601f66f38d74db35d3c76b3622678a2c65ec7b0f69",
+        "sha3_256_hash_of_public_key": "aaa698c34e1b3b6ef69049a883160c66533c8a65249aa35006f003d4eb4350a4",
+        "sha3_256_hash_of_secret_key": "7b84cccab002a139339dcbc077ef8b1b5c7429fb30be5674953060b2f98ae126",
         "encapsulation_seed": "67a216f37d67f5e74f782f1badbce1cc8c80a6130aec305b421899a4faa0a6c3",
-        "sha3_256_hash_of_ciphertext": "df6a835ca5253cb64d669990a60fe03b44a4a2229beade86a2f3f2381d33f09b",
-        "shared_secret": "f155d993eadba79e6c2376daeb7f935d39286b10615ab42c5803d43f15960a66"
+        "sha3_256_hash_of_ciphertext": "5c723e6dd1397474a4b1b6c00a20fc06622542abb6b0e2636c33c7a5628fc1a6",
+        "shared_secret": "468a5377e8dfb3c0f0b79590876887667c470a1855c55d47ada807cee4fbb8d8"
     },
     {
         "key_generation_seed": "6a1aee5e708c1b47f02bdacce4f56c860f74fc7cfec1ef3b58285b1c8ad7fec2230e05b7114ff0395cc6634db1eae8258072d09c09f291e92d6620b177dc50d7",
-        "sha3_256_hash_of_public_key": "69ffbf2275f12c29cbb69f90a8c881721ce39b49dbba550ab93a2c4c94bfc669",
-        "sha3_256_hash_of_secret_key": "76d6db646c55687ff9eeb3f359093a7105a7ef711bd60a4ef7f1a1bbd70ea24a",
+        "sha3_256_hash_of_public_key": "5499cb370a74dbc96de89daa52e6af0482648e3995fce28f7b7c0daca7b78f1a",
+        "sha3_256_hash_of_secret_key": "2eae6d707dd0248dfc530fa6a198a45fbf4e5f885eee6d5448f2775acf090f98",
         "encapsulation_seed": "52b19fea232c9154a3e431e9d69cda40013cf2d485c3cd027ad24e645420420b",
-        "sha3_256_hash_of_ciphertext": "677fe79386a26743faa6fa1c79576e3f898da432af70e1f45a73b582b4c976b9",
-        "shared_secret": "4cc8728603d51b14fca46ebaf01e6b6347ee9c71d192591ee857c206d131886d"
+        "sha3_256_hash_of_ciphertext": "ed38a7b142a04bdbe45124630ff7f1f512873379dabc54a83b401b0240747ef3",
+        "shared_secret": "fc48d9dd239e6fea212e83f63e1dec4bb5fdad92a33d06ec3b5dd53bddcb1d83"
     },
     {
         "key_generation_seed": "6396b328b100e4c7f4bcae69875edea1a1982421558c608c13c592bf7b5d0fef1100ced48add211a5c937b8d6079d8e271af3f949edc61f70e60453aef20dea9",
-        "sha3_256_hash_of_public_key": "41bbd3f5c241a6d65b510dee6662e2a8f35757b0403dcd375e7a15991a7873c2",
-        "sha3_256_hash_of_secret_key": "256673d5b2a0225515bee64da0105c167d031405098819b6992d01c3cc711bdd",
+        "sha3_256_hash_of_public_key": "cfb4f6a03bb7707d37c80474f92c12748b37f448186584df115ee97c195d45a8",
+        "sha3_256_hash_of_secret_key": "5975c8b0cf8a28eee5d81a37b5a215cb500695054dfbf81ed358523ea47f05d5",
         "encapsulation_seed": "64440adb05db3308b189bf999f9ee16e8ee3a6ccbe11eebf0d3ae4b172da7d2f",
-        "sha3_256_hash_of_ciphertext": "9306db283ad2a844ad6d266ff6c7bd8e9b4ffddef78d656c9bd06d52cdc52c74",
-        "shared_secret": "fe5dab115160a7200005216d7e6e7dd8527f9c2eec34f60c6710ee21f7f91730"
+        "sha3_256_hash_of_ciphertext": "216f208bc652bccc0b12ae438a38797293deb7167d8d1f332e6f10c40cc33133",
+        "shared_secret": "7f0ffa83f99901f27f121557ca2da03bcdee03d808e0e4421de3a07c86764d88"
     },
     {
         "key_generation_seed": "a453bcacdd2b0d4646009e5ed451c3c45f08fb827ef733db3c517a9dc1af93e67a3cc8aa3239d4c52ce4c95afdeff6efbfacac10d294edc0e7cf4535059bfdba",
-        "sha3_256_hash_of_public_key": "290261ff6a1d2fabc75feab002d16cdc44bdbdd0967c728ebef0e9814c60b5e5",
-        "sha3_256_hash_of_secret_key": "beb5d2dc34b1dba8c87e4ca2659ed8ebec2d93be0e2d78285efeb9fd998f5805",
+        "sha3_256_hash_of_public_key": "20179b32e6faf885f946898d545245757425d719681b0b2ba24d49340f931cf8",
+        "sha3_256_hash_of_secret_key": "d687a63fd70c35f193671ff82a50ef837be2b2eda67a0e9b8744c7eabc6de7c7",
         "encapsulation_seed": "c8bb46b3a7344ad170c2052fb042b5a3b62e0590562ee82577b1081f6f114d16",
-        "sha3_256_hash_of_ciphertext": "7f94b2d97c0821593745e9b5301a66a81b75e71b15c8c21558c8b8b077d7af5b",
-        "shared_secret": "ba33ea19873105ed9690d40426b2cd24073c822eb86120a4fe8617b5201f9494"
+        "sha3_256_hash_of_ciphertext": "3e1e5f9367549479c085b900389919c611a7bebcf979b8c43ee7d7d72d225ff0",
+        "shared_secret": "6674a584a85e1ef11565916b1779603295226e1eb7ce22a3e06ebf19dd468a51"
     },
     {
         "key_generation_seed": "47ca2b77c5b717f423222c2730ca5cb9c856bc951d01b2b2c80bd76ccb5539b78f1481d7cab000e33fa07de8dc9627a85e76fabb4428a3376e66300cf12a0787",
-        "sha3_256_hash_of_public_key": "7ffefda144195d79e581c91cdf0247f4346e811f890f54f25226b4ab835871a4",
-        "sha3_256_hash_of_secret_key": "7b85555898660cb43a060e367d9a97112b48e3b8f99d437161cf6ba44b5c6922",
+        "sha3_256_hash_of_public_key": "fd648a3b658ce84640d17ad1564189385fe895b25cd30d122a90decaa0583b90",
+        "sha3_256_hash_of_secret_key": "c5562a802a836830118382c2898e583468c545dd1274751f5544cd4ce4c94039",
         "encapsulation_seed": "2e2b70609f3fe029a14d09d5d659871ac776ce2797a0355f16e2eb68f5613fd1",
-        "sha3_256_hash_of_ciphertext": "310c7f22a80995c6e375122f1395604faf5f72fb9fd6819597aba8f370327647",
-        "shared_secret": "2baf80269b225c66a8c35c6f835f15bd6949ae2814cd8c405a0aed313a637701"
+        "sha3_256_hash_of_ciphertext": "89612e82e316ce94bdadac797c4c1a2fcad9b8c3f4944b68d41c06a3572b1f03",
+        "shared_secret": "6843c8212348defcf5017ec29c620642d127ebc33fb539c4d07cca88e5a3bd9a"
     },
     {
         "key_generation_seed": "aaf6eb40e596a5e3e8218871e708b089240dcbe7fd3641f0e5e41e071ce49107e2f8d320ac3cb0c52efdc753282f092bc39baf4a18783a48ea031a191865eb78",
-        "sha3_256_hash_of_public_key": "13dd780ec5347c512cfabf4c2e6a44cb2b17993c7c746f93c1400a5db9f12511",
-        "sha3_256_hash_of_secret_key": "7732b2a074d1c0aa93106ca84711edcb7b8a369f3873cf89fbcebf0d32176f1c",
+        "sha3_256_hash_of_public_key": "b08a2ea8e2ff6fa677e3c2ba136c16dffd11094ad7f4ed4c5e7c11e3898a284e",
+        "sha3_256_hash_of_secret_key": "d5f6f0b2c1f19f49531afce415d0c5f2e72d599a84776637a5da8a5865a0bc26",
         "encapsulation_seed": "4725dd8fb314bfd8ee23731c2341dbe114606d9abe6434c471b5573e7df193bb",
-        "sha3_256_hash_of_ciphertext": "b0003e684b9ce6f284d9a746cb806442e5443430bed95f2e8ad7ee824fb3db2e",
-        "shared_secret": "07318e8edf0ca8f30f49fa906ec814e40ec52922f2c0ace243386ef2bf650000"
+        "sha3_256_hash_of_ciphertext": "66047d58d1d1df4d6f437392d9dd670f8792f5c153a2ca1abaad3689510ea9c4",
+        "shared_secret": "f09ab02775dcc52cbdb2a5159181ab535d1ed680df8fe320856b547166c2abf0"
     },
     {
         "key_generation_seed": "6500f32c93415cfdbc0bd31d78d5be95cb9060c8cfa2013955b56f8b6868b322393308641a9a4647f230201e1389624a296b55192a9819fcb19ab77c25f95445",
-        "sha3_256_hash_of_public_key": "d5acaf411ccb64500879102d9cdf6d9fcad673d874a4153383806fe174b2fc1e",
-        "sha3_256_hash_of_secret_key": "e5c3fdb9d8e92c42ad48684f0fe13aece244d116f8a6d09a764aaa090b3375f2",
+        "sha3_256_hash_of_public_key": "c27bb236759e3a2af7553c03894124a6bdd3e3c87def1f1bf3e01fac4709aa9b",
+        "sha3_256_hash_of_secret_key": "6aaae5e7b8d392e77bf723fe8fe16b30ce42fbe9d3c806ee3a8ee5f801083f82",
         "encapsulation_seed": "818d3bb8ebfb32bf464775f7139bac0a5bddce80ec5798595992f9403002cd5d",
-        "sha3_256_hash_of_ciphertext": "9ada65c57d8292e9a999ac102ef855d5da932a54f80f3d976fe1ca834eee5964",
-        "shared_secret": "38b5d71f3a64feb2cd41d6b7a4ac5440707770dc4c472c3ed141165fb7e8818f"
+        "sha3_256_hash_of_ciphertext": "e84eaa23591588e358ed2ca695c3bb3068d33c878456b1d4f6776736fbdfdb37",
+        "shared_secret": "69c261cbedaf5dd46d3305a59efc0de94b0f31d8f993870b40bf5de2a99abffe"
     },
     {
         "key_generation_seed": "7643cef2d62cc5aaeecf754653ea62294cd2208e5bf3ddeea209e3dc45373d49eac9d531a532770837a854b4f5531f6e0c8d6c10183b30d3435498c2dd142951",
-        "sha3_256_hash_of_public_key": "152641a683dd690d4ac3edf0261200cd9244ae7dab962eca2f3d22a554d0802e",
-        "sha3_256_hash_of_secret_key": "7afdb84b3806783db52ef1f5f0ff89ccdb051704cfd19eec3e2f0830c3b27550",
+        "sha3_256_hash_of_public_key": "1330f4828e22a13ca5031217a3d8e6f8ed708a7026e1a96d8ebc4fd2f54b5051",
+        "sha3_256_hash_of_secret_key": "144f2d8c4a87beb0d92facc2b8f799e176a493dd7d1bb93f1a442bb9b51709e9",
         "encapsulation_seed": "c92aa5fb91c980d9cade9ce99d4c75b2ffa7d6a6ff9bd59def1aa701f2a0992b",
-        "sha3_256_hash_of_ciphertext": "499ffb9a28fcc692e7d61df4696b538f1bbb205ff82d604512220a9e19d87254",
-        "shared_secret": "368a5e417f4fc728f5080e8fe206ca7558909f6537f1012a58b2d9d45b7c6a8e"
+        "sha3_256_hash_of_ciphertext": "765bb37de257e28d5930dfc8383758c8f81ecb71c01876babb15744e15cd93c7",
+        "shared_secret": "d66f47c870254f7eb7ac771dd6e7bafe94d0dfa62240da301a5cd05f2ad7cd4a"
     },
     {
         "key_generation_seed": "f8ee95521060c03bb8dacc79f7eb7db640f545f315613a35d447a09e504cb4e13fc3d8392cb53f36ed647364a04e37278a0e0a45b720f4a75c580c9920eba98d",
-        "sha3_256_hash_of_public_key": "9cc95efe512c84010ccd7118a92522cead44cff28d6e223f76702a47694c8f05",
-        "sha3_256_hash_of_secret_key": "d9a18ebc4b027c9590d0e4eeed88705aaf5d166cc016cf6e0baa07f678f1f0d1",
+        "sha3_256_hash_of_public_key": "2a35c723556eb2782c7cf77ee75f8928f8038ee66db41346741fbd6aa1daf2b4",
+        "sha3_256_hash_of_secret_key": "343704d0299cceebdf5a863d941990ee6d7db9fc55065a78a1e9971ae7460af0",
         "encapsulation_seed": "7e8086a01dc5b3bb9eda25bcc45d27f99874841b97237968495800e007696ac5",
-        "sha3_256_hash_of_ciphertext": "d202a577a7acba1801e03c446279da6dce6f262a6b1bf06d3c15283bf69fca47",
-        "shared_secret": "7d36e561b501a687939aa880285d32cd6d8b66e2e65b2a076d5aa516cb5b2e6c"
+        "sha3_256_hash_of_ciphertext": "167bca50eeecb1d16f81528b307f617529637eabea5c5ade7d138fab600ad6f0",
+        "shared_secret": "166b559e963a2f4c7236e90818442e9d9b2ca49f91d96d54f239b9682d00b5ce"
     },
     {
         "key_generation_seed": "b8bd0493a882e3a49b4e0f6256fb1fea0912562fd9ba26ec3d6c9cc12c8973abd7e4b5d8021c486b9c3114d7cbbeb7cd49eba8a61bc2bcae1f1bef30a1daf76d",
-        "sha3_256_hash_of_public_key": "8b12f00bf09aec2b492cf53686beb31c558d0493cc7b2b9a9dc7265fa9edb685",
-        "sha3_256_hash_of_secret_key": "9979de3ecfacdc04e1229773f36d7b4bdfd731ea0f1fc2f9d56ee1d07e9bb075",
+        "sha3_256_hash_of_public_key": "60d717ee34e223ead8139db400078cb308c3e1bceb046cd9d53f1a2abdf8f924",
+        "sha3_256_hash_of_secret_key": "ca228957fbf5bed26d0dda9acd13ae1e2f5173fad7bdee88bb35d38071dc2600",
         "encapsulation_seed": "bb321ef14d44d8698df879fd52450567657f52a2df8d111185dcd7d4f30a72d4",
-        "sha3_256_hash_of_ciphertext": "53f97fd2a138ceae2b327344c4947cbee6d6563a48d9bc5d8373c4bac5233a5c",
-        "shared_secret": "6be99cc08c8bf10372f7d5c27bc3ecd17ade8afb967aad41a1b33c0ff848a1be"
+        "sha3_256_hash_of_ciphertext": "470189554e2511ad9d7811ff10713a30b691bc45993a66e6d1e46239636be5e1",
+        "shared_secret": "c71845a26ce9635a0a37462bcae6dee1b2f6901e5986bbaef9660cdd5875243f"
     },
     {
         "key_generation_seed": "c0407e41ddf48d333978b89bcf2db01e4613425b456249e76a6f25b8a2827bf5b2dca81e3f5f748d23c9d356a2209f6b2d60247b2e45c9808de497f64f124643",
-        "sha3_256_hash_of_public_key": "3c98fa4af17fd014a60d11ca5e929e4fa2524f7db289ce0947ad90657990c153",
-        "sha3_256_hash_of_secret_key": "2c370afe3301b0481b50ae72e21cbb1be37d2877cd802a1d40e05d9b4e6be502",
+        "sha3_256_hash_of_public_key": "566debcfc9a4f48f6f60ad57731445a7861bb9c371e4ee4407b35df5a730f36d",
+        "sha3_256_hash_of_secret_key": "ca7e59912a6c0c8de01fa508a82136e1a347de53ed87db3b277d82945abdf549",
         "encapsulation_seed": "210a423dadd899b810f011794b79aa7f860823ac1962370e791287d3a1afa384",
-        "sha3_256_hash_of_ciphertext": "c134910358575ee3e211603b58b3d6085cebcb91f32a355ff437fe87ee812e3e",
-        "shared_secret": "f6fec6f62257d9a7041f119fff60f734c928e945fe131bf70338f273c0614ae9"
+        "sha3_256_hash_of_ciphertext": "6874d348fcdfc527bb8d77f876cd5a2497ba205ed2d861ff7f4775286237bc5b",
+        "shared_secret": "66624ae1204f311caaaa567dedcbf695f48afa8c869b468142d05da1dccb1d66"
     },
     {
         "key_generation_seed": "334382d39164d1989696a2ff77b25a28af8bead9883b5365eb6fcca7c1781cc9aba5068af837be962f439f233593d193ce5e08f7d66efb3389885927b89d2523",
-        "sha3_256_hash_of_public_key": "091210fb4f6fac00a24167d9bd2761e601db0a3734e3c835d1e9c5865b1e379c",
-        "sha3_256_hash_of_secret_key": "fb4bf08e0cd8d2f31969f75b420578f8d6dcd845824e427a6261931f1e1b820f",
+        "sha3_256_hash_of_public_key": "6ac9cb9123b99fcd75201ada0fd5daf1a51f1d069822d795f8e736abb8d1fcd6",
+        "sha3_256_hash_of_secret_key": "6d122dbdc5eda08efb5a403acdff8138b27587fa3ae281d07478c809a78f452f",
         "encapsulation_seed": "bc856afe24213e3d14c3d6f9b89223bbcfb2c890722d770fa3492c1e46d1c302",
-        "sha3_256_hash_of_ciphertext": "6076283588ebdb4630d85b2dc6dce53492e11dc8c9445597ec57042bf1e59634",
-        "shared_secret": "9c56f6d91af6741ac13f241f8c960433c0ed4adcc86130877ecc1dbc10573bc5"
+        "sha3_256_hash_of_ciphertext": "35220b822eb6c71995dd092638acbf4f9e8d21cabe6aa378b09ce3a4bd0c4925",
+        "shared_secret": "187e5b0a3b6f881c8c16f777d015d1e9e80917e49f39e4a5362539b7870bce77"
     },
     {
         "key_generation_seed": "6995143e8eb8a6e93840f76eec844f67d2b5f75b1839a5040337e61f9806764a0f4dff8e56f68440836a072412a30d851ace2c7c6f02d60e7a8420001a63e6c6",
-        "sha3_256_hash_of_public_key": "6c206507b89f46c6e9cd5e78b6cc78fb3677ee609cc090cf3782c876fd5f941b",
-        "sha3_256_hash_of_secret_key": "c9123a2bac61c5fc4304da90862d8cb544a31da2cc8b8126ca16a71278f461e7",
+        "sha3_256_hash_of_public_key": "a7ea65e4729daac39a47c305ad3084af028e66f759e0e22469d0386c10bfc23a",
+        "sha3_256_hash_of_secret_key": "5e9b3520f06377c83ce56c67c0c68ab4a72d01069fb9b2d195224afdff9f1d24",
         "encapsulation_seed": "5fc00f89563e44b24cd67d0ce684effe5731619fd08e7d72e2406eb016afb66b",
-        "sha3_256_hash_of_ciphertext": "e57f70dde96de9e66ce28b7d1a3014cb095a8ad00d80ae7735fd499d57e2e6f8",
-        "shared_secret": "021b7e80dfd1258695b61aac785b0134ed6e9864d3cdf5ebd4b3ffdd9a5bbf06"
+        "sha3_256_hash_of_ciphertext": "d9cb296231393633b605db63d825a241d534881afb40165902a66b7725937b31",
+        "shared_secret": "3c4902f19d2eed8fb7470fabe5171d9f4530208c50521e6df3e8c568f8a24f57"
     },
     {
         "key_generation_seed": "995eff7e0d195c6d0533f3dc194d47e60f9ad14696144cde694d60a95f3e96b4b28f7e7a15a005f92400ce33db073d49b53871594a88fc45e0f94207b5f0f2dc",
-        "sha3_256_hash_of_public_key": "0560200b8d070d1db2cbeedf3cb322ebbab3edb80cf474b4178633c210b2fc74",
-        "sha3_256_hash_of_secret_key": "a2424d9992c7e999a5b18e638a22d65e1e5d5029e5fac62a5091095897b3543c",
+        "sha3_256_hash_of_public_key": "21cee8b1f3fe43508e7bb3b567d02568cc93c39c3cc347e2dae6e0144714d80c",
+        "sha3_256_hash_of_secret_key": "c521b58e1826b153453b5a74824a9600e038adc0dd16b43e937c6198a7e16c81",
         "encapsulation_seed": "ea22a76065db4b565ee1807fbd813b43bde72b0e08407fb867c6a18995025e50",
-        "sha3_256_hash_of_ciphertext": "b5928a28fea0e5b0321439f9df86c6f10fa6203bcdac0cc94da7f7d6764d543d",
-        "shared_secret": "2c876ef4c2bd6464c5e4274d5360e210ff389325c1da4bda5495294d7cd126be"
+        "sha3_256_hash_of_ciphertext": "a3edb1125f6515bbe0d062ec4ef058d02475334aabf759ff3ee5cb8ce757b712",
+        "shared_secret": "2a9393a6e60be8ac438b247fd72c75c1f547dcae83c7ba7e791176523f4e5eb7"
     },
     {
         "key_generation_seed": "3e809ec8dd0fec0d911a4e3fac20f70fbb128c5de94dc7184ca7310ae9157a98d8128601c28b1def8d393a0db283229f7c7383152a814e7cefe8ef9d9768c473",
-        "sha3_256_hash_of_public_key": "3a2484828bce833f9262405b562bcade9ff04877838558409d2b60f1b689d137",
-        "sha3_256_hash_of_secret_key": "610db3251ec079ce8003a49d64ec03dd49d89e82ae9f12d26d50938f4a3992d9",
+        "sha3_256_hash_of_public_key": "ece8e4c1277c5b64512a4b2bb7cc80044f98e2b654e5bf0f4ea520caaae1f2ef",
+        "sha3_256_hash_of_secret_key": "30465faed1905ad5be0144da1c46267e425d1dc7a3ed33849cf36f16b1a6f64b",
         "encapsulation_seed": "e9602b34fe73ad57f4bf6ead99743d645641553a5b9b9bf2e7016629e3e9bd76",
-        "sha3_256_hash_of_ciphertext": "723bebfc2e4e934fc9e35383c7f150d31d832e1516c66f8bb2effb449fefda23",
-        "shared_secret": "909b047e7f0fac27df2787ae406fdd66893a98d98e38a9f5b67bb5c8431a77c4"
+        "sha3_256_hash_of_ciphertext": "675290f48411a936f491022e16c9e0f323008c5fcb58b7e041ec362378f33ba5",
+        "shared_secret": "2d5b67aa0cf3c22c0cb58a11b2cbaeef150878a908f8d627457966ad96f2361a"
     },
     {
         "key_generation_seed": "dbf1c465fff3d9f783bd9ee61a573715e45691147b8904439b5ffaa64f94ff7bb6d75eac6c76ced1b0a025b40a55440712ad8424672e761e9bc400d63812006f",
-        "sha3_256_hash_of_public_key": "bb8615509158b63be5f5e51a0e690f2ad6fd0c56fa886bd85902abd52598bc81",
-        "sha3_256_hash_of_secret_key": "3a4a1360d366376a56362fee0aa22756122e3c40226c770797c0baa82192bfa5",
+        "sha3_256_hash_of_public_key": "ef5c4f316e67ab8b72581b6eb228a8f357b716164e0388d504a7f1aafbb06d48",
+        "sha3_256_hash_of_secret_key": "731dd56855921d95b5dd55cd10c7986c4e2007e5a9911192fc4aca270ee28468",
         "encapsulation_seed": "f72b9080a6c051bbdb9b0abc1949034be0f89a9f73fe277ec4d4740c78d04a83",
-        "sha3_256_hash_of_ciphertext": "47cead6dc9f155f4e61afb233c6a8519f016c6f2bf7b1668ed9333daac257507",
-        "shared_secret": "dff8310ce364ba5686b9d42a17922b8d5e9259a176e38d39687a5269455939f7"
+        "sha3_256_hash_of_ciphertext": "1c4c64198564ef5a3075daa0f2a3f3ced4c1313293d19fa3b5bd90c23bef6716",
+        "shared_secret": "2dd5a204c2cc0e2e99265e4243221a99eb3c56c7bc25c442a1cb85ada77d40c6"
     },
     {
         "key_generation_seed": "1f7cfd2b70863154e8a69d1758532e86c20cfc763d67c758bd10a13b24e759b5273b38bddc18488024ec90e62a4110129a42a16d2a93c45439888e76008604c6",
-        "sha3_256_hash_of_public_key": "5cf14252096e4988d8ecc4ac6d29ff09c55d666865863d03a68db523728910a8",
-        "sha3_256_hash_of_secret_key": "404e6febba9802464a188007c2137fc25a4c437611babc8fa8248a0e42e45357",
+        "sha3_256_hash_of_public_key": "191fc1297d126ae957ec70b3e5cc940f2649f5a8cee53a1feb5e68e08aeadddc",
+        "sha3_256_hash_of_secret_key": "e15911b9719d3f23a0e48c435610e7c90226aba4abfd19fd408c42a077a5005b",
         "encapsulation_seed": "f1e5542190db8ecf4b8d617a04fd3783ad0df78bf8dab749afb57db8321d151b",
-        "sha3_256_hash_of_ciphertext": "84765944d4602d3fca6333b699d98e4c8c9b3bc1570d428398a29cc5a7fb96c7",
-        "shared_secret": "faa9833781a7a41691f236feefa0c743bc141f458ecbba98eac4a51ee1ca001c"
+        "sha3_256_hash_of_ciphertext": "09d343c0bffc8ba7efdeea4c39d7cd9917fb68d2831d5fb006b9da54b3bdc81d",
+        "shared_secret": "f672d4af4d2ac0dc3b671317cacb5334b45c985f53c0d6fb7c3a24e5f88ef643"
     },
     {
         "key_generation_seed": "3a19577908efd37697b8edc7fdaf47d1bd3ad01a1b77faf794bee5b9c3192a6fa3729672816f3eba84c9638a79676eeac0f22c8a48e0c5d50a26ff0844c66b99",
-        "sha3_256_hash_of_public_key": "345118a7b9bcc773f0ec10c3e353eb4365d2bbff3b812df4635d5c8265b5d8c5",
-        "sha3_256_hash_of_secret_key": "2eff0ff04aa2f95d9d2a877d2c3b4a09255fed2413da76e63506d0def33f42ff",
+        "sha3_256_hash_of_public_key": "5fb124740e9315cedb69ebbc969314e2b7469c2d2e2bdf2698af4bd116f0d12d",
+        "sha3_256_hash_of_secret_key": "72e032b42c4fc716e8549e83d1ec23495d8cafe3df52428e416b25fadd72bfb4",
         "encapsulation_seed": "74efa414ae171bf60b6f884cb7e5ce12028f49365daccfa23e845d551711660b",
-        "sha3_256_hash_of_ciphertext": "602b3893213ac6168e24c7c20d22a9c9126a9f70b918df134860f394795836a6",
-        "shared_secret": "0f47139a8b007c4ba77c91ee885435dfcd38d38c0aa4f57fc147f08b4751aa44"
+        "sha3_256_hash_of_ciphertext": "7b31918e3e6e1fcc9902554c431841cdbc3567a4244e83551e2c53fb34c47bba",
+        "shared_secret": "25c89884be152d8641686c8334cd51a4477be723cc9c0cdd6092531dcdfa76a3"
     },
     {
         "key_generation_seed": "ae0f65e29f38804a6759f70f4d01e2aaff7fe1c91ebc4f892dd0de3ab2e68ea5e03ff73e02a217659f53d8c47556bf3d8c94040f630d63605e2d0f923579370c",
-        "sha3_256_hash_of_public_key": "772f50f7047714627bf76bc098e0b919145fcd8df6922ebac383e5c556738390",
-        "sha3_256_hash_of_secret_key": "c48cd8eced0093133d3d083baae0f69ebc3e239c373a41db9557c1a46a40d480",
+        "sha3_256_hash_of_public_key": "c5b86efedfe663032fd6ec053e7ae81ee85ae4b3f808156cd357c2b36db2f7fa",
+        "sha3_256_hash_of_secret_key": "37bdba44305f6131a06f3a0b6f3c28efd3214621918780e29c224226fbb44eb3",
         "encapsulation_seed": "0b4c3cffb2ba4380ead13dc0d8acad2356b448a810da1df29f264c44aab6d24f",
-        "sha3_256_hash_of_ciphertext": "84f212f6cac0f0e7a6a27630c0c33f98063bd57243b26fa086d6a37161d75f81",
-        "shared_secret": "182d34d0e83216d26a9d13301fe75a3aeb15ab145433965996255120cc9a5f86"
+        "sha3_256_hash_of_ciphertext": "4d24e8af5814687cf4da155fca19594e382d80fa7f3d8ae1c68884aef2f5e74b",
+        "shared_secret": "bdd73d5ebb59092071fd710a25275c1dc819f549b5cc34b6f8353d13be70189e"
     },
     {
         "key_generation_seed": "6084a235f79dd093ef6d185b54e69df33dacee73a9bf2f379004421a10e3a79d9f684fb055ece19459eb464e91e126a7a6e3ed11ccee0046da234d964c985110",
-        "sha3_256_hash_of_public_key": "a9f015f625356a6bacbb5e565c70184940891589309a571b7166c2ee713b8fbb",
-        "sha3_256_hash_of_secret_key": "924859759e33e4100a02afca0ad0f0e631eeef3b4a70444267e921b0b6eb334d",
+        "sha3_256_hash_of_public_key": "5109d06641e916a660b3e7f849f08b9dcc32c47e4a7df2d5d4a374d3e5718a45",
+        "sha3_256_hash_of_secret_key": "4bf7f9ff35fa2e2253bffea929f17005279c0719fa8febc1df255c6f678a84a0",
         "encapsulation_seed": "1c82471dcdfca3a6942061ab4f3d5bf0d197321437c706d9cccccce449447002",
-        "sha3_256_hash_of_ciphertext": "935ed1ee90431bb81d67fa4c620c973f7354aa5dab63b51686501882e65a3961",
-        "shared_secret": "62a14f68d726235fc16e0ac57ad4ae0eb3fc029abb18567a4ee574b44924693b"
+        "sha3_256_hash_of_ciphertext": "1a1638dced3d08fd9808c56e8d21dee537dc59441f6f338b5365537ae72a723a",
+        "shared_secret": "cbd7e4a223241e16d0527cb926ff8a4c945f11314f238b121a387f9aae140632"
     },
     {
         "key_generation_seed": "acd1c0217fad5caa4235544dd9de153ab1880ccf4c76f16f236fae4e4bfda04cf03a8abb0a5010f400ae5722a75bdf5a2f6d5b546b34d73857cb1bfc7e587aa7",
-        "sha3_256_hash_of_public_key": "655d6f749b0a013bec99e017f5e13bff76680a2f9386f2ac6938d7950d5fa1f9",
-        "sha3_256_hash_of_secret_key": "0511490e76eaba3b276ebadd300c394490589dec54468855977e96a33025e06f",
+        "sha3_256_hash_of_public_key": "1c02b230ed109318ca7c1470f5a0ab154b74ee3990ff20ca8ccb835adfda4867",
+        "sha3_256_hash_of_secret_key": "359e9f6908694d4bd14fb482783e801e14889d6cd7a98a1c2410ee63712f7a6a",
         "encapsulation_seed": "46fe60a18124125ab93e0c578f1c02f1bd1301595013001c7f3c2fa56cde294e",
-        "sha3_256_hash_of_ciphertext": "c28eea97d0767b408e58bbadfdff091ba468c26b585f22bde6f3eeb1fc7bb631",
-        "shared_secret": "4ceda11055991ce1e5d910a240981e39a6a903b20ea6ae6a21d9d56d0935efa8"
+        "sha3_256_hash_of_ciphertext": "085979adc5572c076d146124efc552305b183abbae0bb2a0ed48e9c61e0d4e94",
+        "shared_secret": "7849697d9e1c731b82ee49f017fd67d6bcb906408a9b09213b075f6ecb658387"
     },
     {
         "key_generation_seed": "241191401a63afa750f05662e354dddbc683c776ce3222beb83e3cf913d7ed7ca59b3bd23b49a95bc1fad20070fec930b6060bd827d742b077092e422268e15d",
-        "sha3_256_hash_of_public_key": "1c3c2aed0ff6944819c93f9a9fe77d14a16a385f644de118099fd4f7f57db9a0",
-        "sha3_256_hash_of_secret_key": "0fb711641d1830a3eb4ae1a4bc2fc610ea9a811fdc5274488dd31f9cf52ec04e",
+        "sha3_256_hash_of_public_key": "e5a656d13cdb067db3640acd507a2fdc583369ee08e235663a202af6720934c3",
+        "sha3_256_hash_of_secret_key": "cc30f4f63ca8c0eb14fd5bdc1d20b52bae4ad17db73e5d377b639a8f38527717",
         "encapsulation_seed": "52fb7cb6a633fd2e83f2892bd9441b48fe59ecee6d026f5246fa7f2a5e55ee3b",
-        "sha3_256_hash_of_ciphertext": "9fae0ef351454fb5c87cff7ed880d32dcc2f0654ab8c5a5b66b1e85d8e6feb06",
-        "shared_secret": "8d8257f05a4e76ad11783f7f6850c4f1c34017bf5ab47f89eae202132ada42ff"
+        "sha3_256_hash_of_ciphertext": "b291affeebbe32833082ee24af5e832a762d702fcff1cde35551277aa9c175bf",
+        "shared_secret": "c543e8af9ae37877d6df73cb7c52819c2a252a85bbd12ca9ef1990d73aedf939"
     },
     {
         "key_generation_seed": "b9a6b0c05677e957d41a34ba03bd06f2a9092e31f63389397d7e70fde6409d18e99c0e7b82be89bc3c1eaee6680aa4efd394e40c2b3f30523c8117f7c26a8969",
-        "sha3_256_hash_of_public_key": "357d61586f671648188f070899d2eb3408158adf5e8056ef37ab6d8817cd8275",
-        "sha3_256_hash_of_secret_key": "b22e39d960d7079015d70fba54ae860285f3c182bd5fc8d84c255f5e0f86f800",
+        "sha3_256_hash_of_public_key": "44df0b816ba22f5d471848886dd490d5c76169a14af42c03b0b56a7e26aa7ac4",
+        "sha3_256_hash_of_secret_key": "cad7bfdd5e961f2c4a565c1469e81ca06d806ff463888cc49766beee6c5705b0",
         "encapsulation_seed": "0f81a5f97082121244403da3feeb734f6084b314b8d94beb11627aa6ad1914e9",
-        "sha3_256_hash_of_ciphertext": "388d730604d16fff83eaa4e21a540b2ed8b3138f81b4c1c4cd7bb863325344eb",
-        "shared_secret": "08a60196adf66426b4e7b90be90160e196944d012cc34a524e1e73ca125ba407"
+        "sha3_256_hash_of_ciphertext": "d98b866b2dd00a3b548212490b13549c5abd46d1178009a9289c7a5411afb485",
+        "shared_secret": "e35bb159c5e2b555d89b163bbb2145638ac948d0b10efa8c4f1f385fed047f87"
     },
     {
         "key_generation_seed": "28a96c71577ba00c94f99fe965bc595a26db2b3ca6ab5cf8e443cdd8462b17929c35d165453e5fcdc6f9df64526d9de698f2bd3e6bac6c7fdd86601b9ba5f4a5",
-        "sha3_256_hash_of_public_key": "ef07b1f4886b895a3246241ddc084379eeb0f0ed84bdcd318fe72c9b546413be",
-        "sha3_256_hash_of_secret_key": "132633e3d33bcbc61ff70504e34bb033c92db5086bd924eab4ecbb8e4be983d5",
+        "sha3_256_hash_of_public_key": "e360d6a628c3b1b5dc926153f22a88c7b953085255edd2a72799bda15e49dffa",
+        "sha3_256_hash_of_secret_key": "edbb9da49442811874a46878d74989a664a9e67602c662735fa2358f53e22e2b",
         "encapsulation_seed": "31af9345365549ea0360169ed57daf98cc5444799d4c75d9f1f5d615e9df8a91",
-        "sha3_256_hash_of_ciphertext": "ea130b782f8d0167bd57d1cbead18c1a5a65ac27681847b85d8e09030dee8738",
-        "shared_secret": "13f3b79bb1e5d20ed95c7165a610e122b5de6cb02444cc66e0f1f9ec44c27485"
+        "sha3_256_hash_of_ciphertext": "0fd2b2a67b6844806405a942f14a5bfad8146389fc51916e84e5f355a4b1d2cc",
+        "shared_secret": "c10f4e51bff1a6f49da4cf9504d8c0dd1832c0860090fa892d5de6be27102354"
     },
     {
         "key_generation_seed": "c08ba2ef8c3a0a043afad931652d7a19e6e8cb670f840de5f1fa03309b2ca9ec5fe6141a25f7ab9f875f79e0a82d6ea5cde5a017ab637d5fdb7c42646a1d71df",
-        "sha3_256_hash_of_public_key": "1a2d9ea0d2280249d9d756975c6979a8770bf4b5f6addbd76d045a816bc1be38",
-        "sha3_256_hash_of_secret_key": "23678549b4e6e050b57ed1ad078705d33fe76ac976a9f70312b9cb45be554b0c",
+        "sha3_256_hash_of_public_key": "c4e4ad5295a60c2d41e0b7a7bc92148855ebedb4f2b77da0c706a1bafd6429d5",
+        "sha3_256_hash_of_secret_key": "4e99e5b1477d9b917dcf71fade7fdd558d80dc27f92ef8d10e0532c4d203d160",
         "encapsulation_seed": "774ae54093d694ef40b63b62c73e6c98295f606feb8699807eda1d030ffb996d",
-        "sha3_256_hash_of_ciphertext": "254058fc10c3327f551dfa143d17dcf4dc4319419050cb5e6841a8d5cb6ce9cb",
-        "shared_secret": "fcf4227a487e719499f86e44ff74a5339870e4238c20731e0c85f00229f2a1b4"
+        "sha3_256_hash_of_ciphertext": "6b01efd4611c173796d05d54cc9f44112fd9dd30124ab94a0683aac3f1cc9019",
+        "shared_secret": "b515a69280079b7c57997a183bdc160eaa0ecee319220fa690356aa42d0b59a8"
     },
     {
         "key_generation_seed": "0e3b30e102d707538c2671060f603bb0b8a014103f132d63b09ece07e4a4c75b11eafeca9e810796c34e8cfce9d59342884456007b01ddd12edce6d10ed87e4c",
-        "sha3_256_hash_of_public_key": "a57b333a2f41fda2ea72ea11d8bd642d911f6afe90e60492ebeefdc17a932192",
-        "sha3_256_hash_of_secret_key": "b59171816497ec0c34b963be3ef6366eb051cdebdb145fe445e16b72aa37356f",
+        "sha3_256_hash_of_public_key": "25a466c0b64a911e75243db16841847a8ac72dd835486e96a168b2f9fec46f30",
+        "sha3_256_hash_of_secret_key": "b8909877f446ce420ac8d9f4948a91b1e507b6a18dcf26f17a2043da89d5f610",
         "encapsulation_seed": "9f27a47604ab5146caaf0aafe6d149424f8d66e39ba3baf5e6c73b19221b7e21",
-        "sha3_256_hash_of_ciphertext": "4bb877beb1b9dbe916e61f9d6d7442deb7483128b6db494a0724e081be74ded6",
-        "shared_secret": "3f8cf35d0ba76d75dec611e5fb059db5197862b7e5cc6b116a730734932441f3"
+        "sha3_256_hash_of_ciphertext": "b69f9854abb563142b53f4fbf0c8b02796b1ec9b26d12238d2c153eeb4778ce7",
+        "shared_secret": "cf55eba9c0e1be66a0023794be974825ce8f00444905499486176dfde1838c05"
     },
     {
         "key_generation_seed": "2478f7d3de6041e7e5cd11c5e2ef483d1aa6218eb126444091535f6ae532fa7311136e2681df2ef881b51a092a9badbe72c9772c169808521c47149578621e28",
-        "sha3_256_hash_of_public_key": "d3cd2febe168b1ddf776b954e96085a7d475e3c8cbde68f7c80ffc9fa46b0d43",
-        "sha3_256_hash_of_secret_key": "b41a159ad0a89e7a771ef11e68efc9d79e6add05b261d0e40620a6b667a6c6bd",
+        "sha3_256_hash_of_public_key": "53ac28332ea3f161cf5dbc077e44f725b05ff0ac4abf95f60c5713aef1bfef4d",
+        "sha3_256_hash_of_secret_key": "3d4c14dae9a3cfbd31900b09dfae68161d2c9b0029a9da19716e823ac4ef8ef6",
         "encapsulation_seed": "90044031b7597b5e60a4f946b713e8996d0426d2cb013243d9b7d8f8ef159a0f",
-        "sha3_256_hash_of_ciphertext": "62de1efed6f92fc50d8fdef1ff217cb04faf53196e5af3a7507cb6ea5f822e2d",
-        "shared_secret": "d48544c1ac452c0b821e080e02c9c83e95252fb033617ce270f58e2974679fc6"
+        "sha3_256_hash_of_ciphertext": "c3644f6375368d391486db04c4a2f10e44a2e9d08155d85ea89285cd9a319285",
+        "shared_secret": "1d660952391268c94f6c47347627fe3b2a5e1097d6d85dcc14e3dffe3a4a1fd5"
     },
     {
         "key_generation_seed": "9d405d3ebdaf35fa8722de431b669722acaaea2fd10b814310b17f78b66147d16ceb14f7662be0c42779459f69a145c0e2ce9f0bd9a0cd1bf32ed5694cc9ae32",
-        "sha3_256_hash_of_public_key": "9499c1b006a0ec2c299c41c3f728c3bb7848957fb2bbbcd05b65233b89a2b1b1",
-        "sha3_256_hash_of_secret_key": "bdf5c3beb39ae62a6e29e858962c322fe525a307a163d68f765779b7848bec3f",
+        "sha3_256_hash_of_public_key": "0b6cae64de81b6f1395296905389da76ca7c5435e1c4b2d93cc5c303d31bc053",
+        "sha3_256_hash_of_secret_key": "048101a333d5fbbe4f6968603eaf24b2fccf650e3cfd2ab677dfb6ed9aded61e",
         "encapsulation_seed": "a7a31e140891ea37d2b6424b59b1f84f89220f32dcb73e037eb912b389d34a48",
-        "sha3_256_hash_of_ciphertext": "3a0a1742b1e27f14001e3457a00748f232f550687a232fa409c2098f97e72bb5",
-        "shared_secret": "6b8f4cbb3c4fda3c067d7ba48bf24e24258ca7e26bfaf918b784d01ae74ec57c"
+        "sha3_256_hash_of_ciphertext": "23e2a381c39bcce234f8fc722adc9c6a79fbce377f477b851c29077374a34efb",
+        "shared_secret": "06b3f79ba4b060d1fefdd589c9b87c48cf1acb34e0491e98b28293fb6b801baa"
     },
     {
         "key_generation_seed": "9a86490f0615f3edf789cb0654066e9ee339cc59f968281f3b89213f83c692edfaeb2ef44d2f608621e831187ce79b2d2f4a20f1568bbe76b0d3d5af36111714",
-        "sha3_256_hash_of_public_key": "aa14ea531df0a7f93225de1c75ace0d2692bc750b1b538cfd0d860ae9c5a8c13",
-        "sha3_256_hash_of_secret_key": "155cff081ef58459a00ae63a6ee0ed2698bdbd99c67b4c9dd09f8b0fc3de0120",
+        "sha3_256_hash_of_public_key": "f33aa451c6ad54d556d60210a23da8fb68662c39a1e08d893e1d1e784fb71702",
+        "sha3_256_hash_of_secret_key": "c3851de21b3c4b60dd15e4d39ee3d2f6705caaf871d1d947ff6ebf585a4432ea",
         "encapsulation_seed": "70eb3f791faa91f1f982fa477dbcddeb2c55691c07f93b04cd31b37544c94b42",
-        "sha3_256_hash_of_ciphertext": "8753aea7979a0d3f7aa35b9fab1b320d1b0965899bd51bfc8c1f6de79ff7d92f",
-        "shared_secret": "aa9878a81dd8165350b880c4af6a2adb9e50a48b9e0709f069c02184d3785181"
+        "sha3_256_hash_of_ciphertext": "8d22132ea4ab48c3a7728643664c04cc6cf0b065d70920cb5e714df1a4e5c753",
+        "shared_secret": "46228506ca245daf1bf40b48167a9bd3603c5d123db157645bc93780509b404a"
     },
     {
         "key_generation_seed": "6dfd9b575872560c7bdc2732c4a28dac4db04e535eb8e402c3dffd145c09ce47a2985c1c4d203778597947d710dec806e36b0cd949fe460ef141213bfc525e5b",
-        "sha3_256_hash_of_public_key": "e0013ff7eb7b8266ee94659f3372f5981ce1d87584cb1f0e80da2c0c95c16b4e",
-        "sha3_256_hash_of_secret_key": "7eece78f3f97759d0cfc8a69481271a425c56e540704b2fdaab8b2d920d19e21",
+        "sha3_256_hash_of_public_key": "cba1f135207bd2ab61bf7718dc6825848e742ad56f9f8099bd43905ebd9d6ba7",
+        "sha3_256_hash_of_secret_key": "0b87b78ed42ec5e1f1f56901d4a00e9e3092586a506236c60f68c5d9eec28b8a",
         "encapsulation_seed": "30f4095015ba88b6d969672ca3f438c395dacf7d476ea7a9e805ce932d270a13",
-        "sha3_256_hash_of_ciphertext": "777253af58f65c8a85f3feca46f8d32eb5d3d5d0664ea59cfdf47b89be9f005d",
-        "shared_secret": "5a23296c84df3d660e7c2a973c4e6bddad3fd814e158028ff92b234cffb1afa4"
+        "sha3_256_hash_of_ciphertext": "142f552d24e1f962aca234897bdcf9bb6be66f51a79eec6d329959a929de888d",
+        "shared_secret": "d51687f0a54626d49e07e8c8c272283b6b4f6a0c85c5a6875107b53c100264b5"
     },
     {
         "key_generation_seed": "6fca9f4e384d8418075cc064c70730801bdb8249899d456a77130d5beeb3662cce7683f8a03d3cf04e46970ff7d6a12494ae12558346dfc8fd9370bf944a0102",
-        "sha3_256_hash_of_public_key": "b503f8ec36d39fc7b4b8ada1cbb933b9db9ee118bf081ed75dd5dba7590f6c8c",
-        "sha3_256_hash_of_secret_key": "65d28565658fe991b77136b89255ec2d1cf65368e06f2b30bcedab87ffe39550",
+        "sha3_256_hash_of_public_key": "f118f77224920bf4ff7c69db5ebe12eacdc6012d57e2ccb3d690db251204dce3",
+        "sha3_256_hash_of_secret_key": "e4055dfa4382f838c5e8982aa12cd243f4225cdd6fc804da0bdefa6e14b072f1",
         "encapsulation_seed": "cf31220f44de862e1719570e1b26e897790159366a385452334fe24cdcae28ba",
-        "sha3_256_hash_of_ciphertext": "a7302707d52fc49f3e3637a742826bc8c8267e89c1fdf95b2ab7a0d8f1003c8f",
-        "shared_secret": "d790ec546719fb05125841bda9dd361e162ca4241e2b489a0f948b612309b649"
+        "sha3_256_hash_of_ciphertext": "ea54ccd7e1fd453af841240e69df6d615bb4ef24aedfa2a859edcc35346aa1d3",
+        "shared_secret": "73e86d2bb2813c76a8a901b8c665497e2d16615c5b2d58c9772306a3d6bca39c"
     },
     {
         "key_generation_seed": "e58f71bf175c0550a67e00e0f7b3b7fc36bc2707bf0c93044a492626de36301a7f7054814869cf7625e45647bc1547aff288dbb90699b2ad84893f3b755d9722",
-        "sha3_256_hash_of_public_key": "03341657b159925cedc8967872a45a3c1f0122979af87a878a2019b3f17c8ba6",
-        "sha3_256_hash_of_secret_key": "6bb236b9c7a818f9edec1e5da339755dcb7ca1b663a5a208c38c75e7ad7dc12d",
+        "sha3_256_hash_of_public_key": "8678b1f242830fb21f34f7beb20a96ebbbd6181890cee3bdcab29697c5aefd70",
+        "sha3_256_hash_of_secret_key": "085a1f47c259057a083207778e0186e61e840ba4e051117ad1b781917ba2f752",
         "encapsulation_seed": "bb5e65669a44e5d5c709bafa98c16ccba6ac2c4ae923334f69a11543eda64f5d",
-        "sha3_256_hash_of_ciphertext": "9a9301ca946909c3ee5d2171bc36322179ab4bfa825ffc0b826517accbc78298",
-        "shared_secret": "10086d1a59c41f84a089c239fcd8f8eea3b22c7796f9c1f9b1867b709cb77704"
+        "sha3_256_hash_of_ciphertext": "67bdf5734466e45089d115e7b05350652e3023fd94a6838665250939d06ffce9",
+        "shared_secret": "17b113a1728b3b0847062a3ad34968ec3192cecdd758fa1c3188d57df9fa0326"
     },
     {
         "key_generation_seed": "e3fc575ed51513e62aba655d24cd9c8f1c6c848aaffa946c49a53ac3ea59e474d82c2f1bf2e6aebde5660fa73356982e12999d8fdafbb3cb186341d0386dead0",
-        "sha3_256_hash_of_public_key": "60c001172c4734a620c248654c58f1c10135657083de776116a6acf8a55f3610",
-        "sha3_256_hash_of_secret_key": "b10663e90392d6387c16dcad565bbe1fbc05f32495cf9878706bd0d61d289147",
+        "sha3_256_hash_of_public_key": "d604833a540d9922a7dba53d67a38de1634cddee1b169b45bb9eb3646e55fc0d",
+        "sha3_256_hash_of_secret_key": "8fb99f6500e2639305aa6e30bbaf975271a31a6f3d44abca106dcee248d82b01",
         "encapsulation_seed": "9ddb3aa9c7905d1a438c93bcf78e3e321813580371ab4e1289e2dbf3701972c2",
-        "sha3_256_hash_of_ciphertext": "e4b3ce9e19c204a884f8a5adbe41acca97a22f1f5f2a13f1185021a8a36a131f",
-        "shared_secret": "82ad68065774eabcd6e78c027286ca7c7120987c4984e56f52abeb1ccc7a273b"
+        "sha3_256_hash_of_ciphertext": "ee1b17157592be46ff41bf81d46e2e1cb117b8444f5f09f15abd388ba68e0480",
+        "shared_secret": "5ebc9538f357baa7df0165af3e7fec1af8f4c1c051a214135c1fc03d026cee6e"
     },
     {
         "key_generation_seed": "470b4943f0fe7fd0d8ec5185aba0d1db09d112934e4fb4787e2bbc6b88466e7b8b2809fd40008be70a6b184981101724bc3d5ec5e1956b510b82fd5ad0668a5a",
-        "sha3_256_hash_of_public_key": "647a136f20b22c63afd2b88d14fe7677cf5c2b78223a587068377021f6edfe9b",
-        "sha3_256_hash_of_secret_key": "e70be83a7585618e7b91bc9930a581625e2441962c823a27eda9f6dfff8528ee",
+        "sha3_256_hash_of_public_key": "cac59b140df7d3285c832994e7a4ff5491c786281fdbd6f43a4c3902d4eac0d2",
+        "sha3_256_hash_of_secret_key": "b3b0b286b300cfa670ae8bd95e5373123125f48221999d3eb1762b246d3ba130",
         "encapsulation_seed": "26d90b190a6c3d0d9a86cf66005154e7086749e966e7187c249ccb9329fd3b8b",
-        "sha3_256_hash_of_ciphertext": "6287ca7c4d1eb3afb6ecfc456a4ca9ef5776177dbd5115165424c66e2db061d8",
-        "shared_secret": "2d56c88020d399532bada6516f9a1acc28a565cf252bafd40043879bcd6de1cd"
+        "sha3_256_hash_of_ciphertext": "497227c6f2a41bb30d9b35e59ad197ef362ee2e552e9ddffa74916ae5e5007ba",
+        "shared_secret": "2478974168bef71749a93fc9005dfc0bbfdfb7c5e485878bc04025ac7f97de82"
     },
     {
         "key_generation_seed": "6df4385db978d27b27d2aa5e452e4152b36f097503d9581ac3390105c5727e7dc95fa08ed106ce84660e8a4c90bd2b22634e40769aa0090a101c5dddad45edc5",
-        "sha3_256_hash_of_public_key": "1cde599b2dfc69d59036434cc0423337513fb9506452bd8f42bb82661ad0065a",
-        "sha3_256_hash_of_secret_key": "aa80a266176a7ef8fb22fe21fcf3d3762cfc36734d8b6db3c6e1d4df1eecc1a3",
+        "sha3_256_hash_of_public_key": "8513eaa3de494e114c2700ed07ffc1c2f8ef741765e8a42579da4946ae0a201c",
+        "sha3_256_hash_of_secret_key": "a6fffae6e91aa360d25fdbaa8a1a1a92580510e628b6851d18cc054d72910a79",
         "encapsulation_seed": "7db6d1a129d6123f1f805b79ad3b413012ea86aed42a05e98e7b1f32f9fbbdec",
-        "sha3_256_hash_of_ciphertext": "31c85544389bc3163e6893d9298d947a6cd189b045eadf8dcc265e4b5c750fcf",
-        "shared_secret": "44052d0cc62801e0d9717c65ddcb560246cd901f104b4252eeaef903f7c26af2"
+        "sha3_256_hash_of_ciphertext": "d8484fa4df7c1b4b4a21de27055a3a0d3904a5e481f49a7d8be3a6ab8d9e90c3",
+        "shared_secret": "a3611e119061c60bb8f76b765b1d00ab8dd98b6036338462619adf32ca39b2f6"
     },
     {
         "key_generation_seed": "dbacba825728444921b227cdba54446b3f6881b47be9cd02832f78b023b1bee0e15274a8e2bc08fe818b117ba28c5dfae74d54fcdf6f20052f79be333edc8dde",
-        "sha3_256_hash_of_public_key": "2a50c7a070b3dc7e107eb1e8b96d62305c13327d729bf9d97c69f1fe6eed2b52",
-        "sha3_256_hash_of_secret_key": "6df052019662b83b16b4da0a85b17f2fe56ad269b294438c8ad298d2e2269d2f",
+        "sha3_256_hash_of_public_key": "627d8e894a4fd9228571ecb1041a11f23220b1b83a46d7ec32691ec9bdceac14",
+        "sha3_256_hash_of_secret_key": "bf3c9a678ba1ba22f13b7a66a6b9d78dfe7a6060efc2a0917f50244fef5e83c6",
         "encapsulation_seed": "1d129b27be7384c359d04311fe5c44917d1fde4bfb57314f483ac617edd5ac49",
-        "sha3_256_hash_of_ciphertext": "c485c6e392c29c231c9eb04861fefff1fc27544443ebb316c74f9d4d7d9be68c",
-        "shared_secret": "2e95f47543ff640e6384d65cede004c4fc47e9e2f05649e694c18c7faf975987"
+        "sha3_256_hash_of_ciphertext": "e70bfe45a0db6b8b8bf859eb00c0c4fb81d9c7247c0358de801f8325fcace6b8",
+        "shared_secret": "3b6be80a10667e6ad229725c012d7c5197194d5fc26787d53925d19f81b865c7"
     },
     {
         "key_generation_seed": "690eb71fd7052b906eaec09937a8ed374e0b02afa27c2f14399932be5839fad281c38c2cb5cfafac81b96a810ab749b61806b6d54c9f8cf4bf1be0192423288f",
-        "sha3_256_hash_of_public_key": "5f166082ad3ab0c739cbf0a6bbe2707741d9b5f53a0e16199280a2376c9e5a17",
-        "sha3_256_hash_of_secret_key": "391b71e679b9a0a23a1aeba042ec7df439fa0a18c6442dbfe2bbe05d4fdb5fd6",
+        "sha3_256_hash_of_public_key": "49cec726e5bc6c6280269fb608e754d097ae818b16b386bc895af3bb9f5f2a44",
+        "sha3_256_hash_of_secret_key": "6efe3e1eddfc0cf66dc6c031142bb821e0ffc9a6ff5132d7484ed74a19b52d56",
         "encapsulation_seed": "bbc773ebd2df42c36ae05952d6a64c63a5dfb82ceb3ef4f8d4df3a30ec8c0467",
-        "sha3_256_hash_of_ciphertext": "499c37f74e94c6c724e218f339b8d60ab65190e0a56e39a6b4cf619db98bb57d",
-        "shared_secret": "42f1442e384b4e747794c944f4df154cde33cdff32bf35c2c5234919762030ca"
+        "sha3_256_hash_of_ciphertext": "87ab9d95a1ac05535c082e15d557813d55fdc2bc315d39e25c11d585912f7a24",
+        "shared_secret": "e6a61e88faaa25ff8bed035f8a47afa4f034121457104168a3247e366e781871"
     },
     {
         "key_generation_seed": "32e0ea9089fa928482c0770da545af1bb871a03ce38604138b0d08ea2a10ca2bc06c5bef7b6508409daf847a64c8d30d0974fd3ba7476dc76c46b458a036d884",
-        "sha3_256_hash_of_public_key": "40b3a72c164432e6ca838693ef25b30013e5cf56c1e6142828107a10cabdd169",
-        "sha3_256_hash_of_secret_key": "6f970259ae97422f8698120bfa8e53f4f89589773243db6e7a1859c94181a3f6",
+        "sha3_256_hash_of_public_key": "94b79d85075e5a897a948edceafc78b87b7fbb43b11f82831299a9ee660b3d40",
+        "sha3_256_hash_of_secret_key": "e1bb58ece306c42725d8113fda7732450ac3f78140c4a654e568dc219d26d80d",
         "encapsulation_seed": "5b17a6adad541efcbf5ae4b0c0452cd2ce32e4f0f8701801c5b63e197c1fcbf4",
-        "sha3_256_hash_of_ciphertext": "55e508c96b8b7c06cc9a88b4c9f974abd3e2cdd96ba6f0cf330ccaa3641fbd29",
-        "shared_secret": "a50a07f6b01ee4429848806031637c8ef8da23f253874124452e3771ef98b6e0"
+        "sha3_256_hash_of_ciphertext": "5828c17f7d9543f5ab8275b917a71e5e19748128c72074300c735be711eef8ed",
+        "shared_secret": "7b5182633888d2708c344b6bcc5bd895e0f1c31719ce78efb0eff0240453fb4b"
     },
     {
         "key_generation_seed": "6fb2ec719f2a0dea152bf3f64b9d148f8ab8ba88f64e61f5db53e12d59f525574f797c007e4061f95c7d56cfc7ee5c49e849dde3fea8f25e7876df2a18515c34",
-        "sha3_256_hash_of_public_key": "f475da2ec982c47d91b24bb5ec6c51910530eec26f38541b173b38927d23c568",
-        "sha3_256_hash_of_secret_key": "f8c836ce8a42d6d07f1ff40e2dbf16d264bb6ecd1cc0227ebf792a6bacd327ec",
+        "sha3_256_hash_of_public_key": "d68f592a778a0b3bedd71c5d4f75c2e46b6088ca12a0a5e9596d5999259f13ff",
+        "sha3_256_hash_of_secret_key": "0b13c14b34448c678945e92a0b6019f7c2b1175d2cf3e57b0293d8a12d6d0fd4",
         "encapsulation_seed": "61ab87659525de9656af41246f20e1dbe85c24e335e7ecf9493f46168bc14e94",
-        "sha3_256_hash_of_ciphertext": "d63a88547104683878df29e59de826821fa3a95bdd668e5e838e08a671d887ee",
-        "shared_secret": "c299f650b03170f5cdef5da81e52c2a094b11aaf58426e8c41e06a26c7d5ccc1"
+        "sha3_256_hash_of_ciphertext": "0548193df244610a4877925d64c93b7acf20ead8799f10f87011a4865d8abf4b",
+        "shared_secret": "eff76345f442ea27594bfb6e1e9eeffb55dbd15b9936a3aab881c0d21b45c28e"
     },
     {
         "key_generation_seed": "527fb88c8bd9a4d6031dad15e63878abd2b559e7e08d61f69e8e78fca964ee6ae32d432b4f9f751bde0496c580a181ffed762aa35454a02d3f1f47ee0394c89c",
-        "sha3_256_hash_of_public_key": "2b22f73a770cbdb80da84f97f27a14c5df5b3372d52503d3a20c3cb2bea8b404",
-        "sha3_256_hash_of_secret_key": "a111bb1797a3baeecc223e4fc4accf093d2e069cfd40d45346d2aefc09acb358",
+        "sha3_256_hash_of_public_key": "873d11d816550a4c1b14b584703531dd7cf0d97269125dbef3d73e443d017f57",
+        "sha3_256_hash_of_secret_key": "ce14607863d46839e3d2cfb87de9c2a719fbcf2cc3e2c80d2980c6494c5a297a",
         "encapsulation_seed": "eca2adc3da1fb15f34033405ec08ef2f46163df4bfcccf8842c600ce0bc2026c",
-        "sha3_256_hash_of_ciphertext": "e9c030db90931ef3d2a61077dc33529aad87535e809d1a255fb5b5925f202893",
-        "shared_secret": "5e1ac468279cfe354c4d0df6ead070071b19c9707338158ff7dc133684afe2ba"
+        "sha3_256_hash_of_ciphertext": "59055b7b4f9c5d8adbeffdd707699d800ac486d53ae2b6bf9c84678e3731c7a3",
+        "shared_secret": "d788c3a7c4d8a957b409028cfc62e5266559cbec39534d7f337aad2123bba577"
     },
     {
         "key_generation_seed": "ac6fcfaeeef795b6ef9e062f02bf42975fa01e7d91ba832f74e05269a72684d05aeda108ea4d6c6bc0fb958286850422bc357ca67b83c986048e0d0087fa11ec",
-        "sha3_256_hash_of_public_key": "3d8fe8354d81146fd65af657da08926bd3a6ecbc2f81cb58d1aaacfe5b6e686f",
-        "sha3_256_hash_of_secret_key": "d1c524a715b2d05abc8e8729204b620f4551815cdeb00662b487d58e99c0ac7e",
+        "sha3_256_hash_of_public_key": "55b703fe0b2aebdd29f6ceb606f15213da5f478ed4605a212f52358e2046d5b0",
+        "sha3_256_hash_of_secret_key": "f5351babc3c84e0ec08c483a10ae68cd9ec49a5f46d83547b036a3206e739ba3",
         "encapsulation_seed": "c4f15bec2d7701339d0ade4835193bea3632edcf89e74992620d9eb623a0d0d4",
-        "sha3_256_hash_of_ciphertext": "c256150127c8119ae42a62b90ac9a7119a3faa5442f058bbe5844d29c99c4eee",
-        "shared_secret": "7841501410e4158cf04f92b9d65d0cec732984ea66809130aeb594156829dd39"
+        "sha3_256_hash_of_ciphertext": "860669fe4025419a103b4ef9d6d4f87ad0ed7aa19d14d351809de29acf4ca0ab",
+        "shared_secret": "f4da03d95d99bdcde651fe09b288b46588b50ebf50ac1e35d86077e04f76944a"
     },
     {
         "key_generation_seed": "ba2fb9318d4dbe7488057c33e95e6f054583a2800c41bb83083c330a914a12cfe63f8ffda3565c2424c89b20974b748a65a5aba75133fcb3156dfb6626a83bab",
-        "sha3_256_hash_of_public_key": "36fc15e2340175a2a64ca1cf31a4b38ed5f797aaa8acb0c3d2ed9c19c7099f27",
-        "sha3_256_hash_of_secret_key": "0741ce5533316ef689bd966721b1ee57a272d5eb557dfa6fab6de770a2e7afa0",
+        "sha3_256_hash_of_public_key": "c68e808974e356659cf3d88474ae8af1480f2c4bf5f053b0a8c211d43921f735",
+        "sha3_256_hash_of_secret_key": "0c000ad1fec4db3da84eddf4a6dbd304e1be5e70666ad30085f407545ce7eb7a",
         "encapsulation_seed": "28878249e2ac2b6263422993923a0c8bd05ce56e385ed13c943b03d226856947",
-        "sha3_256_hash_of_ciphertext": "0c6a7cce80da6e6a3c17b46959124b8c26a8a74b5068f707f582cb5b811e282e",
-        "shared_secret": "6b3fe0dd082bf384c3e08497d380516e78ca778de627c112d02dc8c393334d11"
+        "sha3_256_hash_of_ciphertext": "433341b594e5b41e1836cc1dd48b57b9b0c52a23367a9d5d21d01a0e7ed03279",
+        "shared_secret": "4aac182a36508198689ad4b0c24abacfa421cddf073e6ccb3f5c22c37f1c9eb1"
     },
     {
         "key_generation_seed": "aa6dd1e5799cdf7af9c4fc632b3eb9d51d66e85c8e0a21ec98664fc51ab63c7dfda268813efab5204efa60f78bf81d320d01ac09ac06244f7afbd2d80fd356d9",
-        "sha3_256_hash_of_public_key": "26a1b77ae8a807e9de16a9ede5da5aec3ca5f23f5ea00e455d4a091467e6ac6d",
-        "sha3_256_hash_of_secret_key": "2bb0f5318208eba32bfba206dfe174f976431dc12421bc7b3705fc7c0b4a06cd",
+        "sha3_256_hash_of_public_key": "b6481b87d7f462e656db85d6046534ae44d82b1cb737a0194eaac814c7b85493",
+        "sha3_256_hash_of_secret_key": "75a00885e8664238fe44d9d579e183902ab56d67fbb712d249aa8c24f08bb080",
         "encapsulation_seed": "17fc65f7fbd7c75ceec421dee84dff5a8cb22764a182db17e0ebe857f54d60eb",
-        "sha3_256_hash_of_ciphertext": "ba2e94ce526ee4bdcd818855708af8173acac373696df4f910720fb296bc1076",
-        "shared_secret": "cb15c306ba8d5f4f8b723db93bfbcfd4fa02ef32ed8e39c2aeb706a463d9a40f"
+        "sha3_256_hash_of_ciphertext": "974b6e5abd51b9622fdda7fd2fd48ec42ff8c54df7524fe4af72521817b27576",
+        "shared_secret": "a51f089d627c8d7da9740aa9d768778124229c4ea9408941ee04a1940c1762fe"
     },
     {
         "key_generation_seed": "195d6c86a3df4c21e3007d7f2768b43c74cb3060e0eca77f0a5d3271542b9a84ae77e0f9f21eabd8c0c6eea7767f4e10fde5c2d79b8400bf96b19014b457ec21",
-        "sha3_256_hash_of_public_key": "2460170e6cf1da1e7b92037f51b4e7674d9abf74f5c225c5c6ce16a971691284",
-        "sha3_256_hash_of_secret_key": "a364a1f435a2d2a341b59a1886af0d0f3580e56306869bbab819de741ac9f642",
+        "sha3_256_hash_of_public_key": "42a9b1d5b6521a7a4527116aa7c38f6ddf99acd4a7b9837317d99f83732bb7ca",
+        "sha3_256_hash_of_secret_key": "2dad85e2ce45f72dfc5f7fc7deb814ec9d193890e68f7b9898d97407080e7002",
         "encapsulation_seed": "fa0489f3730100609488e951e6aaa15c0f193bc1dbcfcd013bc418d6c507b176",
-        "sha3_256_hash_of_ciphertext": "ff21fac2cb15307ebb70ec04904f636bfac9ba968e86984b4a55dcac70430c1e",
-        "shared_secret": "8dc8bc55a907bcbad27aafbba2cbd957c30794e3770d0984a6323b641e5fe53d"
+        "sha3_256_hash_of_ciphertext": "087bbc08fb8d2b0860269f5fe4b62a2d852adae1a0417f621c8115cecf077f1c",
+        "shared_secret": "b00f65a7930ffc261046644203b94c89dfa7334bb011a4ba896c2d547d96637c"
     }
 ]

--- a/libcrux-ml-kem/tests/kats/nistkats_mlkem_512.json
+++ b/libcrux-ml-kem/tests/kats/nistkats_mlkem_512.json
@@ -1,802 +1,802 @@
 [
     {
         "key_generation_seed": "7c9935a0b07694aa0c6d10e4db6b1add2fd81a25ccb148032dcd739936737f2d8626ed79d451140800e03b59b956f8210e556067407d13dc90fa9e8b872bfb8f",
-        "sha3_256_hash_of_public_key": "7ffad1bc8af73b7e874956b81c2a2ef0bfabe8dc93d77b2fbc9e0c64efa01e84",
-        "sha3_256_hash_of_secret_key": "26e1b5ea0f48b3c87d7ce87113b6a93a49d9f7ede7c5cb15b41382bd3243715a",
+        "sha3_256_hash_of_public_key": "50c8dd152a4531aab560d2fc7ca9a40ad8af25ad1dd08c6d79afe4dd4d1eee5a",
+        "sha3_256_hash_of_secret_key": "2e08d2c82a07f5f67878b54e06848c924ee7a0929cb6440d06fffd9622687b48",
         "encapsulation_seed": "147c03f7a5bebba406c8fae1874d7f13c80efe79a3a9a874cc09fe76f6997615",
-        "sha3_256_hash_of_ciphertext": "a3856ee9fb112b154b397c91398576dda45391b89742603436588d81ce6d1b50",
-        "shared_secret": "c608777086ed9ffdf92cd4f1c999aedd0b42e5e8ef6732f4111246481e260463"
+        "sha3_256_hash_of_ciphertext": "ed14369380d501d2bb28861a26ad092b1bbd6764c083244551c436ccf98dd9f8",
+        "shared_secret": "319839e82ab6b222de7b619e80da8391522bbb37677018494a4742c53f9abfdf"
     },
     {
         "key_generation_seed": "d60b93492a1d8c1c7ba6fc0b733137f3406cee8110a93f170e7a78658af326d9003271531cf27285b8721ed5cb46853043b346a66cba6cf765f1b0eaa40bf672",
-        "sha3_256_hash_of_public_key": "13f0970c03d32967b06cca4cf58e87559128d14cb3f876a1ed10eadfe03fc1a9",
-        "sha3_256_hash_of_secret_key": "9c613d0d3313af8169e65295e8c4f21f0b5d3e78de031e78a12ec864d71b6548",
+        "sha3_256_hash_of_public_key": "d760244a5fbbfdb6ed75a732af8e11edd52e412169c9f523fc8cdb3f8bf21b18",
+        "sha3_256_hash_of_secret_key": "9e62c214ea3922297185b34d0f31c8ff5a47f1bce251e13f911b03ecfe384f49",
         "encapsulation_seed": "cde797df8ce67231f6c5d15811843e01eb2ab84c7490931240822adbddd72046",
-        "sha3_256_hash_of_ciphertext": "557c682bda01552173367f40bd2b2c1ed64aae3f083c80ce2f812d0b60acfacc",
-        "shared_secret": "9401f92689a452b5e58c35cf06690596faa4ec0937a04493a359b59ab3b0fdee"
+        "sha3_256_hash_of_ciphertext": "46906ceb5cb0ce4fc544695cf4576cdcc18f90ffbccd772873edc932f0eb0393",
+        "shared_secret": "3806942c857ab9bf77b1db8d57ec9dca0ffbf6f156f2e250d8b88cc2a74fa1a7"
     },
     {
         "key_generation_seed": "4b622de1350119c45a9f2e2ef3dc5df50a759d138cdfbd64c81cc7cc2f513345e82fcc97ca60ccb27bf6938c975658aeb8b4d37cffbde25d97e561f36c219ade",
-        "sha3_256_hash_of_public_key": "083553153f7d65cd5cbe201e681245eda61e1ec2c7ee6b91a9ccdeb6b76943b7",
-        "sha3_256_hash_of_secret_key": "b4148d4bba0430ddca173618456704ddf440b9b5bdfd61ee46bd79590dd78ff3",
+        "sha3_256_hash_of_public_key": "6e2a888db11de3ab2c7f1fdf15ed8d4bf31f32f1e7031cf236e6e0e757e0cf62",
+        "sha3_256_hash_of_secret_key": "e78c1ff494cfc100087e9869cc4d38934398744e9649ea0e6941ee954e189ed4",
         "encapsulation_seed": "f43f68fbd694f0a6d307297110ecd4739876489fdf07eb9b03364e2ed0ff96e9",
-        "sha3_256_hash_of_ciphertext": "7b7b882320575a3cfa5f0ca2165ed39383921da042f7bce896896fa90fef2aef",
-        "shared_secret": "f2c689c7a8180baf27a4573d3e6154d4f2bff7b3f34d44576e777e2ac1249e8c"
+        "sha3_256_hash_of_ciphertext": "609747225128f59051faf5e4dcaaa00a0e9d46d954cfe8e115172b63b4d12924",
+        "shared_secret": "a1e73a1ebd907a6f176acf808b0d0412d31cff0e9d800a732e1e96bd9f8d7ebb"
     },
     {
         "key_generation_seed": "050d58f9f757edc1e8180e3808b806f5bbb3586db3470b069826d1bb9a4efc2cde950541fd53a8a47aaa8cdfe80d928262a5ef7f8129ec3ef92f78d7cc32ef60",
-        "sha3_256_hash_of_public_key": "9df5746a44b10c1886f62b068d18152a85792781160e1a1a19a25b5ca00555f4",
-        "sha3_256_hash_of_secret_key": "75a93307372e001d4fb028125dad61c4412ac864bf7eac7a213ad3dca6599981",
+        "sha3_256_hash_of_public_key": "a30df672528ae0579ce33db704673783b5ee84d5091361dfedb52080c01938bb",
+        "sha3_256_hash_of_secret_key": "2a0aa950b2107d5e157fb71f554eca7a724b4b6650ad62d554684d0d60f3e2dd",
         "encapsulation_seed": "ea74fbc3c546500ed684bed6fe3c496d3b86d2d6dfaf223969b942e9a8c95e85",
-        "sha3_256_hash_of_ciphertext": "72782e8ee6fe4e4442723e727b5d415f66fda7c363fe6dc7be22d9b8741852f2",
-        "shared_secret": "1dac4f6f8d96ffd931f67b03cee8c4e4bcb42eb8bbda5cb702dadde8340d1524"
+        "sha3_256_hash_of_ciphertext": "4243c3aa6f182bd090700331099c31e4e8db917cc250e7cc1c7ae832657275c1",
+        "shared_secret": "255b06c42b0dc4a66e704a50180ef40cecbf7e4ae4b0604fbbfe92ef3472b671"
     },
     {
         "key_generation_seed": "66b79b844e0c2adad694e0478661ac46fe6b6001f6a71ff8e2f034b1fd8833d3be2d3c64d38269a1ee8660b9a2beaeb9f5ac022e8f0a357feebfd13b06813854",
-        "sha3_256_hash_of_public_key": "9415ce164fadececacd75fdad3284af20c52fa576699029d6e0ce77bf347d520",
-        "sha3_256_hash_of_secret_key": "97f1f85233dba2a50848add15f8f0e60f4ccf3542dc6da5f59e06f6b27c59c67",
+        "sha3_256_hash_of_public_key": "02d985ecfadc5ec08bfb7e2b4c02c4fd9863ed6ea3dc9ffd92b2072db53010d2",
+        "sha3_256_hash_of_secret_key": "6485e51d58c4997419c7a43050a79f9817a122b4821aa4759300e68e3b32214f",
         "encapsulation_seed": "64efa87a12cb96f98b9b81a7e5128a959c74e5332aaab0444fca7b4a5e5e0216",
-        "sha3_256_hash_of_ciphertext": "80f49e8f6f8d442a7678f2c33881a5264b58a5998b7d9a8e10b2febf59ba868d",
-        "shared_secret": "01adaecc8cd981e7f00187622defc0cbb8934464ca4675d86bc7d9b69148c85f"
+        "sha3_256_hash_of_ciphertext": "b732d582ef9230ffcd05436bfa05bb47a9171282448fe37577810fda8b765018",
+        "shared_secret": "2bc3d772ed76d13c7b13c479ebdae8afd841c88199a9d1c6a6635079a9ecff9b"
     },
     {
         "key_generation_seed": "7ec408f52c9aa723d0c41d9987682a5f4ce6c9da7cd0215af60bbaf5484ab353a08ccf451b049fd51d7a9ad77ae14a81569df8c9bd3a8f1ebea86fdcfb823082",
-        "sha3_256_hash_of_public_key": "ca2232297ba8b986dacd401896cb6239f557720d91a2cfb7a73274bac7a0f6de",
-        "sha3_256_hash_of_secret_key": "17446e8436a68423ba4e22a57135d470c7e91fbe0a4da065bdc34897fda89b2f",
+        "sha3_256_hash_of_public_key": "39f1668e454ae9e5f45436a1eea6c01a444bad4a81f1edbae5280955a4ddac33",
+        "sha3_256_hash_of_secret_key": "9554f30b9c2d027f4af92c129c8b0a2d27f9e001075d5c5bb597c0921f17d820",
         "encapsulation_seed": "8a95d71228acaa5f9ae6f9d9ca8ae55fde296463b41083a39e833e37c4c90f88",
-        "sha3_256_hash_of_ciphertext": "a08cfd7a6374d902e153b862449efdee9f912234f3e7a7d2697ebf1909f59dfc",
-        "shared_secret": "6f13bdb1452d9e672c8fedaf9450c436e5fa77e8d58ce83300b8e539f20e9dfa"
+        "sha3_256_hash_of_ciphertext": "22f5aa037e267e4da76371b4dad552d37f4619886269ed8213327afceeac1272",
+        "shared_secret": "cbeb7f1be09e7a73b83be91deb2377e3cf536a89ca695b270436f0dfe5dc9403"
     },
     {
         "key_generation_seed": "c121915bfef6abdfc177dae2f5a24218f9abda2559afc6741b08e0e61ab433eb84ef52db5eaa6df8ec3a0bc5ffa730db0dde8c5f38f266d5c680a78d264a7b96",
-        "sha3_256_hash_of_public_key": "34486689b387ba25dd0e9aedbc53034924ea4ef9497b5772f10ca4d091e9e846",
-        "sha3_256_hash_of_secret_key": "94419fc5d865a97586b71a3414721f04473d4d30e5a8d6a1c438752f19504209",
+        "sha3_256_hash_of_public_key": "7b37a5635248c2a937c2f84856973f47c8a965852de3664c6c3fab0e1ee9ee57",
+        "sha3_256_hash_of_secret_key": "54ffe4435c894861ceddb4a94fc60272d37c04e62a0aba9088cbc409c32a1170",
         "encapsulation_seed": "90d79d75d0bbb8921cf70d46bab497022a8e750efdc99e5f1bae653275441c7b",
-        "sha3_256_hash_of_ciphertext": "6b930dced8da8c0353569fe807e383e2d04836680fb78881ffc6974802131eca",
-        "shared_secret": "c81a637f63a802a5d2b336dd960175176b2b838ffb6de5adc501bef984fed26d"
+        "sha3_256_hash_of_ciphertext": "f4c7d966cfe188f0e9e890f43178f1e7874a1c590c93363fb1c371a8d502650c",
+        "shared_secret": "4a88951f0fdea4f6c1b90865118456771ef756724771f79d752f41c94b8dd754"
     },
     {
         "key_generation_seed": "d86634ecf96cc2603761e284c0e36734cedec64e7ff486469e38539c71141c5a99daf37400cfe59841afc412ec97f2929dc84a6f3c36f378ee84ce3e46cd1209",
-        "sha3_256_hash_of_public_key": "39d1850f7acb36ed2a35e9af6f94a06c31afadaae3545a069f892ecd8929f766",
-        "sha3_256_hash_of_secret_key": "98a2ef35596f2fbc7e462d5ee536f30d8bc3a5272d78cb14c0ce816fbb180396",
+        "sha3_256_hash_of_public_key": "635d7cc758d131a3734e8300b85f16014f607c6cfa02c5864a8b4212aecac182",
+        "sha3_256_hash_of_secret_key": "11aa4a74cb491582e8476d20276ca34e0c1668eedab78cba3522f7f84b044675",
         "encapsulation_seed": "be8a32f97b9a8d596382c02fa2a0eeebc15c083e970ddaa4f2622b91d6718663",
-        "sha3_256_hash_of_ciphertext": "2d277dbc8b03bbec796e778c74b4c3f408f3e47835398039236d7cd861762a9f",
-        "shared_secret": "3031994f1365446186b4a4d6190ac89f928f6706d08c6316d6f522cd7605adfd"
+        "sha3_256_hash_of_ciphertext": "bdce62c2131d018e512d3a4c9822910672dc41d682ffe67235c3c1b8d5df0bbb",
+        "shared_secret": "948e74805c64bf386b623f0b2d105d11d7609d49587372235af7da3d98a5487d"
     },
     {
         "key_generation_seed": "0610678ff4dc3128e1619f915dc192c220f8fad94da1943b90aaec401683a492da1804ddb5aa9b1c6a47a98f8505a49bae2affde5fe75e69e828e546a6771004",
-        "sha3_256_hash_of_public_key": "edc8db1ca35744a75ca14516abe07472d0d1b723f70ca8cf0e5c9341fd2e8c26",
-        "sha3_256_hash_of_secret_key": "fa6de16f50b0c04b8be10d3262005227715f69de5089f0f6bafc1fe26603e525",
+        "sha3_256_hash_of_public_key": "cbdd31edb64a804a434033c3edf156384b40eac3544fc5f4104f323f37d2b017",
+        "sha3_256_hash_of_secret_key": "b66e0c82a925cc45fe7ab174c9f4c1f0f312a354ae049f91e453fc6b27221168",
         "encapsulation_seed": "da2cfaf69e25b2a89ff2557bbb6f69e01d8e2e7bb27a7a1ce7e40fead16f33b2",
-        "sha3_256_hash_of_ciphertext": "c20e526b8837092f1847b40f9b5fda528dfb72780aceb510635b490acb5f7686",
-        "shared_secret": "61419eeacf26714b028d2f7e1e3769ae2f181a7e9311f3312911ead00486bcd5"
+        "sha3_256_hash_of_ciphertext": "251e190f894d11c0542eca0bd6ec612e791191959f0fc509b1d66846e7663bd5",
+        "shared_secret": "f2c33a2426460d9f4c95ff8983e5e6db6e6f79ef8b7b1dbc6ff863fb0e034349"
     },
     {
         "key_generation_seed": "d322d56d8ef067ba1f24c92492b9c56df3a6ef54a304adc1b69913766a1ce69756047447b810cc094d400ab204cf9ae71e3afa68b88586ecb6498c68ac0e51b9",
-        "sha3_256_hash_of_public_key": "b1eef6e8c88ff8da9cc4a9b01d4c08b6b585beb5bb9e084c6c47a717b51feea3",
-        "sha3_256_hash_of_secret_key": "bce9d6b2e45918ea5798910aa9baf289b04d8a5bcfa7e08235dccfc8b9479f55",
+        "sha3_256_hash_of_public_key": "8510df5aab4d05b7daaafd2c33aeaba815b1d15bed1b204f72b721b5eacf1e40",
+        "sha3_256_hash_of_secret_key": "95fa5826a13496a60bcc97431c2fa8c19722a3f71d3a48e145017bee44d66a3c",
         "encapsulation_seed": "511c2ab40782322c06111e144e505328c4e5bfc890a5980a2bbc44aeda4c738b",
-        "sha3_256_hash_of_ciphertext": "811bf647ebaad03c81a84c6a82b4cab108267b1e9c1add3dff1803623471f9bc",
-        "shared_secret": "3871c9637cbea04a2ccd3b62c9399b0a7277a31caba8a8f015d59b0fed845bb1"
+        "sha3_256_hash_of_ciphertext": "94482dcfae7bb95bc8c5d1d92c044a000195b624b5c45239bbd3e46672adf4f0",
+        "shared_secret": "72502cc5436ed5d9c07baa2e1eea833eed515a3616936485e74ed7c0a53c734f"
     },
     {
         "key_generation_seed": "2f1d8a3bebb34540324b9485fdf3d5be3b858f544abc3fc641b5728cafab03ba8d6c42e7270ee2b77b6045385f3d175984a0e260363166c73b0c70c971644363",
-        "sha3_256_hash_of_public_key": "f581c2fec9055830b38cb68fb506aa927443b1afd1b2b6faa6f92a325985c6ce",
-        "sha3_256_hash_of_secret_key": "9567f27ef67c3ada92a02cf25d8ee4a6db69744d3f6de5a0026dac023d04f37c",
+        "sha3_256_hash_of_public_key": "6eba15a38b9c512f892c825db9c850301f99fa3675eacca7097afa57bbf02ae8",
+        "sha3_256_hash_of_secret_key": "18ca54d254ed5111c1c441ace00836230d769f8c6e55c97137aa45e21e04c04f",
         "encapsulation_seed": "dca92dbec9b260dd97e8886f876862d6effc3b91fcf3fbc986cf56ab93ae79a2",
-        "sha3_256_hash_of_ciphertext": "c855f0a4521640b9136035b5d02770dbe864b85a6f54f422ccf2b512e1c07b33",
-        "shared_secret": "3775b12681d854b7ff2eec05cd4ac2db91bf06f3c14db2eb35287129a960ab03"
+        "sha3_256_hash_of_ciphertext": "34ba03705cddc88d5cd9d9b57b0fb6b71a1085c8fe0f01ee4aa05e7ad159e526",
+        "shared_secret": "fb46778f597ebf40dd0125f198c236f064019c6d562ab7d9bf677b4aa2ec9f32"
     },
     {
         "key_generation_seed": "31beda3462627f601cbc56f3ddf4424e1529c04737ef0ef2af6d7401f653b8a1812083bfa3b670e3eaf9b443702fb6db16ac1197656bbd61a8e25ed523b8d1e5",
-        "sha3_256_hash_of_public_key": "f12f3ecad62bd327f1c44ae86c0be6e7f15112b7f6f6d5ec7b13f4dfab718965",
-        "sha3_256_hash_of_secret_key": "32a666c02a41f7b9408c570a3304a80e947a1be650f5f164e376b8b34b72254b",
+        "sha3_256_hash_of_public_key": "0705c8b9c6252d54d5d6c84db86499533a8249a3777302053f40be8f5edf1b0a",
+        "sha3_256_hash_of_secret_key": "69d4a869f04c198fcd19124d714784cec7367a2af7ae1abb2d72868856b515a1",
         "encapsulation_seed": "57c170e691d7a914a901b9a11c62b8b569b3806427557a9dbac9faa720ec3641",
-        "sha3_256_hash_of_ciphertext": "632b389d951d4a4e570d2fee62dd87c3aa2cf0c036dc63462f3ee7e4543ef8b7",
-        "shared_secret": "87662dcdee8b176e2dc60d079be188f63501274bde0829f3595c99d1e564c2d0"
+        "sha3_256_hash_of_ciphertext": "cab086dcbf4c60ebec03282e49cb76aea9a2e9267cf85809b870b4561a11a639",
+        "shared_secret": "e2cb350a013a86fa003da8ad9a424dad20b3e8f3a652455090707643f5c60c78"
     },
     {
         "key_generation_seed": "cbdff028766d558af4466ef14043a1a9cf765f7748c63cc09dceb59ab39a4e4d8e9a30597e4b52ffa87a54b83c91d12a5e9c2cd90fcac2c11b3a348240411a4c",
-        "sha3_256_hash_of_public_key": "4cae8b58e0434fb1475312355a8b40145043bed4b269aaddd654d2e562324bc7",
-        "sha3_256_hash_of_secret_key": "53793d47a6e9e527f109b7611f33063dbe0b8a1423ac02178934f59c3d47ddb2",
+        "sha3_256_hash_of_public_key": "4f500c26b0c4ecaa8393c8c669a8bc6b6652a69b4375c34c7f553a1dfc61dc20",
+        "sha3_256_hash_of_secret_key": "3d9f79a1fb4d58a9848632d580e10829916c1d2e70a8ac04c0aebe5bbe42ead9",
         "encapsulation_seed": "6b5a14e1473abf5a33d44975ca2088bd8fa6fddcb3f80e8fd5c45b9d90c24a5c",
-        "sha3_256_hash_of_ciphertext": "6f88eea1ec597548ec3c0d22c60a92ac4b0c3e17e332983d01a0bdda1157ecf6",
-        "shared_secret": "c5676cf0cc81871d677bd7f5982e6493aa3ea4dffbb30dbaf59e90e4977d2f12"
+        "sha3_256_hash_of_ciphertext": "807dcaa83e9333be78d92068ef7137aedb892d289dc4d73a940f3967f96288c8",
+        "shared_secret": "e329efdcdf764506e1b90e25eb2688be4c3785fc61e6f52b22799a4c130f2d23"
     },
     {
         "key_generation_seed": "4c04310bea66305c6ca8ba6b8f61ca96257a67663afc11761f13fb5c7b324b6b8aec87a9a79204cee2986867a2906eb851b734b8b22b91d6749b1a5f07c44e3b",
-        "sha3_256_hash_of_public_key": "b899475c1802b1dd76a9783d93b4225dc558eea558ddc598cdc45a898b7bbfb3",
-        "sha3_256_hash_of_secret_key": "278b448b48a14a9be1ed211228cfab37d07e5f1e502478e3ad059c83a7c83894",
+        "sha3_256_hash_of_public_key": "c0c5f7d4b5a02c3f5bd2804190e6501b96f9512e4696adc4474fc96c0ec0f93a",
+        "sha3_256_hash_of_secret_key": "ecf3c7bd0fe76e86370196134b054486fefe1c01fce94a0e1a411310e64ca1a2",
         "encapsulation_seed": "40e593754e6eddb7f9cf176ba2d5fd1087c90ad377556d0b0f686537b1a3165e",
-        "sha3_256_hash_of_ciphertext": "36f6daad6b98df3f8e26456d06f112ca69231333e4ebd86e04fe7b8fd8c1bf26",
-        "shared_secret": "c5b03a417c10715a53f3a1efc044a81e266b40a1b16c87aa1f754146ac39b80e"
+        "sha3_256_hash_of_ciphertext": "381e68c6b08f3f132190fe79d22b0d43f09f97523c5445065ee6a649529cf595",
+        "shared_secret": "55ca52096dc335e869b0b4b989020fbdcaba145f9b52ac1dd9453b125dc539a2"
     },
     {
         "key_generation_seed": "38a0d5f41d7dc1896efd1b45b0485634cef149828751b96087a0a6dd81b4d58aa2acf359556df4a2abaeb9dcee945829beb71185b4d6bd18b76e5668f253383a",
-        "sha3_256_hash_of_public_key": "1a7e0760c345cb5875303e20e4c72076c794e56ab75231750a190b45f374d979",
-        "sha3_256_hash_of_secret_key": "eb53a36a9f50baac64b4c7bcb97fecae54d3f66b8311b5a67c5daaefaa63f209",
+        "sha3_256_hash_of_public_key": "ce80f9c0d66e8ddf2d8a428c25ed9bc4dea70d4d4df5dec8f28bd6ad802d3043",
+        "sha3_256_hash_of_secret_key": "5efe184b3bec14dab5a9949716aeb9b3bf816b2408ac04fa344761742f27eed5",
         "encapsulation_seed": "c152523abd8248bed40c3827bcf0f8e8127037a55c780695e2c28ea3e041a44c",
-        "sha3_256_hash_of_ciphertext": "1b4728ec7c6e90ad99dbee3b83438050df88887de2e6d7a6ec55e7a2f7f1bbc3",
-        "shared_secret": "38daf9348e4d89149e4968131370ce3d38a4028727fb85d27f87a95b341340fd"
+        "sha3_256_hash_of_ciphertext": "c5bc628e5caae86332725ad71a762b87c86796721505640abaf3bc1db3faec96",
+        "shared_secret": "24a5640d7d290b1f60ec2d6df54f2d771882ab1564ec2ae66c0eb50f14762a8e"
     },
     {
         "key_generation_seed": "97b5665676e59e3538ebadaa8cd50df1f9fda1502d9894c616a946078e56b621df05318b5f655efe36f1b678cf4b875108a18db2fa312261caf839f84bd956c5",
-        "sha3_256_hash_of_public_key": "0f96fb9e146a1c22cc5d23e9108af0dc5e13b7810b8f5598bbd5f8d4b54c8af7",
-        "sha3_256_hash_of_secret_key": "d494ee913886be1398be54856ebc83eb8cd7aab4268b976583be2e097edc2d64",
+        "sha3_256_hash_of_public_key": "680bbbd975db3835d9102bb96c089439d5964fcdafa63cd86bed5ef8d9a4b990",
+        "sha3_256_hash_of_secret_key": "03a6f481b7ff7b3fc52b1bb7193f11b56c55837255e1bccc235a54b9f32724ff",
         "encapsulation_seed": "ad6466dd59f26b762fb02b19eedf5f79964da68bce0459b91c3a6ee5a7e01183",
-        "sha3_256_hash_of_ciphertext": "3934a38f7c11d237b46c9d93a8ab8d3dfc76b3e020b5cfcd0344eae35a333e45",
-        "shared_secret": "60bc23845c0b116208c0ea02849cea3d8025a7220337c617c4bd304aedcdc1af"
+        "sha3_256_hash_of_ciphertext": "2f2265b4de51e49a8eba21c996b661655b60ce226d7dd53da817579d9c53f00d",
+        "shared_secret": "6094a57bdf3b74480b29731fdc5f976e0c23b5759275ae236ecaf9a9cb331dbf"
     },
     {
         "key_generation_seed": "ef99224a03a85a46ef115474ec5b5d620da6795d6efcca4c9135d19958a9de62df7d92dda83e6b2ef4cce08c9134563063068a196d7b1a1a13623e48ae12528e",
-        "sha3_256_hash_of_public_key": "0bb63b48b8cdd1c7242bd4f017c519b43502656e23817bfd683150488f8b0b44",
-        "sha3_256_hash_of_secret_key": "195207c9e44942d5cfbf338fb9f20317d3ae8be85dac5f10dd60abd802a3caa9",
+        "sha3_256_hash_of_public_key": "dba94ad660ae996986a3321bcccf132d497bb2cb53b6a1817992e5eb25aacce1",
+        "sha3_256_hash_of_secret_key": "120af281a8c1e9799c5ddcfe0807e628beefddaec1edf14472aa72e5ee00ec94",
         "encapsulation_seed": "1a4d5dff5847cfb48333e33bb00ca7301b144aa89dcd412ff5a3b1081d775b7f",
-        "sha3_256_hash_of_ciphertext": "ddcc4d878447ee699abdb85f1463b113784be6d4e42c46379b31c02715243f17",
-        "shared_secret": "2eb03b010e291fca1bb6ed09d22d50b9c7bec93c556f1f273e57048c9c56bb3c"
+        "sha3_256_hash_of_ciphertext": "0580a0d4b05dfa377df2473aaf95c276b2ea33721ebac0c568a126f709575b84",
+        "shared_secret": "c798b2398d8ca4a6fe777a74963266543c7a81f862c845844b0dabceedad6ee6"
     },
     {
         "key_generation_seed": "b12f6fd965ea9c5b947db80fc60c83d5e232dca82e7263027c19bd62e5a6ff550f6aa3e88f7fa8a96067f8cdaeceeac90c2d0b5e277e56e9c405ec9420c30252",
-        "sha3_256_hash_of_public_key": "2d19bf7937eeab0d2a7570d43cf965547542a519be85bdd4921f7d710747ec6f",
-        "sha3_256_hash_of_secret_key": "cd59ca5c7954d87bc8d025683563aab0f9272d6c12cc03914220aa6ee392e6b3",
+        "sha3_256_hash_of_public_key": "46b03c7f8f64a71e96c2cccd1dd4a9239bcd8b2709b37b7e6b02835f3dc1e24d",
+        "sha3_256_hash_of_secret_key": "bd2e811ec1c9da5afcbc5560740e7db77de0494e00e964e9f0a5eee6fb1fc963",
         "encapsulation_seed": "34f44ec2092eeaf686f2ea170591a98527cbb03a4fa9477a7aef6b41a54feeb2",
-        "sha3_256_hash_of_ciphertext": "86184bc66edef41a25ca3350698277f4e49713b821fd0745d276fe490ac636d9",
-        "shared_secret": "be892649db60b2ce07ef18c4a709714933542ab94ee3250cea6e7c6f5eee5d5f"
+        "sha3_256_hash_of_ciphertext": "0aa330b9a2a92d29035d45895392875f8776df8ed67579bc132232d4f25d872e",
+        "shared_secret": "ac574ff532f1cc76e4e7a58f8ad8e276d60e807fe175b19c871d1b8d30c06fc8"
     },
     {
         "key_generation_seed": "9f52af92ca165fdc38788f2b59ba02e01c8281ff7c1e60504688043a5fe814b04f3029e1be4e1c0258c3a22ff5b50b2674cc094ba7018da2a61569845c17d26f",
-        "sha3_256_hash_of_public_key": "6907e1096410ab332e10f37c93d86d9b4657159eac1faffcd1688d182d127844",
-        "sha3_256_hash_of_secret_key": "250d27ac4dc4447520c4c1193ac57d239857ecbeac2b1009dc08dca2114299ed",
+        "sha3_256_hash_of_public_key": "abd035f25bcad20e4ee2d794895e77d234a80ff59177ecdede77c1264e4d7918",
+        "sha3_256_hash_of_secret_key": "f2fadb1ca29bbe8b7065692fd97504b7dca1275a328d3f67958bc55104edd6bb",
         "encapsulation_seed": "6250c81126572eec2da330271db36ee591f060fc7e53eeefe2e1c476c675fa33",
-        "sha3_256_hash_of_ciphertext": "51c6ca6d7536a183416b16b1716cecd3d994dba4b5ba019bced87bb51f9cef0a",
-        "shared_secret": "75556d5854c44805ca5c4bb927c837ff635feaae939220592d89caf74592a0be"
+        "sha3_256_hash_of_ciphertext": "89b5deb9556783c155da8b95370cc3ef02e1c890c51ec53960614c6de4bb031e",
+        "shared_secret": "1bdc185a6a1d872036e8a859f13ced91b38115c0c3e642608c1cb6c8e51f4a76"
     },
     {
         "key_generation_seed": "851ea90fd3854cbf28fe39fb81f68e4b14345cf0d6eee7ec4ce772513df8410d1c0ec046899a777655233e4e1b5ca44e9afbdc67964bfd5d5e3dbb45e60d03cf",
-        "sha3_256_hash_of_public_key": "379c9176059f3a7ddfe021041301bcebbc91e997a0d5bf2ed1d9d125a7129834",
-        "sha3_256_hash_of_secret_key": "57df17dd8b9b1411af66d82f61dd61c4f5235f48d503c164ad0da02a598a69b2",
+        "sha3_256_hash_of_public_key": "5a5e1f55aee1c0a6256ed51c5d0492b2215a71c16b6f0eb9e0a6b346567c6b38",
+        "sha3_256_hash_of_secret_key": "0a66ba24fc4085eb2d301b2dd6cd0f1285366d4584588208453b38b3dfea8581",
         "encapsulation_seed": "35d470bcc5880872754810dfb3f2796da2fd7f397537146f6488c27804072b34",
-        "sha3_256_hash_of_ciphertext": "a5773e0569d9e26225b05bd61591d1722c4c1396789ce3156ef749c115949ace",
-        "shared_secret": "469d60c303b10f517a932d9fc090e61802003e9cba3630224f2c43a4727230e1"
+        "sha3_256_hash_of_ciphertext": "9233674d4ee76dd5e223e449ae63a8a01cf4d84046c1c2d9dcf3e91e397ba4b9",
+        "shared_secret": "f3bc901de0d6680cf84346aba78b5f181e4264db6a0682c04686cc4c1189e50f"
     },
     {
         "key_generation_seed": "d304c9389cc973477f169788abcb9d511f843219d246a9b587822f422a70c2386590a2e5c7ed86cf2c5c2a898662bc9a81418720bbb632ef9cf0b845ed052d73",
-        "sha3_256_hash_of_public_key": "f5515b23187af5dac6d1d090bc7bc01df34ec781561e3d3b8b62164f74946802",
-        "sha3_256_hash_of_secret_key": "2ab40ea093450e534152efb278b45038f1f2cccf13a654f1c5c27b8c389f6129",
+        "sha3_256_hash_of_public_key": "4206dcef1444b937700ee59389299a5d57d73ffb8d5559e9be2ade61b8b79569",
+        "sha3_256_hash_of_secret_key": "81a4e4caa46c883574984f71b122ed7efb7c369dcd3b6bcc1b6c61b9a3339612",
         "encapsulation_seed": "8d667921c5db401a86fe1c35dfcf164a6bb2ab7400fd6a0b67eafd4a0ed11940",
-        "sha3_256_hash_of_ciphertext": "d1b469613c872181c4428440cec1ccf87b82303e4979de6eddd437decd8afecd",
-        "shared_secret": "b545dc066355b91cef05e65107fa11070c455209c55573cc549cd053c8e4155a"
+        "sha3_256_hash_of_ciphertext": "0fb10394527c82b91b0253868a01a330a291e660bcd91a57bf8d922b426894cc",
+        "shared_secret": "61863ecb6b42bb1af06b83263c5fe95c66032597c924369858b530f11ad1c557"
     },
     {
         "key_generation_seed": "89a6e3be304a3518fb82b18ca730f0b359cd6ba90664a493fb4f8edaf965b9c3b6591121e25d64010c25a18676033e1d7278ac5f2d0b43a31f3a4156ae710465",
-        "sha3_256_hash_of_public_key": "9dc0d69094efe63d751e6f9c1e92d2107a7b45fabb820222d30b11595c351643",
-        "sha3_256_hash_of_secret_key": "00f4a04ab804f2fa3ed80a0fa4530fd45ebff8afadf5f5b7d46a672c690ac3ac",
+        "sha3_256_hash_of_public_key": "ecf79082f0a70bf91879f04d701b874e718a6f80f251d986f1d448218e2dba05",
+        "sha3_256_hash_of_secret_key": "636f7b5a71823a450827d0b1d62886abe3195cd149aa94e21971500d5e8cacfb",
         "encapsulation_seed": "ec750b3939385a3f8df868119dc76f77ca845567ef068de6ada5478a56bc78b6",
-        "sha3_256_hash_of_ciphertext": "774abc2c6dc9570eb781a39f79f49f2cc6870a43e8812559d89d1c59bb1aa5ef",
-        "shared_secret": "2c42bc4a172c928bc6ec7480785d63f7281a9e5acfd3f94335d6d7fe5fb9c5d4"
+        "sha3_256_hash_of_ciphertext": "3409c42317e4ad9e4c7baec74ca8a2a8b4a684e9805967a4364d8c82a7d46350",
+        "shared_secret": "f7a6bfd175be93e079f6e9dba996f887a981b3e4de71401be391a6b3bb083beb"
     },
     {
         "key_generation_seed": "d569b935ce015c85f792f8f7fb0d83c4f53b492959361dd4f75fb764d656450176eae84d11c4528382828f7a689a0d5cff87b8ca0bba97feacb39b935a8788cb",
-        "sha3_256_hash_of_public_key": "16829a8aa9f8c4e949d4e6388448c2c4ec6a977f8c5fb80bd75d93a723bc9bbe",
-        "sha3_256_hash_of_secret_key": "659cb66f989532fdf5a741fd03862fb142a05a0fb43ae20bffc5116de1a66d57",
+        "sha3_256_hash_of_public_key": "ccb0b82755814de055067899e6900234a10b223ae2eb0c5fc2cb6dc80c14d476",
+        "sha3_256_hash_of_secret_key": "0ec84a10c5c8b808c20bee872ddc3644f47aa354a563d1501efd59a2481d011b",
         "encapsulation_seed": "74f1d52af09b12c36eb062ea7528550cb4c18a3ce8e4f4ea9fac43ae383bc925",
-        "sha3_256_hash_of_ciphertext": "ff53eb11ffac30f45bc8327d7e7d518f1c2d71bae0052ce8e15903c8d14978e7",
-        "shared_secret": "230a69c53e2192eed6c9b876d6b228fb666b19448e0a2ef8601910d624bc173f"
+        "sha3_256_hash_of_ciphertext": "4796666c40df423443bdfcb143dab3135a5dff82fdd29656fa0ec719ca052d40",
+        "shared_secret": "d9a26637ecaca3315e39d1f2a4f84d2c861fb6383e3f6e6026a7622209ceeabb"
     },
     {
         "key_generation_seed": "5cbb141c2763425c274f7404fe530d9116e08c33f9f200a20b011cf563a28990fc9ebbe336dc464489861db8253606971bd0a9008a433ed17752d04023781552",
-        "sha3_256_hash_of_public_key": "90fe22b38a4fafc045cdbe0c9689745fb45760cb2f0f94f7d13cf8c834c4df3c",
-        "sha3_256_hash_of_secret_key": "10a89c990c7676890a65e1c776cf892ef1431d56fc115ef3115c0b8f91db0690",
+        "sha3_256_hash_of_public_key": "934a0337d7b76ba83dd05a4ed818174aec5065993db278552f32af640097ce97",
+        "sha3_256_hash_of_secret_key": "bfb5736d9164a92877578cf0287d57e8117ebf27ea440995273fe24ecac8fce8",
         "encapsulation_seed": "4b3a70d85f640d1a2a852fb6fe96704af56a7415a8ee4282e9207bc3a2dc116a",
-        "sha3_256_hash_of_ciphertext": "3d1fa5720670ea284567d32beaca2e56853f7b6268e32af381034f13e4cd4853",
-        "shared_secret": "327c548d7df90d813f3b3c92e908c4c55fe4c7277f91b6fa2271c0f149dfb273"
+        "sha3_256_hash_of_ciphertext": "c6ca3b3b5ea095d671aee3c4d3b5f6ad439582ee3f71f128143fe01308511b03",
+        "shared_secret": "287a28afc86b4294ed65766aa77af1c06de1811b859fc0edf5d32b2e8d5d178f"
     },
     {
         "key_generation_seed": "293abb6d1c207927945417cf84883ef010823e11b487ed55239e466e83696d0cff8563038aad865a817cab9ce98846ba75be9363718ecf5fea538aea90b2a558",
-        "sha3_256_hash_of_public_key": "c277a9588d9a781ddff6aa9ea8d259e5599d0adaba2f459598ebd5bc72786023",
-        "sha3_256_hash_of_secret_key": "40609cf26d205ce694ca8baa097bc1342d2462a26678eab90893da147e389d3e",
+        "sha3_256_hash_of_public_key": "d8594fdab618acf08669dfa36e80546853fad47833f24e32ca38b8010c1f78a7",
+        "sha3_256_hash_of_secret_key": "dd03373f5f7333db193db88fc76dd506745e22f5c966054b1082b1e35499cef1",
         "encapsulation_seed": "26e38ac804fb5b4d59ddf747715e7e6041d875f99c7b638024b4af82d622da60",
-        "sha3_256_hash_of_ciphertext": "bd274d905deacefc3d90a9ed76d59af4e814cfc06c118ec17662afa4f6b4fdd6",
-        "shared_secret": "0d95796efa11ef2b4f05d0cd9e1d8db26f3e5839fbba7cd84e00d468decc088c"
+        "sha3_256_hash_of_ciphertext": "52584430c3c95fcf3ff154e68681aad08ce815e2b8fb2ea29af5c9b9b9dbfa4a",
+        "shared_secret": "9bfdfc3572dcfbd3a7daa91cabd1458b9548ad62dc0f1cb27406ff2421046282"
     },
     {
         "key_generation_seed": "74d87c7556f2671f2d666854a4d6e073e69f35421e6e1a428cccea49c37f972ce1fb7456ac0aa1b97068f452cba64ebdc138bcf5d36b0a0fada2a3b374141eb9",
-        "sha3_256_hash_of_public_key": "d3c8cc315c4054d09deac08c6d5d364fd5d47a3c09041bee42c561f978e2d98f",
-        "sha3_256_hash_of_secret_key": "3e1b23ca9dc111c4a3cb0a585c7f4e5d1f27a71533eaa5347e285c7c35e81990",
+        "sha3_256_hash_of_public_key": "d5aa695ed35bb69221a107c73d8fcbd77b3380c10ef11a9464cdb1d7922b33da",
+        "sha3_256_hash_of_secret_key": "bc7a92d35223648c83e8c0432e0a5cfaeecd5781511f5647cb06a59ebfd82c38",
         "encapsulation_seed": "a319d2b8f114f1acd866478bcdeba6fd164dc4e37b0adfa8d8034afb3e197376",
-        "sha3_256_hash_of_ciphertext": "c866f33265de001b3308ec41682803d46dc61d423d61565aa5ab2f1367c93e3d",
-        "shared_secret": "cc047c6cad36dd056b84e6b9a4fb6b1b349d593e104ba94a67b107b291ca4633"
+        "sha3_256_hash_of_ciphertext": "71c7567b921a906a57c570ee63422ab803d692da8b9be3ce184d194c6802e844",
+        "shared_secret": "7a9bf279089ce02f4da09a3055c7d8323a9f5880d6b6c0a07cca7d8d7f938e0f"
     },
     {
         "key_generation_seed": "013bab0212d04ecd54b478daf72748003a25e2cb060ba6cc50bf95c292b8206b9da0c5da5f195b80fbb99c2e8b06926074f3f604b3f6195b5a5b9737876bba72",
-        "sha3_256_hash_of_public_key": "dd1a07043fa0c6452500249601f25de742ab44213e2718cf0ddc5ff6a2a9aa6a",
-        "sha3_256_hash_of_secret_key": "2cfeaf5c1b4195f0374256027d3a888e9a093de8ff9181296d5b1b94048de38a",
+        "sha3_256_hash_of_public_key": "b0a3984fc13ffc6860669994565b9344de9c6eb081e6e4e904bc22b9af2b9891",
+        "sha3_256_hash_of_secret_key": "957e9bebad0ad2aa007e1e04dc78b5990c68bd2e863cbc14880058d4950d635c",
         "encapsulation_seed": "ff646071b2509e6b75790917e08e4f0b0d9f0116ec6291c0b59eaa4b583ad830",
-        "sha3_256_hash_of_ciphertext": "6dad2899c49ef32329180b6b8749c28a24e070fe989027061dea25f0b05490b3",
-        "shared_secret": "2faf2dd50be618b025cd2b53365221f5258e175e4a445cf053c66b3d3a998c8a"
+        "sha3_256_hash_of_ciphertext": "eb38d742fee33458b092a04bf37668a9878a6ca76ddf96b19ae99fdf84fc0516",
+        "shared_secret": "ca5b135e2011c61ec9c4914324b6064393544743885baae2f49c47c02597ebfe"
     },
     {
         "key_generation_seed": "ccb073c4b90be0ad746e26fb093b60c70110bd1dcbcddb566a8cffb7b3caf80e71600a8982c350df524cde514431ded7aec23576530894bcbf0ec0bfef0bb64f",
-        "sha3_256_hash_of_public_key": "f2a8cad42c743eb61aa338049ce917616899c803358541de1e58cbbdcf3c6328",
-        "sha3_256_hash_of_secret_key": "7a9ebb792c7193ffefe6e4760ebd0dec6f67c3f3b0fddb5abb4b7e931ee827e6",
+        "sha3_256_hash_of_public_key": "a89eaf6058fec4baf40c66232a3bfb19625ca6c502007d281f1fccded5fe4d90",
+        "sha3_256_hash_of_secret_key": "b788bcce1ba061bc44e2d0923dbb51a93c9da65f34c24c15b4f5e978342f17a7",
         "encapsulation_seed": "0584270ec26f3b9818e4af074d17b2d51037cc8dfdcbe3b140fa4fed5deebc54",
-        "sha3_256_hash_of_ciphertext": "125f7da90bdf4bbeecc54e47e065b221a6ce42d0569530c136ce2c9415b17e79",
-        "shared_secret": "cd890d2eee7f747441ca9448c7192bcc274e8b0c3c80005cb6fdb4691186d85d"
+        "sha3_256_hash_of_ciphertext": "5357f60afbb1d8bd9499daedd0806d5d777b155c099b0a1bd12bd22a9a158c48",
+        "shared_secret": "9baaa93879d2499d70fda552ce3c6cb030495c99da8934a700327c25a6a2cf8e"
     },
     {
         "key_generation_seed": "2e889f44e28901e9ac7ca6b2fffcb124c8979401b17064d7e1d51a7e3c3adbfa0e145e44aae52cfc609e6f47fd7a6f6af877190ff52256d0ac5b05b89c3f449f",
-        "sha3_256_hash_of_public_key": "3394e8401245fd6348bfa697f6990b6671577ec7b35a45b0101730a801942643",
-        "sha3_256_hash_of_secret_key": "3ecbb219e90e2250ad5ba87f53975439cacc030c3e1641b87ba8c5b3d89a4aba",
+        "sha3_256_hash_of_public_key": "80b93464a435b551b5b59daf155bf824f178335d0d2429544fb0ad8f2f0cb8e2",
+        "sha3_256_hash_of_secret_key": "35d9b38396e525ce4d23bf95670794512922fc90df8b774e2fc3c2019e6a39a5",
         "encapsulation_seed": "51e05c7b4ca3079781e8293f4eccebeeb2f8c8b4c59468eddb62a21bcb4ab8a3",
-        "sha3_256_hash_of_ciphertext": "6cd30cb202554c18809da0819ced4cfe83021874fa9c48c3374b7544e3256f5b",
-        "shared_secret": "e7942359dfb015d5022b790b5e777a93a5963260ae352567d3fb7e27b2ef0bab"
+        "sha3_256_hash_of_ciphertext": "a6fafb106b9c313484f2f855a36fc50a533a7808b54779243e12ad0ea25afb9a",
+        "shared_secret": "58af802548d173804a1d405b79fb292af5b5e18d582eac78221a1cea893757d3"
     },
     {
         "key_generation_seed": "174aaa36410566dc15a5e62874218d7abdde0b2c0f30d877bb80b1abd5f5a0a450a7a2354f7e5cefa6f4a4e9a1c411eb9364506e9e1204a8acb3cb77fbd2c4ed",
-        "sha3_256_hash_of_public_key": "ec9c0d68c84cf3804f14e8daffdd1e28c28d3d55ee782c98c498b0d9bd4ebb23",
-        "sha3_256_hash_of_secret_key": "24a2b3c3efd979a1406e92d5c504d5004079965b5fd0492469f1b4250f7023ff",
+        "sha3_256_hash_of_public_key": "77fb974ccaeed64d486756e7a0ebed1b0253b4e8ae0d6caa6e4dc28daf8613c4",
+        "sha3_256_hash_of_secret_key": "2f0cbd4a26a128100f5216e0c484c21a493cee0649e44fb1a352ba28ddb567cb",
         "encapsulation_seed": "9eca0fe36c80fc5eba171c3ae66a5b1c923faa50b4521bb055e7bf51005c93df",
-        "sha3_256_hash_of_ciphertext": "a2c6cfb957639661086b02d9a312e7483150fae87d84f21f56e48850af7e3b62",
-        "shared_secret": "5d7b6ecaadbae69fbaa9e004634ea609df6ec80801bbe73671f4e52169cc9683"
+        "sha3_256_hash_of_ciphertext": "5ec29e7d6f484ca9c6d2cf1d4266df4d72e9bfcf0ffd968be46519be733aa2b8",
+        "shared_secret": "4e917ad1cd0754e5af0e862e4ca55f6002c919a034f5258624697aa8fcadf76c"
     },
     {
         "key_generation_seed": "351fe4313e2da7fac83d509f3103caf7b4c64a4d458fefdf636785ac361a1390f072d9b5a99f9c7a0a011e4dc10f6b600d611f40bba75071e7bee61d23fd5eda",
-        "sha3_256_hash_of_public_key": "a9d7d5a52aa2dc226832f6e4603322f60b1dc21207e3360712f9c6445d37e64d",
-        "sha3_256_hash_of_secret_key": "2e5342a1c2f58a48e044a26673799c63f88656f6d350a0d7e57bbf8811b2a5e9",
+        "sha3_256_hash_of_public_key": "980defe8c6578a5d9f0c7916576e760f8b37df394e517e60efe2844540fa5281",
+        "sha3_256_hash_of_secret_key": "ffd25b298e4fc5df0cfa979e2e4c1deec257612543c60b7f64542387fb254e97",
         "encapsulation_seed": "0c5719261caab51ae66b8c32e21c34e6d86ee4aa127d1b0195663c066497b2e9",
-        "sha3_256_hash_of_ciphertext": "b79a2fbd2e63aa66a526fbb42440224fad7ce91206df3684d1deb4a3e57bfafa",
-        "shared_secret": "547666f6c72c97a8f06fbd7cda4279165dc82489aba2119416e0dc46795bc464"
+        "sha3_256_hash_of_ciphertext": "b30c4c6ef874b746d2bdc4073a12d5ccb48ce604b3978687df16505897cabe82",
+        "shared_secret": "12ff2c4d37b7cfcd87dad305c59bf2e53451b0d7340ec7ca504e0a6bdb629532"
     },
     {
         "key_generation_seed": "9bc5315580207c6c16dcf3a30c48daf278de12e8c27df6733e62f799068ad23d5a4d0a8a41c4f666854e9b13673071ceb2fd61def9a850c211e7c50071b1ddad",
-        "sha3_256_hash_of_public_key": "fa7ba132b5dfa2e3ce67b64bc72d551f3290d428cfbd45ec026f44c8dc28334d",
-        "sha3_256_hash_of_secret_key": "34306d06720216257691fc65054ed32decd609312f5c5f061e7763ae73fe0aba",
+        "sha3_256_hash_of_public_key": "d61e3bc88050ad387e31f232b0a43b3bea53627750f6af50b92bd72d67225ec5",
+        "sha3_256_hash_of_secret_key": "4ac574a1526dbe11823c392e405d59f6e28b377d68a3c70bee4c0393e724a322",
         "encapsulation_seed": "0e59f6f9047c784c1f00b24454aa4f1bd32c92ae7e626549972f86fab90e7e89",
-        "sha3_256_hash_of_ciphertext": "acd7944297fc3b0d2daa3b0cbc999a43de7e9f948d39b9c6a4746873e285f8a8",
-        "shared_secret": "88c80381cde3db2c1d40aedf8cf923b79b18cf76efe0e46edc3e25e17c7cd8c6"
+        "sha3_256_hash_of_ciphertext": "acf44abb41216fa8aef76fe78c416d2423b2ab54d09107fc10cf96bf5aa23af4",
+        "shared_secret": "63e76a1f1f3b775218902e2411e60a634ba51a51e6d16affc9978857f9242a56"
     },
     {
         "key_generation_seed": "d8b907b34d152ff8603b73051f772daa71eb902c47b7e2f070508269d757e02e36b817736cbc5f7b1dd6eef5fe6332fb1a598f3871e5470d440fd2ea631da28a",
-        "sha3_256_hash_of_public_key": "29f8a01ba71d04d6831c03d1ff294fb58ef6f4041772cc071074829c32a3ac9d",
-        "sha3_256_hash_of_secret_key": "95f9b4063bf05f89ca9f99e393b11c0f2105eafe40abb313f345b58e10519955",
+        "sha3_256_hash_of_public_key": "e1f04e79eead71b8a5a1f1df186fc6c49c981fb42907d705362c69fa907831ce",
+        "sha3_256_hash_of_secret_key": "3de13af567f679b0db868f14500c88264838c11de18560bffbaf76c39a0ae8ed",
         "encapsulation_seed": "a3963ade17d69debbc358dda82c7bebe2c39d25b36813058e7a161542e3f8c2b",
-        "sha3_256_hash_of_ciphertext": "096f7946c01dc61a13dac8b85d9c377f9c86aaf8ddc02163a74169854046a1b0",
-        "shared_secret": "ccda9f28bb09dc0017a1df8e1796a3489c66afd2c3898a39027c843cf022b790"
+        "sha3_256_hash_of_ciphertext": "6fe9a067c7ab99d00f049993f1bcc1dc31cb5f49c40292e4ea495b6929578966",
+        "shared_secret": "c8190ec44fd30bc0a87e53c01423b2d7e34421708dad96ff36108f7e4f6c946f"
     },
     {
         "key_generation_seed": "684a29e4e5480a5f2533e1526b5fac8cdf5927f3d85087c71f928c59690eb56575d12195ec32a8686d0600e45d4a7f54219b0d7a3826d193a51b9156ecf2edd6",
-        "sha3_256_hash_of_public_key": "357376de9843d74252466888727f9dc1ef48d028c0f52c902aa0dfc3de374c83",
-        "sha3_256_hash_of_secret_key": "b8d675ce213c73f9792f328448850047f4410fc500212939ab2e234b619c9104",
+        "sha3_256_hash_of_public_key": "d74e311ba5d734ae2c606d96748cc442aa4bd69460dc2fdf6f6fa8e7afa6af8f",
+        "sha3_256_hash_of_secret_key": "a0873e0ea7707829726b78601828ae101377426881ff4799a6364e9d9c42e491",
         "encapsulation_seed": "97beafabf2c8575586487c7a80e8af5fc50f94b6051c1bc66a5ae9f66be3cea7",
-        "sha3_256_hash_of_ciphertext": "a0810d28d2dec44499bc47d48ae22984c17728547c3ff0cc859702d2a6962f88",
-        "shared_secret": "caea7e78e6f80e126a9f41ddc0ae5946a80cdf617635934b22c9097c5090ce59"
+        "sha3_256_hash_of_ciphertext": "e3daccd3cfe9e491e3b3392e02e99eaf6b4127cd2634aed63fc9ddccef980042",
+        "shared_secret": "ad277878eee2d9a256573ead742baf0cf7daaf2c9296d2d3a005e99a0862cd05"
     },
     {
         "key_generation_seed": "d76b3573f596eb286ab5231feec7499686b13021be36cb126c7ebeb9d7030daf248c0a21ea0bb6d6f56f12300e8584d8e9a34e0e6f52227281151ae4c305fb8f",
-        "sha3_256_hash_of_public_key": "30382cb59feee1b6b0fc129fecb8c74034da92987249bc20cc8ad4a2cfc1bfe0",
-        "sha3_256_hash_of_secret_key": "2600203271549828d0979adea52e2e976b7d9f85bfa6931d6c79e14137fad51c",
+        "sha3_256_hash_of_public_key": "8e1f82b5bb2be84802904df92cc59847bac515c23b50daee429eb8c94daae147",
+        "sha3_256_hash_of_secret_key": "1832add5939d7ae08e4694f416d3f26be1132644f456c1e571f478fc7d263755",
         "encapsulation_seed": "75461decd34c50d6a094b4a64fb75e5e9479f8f9250d82bb7d729dedeb2d4b65",
-        "sha3_256_hash_of_ciphertext": "4d20b7665cdea726a3240782143beb60585d4ae39bf18f4ab5343d4f44c7acd6",
-        "shared_secret": "431bba421ea89647d815a16f440d47f1604b67d9a2d33f2dcd21dae7e65bd5ce"
+        "sha3_256_hash_of_ciphertext": "73ecca3ae4ba76d11bedc7fa427b4174622b4617809397345bf52c73d948ccb0",
+        "shared_secret": "c4be00089dae8cc78187a857fc05261b08cdb75b113ec2e9b295818e00a5b0f8"
     },
     {
         "key_generation_seed": "b87439fde81c9e39eebe7cf741c685785532c1dd23e8ef868b9ce7a541010f3d1646460817a0fce5836bdfe124a7448e7adf7b8ecc2652ac6d280e986682df71",
-        "sha3_256_hash_of_public_key": "f4e474fd64a6d945e85eb4ee7509cc99fd4054de99f819fdbbb05c54ca6e36da",
-        "sha3_256_hash_of_secret_key": "d8a3a0edc73fee057281add9e7cb328566fb22c5082978c69088d76e98ffff90",
+        "sha3_256_hash_of_public_key": "4a578f7a30dad7dc700ddaaa4a07ae3661cd2f542663e9dea36441a18982cb1e",
+        "sha3_256_hash_of_secret_key": "d4ee51b717953716b5c962ce3794d405f97e8b2684d04c2a4bf129a8cec23087",
         "encapsulation_seed": "2607dcf4fd6ca1c614c21b5e37c24981c32b91c8c3e6955777da8a3f5d9c9335",
-        "sha3_256_hash_of_ciphertext": "0f18bede2f42d6fdf32dcd2cf8937ee8d2909eef0aaca8586c3892d608712a98",
-        "shared_secret": "cc0a7809cf6787a4587e090249709f694b709ec8475a42b4705bd1ba312c098e"
+        "sha3_256_hash_of_ciphertext": "1951a0693a870105b90ef2a2a465ce9f75a3e01204026e05235d44a53190f363",
+        "shared_secret": "f4413efa8dba4bf3b8da9cfa4f3ff3d7bae540c7f242a377a1f9a783f7b69542"
     },
     {
         "key_generation_seed": "056661b38038da4fdd7426f32a81576c73ed84843b305168a374f934e27a4e1b79238a80dcfd7c992d84b2dffa67493e669243d4fa38c46b090bdf86bc548411",
-        "sha3_256_hash_of_public_key": "50688de263a82386f39a7b82592247bf5499f1836a3a941413c75f6331ce4031",
-        "sha3_256_hash_of_secret_key": "ff207007724ca5d696ba44cb106f525858111d55323c9fc0fb98d64d4f8de8d8",
+        "sha3_256_hash_of_public_key": "bd7c4b5dcdb1e5e85f26c47050d5a34ad902eaa7a291acd826be0b2131156796",
+        "sha3_256_hash_of_secret_key": "208967e997b80f07f57464dc236175b5b1d9d39105f0d6393f3bbf3b244436be",
         "encapsulation_seed": "38c89bbe7145c29e9a831c11431eb9929cb24fb4992db20737e4687d397fd732",
-        "sha3_256_hash_of_ciphertext": "9dcc43fabf94918ed4f7936960d8c732deb2209090d1303d62d5ba591b51a142",
-        "shared_secret": "cf21da86b3e09c38ce5799637b1492a1a268dbf0ac716499c68bac11a774f41c"
+        "sha3_256_hash_of_ciphertext": "fb05d51f1fb25937ab5377be13522f3e7daf6c4cbeea16ba59e4864fff72883c",
+        "shared_secret": "1ee5706ff92d964b406807e97547072b0108466d36d2ccd7107121ff5e8e5d56"
     },
     {
         "key_generation_seed": "a1b52d871612a1c611ae0944f9e71858f35d3bd14f20e96a931720668bdf0a6b1f135cf64b6403e103afae34da038613e2853bbfc36baafa3c6a95347193f37c",
-        "sha3_256_hash_of_public_key": "1a29c0f2dc4089a85db6865ec90faf2f4ddd25f210eb56e49741866bbca8cf81",
-        "sha3_256_hash_of_secret_key": "477dbc28e4f21587f274e7a3b673f743840da1501c35f0e9ceb8972970de6f86",
+        "sha3_256_hash_of_public_key": "c3ecb18be331d910bb3800749fc94108e75153523c20ff6e89d53f802b23c634",
+        "sha3_256_hash_of_secret_key": "96dda5fc88ca618a47b2dd57fd57e14e717dfbfe59165ea6dc65c71a76ffce2b",
         "encapsulation_seed": "b2c35e33c72d90182791f0e12a0324f5b216efcab2c8da1bee025dfbe13f4152",
-        "sha3_256_hash_of_ciphertext": "877f477beda55ed2a7c34408c04b4a90596b4d94ac1830bc04a0ac9b73761ffe",
-        "shared_secret": "b56f557eb758ae10d22b5d65847cd811475b96f5a46b0ed3bc2f1b9b371fef0f"
+        "sha3_256_hash_of_ciphertext": "7afeba66a6b9933fc6c468781ef721c530afd47c2e061e307a927cb401c7dd5d",
+        "shared_secret": "7544bba4833759c97bcccda3a5018f3efe76878b89a7e3b622c7ecb84bbc76f7"
     },
     {
         "key_generation_seed": "952b49c803d6d6fba69f4375adce8594847a00bcae2179da49af2aed0423250262d7033947ae42ca53522a65fbafe18d3bc3e0cb66164e9a094fe4b44d8977ed",
-        "sha3_256_hash_of_public_key": "3fffc419d3d8a887ff789eb661b2af1ee5b32a302ca267b33eac2ea7e3340b97",
-        "sha3_256_hash_of_secret_key": "0f42068d2885e1a44b2ce4042675118f4fa35f58c1206b965b57ccb52c4f25f8",
+        "sha3_256_hash_of_public_key": "7fea0580712265383dbdf8c3d33e0718a34646e0ad56f9d2b504dabde37714c8",
+        "sha3_256_hash_of_secret_key": "ac73423f1f023605c31289e52dd6b93738ceb80f4cff6f5078148287011cc971",
         "encapsulation_seed": "afb7d6dc2b7eb6d84acc080c1be63c98afe7b07786b5801f716444a3e8e64800",
-        "sha3_256_hash_of_ciphertext": "d8f7b4a0047c18a84ed13e3057e240cb578cdd2ac1e57dbbd6253eca9208d6df",
-        "shared_secret": "aec1264f12ddd2ee8e51b71d703ca5c2718dbd79858240635f9b076c749a5ffb"
+        "sha3_256_hash_of_ciphertext": "ced964577aa26c43e32be71e5d28e712930942a7bba6cf6b8e895a3627300c9e",
+        "shared_secret": "0ba3e280117390015d3872dfdd37a4688dcd8b188ebd4a3d4dde1ddf0216aefe"
     },
     {
         "key_generation_seed": "3c815e57e9233e975fa1630208aab206b71ae0db37a7a8789ac683d9f9b2d29801c8e376fdb140ee343106c093af7cb149b316ba79446ceb4e5e0cedb9b164f9",
-        "sha3_256_hash_of_public_key": "f1de70b1072881eb659a5e890a92c9313c7378d2e960a060b9c918260d4c2458",
-        "sha3_256_hash_of_secret_key": "ecd9d757d80352b4fb51c71976d7b2ddeb927052f9f7a7cc61fa67662d4dc86f",
+        "sha3_256_hash_of_public_key": "bd80f5c5452d1336cfc1cca76d1770b5524b68540b8722795f17d639791a85fb",
+        "sha3_256_hash_of_secret_key": "7b58737b40a0f1e576b5f66de4838cd15ad754884d91eb16a3f571cdb079818a",
         "encapsulation_seed": "28f5e9dbda122b2cf8f3754fe9e0c73a84ad4b0c093522e0b62cf815d60bbc3c",
-        "sha3_256_hash_of_ciphertext": "10b2b1dfe168aace0dce3776456c2e2605f99fdeaadfa3ff5e7a81f6bafcb76d",
-        "shared_secret": "6514a3b97760070116c64014c5695df60d0345b29ada92fe24b672586f5bf06e"
+        "sha3_256_hash_of_ciphertext": "ef240b91b08e0d7bf6727869b881d7d22530b1f643d1f6e38ecb7fa8acb0c819",
+        "shared_secret": "f02b50d251193fedd23743b33c4a2610adee54b61de0a780ea5247801c86fed4"
     },
     {
         "key_generation_seed": "588760826dcfbd36d9abe6ae44a669bb3ebba6a218eab69e30f18a3bd536576e0e860576285483bb5fd36e2f944d32c4317bebc1e441470c1372046a790d79d4",
-        "sha3_256_hash_of_public_key": "b0c77b5407577a9a9cd8864efb80974aae107fa2801b6ccaf341d5456a86621f",
-        "sha3_256_hash_of_secret_key": "0feade68babcf09673bf843c59379520c19081f2bc33940a8dfcee07832ec66d",
+        "sha3_256_hash_of_public_key": "de22432e87b3e1627bf1ce346187554469241c565a5c14cadfbff29e6bdd8d01",
+        "sha3_256_hash_of_secret_key": "ca3fd2d8485917d199c03c92e01ac70fad179957e8d4cb83925c2820a0217cb6",
         "encapsulation_seed": "b0d713cbef0bb1df70cbb425d1e9373e9f7790fdc7980cc96a240dfc53f1e8e2",
-        "sha3_256_hash_of_ciphertext": "b204aa70efa18e31a11b6b92e6c7dab4b2f4766ec5d302a0e93e4feb05fe4843",
-        "shared_secret": "52344e5e173fc6088c9dc555cc90d8e5de19bdfa0d657ad8de1a3c24ea679bb3"
+        "sha3_256_hash_of_ciphertext": "2999800b672abb8ae74c0e7c3a275c7557834e72d7cfccc2ee787cb363fb7171",
+        "shared_secret": "b8651dbc22b4c050fd45f4d0c035c01fa7f12c7b8670f2f2c204eb7b2081d47e"
     },
     {
         "key_generation_seed": "47550e9edacb6ddce3d9ab81f6b61080dd4f2693854acb05e0ccc7a4fb6390fbf89d7d99d5c3e0d10d6ef9af054d842375f695abb28e3b8eb495100f04306e92",
-        "sha3_256_hash_of_public_key": "255d2e2fe01c87cf70bc30703644fc255f83fb47cc5cc5ae2c0e49d6198cae03",
-        "sha3_256_hash_of_secret_key": "1b1050f38bdb785ed43daa264b60c7946d93f135c65e93c95c39fd1f2d7b5311",
+        "sha3_256_hash_of_public_key": "1ab5d1bff67b0e5d82b9e9e2690083ceb0529c937a3dab8c62c17c5678ff82fa",
+        "sha3_256_hash_of_secret_key": "c85f17a54f7ebd908d12286bb5c3ddc8bbadd33c4e9c8220f145f6f96eeb8c97",
         "encapsulation_seed": "32bdcdb7059fe27f6409901980c080308951ffd90deffa8317b4d213a5f04495",
-        "sha3_256_hash_of_ciphertext": "55165f35498250256c30d0f0fba6ec57db352a6ebc05ac42eaa8982b2d48af5c",
-        "shared_secret": "ce80f65731c8fac072f7153bbdc425f76189d01bacee8462060c62dfeddfaf64"
+        "sha3_256_hash_of_ciphertext": "acb8d1127066a716067178df7b5cb5e341ce8266ac52265d2471063c999e6162",
+        "shared_secret": "ad703d0bd4448d8ccd0f1816e024e7bbae4c26017c5b93db0d2a0ee090f8ee7e"
     },
     {
         "key_generation_seed": "610afb64be8cc1df288cfb016ee2f44c6c07113de7f6fee071fe0c3fe31c6215cd292e4c5f9e1a55e0489bceffb204d672a6215f4f3980a646d9f880817c52dd",
-        "sha3_256_hash_of_public_key": "63b304a19162abdc4234e6046109f99f955695580a8b782017e107e45575bd78",
-        "sha3_256_hash_of_secret_key": "19aba21e57d4b3aca7209fd5cbd15f9e7cb9f6777960d9452fed866e9e9234f0",
+        "sha3_256_hash_of_public_key": "daecbaf99973c4a2f7733e70193e1bd7ce2cef900bb0ccdb344a8ab92fece749",
+        "sha3_256_hash_of_secret_key": "82f4f2b59ff099e72adc8ae3a2cd3e22d794591d860ef56b8012c34bfe4d16ac",
         "encapsulation_seed": "4ed7c92d83bd03b2a25b567f17ae55542e2f6a4308ec0f3fe69f8ba5ae24331b",
-        "sha3_256_hash_of_ciphertext": "5eddd27af25f9553e3a5b20e4de86280c65eb689ffa7773dbb5d24640bf51248",
-        "shared_secret": "3b23a3cfe57897fa9cb691ee9805739f40d2bf22930ca9ee48ebb7163cd66bb0"
+        "sha3_256_hash_of_ciphertext": "0c31ab156cf75c5a05d91181b9674eb15cead52aeb4f5686158177152da196d5",
+        "shared_secret": "be5ef071211ee9026f0a2ca4d34a71b516ddadeca881f32705cd85e19d80b233"
     },
     {
         "key_generation_seed": "e1953800acaa85ac02a906c72cb8e8d704e8d27820345f88f71e89c1f549afcc8c64c049c6dfc0f1476cffd520b055756162f7ec94243de6b14ac0b9e5fb366c",
-        "sha3_256_hash_of_public_key": "3c598a48b06d7474da19ca85aff6b2b3303b5d25b96088c52a08cc7f1e87c5fd",
-        "sha3_256_hash_of_secret_key": "03c563426eb21d277421a30ca8980d4de86f7aedead9ab9aefb3d7362104ec50",
+        "sha3_256_hash_of_public_key": "e26f015ade2c914dcd068c7899dbf3aca3d9cf5d6d02b2541da3866666355d16",
+        "sha3_256_hash_of_secret_key": "dbabe1a48f2dacaf6ec42ff2f11662b7f5ccc414dcfe56bba5e6dbd58c95e747",
         "encapsulation_seed": "060ea5d2ed1dd88144a9885e79278590821c22917b55a48920f96b53ebe0e689",
-        "sha3_256_hash_of_ciphertext": "244dfd0105b643caafe35fdc184b8e23c7538370d545e6f08357e83f413de258",
-        "shared_secret": "272ecae17c3d107a8b008f60c8844ac01e09b8bee17eb4972f5f71774af2d54c"
+        "sha3_256_hash_of_ciphertext": "af4e98c6306d11f798678a562eebeddb54d90ccffd16f682e78cd4a031a8d809",
+        "shared_secret": "69cfa5c666c6cbdc6eec7ef004a6b4464ea6b11126aa209142ca28a97cd5505a"
     },
     {
         "key_generation_seed": "c719f9b2d16399b7326ce4eca30dabefe8fdaab18e9f6df888b0a134ef355570e40771856eb77e4633504899fcb86c6a3d433d0b8d60e26f07bd61f1d4ed69bd",
-        "sha3_256_hash_of_public_key": "9911b6283fc6dee66e16d411fe39bbc9f53c30bb54f05044b96c740ca051c61c",
-        "sha3_256_hash_of_secret_key": "06751acd0a50beca92428cf8c803af429068d4e5c4f74cc59e6d3275ea6da737",
+        "sha3_256_hash_of_public_key": "c6ca25b76c4f29e0da8a73939ce8e06a0f6afaf932b5b3ba52d77c8019234be5",
+        "sha3_256_hash_of_secret_key": "e9736ded5ba5681ea4a8ddbfb133493e9187292b91b2eb0bf8a9e437d4fc9a0b",
         "encapsulation_seed": "10ef9426f8c4a13b52325c5bb4ead4596ecf2c6b5bd2d37d8350e90d4164fdd9",
-        "sha3_256_hash_of_ciphertext": "dc8797dfa40479e4edee48d320320ca4a84c55789c94c34ce4f0a4be83ae0568",
-        "shared_secret": "eb456d8919c7e96c4e18d7a0ae27d47996e4f94c46c60b4649b327903acdc0c0"
+        "sha3_256_hash_of_ciphertext": "743a12fc58089484a0e6ecda03b5d87b1a8bcaaa5f312182180c6cc874e25643",
+        "shared_secret": "50660c9d4acfca69b77b3d43fbce809ffef94de6b046b4c9eb0e09b7ee0fb924"
     },
     {
         "key_generation_seed": "e9acbb774be970206c3a738e243b420805a509fa59fa902044be2f0d013650d2ded5edaec5de3bf5b4d7c2f2e18e87f499c1968993eff196753db8045e2c8ba8",
-        "sha3_256_hash_of_public_key": "e78d350d2836d1d17e6ec375a0cbe0d6b2afe1ac036272dd41f8aa769c9d0668",
-        "sha3_256_hash_of_secret_key": "f74b8f9343146c1551a3cf9fb3d4e88febba4e98db745f36678d854230a8d7f2",
+        "sha3_256_hash_of_public_key": "7083b34f12f916a56b46549126b7c115c4f5eff17b81ad53eee6f80fce9a1480",
+        "sha3_256_hash_of_secret_key": "7c31bd14311afdafcc5c0ac3837620ded8276256d11700cfa87ac7273fbf2acc",
         "encapsulation_seed": "a4bd30a64cbf29a4e290fa1cc1dfb99e68348713041e4409a1af23c5d80c15c4",
-        "sha3_256_hash_of_ciphertext": "400cda4e51c1eb539625bbe6679fc13b009e72cd442a1385759e7090e54d31bc",
-        "shared_secret": "3f92ab2eb867d4e2e658917fe95b19042cd768dbbcd895e83b7bfda621fc428b"
+        "sha3_256_hash_of_ciphertext": "44ac8315e3bd161fd5046b270fef9ec89d0f10ab581ae35b58ac1a8e6787be2f",
+        "shared_secret": "61ad103cd549561fbea8e9a7527e3913484d17587bd8cb3c8fa1c9015e0f426b"
     },
     {
         "key_generation_seed": "c1b3cbffad4b306f9af0cdd3028876486dbe858875c9b6497fe20172a986c82b1c96249919cedc2369d8d739ab125e0d2ccb82dfebcd90240a545cdfe07511f2",
-        "sha3_256_hash_of_public_key": "5820c7564d087683c0a4864844335bcbd62afa1ee542c3c1dcd8b72c80824b50",
-        "sha3_256_hash_of_secret_key": "11212a895ad32958d25d2ad32e917bd5bfda9dfcf08e316f733b74479469f9b2",
+        "sha3_256_hash_of_public_key": "d5a0216ca6cb4b8e9443d8405b218e8e434996910f0dd3a18bb5e6069b78e41d",
+        "sha3_256_hash_of_secret_key": "ed9dfd58fd8cb335050353c06aa20fdee83b0b829e52f0e88ee36c5d24193e97",
         "encapsulation_seed": "f4b66a7d3b65b896dfe100b2cad24b175a1168cfd2ae11fd704b835f6bcd311a",
-        "sha3_256_hash_of_ciphertext": "fad3a5efa62eabac076fd38f84e91f3c20f7b263408366c476695a9665972ddc",
-        "shared_secret": "5890e86b38f7fb11708a63f5e98ad65d10db5916e6669e1b0161142e6d30d017"
+        "sha3_256_hash_of_ciphertext": "874eee72727114838ba479867850910242e928cf55c4ef5df087dd4a45ca9d6b",
+        "shared_secret": "6faa40af120f702ce6ab77b8d673984b99928f6835bba2643f4a656ee09ee6df"
     },
     {
         "key_generation_seed": "ff7495b8575b5a98e4fd21fb4c3e58cbb60f14bef21aa74cf8802e3153f14807bdc370460375a778d1a31d01c42b66367ed8d9e8f84551002f552f0e52102b5d",
-        "sha3_256_hash_of_public_key": "c56eb5880e9d9d0fe7901747f75eca1996c722ac47b76f34a4dbaaee0ef8a611",
-        "sha3_256_hash_of_secret_key": "8a90ed45b5910904e2e9f6a6e410d4caf024ef6436fbb75fdd179eaf09f6f362",
+        "sha3_256_hash_of_public_key": "f38eb0f75495417ad36d1269d0daaf16ef6773b1d6ec9088ccdaede77f606525",
+        "sha3_256_hash_of_secret_key": "a9343da6b118687345dfaca02ed6ea3f02a30810f7a0cf4e87e011120108a46d",
         "encapsulation_seed": "1d7b03d3c5eefb8ae5799dc569aa668f1bcb8c86607b089d3530cf61d6380147",
-        "sha3_256_hash_of_ciphertext": "16f18c8dfcb9aa496f8c6f8a76af4cf2405407e0f0467deb4adb7049595b0df6",
-        "shared_secret": "3b09c4579ad60b17eba6029141a6d9765e1abae72ec32f1b329a5e2af761a087"
+        "sha3_256_hash_of_ciphertext": "5420b3316f06f5c7a41ffc5f2c2cf51bede6a2d76dea98caabeeedbab199bdf0",
+        "shared_secret": "60fd3bb8de18c84fef4b07ac082470ea94707724bdb3a3744a8294372d07f936"
     },
     {
         "key_generation_seed": "bdc3fba1c32751139fc45bacffb3ea97f26573d804a5f27a459293d95190ed8efd5a08f656a6eb8cd20679930a31caa6a6331c4b133a6838c223ef9f769f6246",
-        "sha3_256_hash_of_public_key": "717823f0b58cdfacafc795aea529561d11374f02964cf635c27848671043766c",
-        "sha3_256_hash_of_secret_key": "f3c47ab6b2f2a0962faf49bbc31f3101d6f4b867952aa3bbee32408c1b88ee82",
+        "sha3_256_hash_of_public_key": "10f39c60e99a2c3a9968c48ad9a4d66bdc13d2b6bd6cc06c19872dfb955dfd66",
+        "sha3_256_hash_of_secret_key": "eeea88ed273caeb546917fd42f8d4cc3d5ee8b12e7defc95348142cab0b5d738",
         "encapsulation_seed": "554f3385b382f4a46314de37ee3885addfc5332bd4038785094e0a832e9e8c2c",
-        "sha3_256_hash_of_ciphertext": "fd6a149b033707358fc07243d95b0256153c30e65cbc9479ce05ad2f96204a37",
-        "shared_secret": "f15864351fe8e878ad66b402f012668e8bdf21525f09d5bcf4a4dad656d2e480"
+        "sha3_256_hash_of_ciphertext": "a54ee10f5743596fc74e1db113df2ca74ff23321a04a26091f29d8f1028b3cf0",
+        "shared_secret": "ea52046e13966f869631a25174239058b5cf832d3ea8f990729336d308070a2b"
     },
     {
         "key_generation_seed": "447f6076a627bbc5ad7773fbfeb14b4ba9ac43a0f8b99fb6dcd5e452aa3c47ec20a7237801f470fcc2bd9fd7bea8322859b850f7882d362947432913dd068c01",
-        "sha3_256_hash_of_public_key": "7a13afefbba39ad59c088825380398f43f1251b83b0ca9debba0102f902d7190",
-        "sha3_256_hash_of_secret_key": "da94e15b824e73150a408df01cf1c5e4128739524831a4c2f45d0724144010fa",
+        "sha3_256_hash_of_public_key": "07960413271583353ecae73e4b01073ea5a0596a7252a58fb9ee0c3e21a68536",
+        "sha3_256_hash_of_secret_key": "c3bb8d47a1e44670c3f58a6f9ebf64e74f4611f0e9e6d6fc72cce098559bae30",
         "encapsulation_seed": "38bf0033b779edf5367d9ebc01c988af90904c560970815837380650e4749eea",
-        "sha3_256_hash_of_ciphertext": "9193450ad037d38d8e85a46a522d4f6562ef7c7aa1372a2ebbc7ecefd1286bfc",
-        "shared_secret": "1f1a7f0d0d86a52a6679c431c322263b185b0c90ce40db054928be438f38d47f"
+        "sha3_256_hash_of_ciphertext": "0122ed21e9ba6ae489439e6777c898ed1cff1b8826d1555d5080eca6fe0bb0fd",
+        "shared_secret": "65911246b31f72b69db5af1099502977bf056200c713d28fc41ffb81cf591f0d"
     },
     {
         "key_generation_seed": "2d5df64d62cb07fe630310bb801c658dbf3d97993e68626745de39d37fbfc2b27b534537addaba4ecf14f02ab317d36cb9f0f50222ced7cf029dff8a0d3d2fd9",
-        "sha3_256_hash_of_public_key": "dd4cfbc29de3568663a3a044c3f897714363b0fdd3b6ee55f796292d34c7c79b",
-        "sha3_256_hash_of_secret_key": "6142d02fd4501c7bffac124bb8f26813009d2bfb91023a3fadea9506a40e1467",
+        "sha3_256_hash_of_public_key": "c0216723f9659d2981e083cbd94a6b8d67b645565ff3952bd486ab2422c3a11f",
+        "sha3_256_hash_of_secret_key": "c97dfe86bcada59aa78453ad7415bc0a9abd4e19fd169d9bbc6e767f183c29ae",
         "encapsulation_seed": "048ea516d0ebbd9f709b47eaac66f344c571cf50f0d01c9466aa061a50b66a24",
-        "sha3_256_hash_of_ciphertext": "bb6e0249218f8bb4712d60e59f51cde2dfecfc1f828eff42f2707aa59f12164c",
-        "shared_secret": "aae9ca8c35deddcfd7dbaa7780fe31c102aa90cc594eb56edc782fdc4eb53b41"
+        "sha3_256_hash_of_ciphertext": "80309320e0915f70f0c4d524128001b0b47b4a2b918a81e90d350b41229479bf",
+        "shared_secret": "519e938e10ba46ce96614a4721987cf49a26978ff66fe776d86df11b4405820e"
     },
     {
         "key_generation_seed": "25056d1b8113bb362dd979d98643d7a7ac9c4f95994c0ba060609b6d07002ff3f48a9254dd40b117941fa35a66bb50296327b725525deef70e128ca8045ec451",
-        "sha3_256_hash_of_public_key": "9ca90d64e28a5bbc54c36053ed333c530f72549c2afd77b10c2944fc833408fa",
-        "sha3_256_hash_of_secret_key": "510f84cae4d4307d7848f4c9665061657ae81526139a8b6a4076ad3df919abfb",
+        "sha3_256_hash_of_public_key": "7217747a04f04be3895e711a81080ad9334e567579107a2ef675e670e64dcea0",
+        "sha3_256_hash_of_secret_key": "e1678c29ecfdf30919c011d7c74ef12ec8c5bfc5fd25b7ba0743dc5c6dcb7759",
         "encapsulation_seed": "686c921c9db1263e78ae753b1c9c2e7936b8229dca48c0942c56c6bca4f10917",
-        "sha3_256_hash_of_ciphertext": "36b3567939ee624d5088c4daa597c73349270a754d3c272ec3ca5e08bf896fec",
-        "shared_secret": "970fe36e57a253e88cc80c9da6867dd66fd8da1dc15c85a480a1a45eed708ff5"
+        "sha3_256_hash_of_ciphertext": "7b26d9eb595123551e62d619871d7461a3fc9c1f06e9ff5e9f60f13c7112ea28",
+        "shared_secret": "516e695dc4f237c1a4b451a67426baae02df1acd1f7f57adb00735bc7ed295bf"
     },
     {
         "key_generation_seed": "e4d34e12982aeeb1d62fd488d9b9e28557ed3429292239fb4f76fa9098009acae6c45c7fc62329b13c8d29844405db8ff6860de474bf727ecd19e54e6e1a141b",
-        "sha3_256_hash_of_public_key": "da073c98794493ec169c78eb75a39c1594ccfa635b8707325e0ab6cb8576e30c",
-        "sha3_256_hash_of_secret_key": "7829ef884941abc63f66889c3d44381f5450de1b95c6b6f79f909d74b27125a3",
+        "sha3_256_hash_of_public_key": "fe467c500bc35d123dcf8ea7bac85cbe312d3a500b7077f3f2cab56b5b12992b",
+        "sha3_256_hash_of_secret_key": "6ac91a04136545c6446482785f98d74caf50df6450bd7c90981cd67f1f927c49",
         "encapsulation_seed": "2387772e50059cabda53cb93ba24b19ae529496c03b36584169451525c4a0e7e",
-        "sha3_256_hash_of_ciphertext": "43f8a2c466c09c915fdbf0d0dc5069ae5333790e7efce86c163d360dd0fdc0cd",
-        "shared_secret": "8eb310431276a31c1913cfa2e2d6b0dedc8a208c7470251daebc5b1bb6ee78ec"
+        "sha3_256_hash_of_ciphertext": "e5ed6db322f02e30a512d80c9e3e69c996250538b35cadea0f5356edc88dab8c",
+        "shared_secret": "f72c09754b77936ceae9858894db84cf773066ea0b594a297eaa1c2e8429c456"
     },
     {
         "key_generation_seed": "cd6a99396eb3539ca663a51e42063a3a262cc1c5a5fce1566f0597b52ad9fa325a3407f591791a5db4578b5972093a95bec3b8e70c1d542c9b5c9789729f8922",
-        "sha3_256_hash_of_public_key": "c2aa254714dac09b9e712572b24154be391063afd3cd8cf4cc4ed8ef21f0cfe5",
-        "sha3_256_hash_of_secret_key": "2e552fd01c00cf43110aacac37d01c02e5f59c87133e3769d3b2bf0fd2e4431d",
+        "sha3_256_hash_of_public_key": "bae34a322cf2b60ef01bbc17bea1e9e16a23f36c4c3d7ed1c0502d976e19e336",
+        "sha3_256_hash_of_secret_key": "8677740355f861f064989b5ad16dcff58122cb4c2e2d53467fab1c9898a0c369",
         "encapsulation_seed": "155c29c5f0378df0cd0e847a80a07143cf7522fcd880c9229eb9feb1ce340cd2",
-        "sha3_256_hash_of_ciphertext": "854806aa3266473aa5fa6097095d5f21707ab4df857d927e8848146bc4cc2bb2",
-        "shared_secret": "425a88aa4cbb6b6de122f1730aee536f1cdb8fc84751fc6eb2b42bcde5febcb1"
+        "sha3_256_hash_of_ciphertext": "37bc68f32cc83fd680c034488594fe78a442241b1e26bd30019a48f65dc51a50",
+        "shared_secret": "5cf212769657fbffc33af54b153bee9dcf7a073bd5c8764c04d508448f0128e4"
     },
     {
         "key_generation_seed": "6c8c53ed6f65e6b2e324b84364e10de42d1c26a106d4d1c99eee79c78586fb55b9402bf02481ce4b27a52e87feb92c4399c7f2988d40e942e7496ad15ad2aa88",
-        "sha3_256_hash_of_public_key": "8aaca951e0573f28d50831960a28dd11126f0eb080afc55f394e8eaf6379f6eb",
-        "sha3_256_hash_of_secret_key": "45592f0d94666d8201247fad4d0acdfdb4635a5e4fa85b7e25b2391639451bdf",
+        "sha3_256_hash_of_public_key": "429837b53bc044a7c2ce503b7946e69f1284a5be8b097f6e22c58091e2308d5d",
+        "sha3_256_hash_of_secret_key": "41e6f06eeb205a80be7ce4c2f7b9aa56cd43d0d46a57c5383cb5efbb08e1ad6a",
         "encapsulation_seed": "a9cb9a61a3324b1ea5afe693b32784e2871096b2ca14a11acc9577c52359a241",
-        "sha3_256_hash_of_ciphertext": "035223323ac02f2a52f9c19da46b31a7e189073fd5ef5ceee6ab8dd1b062b6d7",
-        "shared_secret": "457efc40f2e99aa599ac1ef92f9efbfc93d17fcd793837857f6a5c91a8dd7da2"
+        "sha3_256_hash_of_ciphertext": "4742a70abf84eee1f33224e8970985a3a19b75372d18a845b8dd2ae504127fd4",
+        "shared_secret": "3a89607d3fabf4d3165f3688b0ae0b6eb6f1b4a21c53c6b75425cfeef90e9905"
     },
     {
         "key_generation_seed": "2107204cd995f1df14314d5381f8c5440f09a347502e161cffc0a2ec3dcfbc7324c3da70fe850e80aa818301d60c70f3038153866dcd5d179e22db59b8991bb4",
-        "sha3_256_hash_of_public_key": "f15a8fc937b12ff78c54fc273fcd7dd5611e5835472ed377652ae64495f9cf52",
-        "sha3_256_hash_of_secret_key": "dcdb853d17884fb04396dc10d34bc84d594343ceadda564fcdfa9b4d47dd4e3b",
+        "sha3_256_hash_of_public_key": "9ce5a577cafb7d5ef62f8d4e4095db51fa5eb7dcfdcbc572875024e761563c0a",
+        "sha3_256_hash_of_secret_key": "2bc70c0108949e4e8a78b26297ffb975921f9561b25615682a138aa13fc7f4a0",
         "encapsulation_seed": "e99fbae8a024ebbbdcef32ce213f6aa942e3eca925e5da4c09975d773b33a175",
-        "sha3_256_hash_of_ciphertext": "a94ff1a0c62792c0e1dbe578210ba5a7f3cf8a9f9763a16362d66a3082e4753e",
-        "shared_secret": "99b58031465868d0617fa795e6be1c33a870a1e154a85a2bf61346f7c55f3b76"
+        "sha3_256_hash_of_ciphertext": "903b833443ad71f4ba81952774d1d3ace19f4f419cd36ec226a9602a6211a66c",
+        "shared_secret": "b9a77422a72a785193d07040c3e562d36406c5125301ba5ff6f703a44cb89764"
     },
     {
         "key_generation_seed": "63a925685a8ac5bbd918faa33ac397d1ffbcf99135d9da7c3d6ff7aa4c50af3d3afdb8a246a56ee71465591831c371f2eb87467b0559dedd776ba063ee6d2f93",
-        "sha3_256_hash_of_public_key": "ef7ef8d7d81aa907fece4c1920c7ca9dda3bb9d57f09193487bb89d6422f10cb",
-        "sha3_256_hash_of_secret_key": "2bef3558b547044290d1232a580a6a473cfcd8d87ced6305f996d4db4f46e6af",
+        "sha3_256_hash_of_public_key": "0783d9d571c555c109af25029cf5faa10bf8be57626148ee76966388f7a1957b",
+        "sha3_256_hash_of_secret_key": "d101adf751b9e2cd8fbb1a92204687cd1204b7e8826802bc7be31a4ff31972e4",
         "encapsulation_seed": "67a216f37d67f5e74f782f1badbce1cc8c80a6130aec305b421899a4faa0a6c3",
-        "sha3_256_hash_of_ciphertext": "0b60d83d562b66153e07bffb5bb05b7d268351377381b04f1e59201f961f1907",
-        "shared_secret": "387705c2ed600492a0b06f5587ae3c40be55e6d5592597e57cb8015de9e9271b"
+        "sha3_256_hash_of_ciphertext": "b088bd59842ace2d0193312ec95547fa1a2f11c4ddf9f2a271bc7692ac18b49e",
+        "shared_secret": "b86770d1e8242475986327e5c070dd5926baaf2ec90d017cc1e2c8d1af83d9e0"
     },
     {
         "key_generation_seed": "6a1aee5e708c1b47f02bdacce4f56c860f74fc7cfec1ef3b58285b1c8ad7fec2230e05b7114ff0395cc6634db1eae8258072d09c09f291e92d6620b177dc50d7",
-        "sha3_256_hash_of_public_key": "99b151aa6b4654589afc36b8343fcbdc09a3e5255b378d6ee5629cd8b3cfd555",
-        "sha3_256_hash_of_secret_key": "b7a7d95034017d523ae23e29fc400e9a0b320f9778ba1587b69dd012f2aa47bd",
+        "sha3_256_hash_of_public_key": "c9f63c66089182c0137f996d4dda23bba1dd9360ddb61f816c3f5ac0d4c49242",
+        "sha3_256_hash_of_secret_key": "9050ae3b945fa900606a71d1da24d0aa4895a1980b6ed9a445bc2c902d739079",
         "encapsulation_seed": "52b19fea232c9154a3e431e9d69cda40013cf2d485c3cd027ad24e645420420b",
-        "sha3_256_hash_of_ciphertext": "3a4ba04bec2aee99c5e4e2459f1aec52fc950ab67b61570d57a17c4f3d9031d5",
-        "shared_secret": "2a426534e3c23e28a237047aec83d24abcef8c7f77d85d8b27aedd7c50263010"
+        "sha3_256_hash_of_ciphertext": "87088357969288bc4eb6595197e9e8564dad0d631ef0d2d02570783664fe0878",
+        "shared_secret": "99d2bf8ba621976b78aa1380fdb9a76e5e51a3cab0d6cc209b59e38e1b85fec9"
     },
     {
         "key_generation_seed": "6396b328b100e4c7f4bcae69875edea1a1982421558c608c13c592bf7b5d0fef1100ced48add211a5c937b8d6079d8e271af3f949edc61f70e60453aef20dea9",
-        "sha3_256_hash_of_public_key": "339ba63f705606d8c7fbbd6e66dadbf23f532d5423802c836f2105a636e9e6da",
-        "sha3_256_hash_of_secret_key": "60aa684e7cbf79e9c70504608a4c0f2cf8dc207f71b1d0ef5e3a99013ee866cc",
+        "sha3_256_hash_of_public_key": "68d276d24d6a0b668f74a9eee1094f7100980cd5ab191264dc86ca4989e269e6",
+        "sha3_256_hash_of_secret_key": "ce7914dc21e76abfd11a2309404604fac94ce85d6324594d337321495c26b4e0",
         "encapsulation_seed": "64440adb05db3308b189bf999f9ee16e8ee3a6ccbe11eebf0d3ae4b172da7d2f",
-        "sha3_256_hash_of_ciphertext": "f5d1973f7c10d3ff7cdb66195ce52e182f40ce5b9f16ef67e31ce8632cf617e8",
-        "shared_secret": "ffaf18d4fdb39a4aedc80c7985843f6b87a02e36c69dcb00f3cb01a619a77779"
+        "sha3_256_hash_of_ciphertext": "5b2f1785250f72e772f96ca3d2d99820965187f94cbad9bf1f29f4dbb24527c3",
+        "shared_secret": "48d6e820ff23d18a3626489b28221139d7f05877f9cca10c70fe501b6e02f7b3"
     },
     {
         "key_generation_seed": "a453bcacdd2b0d4646009e5ed451c3c45f08fb827ef733db3c517a9dc1af93e67a3cc8aa3239d4c52ce4c95afdeff6efbfacac10d294edc0e7cf4535059bfdba",
-        "sha3_256_hash_of_public_key": "1f9e26333b637ef9beb8881c63f9412b07c47a276af0e242062a54026bcee2bd",
-        "sha3_256_hash_of_secret_key": "f7f38ae2caba6d7e87b7bee8b127a9aecbc0b795345952d65bb4435e3720f89d",
+        "sha3_256_hash_of_public_key": "7dd4a31d305a83e5697fabb60e6455ac74836f27e314af344eb24f49deb9961b",
+        "sha3_256_hash_of_secret_key": "154088c783a65fc828cad9c8cbfba8314878b2f08ff380868ab611eadad2a649",
         "encapsulation_seed": "c8bb46b3a7344ad170c2052fb042b5a3b62e0590562ee82577b1081f6f114d16",
-        "sha3_256_hash_of_ciphertext": "c42f9beac87086ca603d95377c5e539735752eee043653fbacef0d2824b91d86",
-        "shared_secret": "1b37c256820ae408a0005a1fe7461d54e53813e6e7ad58ca3dde46a53a44590c"
+        "sha3_256_hash_of_ciphertext": "fbe04b3fbef5e37be07541982a5e430ada37c016a933733c016443d9c1d628d4",
+        "shared_secret": "8452c98810f3a608492f944192785c59dffbb137f6ee1e8835d1cf5a1b63a185"
     },
     {
         "key_generation_seed": "47ca2b77c5b717f423222c2730ca5cb9c856bc951d01b2b2c80bd76ccb5539b78f1481d7cab000e33fa07de8dc9627a85e76fabb4428a3376e66300cf12a0787",
-        "sha3_256_hash_of_public_key": "64b9f8198bab9b3b2f2a1704cd4ddf6b3cbc216ddc0f062a72ef40115917fd21",
-        "sha3_256_hash_of_secret_key": "a3cf5841bedd9be95061b910333190834063e5cbcf0fd32673f8cf3f6b548d17",
+        "sha3_256_hash_of_public_key": "012135370b86ad6bfcc4eb9894044dca11d5eaab6caf8798e4496d798f7d4fae",
+        "sha3_256_hash_of_secret_key": "2d7247baaef746204bb9594f475451b47f9f53b8bf53350bb53ae21ef5d7d65f",
         "encapsulation_seed": "2e2b70609f3fe029a14d09d5d659871ac776ce2797a0355f16e2eb68f5613fd1",
-        "sha3_256_hash_of_ciphertext": "056998cb46e48667cb4bda6dfcff9321219b13fb1a682e90bfba6ca025bbe6df",
-        "shared_secret": "12871c83c35db351c2c0b4afe0f0ce9fe1f21fdfbe8c18a485d5c1292faa531c"
+        "sha3_256_hash_of_ciphertext": "3064b16e1be747e026d5665bb33cb093ce1155a15ea66c15600c6e48ab763343",
+        "shared_secret": "8502f3f616159a2072339f7858c74288420ee98612d43a7c8eaffdf595774258"
     },
     {
         "key_generation_seed": "aaf6eb40e596a5e3e8218871e708b089240dcbe7fd3641f0e5e41e071ce49107e2f8d320ac3cb0c52efdc753282f092bc39baf4a18783a48ea031a191865eb78",
-        "sha3_256_hash_of_public_key": "de4ce515b882c849717a1ab34f2ac0238c868f415630c1155bcfb302d346dc91",
-        "sha3_256_hash_of_secret_key": "4b917d9daddcdc932fe0448063a24a592edbb0e6e40b5b53812f20a4cff7a0a3",
+        "sha3_256_hash_of_public_key": "6ed803f13344c56b643da0660d085145295dc167f9e5129f975b8451c0baa9db",
+        "sha3_256_hash_of_secret_key": "503da421e54047be5d11aff48955bb3546c009142fe4d7696325e00e9fc2ac2f",
         "encapsulation_seed": "4725dd8fb314bfd8ee23731c2341dbe114606d9abe6434c471b5573e7df193bb",
-        "sha3_256_hash_of_ciphertext": "e4eec4f31749692984bee94c59e2947afc769197fc18b20d2e34ec92e7d15ae1",
-        "shared_secret": "adf49431dcdeb29f729459cbf3c2b94151005c7b841eac921a71262d65dcff99"
+        "sha3_256_hash_of_ciphertext": "5507ab835727e16403196f1d6d89678f60998115bfefa2d55f2956db8ab54b06",
+        "shared_secret": "9df5a20bab82e9e81fa4273f9fa61f9b3119fc49603c57d0309875fe2d87bb20"
     },
     {
         "key_generation_seed": "6500f32c93415cfdbc0bd31d78d5be95cb9060c8cfa2013955b56f8b6868b322393308641a9a4647f230201e1389624a296b55192a9819fcb19ab77c25f95445",
-        "sha3_256_hash_of_public_key": "93b60f0d00c09af885b5a0cbe942fde6afc4841428104710823bdcc12319eb35",
-        "sha3_256_hash_of_secret_key": "953ab28bf8cf18e86b8c80efae0bb47582d720e787fd2af27d9789c1ffb7ea1c",
+        "sha3_256_hash_of_public_key": "f2de14fc5d972013cac0050250dacabf48a7e75aa6b104b3fdaf69eeeafb6312",
+        "sha3_256_hash_of_secret_key": "e89d33d19d1437b6ddd2c36f1e7312de9c7544b0970d0a03fc7bb65b307b3d1c",
         "encapsulation_seed": "818d3bb8ebfb32bf464775f7139bac0a5bddce80ec5798595992f9403002cd5d",
-        "sha3_256_hash_of_ciphertext": "ed5b2ff1ee4222029e7c0d858da6ff1a1417a74a501b80d1b5b6a4941329e892",
-        "shared_secret": "35e1521271e7ab9931b2c25d75f0f09a89b3f83a6bb62ceb99e8e00c5cf78afb"
+        "sha3_256_hash_of_ciphertext": "54f148b1433b2fe11052c25a2499a47fe77860f320afae6c291ccd9c3cfe2bd6",
+        "shared_secret": "44b9a28392480fcbabd5365202ca4131327b953bcae892fa70e7aaebd19789a3"
     },
     {
         "key_generation_seed": "7643cef2d62cc5aaeecf754653ea62294cd2208e5bf3ddeea209e3dc45373d49eac9d531a532770837a854b4f5531f6e0c8d6c10183b30d3435498c2dd142951",
-        "sha3_256_hash_of_public_key": "167a2fec4d72cac2ffd844246eebabdac0c074e4f984433744e31d299faa389c",
-        "sha3_256_hash_of_secret_key": "9afc4ddea68ca10e36d9b12d3c34595912eaafed49d8ffce01cbed09501f7527",
+        "sha3_256_hash_of_public_key": "ceb07ab4ac0d98f0c46e717b33ba80963b3cbb7c1ca92af96561ebc93a1d7d25",
+        "sha3_256_hash_of_secret_key": "3b05f4e5131ee068e97b05399c2c8de24ccd9ab9f296113e5656a5f5319a9857",
         "encapsulation_seed": "c92aa5fb91c980d9cade9ce99d4c75b2ffa7d6a6ff9bd59def1aa701f2a0992b",
-        "sha3_256_hash_of_ciphertext": "a076b58fa98a7282c2cedc1e93c1473dd15b15c1ecef192955d8a813180b3217",
-        "shared_secret": "715519f07b29bbecfc0776e35417558e3bc50c76b8da6fd4c99391b7bc7873cf"
+        "sha3_256_hash_of_ciphertext": "e9ea9f340c3af4ebf224666002ba0b9ce78b30da220a7bc9a85c244a748e99a4",
+        "shared_secret": "1d66e17254ad9293b69b3a27daf763c95daf081ac0d3301fda9e4c80c2538c3a"
     },
     {
         "key_generation_seed": "f8ee95521060c03bb8dacc79f7eb7db640f545f315613a35d447a09e504cb4e13fc3d8392cb53f36ed647364a04e37278a0e0a45b720f4a75c580c9920eba98d",
-        "sha3_256_hash_of_public_key": "955468734662471c953fa516b35b3a53053ff396b7e2798fe07a2ecd549d6c06",
-        "sha3_256_hash_of_secret_key": "8bbc886fcb7516e7888880921abfaa72823ace9d50cf0afc2f68c4a7c3dd2e53",
+        "sha3_256_hash_of_public_key": "0c59cd46ea3f85a41faa2e7e6f882197b1e6d9c4608f6da53ae32e69b65bfdbf",
+        "sha3_256_hash_of_secret_key": "c2f434d6791b33ba27d9182fe9866bdc45363fc3eecd5c326cfb0f54b802e73e",
         "encapsulation_seed": "7e8086a01dc5b3bb9eda25bcc45d27f99874841b97237968495800e007696ac5",
-        "sha3_256_hash_of_ciphertext": "87914dbce6a365f7335188d83f2394b0fdafc9b0676c022608401cd93d294f36",
-        "shared_secret": "5a4ba3737140bf227c0e618f74191b3de1c1b8e24b032036942de66a13ef5a91"
+        "sha3_256_hash_of_ciphertext": "3446fad5d4343bed981336397ef68076d6e5f407811a5f90cfca8e1dd1a10504",
+        "shared_secret": "63fb0d287b6bd4ac3eb9f5484195e5dc014dcb96227ed53a90b0825458343b05"
     },
     {
         "key_generation_seed": "b8bd0493a882e3a49b4e0f6256fb1fea0912562fd9ba26ec3d6c9cc12c8973abd7e4b5d8021c486b9c3114d7cbbeb7cd49eba8a61bc2bcae1f1bef30a1daf76d",
-        "sha3_256_hash_of_public_key": "f7310c0531060051469ffcd2f88e3200bec6c721bca1fa4c9e7bf1773d7ccb19",
-        "sha3_256_hash_of_secret_key": "16c976495bbd05ee6715f30a9323aa41ecc320e2e63479148ab3a51132afd7b5",
+        "sha3_256_hash_of_public_key": "9a27aeacf3b2c7d67d982798b8db46d38a070ea9791d1629565c996ee4608f84",
+        "sha3_256_hash_of_secret_key": "05b7b98e7719b93336b1458d50915fcb34df77f6c9bfd071c4335ba30fb53d19",
         "encapsulation_seed": "bb321ef14d44d8698df879fd52450567657f52a2df8d111185dcd7d4f30a72d4",
-        "sha3_256_hash_of_ciphertext": "37ff2acef57d0665358cc5ec7f489160d602d41c21cbb3332670f3cf0044fc39",
-        "shared_secret": "87528a4a961de06d5856004eba20a44590a1bd88318fcd1ae1dbfbfd41f152b0"
+        "sha3_256_hash_of_ciphertext": "b24364532395130a27b30bbf75233f8f5e21f487625a13ead9655fa97511c370",
+        "shared_secret": "638a89c9132f4bb5c91f20327b6a6892da980dd71210b85e8361ee4579397ccb"
     },
     {
         "key_generation_seed": "c0407e41ddf48d333978b89bcf2db01e4613425b456249e76a6f25b8a2827bf5b2dca81e3f5f748d23c9d356a2209f6b2d60247b2e45c9808de497f64f124643",
-        "sha3_256_hash_of_public_key": "152c13a9a4dfbade0f98e8a5136358f69c93f0722addc008952cf72e1bf350b1",
-        "sha3_256_hash_of_secret_key": "b93c3fb9dbddaa560dd52c6a1c37f6aeb2111e46b7b746419e3c27fa43a27211",
+        "sha3_256_hash_of_public_key": "6551690ce0c13150e3fe4bf4488a12716ae41ba97a5a19c5f79aef958fdc5e2b",
+        "sha3_256_hash_of_secret_key": "9b22c44dbc5697593b45dec0a1bd71e39f161ac5d6bc3c6a42bb284198c37bfd",
         "encapsulation_seed": "210a423dadd899b810f011794b79aa7f860823ac1962370e791287d3a1afa384",
-        "sha3_256_hash_of_ciphertext": "b62ee0b20daf3a87406f7f8428d6dac79ad5f95c225956a564f896658ed51eee",
-        "shared_secret": "3652a13e36459a324958a2c45328fe4ca6163ba833400e643b0a6e51bbc594fe"
+        "sha3_256_hash_of_ciphertext": "1a062c18048287620c01569eed7861d0f777b012d6a367de356da11b4ffad218",
+        "shared_secret": "6dbdb6721e684477737c6d93a46f236df54ef388042e64137ceb20b65092b25a"
     },
     {
         "key_generation_seed": "334382d39164d1989696a2ff77b25a28af8bead9883b5365eb6fcca7c1781cc9aba5068af837be962f439f233593d193ce5e08f7d66efb3389885927b89d2523",
-        "sha3_256_hash_of_public_key": "97e5b18cff525ef46fd8a6aa6e5e4b8d953fe1e67b5771d1b99ff18e754553be",
-        "sha3_256_hash_of_secret_key": "55102f3a620209b46e41531919a1b6f091c86bbcc5bdcb52b18f9a070680bd66",
+        "sha3_256_hash_of_public_key": "7b4290aac9f45f161c01c9937d8c80d0c046af66529ef85784291b00ed72c553",
+        "sha3_256_hash_of_secret_key": "db2d354428b28f64b6fb539f22572b5fdd64d5c998a72439c464094c6e9d46e6",
         "encapsulation_seed": "bc856afe24213e3d14c3d6f9b89223bbcfb2c890722d770fa3492c1e46d1c302",
-        "sha3_256_hash_of_ciphertext": "6d20fbb0cf418e91e295f391160df696348b3fa99542d12584c0da554b96153d",
-        "shared_secret": "c07d965e4a87e89e9fd5db44cdf225b20157a6842e2862ecb4f72d8aac933c2b"
+        "sha3_256_hash_of_ciphertext": "878b93664e070bf3b9865e39a0a141e8dbc7175a4235e7a3569633c3fac500ad",
+        "shared_secret": "f450baabaafdf4f09360b861251116f9a202b9cbc578105e0c2235689a593362"
     },
     {
         "key_generation_seed": "6995143e8eb8a6e93840f76eec844f67d2b5f75b1839a5040337e61f9806764a0f4dff8e56f68440836a072412a30d851ace2c7c6f02d60e7a8420001a63e6c6",
-        "sha3_256_hash_of_public_key": "7b5c67fa6e0ff374f691540fff0b4d14d4ed8a8a8c48b14b2a35facb413a5ee6",
-        "sha3_256_hash_of_secret_key": "449e7b1644520512fa25ea48f468ce9f866ea08178e814f11561efd4e4aad792",
+        "sha3_256_hash_of_public_key": "9f746fa2db59882bf5fce5068668fd76eb4104a839e0476fb6e74147c990dbe0",
+        "sha3_256_hash_of_secret_key": "1e51985313159004ae5270ab60c007c21bf91ff6b89ecc347262e7618f019a85",
         "encapsulation_seed": "5fc00f89563e44b24cd67d0ce684effe5731619fd08e7d72e2406eb016afb66b",
-        "sha3_256_hash_of_ciphertext": "e4f728484e23e99dcd35c5d3ca6d62e3a829e60a784faec5dd9fbb2d0cfa8bd7",
-        "shared_secret": "a502041eee317af1e9e6f9a9c12cc98415b358ff179d4d64ba5b7463a1f33b0d"
+        "sha3_256_hash_of_ciphertext": "76a74608aeadcad7718770ffe0ce605e4c2db408e7ab05e148d14302764f2fd4",
+        "shared_secret": "6847f9fd5f6d4d466e74e5de9e820d151d265111ceecb4c3e25cb6630549688c"
     },
     {
         "key_generation_seed": "995eff7e0d195c6d0533f3dc194d47e60f9ad14696144cde694d60a95f3e96b4b28f7e7a15a005f92400ce33db073d49b53871594a88fc45e0f94207b5f0f2dc",
-        "sha3_256_hash_of_public_key": "8e49b73bae3b0285bbe1676eb6fad2641e7354e4c0a4feb0b74bb16708b01351",
-        "sha3_256_hash_of_secret_key": "23a598fad0141bdf07257c662d22549343a01d75eea9c1ebcdeb4a138c6e215c",
+        "sha3_256_hash_of_public_key": "ca424f4dff49b1fdd2daed31b550335e1b51ad805aacbd08110e982cfa39cfbe",
+        "sha3_256_hash_of_secret_key": "b809de4eaaf33b2634c8cbb9dea51de07fdc89017bb09e7e5e2f459c725dc31b",
         "encapsulation_seed": "ea22a76065db4b565ee1807fbd813b43bde72b0e08407fb867c6a18995025e50",
-        "sha3_256_hash_of_ciphertext": "cb2c217f6ad9c504c9fec4750db44d2c339017542da415ad81094290006e9273",
-        "shared_secret": "a354e870cd600e5a5951aad3491c31a80b0545c1662f830d7f0b6d144ed3733b"
+        "sha3_256_hash_of_ciphertext": "bd455a7bc9d4cfbe4f1f013ff9ecaea8ef734015c88e8fd3b74d82aced0f820c",
+        "shared_secret": "6d9d9cf40be1ce9b6d16cbc4bf80391e6dd0fff94a8f3df6ccd3d9f11c7247c8"
     },
     {
         "key_generation_seed": "3e809ec8dd0fec0d911a4e3fac20f70fbb128c5de94dc7184ca7310ae9157a98d8128601c28b1def8d393a0db283229f7c7383152a814e7cefe8ef9d9768c473",
-        "sha3_256_hash_of_public_key": "f5de62d662f480d4ed8ba235b4aaa4bfff19edebbbfbd96e5a9b7c4e89365c3e",
-        "sha3_256_hash_of_secret_key": "583ad55aa14bd6a4310d3ab7aa619cf59c93906251f5721a0bf880a866517f70",
+        "sha3_256_hash_of_public_key": "3bef1bb7af08e62ae7b2022542b1d6e61555c6d4fc7129c36fed2a31634b229c",
+        "sha3_256_hash_of_secret_key": "928ae410a509eecaec894aeccf742af6d19c570d749d409121f55f184d0f0fda",
         "encapsulation_seed": "e9602b34fe73ad57f4bf6ead99743d645641553a5b9b9bf2e7016629e3e9bd76",
-        "sha3_256_hash_of_ciphertext": "a9f97b3e253dcb15c8ef4c5576786d967e504e8f76c0bf46e051b8f123fce22d",
-        "shared_secret": "cd98ddb938549cc7c4fe56cda7f3ef213f1aea49fed4fb81b940c7e894be1e54"
+        "sha3_256_hash_of_ciphertext": "39f4143e1f1f4175f292c05c6f9ff720576c1066994619debe0a9b271f715827",
+        "shared_secret": "41bde508779ffc73ac9445cae93178a76c94cc1731864787b61fb05d6e62092e"
     },
     {
         "key_generation_seed": "dbf1c465fff3d9f783bd9ee61a573715e45691147b8904439b5ffaa64f94ff7bb6d75eac6c76ced1b0a025b40a55440712ad8424672e761e9bc400d63812006f",
-        "sha3_256_hash_of_public_key": "ec2fc5834e128c5e1460d8cb0c35ab340d706a6c8b52070a7e41a6405fada53f",
-        "sha3_256_hash_of_secret_key": "954a43f78ef0b5a279c0d020c08d930cc5e83a385c09afed508f9ef6f1a27920",
+        "sha3_256_hash_of_public_key": "11e7ed6e44be95d574fc61b193a8c6f257063e1cc581535df4a91249f985bbd0",
+        "sha3_256_hash_of_secret_key": "07492772a3d609e4bb4d1637ca18574840327c819163479e2b48d2222f367f86",
         "encapsulation_seed": "f72b9080a6c051bbdb9b0abc1949034be0f89a9f73fe277ec4d4740c78d04a83",
-        "sha3_256_hash_of_ciphertext": "f137abde6208e2c014a5a7eb1aac7b910a21df3a7dff68dcc40cba4f34b839d1",
-        "shared_secret": "e0d0d574b1287716bd7e0a44feea36ec28469bd36713fa8a53b0a104f322016f"
+        "sha3_256_hash_of_ciphertext": "7830aa71d1dd4bd1dbe16d3421fede1ad06b610a4b6c1dc3a1da2e14c2f137d4",
+        "shared_secret": "e73793295bfe814639ff70d76b5d1c8a397d6821019edf8b8485e92823d71198"
     },
     {
         "key_generation_seed": "1f7cfd2b70863154e8a69d1758532e86c20cfc763d67c758bd10a13b24e759b5273b38bddc18488024ec90e62a4110129a42a16d2a93c45439888e76008604c6",
-        "sha3_256_hash_of_public_key": "5e7f49b87bb2319dba8d3485fe814aedb0b43173bc48f3a793554c3e8bf90c17",
-        "sha3_256_hash_of_secret_key": "74eb7c05fedc78406453b8f021f8a71cce4b3ad0c4d38bc8d581000a38908574",
+        "sha3_256_hash_of_public_key": "37161ec72128762f73e547d28165a02a931ac7319244888d46f10f15a1d9759d",
+        "sha3_256_hash_of_secret_key": "7b2ed324aeacc4fc954ba4424dc19fc04e818de483c5965b5205c9c0e27884e3",
         "encapsulation_seed": "f1e5542190db8ecf4b8d617a04fd3783ad0df78bf8dab749afb57db8321d151b",
-        "sha3_256_hash_of_ciphertext": "2018b7eddcf255f6a171af914ef44153fd60976c5c7368998a218b1d81e34e33",
-        "shared_secret": "bd97eac1e35a06536e713a2ca5e71e35277b948172cafef0c35e1558efb61676"
+        "sha3_256_hash_of_ciphertext": "56eac010976c39eacc2fb050acb18669401c19aed1113f57f90fc54897eb7e18",
+        "shared_secret": "24895cc54471c7762209dd3f950cf98adb99fbf32acfd52519f89d35a7cdeb4e"
     },
     {
         "key_generation_seed": "3a19577908efd37697b8edc7fdaf47d1bd3ad01a1b77faf794bee5b9c3192a6fa3729672816f3eba84c9638a79676eeac0f22c8a48e0c5d50a26ff0844c66b99",
-        "sha3_256_hash_of_public_key": "e3f73c56254fac37209f5a59818fbaabf5abff3320b0b3ee00e20679b5728c12",
-        "sha3_256_hash_of_secret_key": "1e1cff1c4e09318bdc174bff8ef0817d6e7414355adf930bb35e71a7a0b95abf",
+        "sha3_256_hash_of_public_key": "07db8e2dd15a3155e48110bd70f8530b01b3c9b100265e679f200c5ce861e1bb",
+        "sha3_256_hash_of_secret_key": "ec0c72a37a1246be24d8375af854d250886ba7dc5853222ddd6411516afeaee5",
         "encapsulation_seed": "74efa414ae171bf60b6f884cb7e5ce12028f49365daccfa23e845d551711660b",
-        "sha3_256_hash_of_ciphertext": "d641fde487a3659350dc41f329e0d41741bd4389346da9270eda4f5829ce9ee3",
-        "shared_secret": "2ed540764a77b17c6b9608bf86d8d8703f80718044d52dc79cbc1838f91fdd7a"
+        "sha3_256_hash_of_ciphertext": "2db2eaec38b9af9a8f60de3f85edb147a81314256e2ac9a3703d0cbfe5df0399",
+        "shared_secret": "32cb949b65d265d2672406bc2d984d35884ef8b7c4fbc7b698e0045c2b40231c"
     },
     {
         "key_generation_seed": "ae0f65e29f38804a6759f70f4d01e2aaff7fe1c91ebc4f892dd0de3ab2e68ea5e03ff73e02a217659f53d8c47556bf3d8c94040f630d63605e2d0f923579370c",
-        "sha3_256_hash_of_public_key": "bc0a40ba03d27bbbfb91654fdcfab2dfb3e94d9607b99c1d7da1f2663bfa2598",
-        "sha3_256_hash_of_secret_key": "dd55c195b92ff410b9ea37577ddba0385bbf067b3053b0a678e8106c07b98c9e",
+        "sha3_256_hash_of_public_key": "b5b47d79ddaf113c079ffd5f7e3f6625fa5bc21c6b935c0a1f8c51e885d0ff5a",
+        "sha3_256_hash_of_secret_key": "a6acd69325eefd0767e776d90cfb4a14045b1886df0e42af7d090d0bb5f8fe88",
         "encapsulation_seed": "0b4c3cffb2ba4380ead13dc0d8acad2356b448a810da1df29f264c44aab6d24f",
-        "sha3_256_hash_of_ciphertext": "7387b045cefcf3d2c659171ee41acf3857b9f63f1ba20c3f0832cfe41a26ef75",
-        "shared_secret": "1e5ba1b64fa8ad0494c96ba27e288ee2b479c24634285f8919e58e9b9c8be78b"
+        "sha3_256_hash_of_ciphertext": "b275d4c4a8953ff39e862f3efa28e0b09ae8df904466f8ae138ee4fc80c97e20",
+        "shared_secret": "8665fc425446f176436ce8b168862f5357df35b10bdc40009156ef5c1c29eb3a"
     },
     {
         "key_generation_seed": "6084a235f79dd093ef6d185b54e69df33dacee73a9bf2f379004421a10e3a79d9f684fb055ece19459eb464e91e126a7a6e3ed11ccee0046da234d964c985110",
-        "sha3_256_hash_of_public_key": "e16da7f99bb7bceb75a6468a921ab9fe53aab2972ca616ee10697c204df1e350",
-        "sha3_256_hash_of_secret_key": "2db70f5bb4e8927fd7696a4d802817fa58c43f9b2618ed27c7584cce8acf3506",
+        "sha3_256_hash_of_public_key": "2ac8b64e47ace9bcd950e9927b11007b6de8cfa665def178c2802ccabad0015f",
+        "sha3_256_hash_of_secret_key": "bed9f996e491adc613f2b3d95bd3a6192d86c6d9e92b8119fd6a239650f4f844",
         "encapsulation_seed": "1c82471dcdfca3a6942061ab4f3d5bf0d197321437c706d9cccccce449447002",
-        "sha3_256_hash_of_ciphertext": "0159f5e60336eec1fda83aeffbee92eddfcac6f92b0fef7a4a38fb20d1a771ca",
-        "shared_secret": "96ba12c7f8a0d864ce1434b789c09753c2d1f7ade6a5a0e679ce2ea0b6d66c83"
+        "sha3_256_hash_of_ciphertext": "a1778ba772b1e1d6d437153ea0ce9b862e0e5f145dbf3eb78ef5b9178b238762",
+        "shared_secret": "3aff110a6728373d6dbb5fa2ab0a67c1030adefc1b78c7fbbc3e72d5c58a6c17"
     },
     {
         "key_generation_seed": "acd1c0217fad5caa4235544dd9de153ab1880ccf4c76f16f236fae4e4bfda04cf03a8abb0a5010f400ae5722a75bdf5a2f6d5b546b34d73857cb1bfc7e587aa7",
-        "sha3_256_hash_of_public_key": "fb80edf4f67823ff4e53a8963a9c9937fa9f8e014b750e11b4c4bb1a361d6484",
-        "sha3_256_hash_of_secret_key": "fe67beff69ea75d4953d71c038559591b2a0349ddcdfeaf7596dcd02f57db2b9",
+        "sha3_256_hash_of_public_key": "1065414e7a040c3dc4163626f3d589ce9934d1687dad9363fc7fe0f29df31cef",
+        "sha3_256_hash_of_secret_key": "50fe0449eadf5e098ab8a1aa24880248c23116468c0618bdbc18812c53bfbf5f",
         "encapsulation_seed": "46fe60a18124125ab93e0c578f1c02f1bd1301595013001c7f3c2fa56cde294e",
-        "sha3_256_hash_of_ciphertext": "6e68fe27fe416c12819fa8a48eb29351d1d74a9200c408b55294ea374046c3d3",
-        "shared_secret": "07dfc04ebbb7ae537b594210a9180f647d3d385d1c1bb56abb8174111eb246df"
+        "sha3_256_hash_of_ciphertext": "3f4c82eb2d1f0e8979166e648d53e827952689def870dea7ba7880c8908d4322",
+        "shared_secret": "da50f540be5c16fae6f864fa5ce3118d327efc33609a9af8a10f8c48928aebdb"
     },
     {
         "key_generation_seed": "241191401a63afa750f05662e354dddbc683c776ce3222beb83e3cf913d7ed7ca59b3bd23b49a95bc1fad20070fec930b6060bd827d742b077092e422268e15d",
-        "sha3_256_hash_of_public_key": "d9f630c3838eb161374710d9f01bc70d4ef928fcb1c38bed93e30f3633a05e01",
-        "sha3_256_hash_of_secret_key": "ca4a4ab954c3a4c8b960fdfb7dd7cf5e8d103f7936f31e720e5043010926829f",
+        "sha3_256_hash_of_public_key": "133970ebf50f015c58571928cca31d603f0a84b2698e6beb36b378867824d88c",
+        "sha3_256_hash_of_secret_key": "8a28f2fdd26f28f64b8c4f61c344ecf9729a807e56307eafd82ac5621163328a",
         "encapsulation_seed": "52fb7cb6a633fd2e83f2892bd9441b48fe59ecee6d026f5246fa7f2a5e55ee3b",
-        "sha3_256_hash_of_ciphertext": "3b6a1f5d06cd55c98ce6f4dc5b17fce8cb05b33b1d89b618a027e4478d8b5e69",
-        "shared_secret": "81fdb9267988ad39ab57e2fc8d4c280e0000dac3471b0936083aec68b49fd92b"
+        "sha3_256_hash_of_ciphertext": "38eb23460d49cb37a41c9c50d6ef7512eff1f503a56c632d326827fb88a938c0",
+        "shared_secret": "f295340ea250a6a1baeb199ea745ebe5585578d07cd8f579dfe5cbb75f852d9f"
     },
     {
         "key_generation_seed": "b9a6b0c05677e957d41a34ba03bd06f2a9092e31f63389397d7e70fde6409d18e99c0e7b82be89bc3c1eaee6680aa4efd394e40c2b3f30523c8117f7c26a8969",
-        "sha3_256_hash_of_public_key": "5c27fa929adc826f98fbf0a7fdce33c8f215b34e70450da0767240741894ffa4",
-        "sha3_256_hash_of_secret_key": "0116eb35f3138aa7371a058661a92a4bde258f823747b70ad40767c27d7bc7f4",
+        "sha3_256_hash_of_public_key": "51d50a091fdc9e324eacb8c5582044e0e16efb18341492977e616c7f1f952c21",
+        "sha3_256_hash_of_secret_key": "fb9b532c1a823ac87406089f5928708f4f5745fa50131440ca41a239ea381695",
         "encapsulation_seed": "0f81a5f97082121244403da3feeb734f6084b314b8d94beb11627aa6ad1914e9",
-        "sha3_256_hash_of_ciphertext": "83f17a1e23402e14a58a32343e1083434eb10b90a8080d01ba112b83ba15f7f4",
-        "shared_secret": "703958ce09d7d6a5bb09e88de8df95c8ee2598544d50193be50534947530fa37"
+        "sha3_256_hash_of_ciphertext": "33407637b6c52ca8713cbcd5309b7e5d63d7b1c8887b0ab5506843f4aeaa1267",
+        "shared_secret": "2de1d0b40d434d5266402b7b59baa358ef79a03d4c8156bde44b404a7f686e75"
     },
     {
         "key_generation_seed": "28a96c71577ba00c94f99fe965bc595a26db2b3ca6ab5cf8e443cdd8462b17929c35d165453e5fcdc6f9df64526d9de698f2bd3e6bac6c7fdd86601b9ba5f4a5",
-        "sha3_256_hash_of_public_key": "dd8aa653122eb5e3a4c3c877e95e8ecfcfef1ac9e0e6af92cce8ee89d09188fa",
-        "sha3_256_hash_of_secret_key": "8a5fbb715cf44c86b736227e56b53d91ebbea432fb1f1d6d7cafe42da8457b2c",
+        "sha3_256_hash_of_public_key": "6e7c2180244cb10082ffbbb0a494d5a9979595e55054ba2c9b3cd4d2710e90db",
+        "sha3_256_hash_of_secret_key": "16bb4f8f7500929af2822705c7728f86696c3911e37fa861c7cddfc7dc154c03",
         "encapsulation_seed": "31af9345365549ea0360169ed57daf98cc5444799d4c75d9f1f5d615e9df8a91",
-        "sha3_256_hash_of_ciphertext": "862f660f11fb4252070e948ea2c141202246d5117ec151e6d5fcd0783bd76bb9",
-        "shared_secret": "c86d221cbc5ff6a994d9111acbfff23f7dc0cd934412b17d89f0f27e3cbd1a15"
+        "sha3_256_hash_of_ciphertext": "df3222d35857e0504dd490fe5a9cbf0912df0cebcb0c2d23b4516a2524223747",
+        "shared_secret": "ffc02cfa2a2fca2b11bfcfe1d4e273eca98ae7ada761ab1860bfff0993590dc3"
     },
     {
         "key_generation_seed": "c08ba2ef8c3a0a043afad931652d7a19e6e8cb670f840de5f1fa03309b2ca9ec5fe6141a25f7ab9f875f79e0a82d6ea5cde5a017ab637d5fdb7c42646a1d71df",
-        "sha3_256_hash_of_public_key": "b7c80e434104e9838cb08529592a5f81b0e8ead186663db8facc569b09e75c9a",
-        "sha3_256_hash_of_secret_key": "c5f84c36f3b8af4b4d90a040d929b116b402840f487d437f9b330f6ff3ec36fc",
+        "sha3_256_hash_of_public_key": "f4a6a5b6ad7ee1a9c00b029b4e13f35eaa5e0d8e29e1630e4ec8358c7ffa69d8",
+        "sha3_256_hash_of_secret_key": "b8744fd9cc9b311fcbd44b38bc6cce171fdc51648bd8ecdb788806e411b2d26a",
         "encapsulation_seed": "774ae54093d694ef40b63b62c73e6c98295f606feb8699807eda1d030ffb996d",
-        "sha3_256_hash_of_ciphertext": "a372aefe804077da915a423dad55b76ff08a58d222aa66305599ff301128ae13",
-        "shared_secret": "c0146ba47b3d4178919879721f69ac896d6911d6e86de1e8f05797d467053222"
+        "sha3_256_hash_of_ciphertext": "8165e43445e3768723ebdb5b30a889fab93d968bb8b7f29593d1270ae8f2fa31",
+        "shared_secret": "fb1fd6845fa3d004d1bc20286746142ab695769cc1162b637af8dedb799b92b9"
     },
     {
         "key_generation_seed": "0e3b30e102d707538c2671060f603bb0b8a014103f132d63b09ece07e4a4c75b11eafeca9e810796c34e8cfce9d59342884456007b01ddd12edce6d10ed87e4c",
-        "sha3_256_hash_of_public_key": "e619285c692532735f1582d227b9a9e77b1eae4aab9eaa79f6ce7ac2fcac8318",
-        "sha3_256_hash_of_secret_key": "2d4ae4f98c61bd104fbc1ef512b946202f95ecaa0ad7353a686141be5fe18116",
+        "sha3_256_hash_of_public_key": "feda6a06105c411971aadf2bdb1dca5508a2ed6efc6b47fa1157e3defe424d21",
+        "sha3_256_hash_of_secret_key": "fe461230d70c176e7f1ab48aa846a814546bbecc739b69f7f0bc35d78898bf47",
         "encapsulation_seed": "9f27a47604ab5146caaf0aafe6d149424f8d66e39ba3baf5e6c73b19221b7e21",
-        "sha3_256_hash_of_ciphertext": "462b78ef50b2c1ce761fa7750ab5ed2a7315e474a92ddae74bd23013b0d9ad0a",
-        "shared_secret": "a33f72941e0947735925e5be668b3481e0cece75ef48ae6db0d66f0fb2ec428e"
+        "sha3_256_hash_of_ciphertext": "5955cf996fdcce7ede746dfefd98410fe457cc2caa99d8edcd1fe25087e786eb",
+        "shared_secret": "3afd47ab403f63e4b15081cf8e369d2aad856efcd26e0c5e21c90bac2e7e7ec5"
     },
     {
         "key_generation_seed": "2478f7d3de6041e7e5cd11c5e2ef483d1aa6218eb126444091535f6ae532fa7311136e2681df2ef881b51a092a9badbe72c9772c169808521c47149578621e28",
-        "sha3_256_hash_of_public_key": "dd3761c0e96678a959f30997e96d6a59858528c5e10234398e2da2e50ffcc517",
-        "sha3_256_hash_of_secret_key": "c6f5f9285f93d2ee6d180353799df5fea713870ca06de901e9c12e8a01ead6b6",
+        "sha3_256_hash_of_public_key": "2ec40df65eb82037e9c78a2c56e27df1b457c5a07320f073e50af9eff265a12c",
+        "sha3_256_hash_of_secret_key": "d910cbe9fe922779b56cbc8f414b1ed77df2e1ac9a7e2216b4c978bf621d5bad",
         "encapsulation_seed": "90044031b7597b5e60a4f946b713e8996d0426d2cb013243d9b7d8f8ef159a0f",
-        "sha3_256_hash_of_ciphertext": "2e552ce25fe0771bfa135939d85bd68ed07959709da470df50be36aa8ab2890d",
-        "shared_secret": "3d77b9b4ade74443fc573c393b82c0cfd2bc2769327f273c14e66eab9f8d9ebc"
+        "sha3_256_hash_of_ciphertext": "29de5f93b185432882f638e262772e1155ac7b753aaee72c927025c16e3a6c2d",
+        "shared_secret": "f2284ed700026dbbd105e4060f057fba783cec693cb8f3b2dbd43ac1210e8472"
     },
     {
         "key_generation_seed": "9d405d3ebdaf35fa8722de431b669722acaaea2fd10b814310b17f78b66147d16ceb14f7662be0c42779459f69a145c0e2ce9f0bd9a0cd1bf32ed5694cc9ae32",
-        "sha3_256_hash_of_public_key": "6d9e513a7cd137583507ad7256844bcb9775ca82ef5f411331a7c37ce451181f",
-        "sha3_256_hash_of_secret_key": "1dd2623a7413ff14549690b642fe90ce16ebe7acea38be795a4936b8d86b93aa",
+        "sha3_256_hash_of_public_key": "d2a838249b7caf28e67f222ed57f2447f3aef51c0994fbf4b3932ae95d66cdac",
+        "sha3_256_hash_of_secret_key": "cbbde6da7c1ded26b1db4cb807c5d99a1399f80b3060e689428d06de92921268",
         "encapsulation_seed": "a7a31e140891ea37d2b6424b59b1f84f89220f32dcb73e037eb912b389d34a48",
-        "sha3_256_hash_of_ciphertext": "b4c64b73ba056f9ee7c3587ba0825bcc7172a6da749cdd86c1ef60cf84515883",
-        "shared_secret": "812d6c4becfdd4a95f234e8fcae1d9b316266d1c519545bbb7fab8a19f3519e0"
+        "sha3_256_hash_of_ciphertext": "70e6ac1c7668285a8384a163cdf4563d6dac4429db21832977ebb3322f4385f8",
+        "shared_secret": "3dc10519f227454873ebde9b608ad5203fbaed1a29d44b4c556e75218a47ad07"
     },
     {
         "key_generation_seed": "9a86490f0615f3edf789cb0654066e9ee339cc59f968281f3b89213f83c692edfaeb2ef44d2f608621e831187ce79b2d2f4a20f1568bbe76b0d3d5af36111714",
-        "sha3_256_hash_of_public_key": "b252e5abf757e116a92518eb72df9f9ce66b07edf4d31be225585a6a827a35b8",
-        "sha3_256_hash_of_secret_key": "45ac74f2a699f1e3559e2d1442638290029688cec3da96c58ea697e1ed1d4178",
+        "sha3_256_hash_of_public_key": "ac670f00545ac0e074de0422a500a813dbbd25b9e0f64719af4363ea4314fb93",
+        "sha3_256_hash_of_secret_key": "edc3684f5a4cb567ff0fa966db8310ebb4beb1cd181c34195d7730a98479f529",
         "encapsulation_seed": "70eb3f791faa91f1f982fa477dbcddeb2c55691c07f93b04cd31b37544c94b42",
-        "sha3_256_hash_of_ciphertext": "4dae8b2d08afb311ef727118966c6c17652f1464e6cdd26ac23551d31b013415",
-        "shared_secret": "c8757f45a1e334ad99a0d2adf12e79ef2bcb96ea1876bc29a4ec5cd660923d82"
+        "sha3_256_hash_of_ciphertext": "5da75488b130901d419a7e7ed1932f5c2b71acdc56ebb7854de51bd6078c6067",
+        "shared_secret": "f04ce13f4c9debf1eab149f684f39bc9aa5223cb5db8345b63369312f1dea129"
     },
     {
         "key_generation_seed": "6dfd9b575872560c7bdc2732c4a28dac4db04e535eb8e402c3dffd145c09ce47a2985c1c4d203778597947d710dec806e36b0cd949fe460ef141213bfc525e5b",
-        "sha3_256_hash_of_public_key": "18c081231277f424c5f3f1f6b4db91958611fa28bcf09ccb2573da64547e1958",
-        "sha3_256_hash_of_secret_key": "f32167b39e19dbc0db58a5eb79e735337ffe154c75b0f2c091e009d0cec366d2",
+        "sha3_256_hash_of_public_key": "1631cb83581d2d33b3c66f9e7e06ed518552c70eccf267add0f31d8b855c211c",
+        "sha3_256_hash_of_secret_key": "2db46b56e168b69771389f76bf9720a14a3b9cad37a2926726acf21f3f9a5dfc",
         "encapsulation_seed": "30f4095015ba88b6d969672ca3f438c395dacf7d476ea7a9e805ce932d270a13",
-        "sha3_256_hash_of_ciphertext": "3a246e10c7c20d77a9e4bd6d3a90d73ae456501dc989210c798293d0b449852c",
-        "shared_secret": "be765dc236062da9d3fef68c645b9a8a5494c351d37790c1e7cd1089d97971b3"
+        "sha3_256_hash_of_ciphertext": "652bd99cae2b04f5f3f6f87a94ba5e48501fd7a833e38bccbe49e3af7f7a7911",
+        "shared_secret": "ba09aa954a79c48b972904b3d3a7dabfee1128cdee6e407b6767fb1660699d88"
     },
     {
         "key_generation_seed": "6fca9f4e384d8418075cc064c70730801bdb8249899d456a77130d5beeb3662cce7683f8a03d3cf04e46970ff7d6a12494ae12558346dfc8fd9370bf944a0102",
-        "sha3_256_hash_of_public_key": "0ac7db13184d6ae6e21a14a63a2ab3d6d5d1ee7f4a6011413a0295b752fd2c28",
-        "sha3_256_hash_of_secret_key": "f69bacdf5992e64369aa4325b70af9f0e8a399cadafe48d854c288cc4eec627e",
+        "sha3_256_hash_of_public_key": "afae13836d8e9f730bf1ae7dfb2223fd6a0b9c6f0d05060b8e70df3026f43d6a",
+        "sha3_256_hash_of_secret_key": "4f595b13c6da7adda204b214fbe724d25d5238311d23f1f5650bc00c6956fff5",
         "encapsulation_seed": "cf31220f44de862e1719570e1b26e897790159366a385452334fe24cdcae28ba",
-        "sha3_256_hash_of_ciphertext": "d4200c5ed5cb4e30e8e74a5c8c30eacd48014d326ae72f73618c5680f04999d8",
-        "shared_secret": "e72888e8dc5fe30f0a9c01e2e4599a7046147a81da280c393a48bee1b43bbb5b"
+        "sha3_256_hash_of_ciphertext": "92a88651ca5037af5decc779fac443cfb81ad01587b9ef18d859125de0991918",
+        "shared_secret": "4af69fdf303ab72a07b75ea0bca8bd49d27846679ac934f1b47d84ea679aedbb"
     },
     {
         "key_generation_seed": "e58f71bf175c0550a67e00e0f7b3b7fc36bc2707bf0c93044a492626de36301a7f7054814869cf7625e45647bc1547aff288dbb90699b2ad84893f3b755d9722",
-        "sha3_256_hash_of_public_key": "27ea5a76294070ab10a6edc502d82be3d240672e5fa61377e73e5e19d11f64a3",
-        "sha3_256_hash_of_secret_key": "33161a2b269ff022ff4699b05ac7fac1374d733e46800447164d3e528ff89dc4",
+        "sha3_256_hash_of_public_key": "028cc8b25a75078c9dfe80202673ad40d43982fb7c16ba843828cf2d3355c3b9",
+        "sha3_256_hash_of_secret_key": "35b530c4aa49062fa74619f8db44634025c8734627fb7617921d5a9d13b6cab2",
         "encapsulation_seed": "bb5e65669a44e5d5c709bafa98c16ccba6ac2c4ae923334f69a11543eda64f5d",
-        "sha3_256_hash_of_ciphertext": "8995a8a9b59bd5adbe1fa10cc20da5348737cce9088be7eb0ba1f6215d68b9a9",
-        "shared_secret": "e3f13c77fa9eb329c218e1bd5823d6e07249fa1b455770ae57b2a00aa8c69c5d"
+        "sha3_256_hash_of_ciphertext": "93a566a42b8975994e2bac3278707c11162b88f1b4ab8d74c1de7049025fa3ac",
+        "shared_secret": "ffc3fe6705226234506ded36ab2249dfea6b9d430c6a36e7ea2b53a7677c6fcb"
     },
     {
         "key_generation_seed": "e3fc575ed51513e62aba655d24cd9c8f1c6c848aaffa946c49a53ac3ea59e474d82c2f1bf2e6aebde5660fa73356982e12999d8fdafbb3cb186341d0386dead0",
-        "sha3_256_hash_of_public_key": "9898462f05bea461adb40faacdfdde363c06f58bc756f0a8417df63a66d3a544",
-        "sha3_256_hash_of_secret_key": "e10192b72796b2da465303c0bbe16f1e23e08f9680ba92fc22d568ac84352113",
+        "sha3_256_hash_of_public_key": "7f98f9d79387c9fc714d8b6967d9a4d3fc42b70e9bf3a92c91d141064bc0b96c",
+        "sha3_256_hash_of_secret_key": "29394668f440482d6574652b57ed9c2ed7462c9692eb58adf6ae9ce05173b0fa",
         "encapsulation_seed": "9ddb3aa9c7905d1a438c93bcf78e3e321813580371ab4e1289e2dbf3701972c2",
-        "sha3_256_hash_of_ciphertext": "573aa757ef6fa5110ba7b948c325718f87c6bc9ccd596debff4e6c7dac1fa8f5",
-        "shared_secret": "a8498502e012b5cd006e77fcbb9fab801dc3748a0da37587dcd41310fa945e09"
+        "sha3_256_hash_of_ciphertext": "d5bcd1979e7ffb8a4a4e5f0463bc23cc0bab3342930a3f264818974996874794",
+        "shared_secret": "c0ffc74903a9caaa660206f54ff6cc5c2e928fc12d07d079f8543e1df5a7d8fa"
     },
     {
         "key_generation_seed": "470b4943f0fe7fd0d8ec5185aba0d1db09d112934e4fb4787e2bbc6b88466e7b8b2809fd40008be70a6b184981101724bc3d5ec5e1956b510b82fd5ad0668a5a",
-        "sha3_256_hash_of_public_key": "a24e6203d9b1aa5cd06c44f048da7225e33952617f12b4289494b3969857c2ff",
-        "sha3_256_hash_of_secret_key": "61f1e3b3a9ce59d25480d88dac106cebc81272c0c9449c9b22048f67419d940a",
+        "sha3_256_hash_of_public_key": "f4a3d6f2e2c32b72d9919dde7e967db8a0244c9a5bebdc5fa3943b16e14c8f0d",
+        "sha3_256_hash_of_secret_key": "9a00d5cd9ac58ac41ba4c02626d3e90ee57de66b0fff235ed3a31162ded60fa5",
         "encapsulation_seed": "26d90b190a6c3d0d9a86cf66005154e7086749e966e7187c249ccb9329fd3b8b",
-        "sha3_256_hash_of_ciphertext": "7f92312ab16635c5e90a6d41ac65e594e37754359331b0814e09da9c7eb945e7",
-        "shared_secret": "780b2d0ea585a6ea41dcf43197b9ca4648454e30a3057f0d47f6e79a2bbc365e"
+        "sha3_256_hash_of_ciphertext": "c455347d8a46af3ca2cc5835896c0712216265b1497ba5bbf0e413828181ec4c",
+        "shared_secret": "e4c5b2f26118f93f7aaa899350850a7580845540522b94681fe1236f0b70f6bb"
     },
     {
         "key_generation_seed": "6df4385db978d27b27d2aa5e452e4152b36f097503d9581ac3390105c5727e7dc95fa08ed106ce84660e8a4c90bd2b22634e40769aa0090a101c5dddad45edc5",
-        "sha3_256_hash_of_public_key": "cb2e9159ab5225a75d02268af2dac89a0afb33fe83a45f552e2bf542868c0683",
-        "sha3_256_hash_of_secret_key": "d2ce7cdfbe3ac715b2c87b1231fe46d5385a77caab367570a955bb562d23183c",
+        "sha3_256_hash_of_public_key": "bece5ca55652de7b7f5917be686f171b7ae79cc71abcdfe2e1b687f72ba8804e",
+        "sha3_256_hash_of_secret_key": "afb4bada4508b4d742dca22986b0a49bd993059439634aa2626bbf4d7a62a604",
         "encapsulation_seed": "7db6d1a129d6123f1f805b79ad3b413012ea86aed42a05e98e7b1f32f9fbbdec",
-        "sha3_256_hash_of_ciphertext": "1113b9a38ec4629ad20ecb594b64ba242a5a4db7bdf32914f9eb34ecc76c4a1c",
-        "shared_secret": "7832b351d71984cb60e6e548e5b4edeedf9749f8b3bc96fd208b6bb557251de8"
+        "sha3_256_hash_of_ciphertext": "2ddab8f63d385090a48a0fcaed299cc939c216e19918eb8ce3dc387a5d8e4bd2",
+        "shared_secret": "2f2c8b7bc2d69d8aa65a27ab9a6f120ed179e358e5a7edc9a6f0a6c852cf31fa"
     },
     {
         "key_generation_seed": "dbacba825728444921b227cdba54446b3f6881b47be9cd02832f78b023b1bee0e15274a8e2bc08fe818b117ba28c5dfae74d54fcdf6f20052f79be333edc8dde",
-        "sha3_256_hash_of_public_key": "7f8d36076b3a8aa13b633650726f7e907806a0573402ef3af129f611def1a813",
-        "sha3_256_hash_of_secret_key": "0b38e04daf35259696487ffaad947f481756bc3e94dd1a73b81bf8a6da4a43c3",
+        "sha3_256_hash_of_public_key": "141216a25195bd89a10315ce19a15765a65eaa8e2a9b73273bcc6c5366c9923f",
+        "sha3_256_hash_of_secret_key": "975863aa11c03739bc450264ef3e2a695e58594e1a2d59e3c3e21b4b63a156f7",
         "encapsulation_seed": "1d129b27be7384c359d04311fe5c44917d1fde4bfb57314f483ac617edd5ac49",
-        "sha3_256_hash_of_ciphertext": "eefa4d255cbd39fb5686d14a6a574d4c75c6b138a45a09cec12287c281cc00e8",
-        "shared_secret": "468ee020867cb766cd0a9ce1bfe9e7dbb56ae66c131a4540f211837c1779e11f"
+        "sha3_256_hash_of_ciphertext": "8177914d5ecc8588925343c7b2f4d4e4649cac040a7f629bb151aa3dc3437cbf",
+        "shared_secret": "921a38055c96bed7e7180d4ebc7eca6aa75192ce81a6a1f46ad73ad668b33879"
     },
     {
         "key_generation_seed": "690eb71fd7052b906eaec09937a8ed374e0b02afa27c2f14399932be5839fad281c38c2cb5cfafac81b96a810ab749b61806b6d54c9f8cf4bf1be0192423288f",
-        "sha3_256_hash_of_public_key": "ff2044ee6a3bfd4f7033dc4bbd6283b534cd3fbbf1c4af072fea1ba37d3262d5",
-        "sha3_256_hash_of_secret_key": "ed62dbd78c007d385c786f2607715a69a44804c4e88111861d175875bc0b09ee",
+        "sha3_256_hash_of_public_key": "473638d5ab7765f1748d03eaac231bbec8c33f5717af7f95be3666edf99ab017",
+        "sha3_256_hash_of_secret_key": "4f80d7afd1ba46100276377b3aae1c1d117f18c1a07e2fc05f3bf1d06577fa9a",
         "encapsulation_seed": "bbc773ebd2df42c36ae05952d6a64c63a5dfb82ceb3ef4f8d4df3a30ec8c0467",
-        "sha3_256_hash_of_ciphertext": "d16b23897beae9fb1a6ca746d3c15ef52c8ac454cd518d5a90a561cb588a0260",
-        "shared_secret": "f04a17a3737285f2257a6374a0057776ea24bd731724851d12ac2e06e959fa26"
+        "sha3_256_hash_of_ciphertext": "9d49af9ab6c3a2b98021b5ac47677e4ca6c0e01225f9e8b8fc266a2a47affbda",
+        "shared_secret": "218bd3bb5a1fc53ee08c4294c62eec9c99e3bd05ba0c102f8172005f1f2e5cd2"
     },
     {
         "key_generation_seed": "32e0ea9089fa928482c0770da545af1bb871a03ce38604138b0d08ea2a10ca2bc06c5bef7b6508409daf847a64c8d30d0974fd3ba7476dc76c46b458a036d884",
-        "sha3_256_hash_of_public_key": "c7ca6ebbe17f30f8ce49e15c40c1ea5456f43624148eaecc9f3018f7beb96bdf",
-        "sha3_256_hash_of_secret_key": "7886dadfd208ab926afd2376dc11a004d8b793d7a30623df27109f9a4d4b0916",
+        "sha3_256_hash_of_public_key": "88c5687884496ccbd4372a334045192a50e1c410459f95cc29fb4c5f68401c8a",
+        "sha3_256_hash_of_secret_key": "e4969f01fb75bdcc6303dd42eae66c1eb61243df224a40d15866276ed78262c1",
         "encapsulation_seed": "5b17a6adad541efcbf5ae4b0c0452cd2ce32e4f0f8701801c5b63e197c1fcbf4",
-        "sha3_256_hash_of_ciphertext": "4fdbbb522c23abd8a69c583c2c68ddc28fa4da85a6bf208a22d19e7ef40d98b3",
-        "shared_secret": "fcfab6cb3daf0c64b4ce007499f097f6421e00905fd4daca7da7a29b9c8f6325"
+        "sha3_256_hash_of_ciphertext": "4a21b63af1aa34591dbc9a73e8bd73de08db38e6f89c68b8ec8d8e148d13e7e2",
+        "shared_secret": "c274199ac90600ee9d5bd055de33e12194f275c283dda609dddfcdf251066233"
     },
     {
         "key_generation_seed": "6fb2ec719f2a0dea152bf3f64b9d148f8ab8ba88f64e61f5db53e12d59f525574f797c007e4061f95c7d56cfc7ee5c49e849dde3fea8f25e7876df2a18515c34",
-        "sha3_256_hash_of_public_key": "61fb6cfc0f388e34fb28ed783c2733453005eea03d3fee4b01bb6364abc01c30",
-        "sha3_256_hash_of_secret_key": "b724f25cf64bdaab1cd29c9cd1f8ee6cf4104c26fa3caf53b77d61cb5c35222e",
+        "sha3_256_hash_of_public_key": "2918142a2fe3109d07b30d97f61948f778aeee6c1f4bca93fc3e85c8f7a1a0bd",
+        "sha3_256_hash_of_secret_key": "7fac41c1b4302142bf14516ff9e04fc45d080694a2ccb1308b2e0a622fc02195",
         "encapsulation_seed": "61ab87659525de9656af41246f20e1dbe85c24e335e7ecf9493f46168bc14e94",
-        "sha3_256_hash_of_ciphertext": "5ce7558ab39d932fd35fc346aaea5aff4bc90e65c17b5760996e84687dcb5402",
-        "shared_secret": "dbf4cd1f5cddf15322449ddfe147ae0605d0315ff9da6421069b47c3a67a65c4"
+        "sha3_256_hash_of_ciphertext": "4e821fe341ecc68fb82536d1c04a608bda2ead87fa3943913f1c3e615c2b4295",
+        "shared_secret": "74d6a6fc4f573043e3085c379d4c809e2a247fa896f1ff1d323c9f3cdd6ab4de"
     },
     {
         "key_generation_seed": "527fb88c8bd9a4d6031dad15e63878abd2b559e7e08d61f69e8e78fca964ee6ae32d432b4f9f751bde0496c580a181ffed762aa35454a02d3f1f47ee0394c89c",
-        "sha3_256_hash_of_public_key": "9333445958cf50f9cfba453f058f562158bc253e535e4e2f07715531a1c6289e",
-        "sha3_256_hash_of_secret_key": "9bb80f6928e0d09847b4c7e77ba6bf2cd0f75bdd147e884b92d3c3f2e9d839d6",
+        "sha3_256_hash_of_public_key": "46ba08cce40a82de21b6823914ba4a5adbb44127199b72bad20ab9bd5e39e3f4",
+        "sha3_256_hash_of_secret_key": "d7e4f12363fd2f668b1a217cbf1c4febcd396f8adb044fec29f8b8ec1c56edc7",
         "encapsulation_seed": "eca2adc3da1fb15f34033405ec08ef2f46163df4bfcccf8842c600ce0bc2026c",
-        "sha3_256_hash_of_ciphertext": "57651b24ece777c321c6e59ba774951e2a3c4720d370e3af928238ff60c9565d",
-        "shared_secret": "3f4848a2de1cdd8a0403da22f609809a20c2cfc0ae619be0cac350897fead710"
+        "sha3_256_hash_of_ciphertext": "b6d6f3fb92c3b89977bf645bd1fa40cd79278c1b62c34d2ae81cc8d490bf5d4f",
+        "shared_secret": "1adda35e06f93bdd9df93ba0630ab5ff850f0affea21a4a4f4416499691f00d7"
     },
     {
         "key_generation_seed": "ac6fcfaeeef795b6ef9e062f02bf42975fa01e7d91ba832f74e05269a72684d05aeda108ea4d6c6bc0fb958286850422bc357ca67b83c986048e0d0087fa11ec",
-        "sha3_256_hash_of_public_key": "ee6cb12a54341aeedc99f1040b01603c35f07c5487ffac7b4fc1925f49026916",
-        "sha3_256_hash_of_secret_key": "4e498a0606b1f9cd72b9d2493428730712bdaa4a7fed8099b15d9e2873bbdf7e",
+        "sha3_256_hash_of_public_key": "9fa4388332705d549be44d4c446d8af0c9a58903dd51c55e2d70a91e4b54407e",
+        "sha3_256_hash_of_secret_key": "5bb1cfedbd23f4b62e3fa8666d03a3fe57999f303106d10156ed940df6789e43",
         "encapsulation_seed": "c4f15bec2d7701339d0ade4835193bea3632edcf89e74992620d9eb623a0d0d4",
-        "sha3_256_hash_of_ciphertext": "1fb55bc4e6d95931087b23945ce9448207fbbc14bd284f6bcda65fcf31d68fdc",
-        "shared_secret": "eed5b71764da1763a01184a1eb51dedb4eaa9dae7890b1c7dbc7e7132c30e737"
+        "sha3_256_hash_of_ciphertext": "74c4917793f1a4bfba6edb825fd8385ec49ef98ba4d0fb2763a3c062b789c6bb",
+        "shared_secret": "90f3088cf55b35ea835c7b556c5fff3eb4983cd4b85f3576b2ba5106be28b365"
     },
     {
         "key_generation_seed": "ba2fb9318d4dbe7488057c33e95e6f054583a2800c41bb83083c330a914a12cfe63f8ffda3565c2424c89b20974b748a65a5aba75133fcb3156dfb6626a83bab",
-        "sha3_256_hash_of_public_key": "42ad42d6d3b13c72b16287909bc4c0da04900536a1e48a1a28db4f5ee2d2e771",
-        "sha3_256_hash_of_secret_key": "d6f909b6679487a8718c843c4b894785ee046c4d86ad2794c22ee912113dad1f",
+        "sha3_256_hash_of_public_key": "8a975b476c316b0c6602a00f3038c1cef0b5d1eed8a554893ee392c1964c8260",
+        "sha3_256_hash_of_secret_key": "3f7ac95d96cbbe85821f3259785a53eddb526c275cc1801a5d3638f25c766df3",
         "encapsulation_seed": "28878249e2ac2b6263422993923a0c8bd05ce56e385ed13c943b03d226856947",
-        "sha3_256_hash_of_ciphertext": "54043d4b2be7ecb264847dd0bcde9076523e798aeee942be82d61d51ef0253c1",
-        "shared_secret": "4218fc9abb402e67ac946c7a7c6f9029108f67de469e1a9987d570f011b685c3"
+        "sha3_256_hash_of_ciphertext": "19c26012faf4102167b1a79ed9f780c3bb895032ccc1901a744ad5d8ade102c1",
+        "shared_secret": "7e84740186a9dea9c979b6933b68d0b9af8ee1d916e3f87df4b1917b7a0c4dae"
     },
     {
         "key_generation_seed": "aa6dd1e5799cdf7af9c4fc632b3eb9d51d66e85c8e0a21ec98664fc51ab63c7dfda268813efab5204efa60f78bf81d320d01ac09ac06244f7afbd2d80fd356d9",
-        "sha3_256_hash_of_public_key": "5b70c5bb1b7af3b643588aa7c20567d4259dbe6abd7617a61b48185de8f21e1c",
-        "sha3_256_hash_of_secret_key": "f03297b8577b131e39946a288f7ca9070e70c1e00e6ff126543556f60dbafead",
+        "sha3_256_hash_of_public_key": "404c611e22377f1c66fda96a3839f300960315b3292e81af8a7a68cb66742b6e",
+        "sha3_256_hash_of_secret_key": "12360a2f88f03824f90b447cb276a6866812cc2fc9e86c6157bb6b55d43478cf",
         "encapsulation_seed": "17fc65f7fbd7c75ceec421dee84dff5a8cb22764a182db17e0ebe857f54d60eb",
-        "sha3_256_hash_of_ciphertext": "c3d51c14b28feb48ee67945a2f9e2ababb8682a839ca1148ddc99f909e8c0bc1",
-        "shared_secret": "95a33968866dadc1fd8748768a99f6bb444e3d76a65ec5fee0c8a833978d4585"
+        "sha3_256_hash_of_ciphertext": "bfb68fa61c915e0d72f52b6f965e76431af7dbda5966204724554d6003d9ee3b",
+        "shared_secret": "d5d75f5873c5ddfd993ab8b92c6403d97872d0b49454833449a50d35c62d7546"
     },
     {
         "key_generation_seed": "195d6c86a3df4c21e3007d7f2768b43c74cb3060e0eca77f0a5d3271542b9a84ae77e0f9f21eabd8c0c6eea7767f4e10fde5c2d79b8400bf96b19014b457ec21",
-        "sha3_256_hash_of_public_key": "01782fce09e644e310c9286f1e381be9ea8c54a1804e61f2958c1f975aec185a",
-        "sha3_256_hash_of_secret_key": "3d1b220e747de4ca99a9882a00860ed00abcf2e6eea60cba5194977f97c87770",
+        "sha3_256_hash_of_public_key": "b8f0c8b00c73e9932c2fbc4c725df70077b41c0650a135b669e21b23d9bc971b",
+        "sha3_256_hash_of_secret_key": "409121ba5acb834e89f26a98528692f9e9db0611e4f86006f4c50149d76780c8",
         "encapsulation_seed": "fa0489f3730100609488e951e6aaa15c0f193bc1dbcfcd013bc418d6c507b176",
-        "sha3_256_hash_of_ciphertext": "8dbc778809c9cb1de5301be5bce766f1acd7d8f74ecf30619c398250def57d74",
-        "shared_secret": "c9423277519ab439fca3f5fab4c29c8123a55eaf37d94d70e27afffeec1b3b9b"
+        "sha3_256_hash_of_ciphertext": "c034222dceb5bf171125a1e5a007f6cd53565f669a1aa8398236ce42831e854c",
+        "shared_secret": "14edc3d14c4d60abf7dffcb8419df6b4fb5d45961f2acb3ffa0870e98e33682f"
     }
 ]

--- a/libcrux-ml-kem/tests/kats/nistkats_mlkem_768.json
+++ b/libcrux-ml-kem/tests/kats/nistkats_mlkem_768.json
@@ -1,802 +1,802 @@
 [
     {
         "key_generation_seed": "7c9935a0b07694aa0c6d10e4db6b1add2fd81a25ccb148032dcd739936737f2d8626ed79d451140800e03b59b956f8210e556067407d13dc90fa9e8b872bfb8f",
-        "sha3_256_hash_of_public_key": "d4ec143b50f01423b177895edee22bb739f647ecf85f50bc25ef7b5a725dee86",
-        "sha3_256_hash_of_secret_key": "245bc1d8cdd4893e4c471e8fccfa7019df0fd10f2d5375f36b4af5f4222aca6a",
+        "sha3_256_hash_of_public_key": "f57262661358cde8d3ebf990e5fd1d5b896c992ccfaadb5256b68bbf5943b132",
+        "sha3_256_hash_of_secret_key": "7deef44965b03d76de543ad6ef9e74a2772fa5a9fa0e761120dac767cf0152ef",
         "encapsulation_seed": "147c03f7a5bebba406c8fae1874d7f13c80efe79a3a9a874cc09fe76f6997615",
-        "sha3_256_hash_of_ciphertext": "bb62281b4aacc5a90a5ccdc5cd3dbe3867c502e8e6ec963ab329a9da0a20a75a",
-        "shared_secret": "729fa06ac93c5efdfbf1272a96cef167a393947ab7dc2d11ed7de8ac3c947fa8"
+        "sha3_256_hash_of_ciphertext": "6e777e2cf8054659136a971d9e70252f301226930c19c470ee0688163a63c15b",
+        "shared_secret": "e7184a0975ee3470878d2d159ec83129c8aec253d4ee17b4810311d198cd0368"
     },
     {
         "key_generation_seed": "d60b93492a1d8c1c7ba6fc0b733137f3406cee8110a93f170e7a78658af326d9003271531cf27285b8721ed5cb46853043b346a66cba6cf765f1b0eaa40bf672",
-        "sha3_256_hash_of_public_key": "2cedad700b675e98641bea57b936bd8befce2d5161e0ef4ef8406e70f1e2c27c",
-        "sha3_256_hash_of_secret_key": "0a84cc895da138b944accbef3ff1a0004b8a0d8af5d426d2b82ea4c0e585cc6a",
+        "sha3_256_hash_of_public_key": "7b00751eb9b1253231213f8a14f06f0fe1b7a4fdb7d1cfe44c161e577e5e8f0a",
+        "sha3_256_hash_of_secret_key": "3a8c009e8e648ac572d5592e4a92907fae0c1767be41c544b59dc3ffe61f7ded",
         "encapsulation_seed": "cde797df8ce67231f6c5d15811843e01eb2ab84c7490931240822adbddd72046",
-        "sha3_256_hash_of_ciphertext": "c15158a536d89bf3bafaea44cd442827a82f6eb772849015f3fec68a29d589dc",
-        "shared_secret": "c00e4ede0a4fa212980e6736686bf73585a0adf8d38fec212c860a0d3d055d1c"
+        "sha3_256_hash_of_ciphertext": "bce1bf3450f574130b9561ee11565fa41d599d05d2136f10ad2c013eb5d13ca9",
+        "shared_secret": "5f0c5d9f39d3e724b5a2bd54e69e360f72ffab5d4d6cc5e572fecba80acd4796"
     },
     {
         "key_generation_seed": "4b622de1350119c45a9f2e2ef3dc5df50a759d138cdfbd64c81cc7cc2f513345e82fcc97ca60ccb27bf6938c975658aeb8b4d37cffbde25d97e561f36c219ade",
-        "sha3_256_hash_of_public_key": "3dbc65b722a8982d058e27d409f04f744551ecde9015b62607cf67bb8ececbb8",
-        "sha3_256_hash_of_secret_key": "0ffced333b5d13fff22b81e66d57b6e2a6dba0285fe2a82d5537df51a8d3eac3",
+        "sha3_256_hash_of_public_key": "9bda55b63cffa9bf953993918b18cd6595ea6433b479e89b5cd3c9339e4468cb",
+        "sha3_256_hash_of_secret_key": "d5fc96564df6e53622b2db8295a80a44e3bad7147696e2ad1f728639c98791b1",
         "encapsulation_seed": "f43f68fbd694f0a6d307297110ecd4739876489fdf07eb9b03364e2ed0ff96e9",
-        "sha3_256_hash_of_ciphertext": "aec80e6fe21e2616352b4c148f9fa0e30986541fb0969df7873b1336b23a8de0",
-        "shared_secret": "8f50401bc9b1f857fd870902d4065f6cec8cb825db3eb22573c6167442b6e19b"
+        "sha3_256_hash_of_ciphertext": "2a8b5d9bdcac1b7ffb6d655368e15148308eee98ae34f4105eaae87f24a008a2",
+        "shared_secret": "7f3bcc03a35a0030255264914e5d88a0c93611c7ca21f0609678a88ca42ce1c9"
     },
     {
         "key_generation_seed": "050d58f9f757edc1e8180e3808b806f5bbb3586db3470b069826d1bb9a4efc2cde950541fd53a8a47aaa8cdfe80d928262a5ef7f8129ec3ef92f78d7cc32ef60",
-        "sha3_256_hash_of_public_key": "94391b7a41175a41c15cd995ebc69c83b29e4bcea6c186611dc4a79578e37f4c",
-        "sha3_256_hash_of_secret_key": "e3904266e186b34a397014c95f6d314cd6e1c813348b02e977d0fd21d9bb681b",
+        "sha3_256_hash_of_public_key": "647a81f0f1b3e3dacb6e73e900f7c078cdfaa7119a5ede48c7685fdb7e0fe2f5",
+        "sha3_256_hash_of_secret_key": "1cf686cb8732c73a38b35d73b0b28fb120bc89cda1554d9f12adedc057862081",
         "encapsulation_seed": "ea74fbc3c546500ed684bed6fe3c496d3b86d2d6dfaf223969b942e9a8c95e85",
-        "sha3_256_hash_of_ciphertext": "39fa8e1d0a5e4bb987618734ee4903771886030b2d8bea4b5a9b0cb672ebb279",
-        "shared_secret": "3221d7b046caccbded38e369625f69bac60c2d7efacad8f24170b10c5d222830"
+        "sha3_256_hash_of_ciphertext": "1c51c85ce66d80c1f9bb138e5bce84dd75cee4260c8817e06c6f2bd920601530",
+        "shared_secret": "c630736985fdb7830d7446e18b6b81fa4a707a6058964b99190120de85e7559c"
     },
     {
         "key_generation_seed": "66b79b844e0c2adad694e0478661ac46fe6b6001f6a71ff8e2f034b1fd8833d3be2d3c64d38269a1ee8660b9a2beaeb9f5ac022e8f0a357feebfd13b06813854",
-        "sha3_256_hash_of_public_key": "c5dbd68b3a8c148b2e7ac049bb986e14dd1cebfa1cbf3edd6bae85a4d2dda082",
-        "sha3_256_hash_of_secret_key": "b3fa7958f4b7ccb68712ae948c3f08740c8b89a69e53ad4e9959234e6869d8fe",
+        "sha3_256_hash_of_public_key": "811aea11a24a4b09e428415f82ee836e930c3b77867aafc5e6728149e3f2bd1b",
+        "sha3_256_hash_of_secret_key": "6a1ff1351c538a5661fc3576c29408c19f42da3688fa16f9ec5ead6a84420db5",
         "encapsulation_seed": "64efa87a12cb96f98b9b81a7e5128a959c74e5332aaab0444fca7b4a5e5e0216",
-        "sha3_256_hash_of_ciphertext": "ca9f95c38dc95f51b6b62ec709539f0d1e9fa64e49ce4ad10bbe62868f35cfc5",
-        "shared_secret": "1d746afc4160c75aaa6c6967f4eee941e09546a039027f05f0f8a483710ac334"
+        "sha3_256_hash_of_ciphertext": "db4dedc1e4d383acaf974fb50ffbf881bd3938ad196fb9aebeeb1bf1ddc94e10",
+        "shared_secret": "41e078d0d0c4fe5df5c6683171d5c1c3f1ef152c4945f9cb299f74278ce4cc4f"
     },
     {
         "key_generation_seed": "7ec408f52c9aa723d0c41d9987682a5f4ce6c9da7cd0215af60bbaf5484ab353a08ccf451b049fd51d7a9ad77ae14a81569df8c9bd3a8f1ebea86fdcfb823082",
-        "sha3_256_hash_of_public_key": "62e0447f7b5ae8a806b741ca5c302230b555c3786c11f3eb43894a8f45e3f7b1",
-        "sha3_256_hash_of_secret_key": "1a3249c268754c86d2e02ba9d87c2b60b220bf2406b71037cfaf6b089477ffb4",
+        "sha3_256_hash_of_public_key": "76c64235d8bd63438f13dcd038f286b9f4242070a5bec4d8990075008667aad3",
+        "sha3_256_hash_of_secret_key": "fb19a847c01b5bb4bc607ce0c65e50ca6869946a97625baea129c2ba07e00c01",
         "encapsulation_seed": "8a95d71228acaa5f9ae6f9d9ca8ae55fde296463b41083a39e833e37c4c90f88",
-        "sha3_256_hash_of_ciphertext": "ec7bb1327a69aeaf626a76d344be1156eac160262128a64477a194805b926233",
-        "shared_secret": "722fccef7142c46f74eb57a10b13e420d6554e9d18507f660bd1be96d3cebbcc"
+        "sha3_256_hash_of_ciphertext": "c8c63c879a7a803db4e5779ca5acb1f16f5c86c38258f583a9f1e43303ff36d0",
+        "shared_secret": "7da491b5623a43ae17160a54e45e8328453cfe1acc692a1e300906ebd2a1d9b2"
     },
     {
         "key_generation_seed": "c121915bfef6abdfc177dae2f5a24218f9abda2559afc6741b08e0e61ab433eb84ef52db5eaa6df8ec3a0bc5ffa730db0dde8c5f38f266d5c680a78d264a7b96",
-        "sha3_256_hash_of_public_key": "0c1d832af7b7282d8bd81a2237107ee60d81e28eb64d6a153ae0eaa1a25797c2",
-        "sha3_256_hash_of_secret_key": "fd6b5d3f120ca009871ca24552a6118917ea882f12f30dc8097f6614d9d36080",
+        "sha3_256_hash_of_public_key": "ae654e4412fd220548280b7a6ace9f2f0bc7b059fc103060346e53bc3c3161d8",
+        "sha3_256_hash_of_secret_key": "9088118150f9137e8ed76eb5e3a706f66f31c570fa7f0dfe75c0e81c4540878e",
         "encapsulation_seed": "90d79d75d0bbb8921cf70d46bab497022a8e750efdc99e5f1bae653275441c7b",
-        "sha3_256_hash_of_ciphertext": "da36cb6137a777acb4afbc0932811f75ef1d6732031309ae7e2de1543aaf5c2c",
-        "shared_secret": "ee7c5fb6a63ace944e1eae1bd4b182263d918754c33753b904853551b2b46cb8"
+        "sha3_256_hash_of_ciphertext": "2ce235a49669184efdbff64176f93017127735170c2e1c1b159fc746ef30d18e",
+        "shared_secret": "eeba3c0571fa453fcd9f7f0d6baeb75d59ec9854c12846089d65bd8dadf9f6b0"
     },
     {
         "key_generation_seed": "d86634ecf96cc2603761e284c0e36734cedec64e7ff486469e38539c71141c5a99daf37400cfe59841afc412ec97f2929dc84a6f3c36f378ee84ce3e46cd1209",
-        "sha3_256_hash_of_public_key": "2b757ac0425152bef72ed852ab1eb44f4359499407bb6a020ff843a31657c5fe",
-        "sha3_256_hash_of_secret_key": "27dbbc7918c31e9ab57808f439c4f4189cc318a62422457f4fed733be959c816",
+        "sha3_256_hash_of_public_key": "6ecea55c3d5c042d2dca3a3925faaa9112561827dceb0754580814a84be19b87",
+        "sha3_256_hash_of_secret_key": "33448769334ee9aa43d7ac22a003d9ae89a1ef5a9765deef2946c91fea0a1a5e",
         "encapsulation_seed": "be8a32f97b9a8d596382c02fa2a0eeebc15c083e970ddaa4f2622b91d6718663",
-        "sha3_256_hash_of_ciphertext": "85efbfd0b096fa921711ea66b17bcf7c9a6240711b38a88830dbd9d716f07195",
-        "shared_secret": "77cfbdae47854e9e10765cf397eca9ab2bf2b7522817152b22e18b6e09795016"
+        "sha3_256_hash_of_ciphertext": "14540bfc038f3eb76f418a8851513054a998e16a06f97c117417ae0a35f90e4f",
+        "shared_secret": "8bf57e5d1ce24e9942b1b3f456d184d4c0937b9b699e69c6524e93e140f39c90"
     },
     {
         "key_generation_seed": "0610678ff4dc3128e1619f915dc192c220f8fad94da1943b90aaec401683a492da1804ddb5aa9b1c6a47a98f8505a49bae2affde5fe75e69e828e546a6771004",
-        "sha3_256_hash_of_public_key": "53b9d62e64f9069d9fb94ea2c0806459b201531f4fddd708d162981cc1fb3757",
-        "sha3_256_hash_of_secret_key": "f4b964b7ab3e09fdf3d91527da06a4d29ef28344709a41739ef56f18bd5b984b",
+        "sha3_256_hash_of_public_key": "576cb9d31e5146967756cf7356926f2e20fc7c1fde9954cb2f593d96a80ab860",
+        "sha3_256_hash_of_secret_key": "2031c133d7d85e616d932c6204d7ec0f3bd0303ec609e3c7c08092e1ea443972",
         "encapsulation_seed": "da2cfaf69e25b2a89ff2557bbb6f69e01d8e2e7bb27a7a1ce7e40fead16f33b2",
-        "sha3_256_hash_of_ciphertext": "379a57a8f19110d5e0d747a2c184877d71f00fea95cd815b4c0e8782b12bec6f",
-        "shared_secret": "8be7a417efbdd3587c6f82ddd1d29956789d28c2413b8383590c5b80cc53e04a"
+        "sha3_256_hash_of_ciphertext": "20e06ce25d864f8e7a80a19e23cee6830575a072476504fd10e37b296ef8de73",
+        "shared_secret": "2f714d31bbc778518e2b67d264065d9731c12149cf931211e649addd6daf0b92"
     },
     {
         "key_generation_seed": "d322d56d8ef067ba1f24c92492b9c56df3a6ef54a304adc1b69913766a1ce69756047447b810cc094d400ab204cf9ae71e3afa68b88586ecb6498c68ac0e51b9",
-        "sha3_256_hash_of_public_key": "9cfeca12dfe978bf0b7ad7271487cf61b2b8f7c60f389f33fc18439a95bcbb63",
-        "sha3_256_hash_of_secret_key": "a2e37a55c9b80fb423f40585180b011f32402d0320259285b6e278df6c20ba60",
+        "sha3_256_hash_of_public_key": "3e9976d61a687df88a8abcc6651446b81b7d136df42bfa03473c84dfd64fdb3b",
+        "sha3_256_hash_of_secret_key": "5da40cacace6fa3712e49ef6700cd819aeea88264e6dc996681fff43d98c9830",
         "encapsulation_seed": "511c2ab40782322c06111e144e505328c4e5bfc890a5980a2bbc44aeda4c738b",
-        "sha3_256_hash_of_ciphertext": "44053f01ecb88811b9ee7a9ddd4234f94507c7cf64b6803b28c54bc605ec4e31",
-        "shared_secret": "79fcd201101e7e277c1b6cdc4475d63ea1dbc42ab94cf873bf0163c2aab0b5ff"
+        "sha3_256_hash_of_ciphertext": "48ddf3c7cf3f02af111c71607e93922176d0173ec63e890235fe981412824edd",
+        "shared_secret": "f2c29a0a4782d83f2073c7c37d90556b1a005f072f94063d2db8114430f36c8d"
     },
     {
         "key_generation_seed": "2f1d8a3bebb34540324b9485fdf3d5be3b858f544abc3fc641b5728cafab03ba8d6c42e7270ee2b77b6045385f3d175984a0e260363166c73b0c70c971644363",
-        "sha3_256_hash_of_public_key": "9aa64a30bed5aa8300772066ef577f79bf4813e3315a15f2c28b2665e4dc7e2f",
-        "sha3_256_hash_of_secret_key": "837eb6ce037f235273d7686fd9d01bea14026e0a0f5f943884f18409cc4bc70a",
+        "sha3_256_hash_of_public_key": "c0cfd4113c5edd408adcd03d38b12f0b6ac17525c618d6d151a761a9eebc2635",
+        "sha3_256_hash_of_secret_key": "2c6ec490ffd55e0a744f3c506a497cf4af575cce6368bdc3b3bdbbae733fe7b4",
         "encapsulation_seed": "dca92dbec9b260dd97e8886f876862d6effc3b91fcf3fbc986cf56ab93ae79a2",
-        "sha3_256_hash_of_ciphertext": "02798b5af1a76a2b478ee05c630e62618e5e2d7ee0c411a82ed2bf888706fe28",
-        "shared_secret": "6c4484b6d7b0a376f52abb1811c712368a9f34bd108ffe7ca31c36a6ec8140f3"
+        "sha3_256_hash_of_ciphertext": "b6ba4dfdae02842f96b915ea0ebd1c97972c170cae975c89c5fbf26cbe9a52d0",
+        "shared_secret": "13c99ded4db3e6618f5927d58c89afbe83c86a86ac2073421b2560b3f8be5aa3"
     },
     {
         "key_generation_seed": "31beda3462627f601cbc56f3ddf4424e1529c04737ef0ef2af6d7401f653b8a1812083bfa3b670e3eaf9b443702fb6db16ac1197656bbd61a8e25ed523b8d1e5",
-        "sha3_256_hash_of_public_key": "241e5c7b836862d7482d507973ae3fd8dae96eec4ecebcedb68fbda75e04b401",
-        "sha3_256_hash_of_secret_key": "95c79c2a867b3e8a4e4e545ff626cd49893b8e87eb188ed1516b159a24736c97",
+        "sha3_256_hash_of_public_key": "71c5534bb819e61a9d8a257ff2eb29598ae92eccfad38abbfc9bccde5ff95a1c",
+        "sha3_256_hash_of_secret_key": "107c5ef0842d1dfda257138d681ad7e1390e12c697111a2c804d8f014361cb4f",
         "encapsulation_seed": "57c170e691d7a914a901b9a11c62b8b569b3806427557a9dbac9faa720ec3641",
-        "sha3_256_hash_of_ciphertext": "cf3b2e2dc822949eb13638299fc2d5102c7132aa6cd54dd7834b13f05a4dece2",
-        "shared_secret": "8554d6af350f13471cfd45c23882e43dc81d8a094f6299e2ad33ef4c01a32058"
+        "sha3_256_hash_of_ciphertext": "671e3c316d4d8411237db4383fca82f76692867e9f6d15a2b82b17d934392341",
+        "shared_secret": "83302cab48eb0832bd8df0db3fce81595754772e4c951c444a1b2ee9f58c48c1"
     },
     {
         "key_generation_seed": "cbdff028766d558af4466ef14043a1a9cf765f7748c63cc09dceb59ab39a4e4d8e9a30597e4b52ffa87a54b83c91d12a5e9c2cd90fcac2c11b3a348240411a4c",
-        "sha3_256_hash_of_public_key": "6ad1d739f1598a16c608a240cd13dfaf8263d74866315e2898a3431cf19e4685",
-        "sha3_256_hash_of_secret_key": "1ef733faa4f2cb53cb5d8975aa6797b5f37fd918aeda02178a40584475cdf667",
+        "sha3_256_hash_of_public_key": "4b53b4aec0d9f86a6377c63ff80150e40fc5347714c07591dc71c6beb8daaafc",
+        "sha3_256_hash_of_secret_key": "ed13d2a9ae5541b3fbfa19891b8c8a9f4f0957d940eb5d08ee0cd18cfb28e7a4",
         "encapsulation_seed": "6b5a14e1473abf5a33d44975ca2088bd8fa6fddcb3f80e8fd5c45b9d90c24a5c",
-        "sha3_256_hash_of_ciphertext": "1706e6983032950b47cb6c8586178b42d515ce929c1434c1a8c9e36d8b4db7a3",
-        "shared_secret": "f9646f73de3d93d8e5dc5beeaa65a30d8f3a1f8d6392190ee66ff28693fbadfa"
+        "sha3_256_hash_of_ciphertext": "b83f6022179a08cdadda2660f8cd7cb70df4be0be3ad85bebb090d086079b1d1",
+        "shared_secret": "93ce6d06568d795c2a28d1196f53cbaa2cb05df1427ac76f44df09d479e14241"
     },
     {
         "key_generation_seed": "4c04310bea66305c6ca8ba6b8f61ca96257a67663afc11761f13fb5c7b324b6b8aec87a9a79204cee2986867a2906eb851b734b8b22b91d6749b1a5f07c44e3b",
-        "sha3_256_hash_of_public_key": "9510a2a0b4fcbd414fc61aff04a8df579660d14b13c40ec0470c45f639b65a58",
-        "sha3_256_hash_of_secret_key": "0bcfa8078582f60e218047d0016437601da8431f34ae6da12921f53958f32819",
+        "sha3_256_hash_of_public_key": "c2d52d0c837eb40dac0653a5e862d9fb8b832629cece9eaeb6d5feb48b6ef5da",
+        "sha3_256_hash_of_secret_key": "73ee0632229d740dd746e3ef7f0f1c29944dbc2d8f39b7860807c41c18bbb3af",
         "encapsulation_seed": "40e593754e6eddb7f9cf176ba2d5fd1087c90ad377556d0b0f686537b1a3165e",
-        "sha3_256_hash_of_ciphertext": "f9341d26e39b38a88ddef1708c96ee2068f569a59a4010745730d8290d637718",
-        "shared_secret": "1ee252e97b69445f7f109187645cd2879f55e10eb8361ab43b3492ff51f01815"
+        "sha3_256_hash_of_ciphertext": "3685126e86797a881f3bbee0eb85b76d755ff03858735c326731b8d802f023b5",
+        "shared_secret": "071db527a2ee8ce982527cb19355793859bb8557e7cc99dec58a53153eceddf4"
     },
     {
         "key_generation_seed": "38a0d5f41d7dc1896efd1b45b0485634cef149828751b96087a0a6dd81b4d58aa2acf359556df4a2abaeb9dcee945829beb71185b4d6bd18b76e5668f253383a",
-        "sha3_256_hash_of_public_key": "cfbe9649d9d1c384baad67b91b2f3e21f2fadd6bb582a0b9cb016051dd82c75a",
-        "sha3_256_hash_of_secret_key": "09b118f7c4d059baf27284d127d4e85d55b84e4c92bf3127eeb318d2f5765401",
+        "sha3_256_hash_of_public_key": "4ff02338c9bb711d263140c471409f3c42813f38424698563d9550f85a168f2d",
+        "sha3_256_hash_of_secret_key": "3c89443dab5ce46f82f6b8260af0293ea52a680f1c4fe5e042f0aefb707526f3",
         "encapsulation_seed": "c152523abd8248bed40c3827bcf0f8e8127037a55c780695e2c28ea3e041a44c",
-        "sha3_256_hash_of_ciphertext": "94a8c287238191a107e74e31ec099086d83f198e6b0f3321da4d8f46ce01a0b2",
-        "shared_secret": "1e1ea5d6a18873c5c7fc8da79093f6d3db5b28fdd0aaa42726ad130c78e9bb88"
+        "sha3_256_hash_of_ciphertext": "b20e28f42ee5cf5569f1833af90334952074dd0ea0c2520f03fdf0fb24c17a64",
+        "shared_secret": "598bd66a4a063652b2a6b25b8d1c3bab0251682ce6c362a8c680295f47f3d6d9"
     },
     {
         "key_generation_seed": "97b5665676e59e3538ebadaa8cd50df1f9fda1502d9894c616a946078e56b621df05318b5f655efe36f1b678cf4b875108a18db2fa312261caf839f84bd956c5",
-        "sha3_256_hash_of_public_key": "a19c2c9c907b129d01cc44a95949121c39534cc98b6d105e60fe519a000cc2ae",
-        "sha3_256_hash_of_secret_key": "f1c00070780a7a2ac5b57ff3ff765ca75278bb661d1635cac92792f9454fe8ba",
+        "sha3_256_hash_of_public_key": "bbccdbce67cf49fea044df5c767996681dd2714937d31c822f3c58cc34785aa7",
+        "sha3_256_hash_of_secret_key": "64fde53d297945ef2a0af6ddd044520cff8ec1388aa471e47ba4299c2cd46da4",
         "encapsulation_seed": "ad6466dd59f26b762fb02b19eedf5f79964da68bce0459b91c3a6ee5a7e01183",
-        "sha3_256_hash_of_ciphertext": "56e0b8ab3b302fae682938a45d9931e092d78877d1f8834bb43cd5c85582a205",
-        "shared_secret": "24619bb17c912fc992bd8272969cd5b6fd6b030122ee5af9365cac8b38e569fc"
+        "sha3_256_hash_of_ciphertext": "6f4cde00d3775858761742957833fe632e3d3082a9a6180477291bc23b682674",
+        "shared_secret": "92bd980f79cbb34c67594c6922549b99962e54d388034ea61f892fe250581c4e"
     },
     {
         "key_generation_seed": "ef99224a03a85a46ef115474ec5b5d620da6795d6efcca4c9135d19958a9de62df7d92dda83e6b2ef4cce08c9134563063068a196d7b1a1a13623e48ae12528e",
-        "sha3_256_hash_of_public_key": "e4174b6e7542fbe80ab2bc06dfb802f691aff147ff90332d5ea739216c18d872",
-        "sha3_256_hash_of_secret_key": "f3f3a292f5cf01d6f7266461c9e8cd44bfc8f17e16035ab8d10af8177f389b86",
+        "sha3_256_hash_of_public_key": "3ef3581d438af7dec621304e0091f797346ca18a41f39401e9d03200ef48beb6",
+        "sha3_256_hash_of_secret_key": "299a76e97511d90f7925100db418472a9c3c12d6d48acf03618a6960998ee733",
         "encapsulation_seed": "1a4d5dff5847cfb48333e33bb00ca7301b144aa89dcd412ff5a3b1081d775b7f",
-        "sha3_256_hash_of_ciphertext": "5f878ca21c8c27ae9c41c43aaf1f3a2af62c73296e165c08b88c5b22592867be",
-        "shared_secret": "a990af801ddcf2009c82fe657fe3f068bae7e6bfc661e3e588354ba7d1b176e6"
+        "sha3_256_hash_of_ciphertext": "4ede793372276800e22c1893ae554ce0b53e413fbbc3595e69feadb2e1f6d57a",
+        "shared_secret": "b7325a08fa617e19260264bb02ed6b8ab2081589fd5dcc1e92b9d0d4ebfdb6b6"
     },
     {
         "key_generation_seed": "b12f6fd965ea9c5b947db80fc60c83d5e232dca82e7263027c19bd62e5a6ff550f6aa3e88f7fa8a96067f8cdaeceeac90c2d0b5e277e56e9c405ec9420c30252",
-        "sha3_256_hash_of_public_key": "2006a70fa33ff4a65b00553734c5bd8cca0a65eb3a115d96b8aa90f8fdc5f8f4",
-        "sha3_256_hash_of_secret_key": "7334d4a1755e1e639b3e9eadb5996cd910b55d1de5790469f229231d3bfb1528",
+        "sha3_256_hash_of_public_key": "fa06bb0ff42f4d610a7b3df7544d66b97a486967cd9b62ba0142ebb10b8ee4ee",
+        "sha3_256_hash_of_secret_key": "4dcfc0ce12c4e87f02c616a8fb18c359cae017a2f8d339623a174dfaebfad98f",
         "encapsulation_seed": "34f44ec2092eeaf686f2ea170591a98527cbb03a4fa9477a7aef6b41a54feeb2",
-        "sha3_256_hash_of_ciphertext": "c2079637916c089b2afb9d6e9c6fa51308ab7720d5c2fca484c34ce614a14fc0",
-        "shared_secret": "11a2ceaa0c77f0602c4b2be3499e6df6b0339d9de90d04b2b12829f4758afaa5"
+        "sha3_256_hash_of_ciphertext": "591bf77f74463c50a4ffbe97c892e11f3cf7601813b7ad83b17038a173e21442",
+        "shared_secret": "b400082a764291666c080ae9ea9f22c383f3c1e87b4cc56775a19c8ec29a4157"
     },
     {
         "key_generation_seed": "9f52af92ca165fdc38788f2b59ba02e01c8281ff7c1e60504688043a5fe814b04f3029e1be4e1c0258c3a22ff5b50b2674cc094ba7018da2a61569845c17d26f",
-        "sha3_256_hash_of_public_key": "631e1de2556ae65d57e600c21e8e355a4ed586d667177ca0b7545cb5a23d669f",
-        "sha3_256_hash_of_secret_key": "3d4d2c680a1e6aa83861ad95043ded260e720ae80060320feffa309b4281ba3d",
+        "sha3_256_hash_of_public_key": "86538ecdf65b7a485b73a34a72193af1ea3f884d820463601c7f843672bbec7d",
+        "sha3_256_hash_of_secret_key": "70e91b44585ed93e802868e0bfe88f68995f3c85d25c2a36b0b7d8de7c5e2f8d",
         "encapsulation_seed": "6250c81126572eec2da330271db36ee591f060fc7e53eeefe2e1c476c675fa33",
-        "sha3_256_hash_of_ciphertext": "2e9d6551050e32e204d7c062a4c18b8abdb91346e9f2c2708776827e0be4c514",
-        "shared_secret": "7571990ef1ef7e15cc920318fb75fd38c4ceb9abf7a4b1adc2175f99d1a0a275"
+        "sha3_256_hash_of_ciphertext": "83754e315ef22788354c1ec632429566929f9bd53e77d1d2cb52005274f64e1e",
+        "shared_secret": "03c7470224ba22fde280005d9a8f8354c49459e9a168cc282f9d41f4f0d2da2b"
     },
     {
         "key_generation_seed": "851ea90fd3854cbf28fe39fb81f68e4b14345cf0d6eee7ec4ce772513df8410d1c0ec046899a777655233e4e1b5ca44e9afbdc67964bfd5d5e3dbb45e60d03cf",
-        "sha3_256_hash_of_public_key": "87f3829eff562789b3e19fafec92e4b5f95b45f3786f12d9c24915ca484a49ce",
-        "sha3_256_hash_of_secret_key": "9aa6c0546cf02085e2b3af65a7d7fd32d0f6d8080e1e7fbff6c39bcf3086ece4",
+        "sha3_256_hash_of_public_key": "27757389a4a68c898dab92d0f63c3340dfba51e00312a05e721932b95b11f6da",
+        "sha3_256_hash_of_secret_key": "b43f88e419ae589b85bb0ec6c9712d4870dbaf35d4c96d06ef0f8b9753b60034",
         "encapsulation_seed": "35d470bcc5880872754810dfb3f2796da2fd7f397537146f6488c27804072b34",
-        "sha3_256_hash_of_ciphertext": "14da42e207477f4383faf4004e58675f0380e7d621421b3c36b877acf3a45d5a",
-        "shared_secret": "27ba4cb50ae44cd938585e0a4905d76053dd851e5b6af4fd787446079aa5a4ab"
+        "sha3_256_hash_of_ciphertext": "0eb3d2bc103f7801dd8e002c6cc81bbcf11e070f465aba9b0b725fa9454acda7",
+        "shared_secret": "c31f7372e8c194a9589042477f34da3a60d591ea65e13bcccc07ba59402ede6d"
     },
     {
         "key_generation_seed": "d304c9389cc973477f169788abcb9d511f843219d246a9b587822f422a70c2386590a2e5c7ed86cf2c5c2a898662bc9a81418720bbb632ef9cf0b845ed052d73",
-        "sha3_256_hash_of_public_key": "699fb2f061a75f111f4a7a60195d9045dc01716b6502cc107cbcedf122e8f619",
-        "sha3_256_hash_of_secret_key": "421f16805b1ceffcd64128b1296521ef812d3a8f4c5e3875a049f8de456b021a",
+        "sha3_256_hash_of_public_key": "efe6e93d8e755292fa875609f2f63bd194c87e6f04db7c83d8bb1b9d868bb779",
+        "sha3_256_hash_of_secret_key": "f54233dfd4679cbd6eb6f18c0615745d5b4fc2fefade52d966bffab6f0cc259f",
         "encapsulation_seed": "8d667921c5db401a86fe1c35dfcf164a6bb2ab7400fd6a0b67eafd4a0ed11940",
-        "sha3_256_hash_of_ciphertext": "b2485ef56c39d468193e387e72794e0ddc9b5404c1a6d90c3b94a5f3e13ba7b4",
-        "shared_secret": "d17b2738213a98f29ee46747c93308ee7000fa404b9a0c1acf3f89654ca2446e"
+        "sha3_256_hash_of_ciphertext": "942f3cd64ed1b2675f9f9823c068d59b2e007e66d38e06a2e4558dcba7f11efd",
+        "shared_secret": "9dfd08dbf59350ae2308096f935c6767daeddeb2c6997992d4a02c14b0e58c60"
     },
     {
         "key_generation_seed": "89a6e3be304a3518fb82b18ca730f0b359cd6ba90664a493fb4f8edaf965b9c3b6591121e25d64010c25a18676033e1d7278ac5f2d0b43a31f3a4156ae710465",
-        "sha3_256_hash_of_public_key": "d3413880d082f26986fcf452a84a8da934ed06198b290ada1789e74d9081a9e7",
-        "sha3_256_hash_of_secret_key": "7b546a42ffe6b65cd9c5b8857c2518f4f8e0bf835c894a68d1743691fc9aad9d",
+        "sha3_256_hash_of_public_key": "87ada29bf78a689417b645fe127d124339422be80a993e623d13bc59f3406a6f",
+        "sha3_256_hash_of_secret_key": "6b8d44a2a71f2901b7ea97bd24df8d46041cd9ad4f0bc5d42ca27ee44981f740",
         "encapsulation_seed": "ec750b3939385a3f8df868119dc76f77ca845567ef068de6ada5478a56bc78b6",
-        "sha3_256_hash_of_ciphertext": "8290f3c4bec7c3b93f3d26e0be3b3fbfdd9c3f5806188fcf0fa1339133f29c7d",
-        "shared_secret": "954af53b4add522514b34cd2ab96669a76ca13f82aa2fd70826bc8ee790ccefb"
+        "sha3_256_hash_of_ciphertext": "aa86248e7e906ff3072a00647cbd3f6e5d0f3a4ec40efa6deb94b2df901d0097",
+        "shared_secret": "03952e1a4915d112b87569d1f79a39f5d69a8dc11c96d70c529d2162a6024dd7"
     },
     {
         "key_generation_seed": "d569b935ce015c85f792f8f7fb0d83c4f53b492959361dd4f75fb764d656450176eae84d11c4528382828f7a689a0d5cff87b8ca0bba97feacb39b935a8788cb",
-        "sha3_256_hash_of_public_key": "e6eec2929feac2a86c9dacfa6214e2e353fda2d547c3829f5678025ff8418a1a",
-        "sha3_256_hash_of_secret_key": "5fac243c82807d7357a61023226a7c270525d96932162ca5c09fc8f7b9ec6cb3",
+        "sha3_256_hash_of_public_key": "0c87bedd5c16c32cc3867910f734bdcf09869c7604a59ce36660074f561e12da",
+        "sha3_256_hash_of_secret_key": "a72b7d93adcbfc6d89485fa923a4b1095e3d593916496e521187224efa42ffa5",
         "encapsulation_seed": "74f1d52af09b12c36eb062ea7528550cb4c18a3ce8e4f4ea9fac43ae383bc925",
-        "sha3_256_hash_of_ciphertext": "f1b10c800a42ae606c72eaad76accf059cccc02299fbd78a5d091f183f6c3f0e",
-        "shared_secret": "d0bbc576fb1aa43b6e76db0e87bc4ee3fa057c31642b37f3339217a1b041b521"
+        "sha3_256_hash_of_ciphertext": "7a75e486cc2dd3ffab4b1072b4056de9a56b55cf324e58d3f6cfd031a0dda594",
+        "shared_secret": "6d2e1f456c87d5a3c79456a6d35fda52f3e9cb858f85a5f7931f532fffe26dee"
     },
     {
         "key_generation_seed": "5cbb141c2763425c274f7404fe530d9116e08c33f9f200a20b011cf563a28990fc9ebbe336dc464489861db8253606971bd0a9008a433ed17752d04023781552",
-        "sha3_256_hash_of_public_key": "c74f3b7fa6e2ef8ce99508c89cf3c71d666ab065a262581a5fb01b2c9b9444fa",
-        "sha3_256_hash_of_secret_key": "5c6998a20960109a4c9808f8f8575697b2b8d18c44c7e9dff97585ae43e6004c",
+        "sha3_256_hash_of_public_key": "9a9a59f83fc58d7194ccc92bd78a45f97f721a1eb554499d0e4d5b37aefc23a8",
+        "sha3_256_hash_of_secret_key": "ea5ce3a271f5e46f925259832d187a3c893e8088b76c19c93e0e798e4320d2fd",
         "encapsulation_seed": "4b3a70d85f640d1a2a852fb6fe96704af56a7415a8ee4282e9207bc3a2dc116a",
-        "sha3_256_hash_of_ciphertext": "e9ef0852ee47744b8c3e12cd728d9017465014eef51edf83a4502cb5218cee20",
-        "shared_secret": "91fbc37d4749ec6175c12f0d8eb6b6a8621e693c79f85f5cd2f557cafec5e7e9"
+        "sha3_256_hash_of_ciphertext": "d71fc29140e8725a4c4e8779d0ad3007990e08b1eb38856cc56f522e3079f601",
+        "shared_secret": "5c7c5cafe1fd7f3d12431ae93815c03419ff95b132caf568671ec23bdc74381c"
     },
     {
         "key_generation_seed": "293abb6d1c207927945417cf84883ef010823e11b487ed55239e466e83696d0cff8563038aad865a817cab9ce98846ba75be9363718ecf5fea538aea90b2a558",
-        "sha3_256_hash_of_public_key": "7378ef967195c977d43a50d03205044006715a6a8a8263d717f40170b49e6bd0",
-        "sha3_256_hash_of_secret_key": "30bd5f16c3f242248a4c4cddc43508bf54535958657bda4dcf105216ddf47eb0",
+        "sha3_256_hash_of_public_key": "bda0815dd53b263afcc1f71d2501128c41fb3606af71c5e68f0752c6d3a479c5",
+        "sha3_256_hash_of_secret_key": "d502e7e6df2d84e46cef88a84c53f1fddd5488accd5e1e43aed5f4f08e16a8a7",
         "encapsulation_seed": "26e38ac804fb5b4d59ddf747715e7e6041d875f99c7b638024b4af82d622da60",
-        "sha3_256_hash_of_ciphertext": "37843616c8a4f7ea9480740b6624f41650da2bb1664cf228d85d6d71a0624528",
-        "shared_secret": "d586b441b8eaf7d053cc96b6835f093426677a7c3acc51aaa3ddbb66dd14a623"
+        "sha3_256_hash_of_ciphertext": "8d4b1f3ee23ceecf073d6576609767401286da5189a1b267bff30a710a69e67a",
+        "shared_secret": "1427c322f72898a0fffd13f674719c9288d524bdd19e6a362533c1108e3a6d2c"
     },
     {
         "key_generation_seed": "74d87c7556f2671f2d666854a4d6e073e69f35421e6e1a428cccea49c37f972ce1fb7456ac0aa1b97068f452cba64ebdc138bcf5d36b0a0fada2a3b374141eb9",
-        "sha3_256_hash_of_public_key": "16fe956be4601573d72306a251f69bc2181253e2417e178341fd6553303ac189",
-        "sha3_256_hash_of_secret_key": "873c94f8bee9fe37265d5dc0c5d3bc1c706057c7efb3cd2cd5ca9ba45498d0d1",
+        "sha3_256_hash_of_public_key": "e3e96e658787ba3f6ffb47de56322541a2c81f68e2825c74cb75ab01d4b719d6",
+        "sha3_256_hash_of_secret_key": "17f821aae147fa517cf35169f9d0b59a30ffdd0ff8f46c1c9bfffe6791392f18",
         "encapsulation_seed": "a319d2b8f114f1acd866478bcdeba6fd164dc4e37b0adfa8d8034afb3e197376",
-        "sha3_256_hash_of_ciphertext": "cc677a81c73ea5139eed8d85782978d06192715933bc5aef560e737f6d57d0a7",
-        "shared_secret": "409bfd9102bd4632c6b5d3610eb349fe3e3bc51e73acc78a8e994a070e20e10c"
+        "sha3_256_hash_of_ciphertext": "7638e455aa855489cedd385a58cad62c49ee25f60be02bbcca6d7c3c383d27af",
+        "shared_secret": "d399b5ff0756707f8d1a1c2a683465c9ad4899788420643d59edf78f79b28dc1"
     },
     {
         "key_generation_seed": "013bab0212d04ecd54b478daf72748003a25e2cb060ba6cc50bf95c292b8206b9da0c5da5f195b80fbb99c2e8b06926074f3f604b3f6195b5a5b9737876bba72",
-        "sha3_256_hash_of_public_key": "633bee89571e8fc16151491ea71234ab83289426559f90c67903a36e4afaa6f4",
-        "sha3_256_hash_of_secret_key": "3c3cff5f49a802cec693efbfc264f6a385210b1eed20f7bc5b07b51839961d14",
+        "sha3_256_hash_of_public_key": "eb3fdfcc0b171aa975028f96cd47fdba421ac08e29a0044cedc29fce35eb8510",
+        "sha3_256_hash_of_secret_key": "d1266b01cdbc6774ff0edbe64a593a110c462d07071077faa86faa9a0aa2365d",
         "encapsulation_seed": "ff646071b2509e6b75790917e08e4f0b0d9f0116ec6291c0b59eaa4b583ad830",
-        "sha3_256_hash_of_ciphertext": "6d94a31cff4761e3993308cb3e812a4a7f04f64d02ed3b46b418c2fc16189dfa",
-        "shared_secret": "5dd151a8015c0b16d79822832ff4cc0da7fd38eb73b7da59bc519d4d2374b808"
+        "sha3_256_hash_of_ciphertext": "0ed3b8be821742190f88bce0d86f834dec2a829496c5eb5bf51bab1a8419064c",
+        "shared_secret": "1a0ad65924728c415ee9c92d0dcd91396665a24c59cba878050390acf2eb44dd"
     },
     {
         "key_generation_seed": "ccb073c4b90be0ad746e26fb093b60c70110bd1dcbcddb566a8cffb7b3caf80e71600a8982c350df524cde514431ded7aec23576530894bcbf0ec0bfef0bb64f",
-        "sha3_256_hash_of_public_key": "3217d034b472a846cd317681c0f36feea187bd40e546dc4ad69c2e67fd9d8303",
-        "sha3_256_hash_of_secret_key": "1503bc141825d523c9505d34f50dc0a01d7bc91cdaee6b99f4a85a24ce800496",
+        "sha3_256_hash_of_public_key": "d046d93317dc6d0ff28990721c3f94a93024ce01b01c0ca55d634c191c4280fa",
+        "sha3_256_hash_of_secret_key": "bdf5539c63b463c3dfefb7978bc44a46803117ccf066475bd17d5c82fcb49c0b",
         "encapsulation_seed": "0584270ec26f3b9818e4af074d17b2d51037cc8dfdcbe3b140fa4fed5deebc54",
-        "sha3_256_hash_of_ciphertext": "a63613ccfd2ecf8aa3adf0103ddd9eeedbde3282443bcf02513b4ab87360cabb",
-        "shared_secret": "1c729b8e580e124e715f19ea6f2409fc6de741afa3d9919b2b8bf3e54c053b51"
+        "sha3_256_hash_of_ciphertext": "b0cd3d31583e15ee8a55d85cd770cc6d64ab83429aebefdb55674f382b605c80",
+        "shared_secret": "9104061d3dbfac187f3a9eed801545a52f1fb0c3979ca8315aa31f67775d1036"
     },
     {
         "key_generation_seed": "2e889f44e28901e9ac7ca6b2fffcb124c8979401b17064d7e1d51a7e3c3adbfa0e145e44aae52cfc609e6f47fd7a6f6af877190ff52256d0ac5b05b89c3f449f",
-        "sha3_256_hash_of_public_key": "d1756ecfaeb695001ac490f36c4638151bee98d367fb7adf0e06a470844068af",
-        "sha3_256_hash_of_secret_key": "a21acea0fd4354eb0c78d47caaf93c9f2434f1cf2d6b2194871ccd98f9522ced",
+        "sha3_256_hash_of_public_key": "21b12640bf755e94ba06204982458a9be11e1da542ece4f3d284886800fc8e8e",
+        "sha3_256_hash_of_secret_key": "4e3947282ebe9f8cd652343c30dfec9a5123c237af2fbb25aca522b6bb6bc4a9",
         "encapsulation_seed": "51e05c7b4ca3079781e8293f4eccebeeb2f8c8b4c59468eddb62a21bcb4ab8a3",
-        "sha3_256_hash_of_ciphertext": "3b322134b37fe8f5d7268fb74d1634ab8b35d456a973f7b0b427fb40a93b6db2",
-        "shared_secret": "b95ac8b73c703ab1154152b3ac73f054596ed23d3be328fbe20f936ea95fa926"
+        "sha3_256_hash_of_ciphertext": "43c21d2fc350a9682e8105ed680b36a04d02579ebab292d0a05db185021dcb44",
+        "shared_secret": "ca249f10d39267ec3725f56b90eb2e22cf8b577116af350f3d3c1e2cf090ff73"
     },
     {
         "key_generation_seed": "174aaa36410566dc15a5e62874218d7abdde0b2c0f30d877bb80b1abd5f5a0a450a7a2354f7e5cefa6f4a4e9a1c411eb9364506e9e1204a8acb3cb77fbd2c4ed",
-        "sha3_256_hash_of_public_key": "1b1b0a8682caf72df2e0a48513a7358edbc77a615d6be6fe2a7145be66b7c509",
-        "sha3_256_hash_of_secret_key": "3e214f25fbf4d1bb670a87367399e1b2a9da3491cac5a22a2c18dcc44f3f1bae",
+        "sha3_256_hash_of_public_key": "95d9e5b9151d87fed52e287992acb897a07b10ada1dd83409a5ccddabf9d7cfa",
+        "sha3_256_hash_of_secret_key": "79e973da94d9166321c476a28a98a8d03ce079c9a99d6e4f55d2e2b4de936123",
         "encapsulation_seed": "9eca0fe36c80fc5eba171c3ae66a5b1c923faa50b4521bb055e7bf51005c93df",
-        "sha3_256_hash_of_ciphertext": "a2cd589c24c4c75bc0a3864dc84a85a7f0f3ac11c8578757f8e94054a7c186aa",
-        "shared_secret": "8c3851393e5c5997cc95f06da96300f6dd85c041343c98db2e742aaa5f78b298"
+        "sha3_256_hash_of_ciphertext": "18ccc37804b42db21ae4d7e238fedf4594f3d55303dc80c0e51c748ff4906ac0",
+        "shared_secret": "82a3856ca48c5dc582ac25605ab0c675ad646ee19acbaaab4ccb5350a3881b49"
     },
     {
         "key_generation_seed": "351fe4313e2da7fac83d509f3103caf7b4c64a4d458fefdf636785ac361a1390f072d9b5a99f9c7a0a011e4dc10f6b600d611f40bba75071e7bee61d23fd5eda",
-        "sha3_256_hash_of_public_key": "2c54df6e9020e1e44b11b471dea97a382a2fe8d1042565bcd51ef21cc0884d68",
-        "sha3_256_hash_of_secret_key": "c6bc9c9e797a02684d3ad8de47919b8d8fdbee09258d084c7a9dc963c80401ac",
+        "sha3_256_hash_of_public_key": "3a7acfc3d283541d985e0abd85eba5315a17d6c4a7e4f248673da60c341c29fe",
+        "sha3_256_hash_of_secret_key": "2fda122953c3d9db88caa36cb8d5621663fec1dd0e19a274a5d85bea7a126076",
         "encapsulation_seed": "0c5719261caab51ae66b8c32e21c34e6d86ee4aa127d1b0195663c066497b2e9",
-        "sha3_256_hash_of_ciphertext": "0cd687f1c3e0d67c46cebf93c1217ddc972ad8662dd05830db350e1292542c1c",
-        "shared_secret": "4b681fff6a755e1dda908d070f0d9ac610d85c73079c1022fc67d255e36f1f71"
+        "sha3_256_hash_of_ciphertext": "024ade86d89c33d9d38face3b92986e72c699467402fe9c5aaca0904c5f5737a",
+        "shared_secret": "f1e13731a14d39f474806b8c177e23e4e2301a3b839539fef9591a71e4f67d29"
     },
     {
         "key_generation_seed": "9bc5315580207c6c16dcf3a30c48daf278de12e8c27df6733e62f799068ad23d5a4d0a8a41c4f666854e9b13673071ceb2fd61def9a850c211e7c50071b1ddad",
-        "sha3_256_hash_of_public_key": "bdcaf7b417da8b8933279b33068f6fda313826c2eec500b224cbe046abeb37a7",
-        "sha3_256_hash_of_secret_key": "c96e176b19f4135add434d0dd219024587d49fdb649bf470e84d9518bbfa2879",
+        "sha3_256_hash_of_public_key": "21916dfe025b78fc6d4dd1d1541b51cd3eecca90ae52177431b33c708faf17b5",
+        "sha3_256_hash_of_secret_key": "c98bada554f301506c532ec774ee112106358d0b320407fb34051a604777f030",
         "encapsulation_seed": "0e59f6f9047c784c1f00b24454aa4f1bd32c92ae7e626549972f86fab90e7e89",
-        "sha3_256_hash_of_ciphertext": "b38711e358893a864b475f35328b2450fffd5087d631844f7ab0995de2b8310d",
-        "shared_secret": "bbaa67f1dad879f2fb33bd4ead45aec354bc8f05c7cbea1e433509faac022edf"
+        "sha3_256_hash_of_ciphertext": "b2737a0bd104c46a5f861914855f498287a33076c32a4241a46cf9690181ee98",
+        "shared_secret": "79c5817a4ba25295cfdc817cd303f3465852b93c0c908fc4a79e88c45f3b81f6"
     },
     {
         "key_generation_seed": "d8b907b34d152ff8603b73051f772daa71eb902c47b7e2f070508269d757e02e36b817736cbc5f7b1dd6eef5fe6332fb1a598f3871e5470d440fd2ea631da28a",
-        "sha3_256_hash_of_public_key": "61e27e954728e2e2e230c94ff009417d7372938e2c29c38af22184eed530fa1f",
-        "sha3_256_hash_of_secret_key": "8baa58b1d3fab8ec5cee8841c9012506cad40bf58a677adac88f1a6400506d40",
+        "sha3_256_hash_of_public_key": "8f62011fbd5a1c10713d42a00a79ae7672e5e321872971f24ff71ed754178d63",
+        "sha3_256_hash_of_secret_key": "57d13f22524022911276023bff4af90abdf04885e2a598b04fa789123295835a",
         "encapsulation_seed": "a3963ade17d69debbc358dda82c7bebe2c39d25b36813058e7a161542e3f8c2b",
-        "sha3_256_hash_of_ciphertext": "7d47a21d95483a5845a4fddbb07b3435c29a56b5cf26f5d0abfa21bc39a2f2e6",
-        "shared_secret": "2c7b983d66978be80250c12bf723eb0300a744e80ad075c903fce95fae9e41a2"
+        "sha3_256_hash_of_ciphertext": "70dfcd3fb0d525cde1e38e158f6a4234006821031941efe3f9b4fa1e70c8bb36",
+        "shared_secret": "d92f866a744d0af51c8c2ba7b1fdf816e0334bff45182cabdfc722d75f8140c4"
     },
     {
         "key_generation_seed": "684a29e4e5480a5f2533e1526b5fac8cdf5927f3d85087c71f928c59690eb56575d12195ec32a8686d0600e45d4a7f54219b0d7a3826d193a51b9156ecf2edd6",
-        "sha3_256_hash_of_public_key": "672e53b28d579974d268132187e7bd72238639c6f2ca154d50d98c74096ec330",
-        "sha3_256_hash_of_secret_key": "4c72f0a7ef5c3274c49365cca5e6770bc709ef12bdbd4fd7c2eb5faa296cdfe8",
+        "sha3_256_hash_of_public_key": "ed3d1dd05854a6542b24090a680b9aa9d6c65ef31cf1f4f5708affafeb2e3989",
+        "sha3_256_hash_of_secret_key": "d5bbcdd1c2fd57524e7926d071f71114a62b95f0579b62ac0f92ccaaac4e9dad",
         "encapsulation_seed": "97beafabf2c8575586487c7a80e8af5fc50f94b6051c1bc66a5ae9f66be3cea7",
-        "sha3_256_hash_of_ciphertext": "167b4e8b7517cad82ae0f49795918c4d33c79137a9c3e16000c4c55b30b1d382",
-        "shared_secret": "bbc58d06cc14f9e96a10acb1789d93b93933f1429cc53a1735b3cd995f086ce7"
+        "sha3_256_hash_of_ciphertext": "c54e484b3b05c6bb40bef10662de29ecda288b9374dcef8f89220d1bff2d09cd",
+        "shared_secret": "53b3b4ce1e75cfe52d22450bfa763d07985dbc585166b4781a7e6542f9bc03e3"
     },
     {
         "key_generation_seed": "d76b3573f596eb286ab5231feec7499686b13021be36cb126c7ebeb9d7030daf248c0a21ea0bb6d6f56f12300e8584d8e9a34e0e6f52227281151ae4c305fb8f",
-        "sha3_256_hash_of_public_key": "b86d5b13bb8b72a9fb81245ab712f0d10f0e2e09b222143c420e3f2c3acea27b",
-        "sha3_256_hash_of_secret_key": "c25f2e16a0e6fbf0729e5ee89fbbdd71f00ff9a1abbb00cb47f26e9989eaf678",
+        "sha3_256_hash_of_public_key": "6fe12a1e2d742dcaf56c585651ed6edce4f410aca0fc83275b5acb19daeb149d",
+        "sha3_256_hash_of_secret_key": "b9e5eb23d136e49d2b5b7964430a1f98c78cd3526f97b1fa0ffb8fb0ea9ffd79",
         "encapsulation_seed": "75461decd34c50d6a094b4a64fb75e5e9479f8f9250d82bb7d729dedeb2d4b65",
-        "sha3_256_hash_of_ciphertext": "8919940aeb732930c496fa9832b0c09382663accda45be1ee22930c545eb3a37",
-        "shared_secret": "e045e0391e15a66d6208467078f2ba5e429cc586c410ca6c5f3c032c21761955"
+        "sha3_256_hash_of_ciphertext": "763f4d04f8eb62a3599d9d095c77861f122e90a0113fa290b17d500766fe333e",
+        "shared_secret": "e7165b66834d919f8c8737c7b4df17a0668c57a87b821af78fe68cbea325aab6"
     },
     {
         "key_generation_seed": "b87439fde81c9e39eebe7cf741c685785532c1dd23e8ef868b9ce7a541010f3d1646460817a0fce5836bdfe124a7448e7adf7b8ecc2652ac6d280e986682df71",
-        "sha3_256_hash_of_public_key": "85441cbd71c18717e9de7359b920a9a3bb7f32e619806f4e4718c585085be624",
-        "sha3_256_hash_of_secret_key": "93b65d2df33d3e3ab0d53c1d0a21f3752e2c5962f7d960b888b2a8c495b1b133",
+        "sha3_256_hash_of_public_key": "30c784bb2ca3538979b24246c2644907484719c531ea39f13c5a34046f8e5cc3",
+        "sha3_256_hash_of_secret_key": "ff96c20a150142ec36186277a6f7b15e4fb93e9648385ef23186fbef674f1600",
         "encapsulation_seed": "2607dcf4fd6ca1c614c21b5e37c24981c32b91c8c3e6955777da8a3f5d9c9335",
-        "sha3_256_hash_of_ciphertext": "422509b01b8fff9468e867a2b5ebe5d3e27314de5c058b2c79a61ccf464f4df7",
-        "shared_secret": "0b8584b75838e084839d58c89cb1749e82ec06a0e85464c7546dd96870547d29"
+        "sha3_256_hash_of_ciphertext": "edee28e97f72a1798809668a1b9b9b3dc05d794d69af6cb476f524e6acad3d8d",
+        "shared_secret": "19599e218264837d06839b6cb9a09af3bc4cdc78f7d9c00fe030ee92ba3bd54c"
     },
     {
         "key_generation_seed": "056661b38038da4fdd7426f32a81576c73ed84843b305168a374f934e27a4e1b79238a80dcfd7c992d84b2dffa67493e669243d4fa38c46b090bdf86bc548411",
-        "sha3_256_hash_of_public_key": "065fb6156acaac591f1bf3ce71c4a046be8c6c55eb9a84d29569bd2b144c73e2",
-        "sha3_256_hash_of_secret_key": "0121afcc6aeb8be9f1c5b06d5b65cc1c03e9366ed7b85fc511d853c5eee230cc",
+        "sha3_256_hash_of_public_key": "b30fe432c2e9744430805aef6b75cf3011ff387e323558212b9d71ed71f044f7",
+        "sha3_256_hash_of_secret_key": "2c4c6d6ed6fd6cf8b53a352a038b9fea6648a9521604140f54268381dfaa1144",
         "encapsulation_seed": "38c89bbe7145c29e9a831c11431eb9929cb24fb4992db20737e4687d397fd732",
-        "sha3_256_hash_of_ciphertext": "f1d3b745d86f860e508ad8b6d5c8a72ef833c280ec11e99516f4ead3c42509be",
-        "shared_secret": "3547a15b5748990a5436bdc4db283738eb7d64bdb6ff566c96f7edec607ccc9b"
+        "sha3_256_hash_of_ciphertext": "b536c56ac5b187bf7372e726bef28c7a46b51e2bb3bbbcb3cab014c6f5999061",
+        "shared_secret": "dc5f3931026bcedd2f57b65601f683895c365862d28a65356e94049773de2ae0"
     },
     {
         "key_generation_seed": "a1b52d871612a1c611ae0944f9e71858f35d3bd14f20e96a931720668bdf0a6b1f135cf64b6403e103afae34da038613e2853bbfc36baafa3c6a95347193f37c",
-        "sha3_256_hash_of_public_key": "ced77d358342759291c2bd225b0bd82d659d28a24bbc5eda8f47975b780cd129",
-        "sha3_256_hash_of_secret_key": "16e06287bd8d71c78f1657bbd6d5d12c22f6bad7658e68dd849d7751da950860",
+        "sha3_256_hash_of_public_key": "ab02b962b6350a9e1314baaa272b6b13db3d1edc9f09d3addf07f6826a3556bf",
+        "sha3_256_hash_of_secret_key": "abf4653476aae658e4603990ddddad56c09da5fab6b9a3e328b9fcd670547652",
         "encapsulation_seed": "b2c35e33c72d90182791f0e12a0324f5b216efcab2c8da1bee025dfbe13f4152",
-        "sha3_256_hash_of_ciphertext": "fdfd351fbb15c92843b44489fee162d40ce2eea4856059731490afda1268b985",
-        "shared_secret": "852ba9be42763c5a74a75778eb839a3738a8ceed1520b0588f9dccdd91907228"
+        "sha3_256_hash_of_ciphertext": "fc2394d4ed9b1e2b073d73d02eb4ef8ab3633932e58641a58507d7c977b62c04",
+        "shared_secret": "7dbfce1fc7d937884e7b3fa7c8eaadb37e1663f77d7c8659b8f43abadf16cba8"
     },
     {
         "key_generation_seed": "952b49c803d6d6fba69f4375adce8594847a00bcae2179da49af2aed0423250262d7033947ae42ca53522a65fbafe18d3bc3e0cb66164e9a094fe4b44d8977ed",
-        "sha3_256_hash_of_public_key": "2fdb7c7e39ce1625c20a13a1c91aa5909d8b03b064d00877dce2415020370c72",
-        "sha3_256_hash_of_secret_key": "ffdb52b23a9ca4b71ec882031ebcb33a0ecc6731c13c817b24f3a06e48273778",
+        "sha3_256_hash_of_public_key": "c153354b0187e658306a0c860b1fe6ed14686ca77d37b7c82d66ff62149406b7",
+        "sha3_256_hash_of_secret_key": "bc48868d03fb12ad5a98d35a739388b66e17b589aeb6ad4335d2d2e0c933910f",
         "encapsulation_seed": "afb7d6dc2b7eb6d84acc080c1be63c98afe7b07786b5801f716444a3e8e64800",
-        "sha3_256_hash_of_ciphertext": "215d83f872221c5fd4ee4da557e17299dc102c52dba1fc4bc3f8c16805da7f1e",
-        "shared_secret": "618a8496b8850609c09dd1d18798ee2bfff3ed7ef6f8b8034fffcec98f291d69"
+        "sha3_256_hash_of_ciphertext": "0fdc0a9a35e5cdcdea8d39e95086e35db8f4ec92f13a7d9afad49adb5faf1e70",
+        "shared_secret": "09f64cee1af4d8738ab149d34a106ea7b19ac43e5a2536defe689824409050ba"
     },
     {
         "key_generation_seed": "3c815e57e9233e975fa1630208aab206b71ae0db37a7a8789ac683d9f9b2d29801c8e376fdb140ee343106c093af7cb149b316ba79446ceb4e5e0cedb9b164f9",
-        "sha3_256_hash_of_public_key": "86bb11e7d9c1368fbba34ce3a2f169c2464ef5fbc11f73843c456467b6cdbd4e",
-        "sha3_256_hash_of_secret_key": "5d46659798d268f1314ad1e7c1735c480301f5877773403966e928bc3fd33d1b",
+        "sha3_256_hash_of_public_key": "2ab47ca9355ece6cc643c3274c46efbd6e927b8b4d11ae8f80b5345b487a5c71",
+        "sha3_256_hash_of_secret_key": "9f65505a34f12eee3e5f6ba1cc622dc0024c4be87dc0648ff9e1edf9ffca943a",
         "encapsulation_seed": "28f5e9dbda122b2cf8f3754fe9e0c73a84ad4b0c093522e0b62cf815d60bbc3c",
-        "sha3_256_hash_of_ciphertext": "5ff5d6bdb110bac57e58a4e288d056a1384f9823606a42daef2ae82e0b7574b2",
-        "shared_secret": "cbb8b7a05f48b47d163cf8c2fad32bc586f47f2c2e0911da349f29b1e3286c22"
+        "sha3_256_hash_of_ciphertext": "5c7bfaf193010937498fafd5f4eb4665996c6a963ba25368439dbe05c56bd99c",
+        "shared_secret": "7104fe381d6d7995b4d550278a66a719b9e79d9bdc38fb0bb60212c4355cc520"
     },
     {
         "key_generation_seed": "588760826dcfbd36d9abe6ae44a669bb3ebba6a218eab69e30f18a3bd536576e0e860576285483bb5fd36e2f944d32c4317bebc1e441470c1372046a790d79d4",
-        "sha3_256_hash_of_public_key": "29253478090cb4d580bc2a912645bc685061e5d4437b3811eda69c865ea9923c",
-        "sha3_256_hash_of_secret_key": "aadce411f3708e9727e4a7e4e198781e1ef5e8f4c4c14add1e25f5758649e265",
+        "sha3_256_hash_of_public_key": "3ab27768ce397a94bb7d29f5dad97d54054915eb66be41023e5d7052a10ed1e6",
+        "sha3_256_hash_of_secret_key": "2b091ca0237c155627226a58c1ea9a049127e7e30e397307ae20343e21408dbe",
         "encapsulation_seed": "b0d713cbef0bb1df70cbb425d1e9373e9f7790fdc7980cc96a240dfc53f1e8e2",
-        "sha3_256_hash_of_ciphertext": "675039d66fcb631a050a8b24415b50f331350bd6697f9c977eef15c15d4cacca",
-        "shared_secret": "1eef87404f318351413d52ba8a07cfa5e72f235d6f91afd7fb8ad3e683ce0a55"
+        "sha3_256_hash_of_ciphertext": "1987dbb44cd3fcd1b3fded283f54d82a2dd146508124282d59a8f862be82a2a0",
+        "shared_secret": "79b1ce19715dd0a74ada36d31f63f3242716890a66d6348232c914c8e5c4c499"
     },
     {
         "key_generation_seed": "47550e9edacb6ddce3d9ab81f6b61080dd4f2693854acb05e0ccc7a4fb6390fbf89d7d99d5c3e0d10d6ef9af054d842375f695abb28e3b8eb495100f04306e92",
-        "sha3_256_hash_of_public_key": "286de7dc142efe935e84b0aeebbd32d050fd9d8b008a94e59454b19ea401611d",
-        "sha3_256_hash_of_secret_key": "a6b53edf9efd7fa67a478456a5b6a379876c248f623ea45f4b541a8db00c524e",
+        "sha3_256_hash_of_public_key": "4c20aa5a85b2e43c56e051698c75bfc27bb9b1722501a6502d1c0dac0aa7f1b0",
+        "sha3_256_hash_of_secret_key": "684968be82e153d8eafea3ad507544b512bc1b0768775fa5732a12ec2b3b22c6",
         "encapsulation_seed": "32bdcdb7059fe27f6409901980c080308951ffd90deffa8317b4d213a5f04495",
-        "sha3_256_hash_of_ciphertext": "f03d44bd9bdf3bfd486919fec2177b8b685a9981de4cbc2a9e98b7e9b0a528fd",
-        "shared_secret": "ca2c0bba56645e4fce4b7e38a7bb4b839e754bf2834a302a2614377eddd6ae60"
+        "sha3_256_hash_of_ciphertext": "5a1273ac88362d6933e9f8e203af5df0ce809b23e125abfbea3f72bc386f17b6",
+        "shared_secret": "66e872a4b3baa42bc3e8e4ee787ebe070a094f05d2a0792ae2ae60f8bd0ee0e7"
     },
     {
         "key_generation_seed": "610afb64be8cc1df288cfb016ee2f44c6c07113de7f6fee071fe0c3fe31c6215cd292e4c5f9e1a55e0489bceffb204d672a6215f4f3980a646d9f880817c52dd",
-        "sha3_256_hash_of_public_key": "029a2e12c3e6aa668afb5be8a82576813fac7b8e61c5a88aff94ecc2770c585e",
-        "sha3_256_hash_of_secret_key": "413ae41ee83e17b74ac654c2aca57abe8f8ed0409acf7cc8b301e3d6bb049cfe",
+        "sha3_256_hash_of_public_key": "72c30933b8e50425fefbf58d711f58cbf9fd8ebd2835a1b55469a2a1b993eace",
+        "sha3_256_hash_of_secret_key": "f156a8742efc92c7a7c5e07116d139872ec520aad1fdb146cbcff70c350a45a6",
         "encapsulation_seed": "4ed7c92d83bd03b2a25b567f17ae55542e2f6a4308ec0f3fe69f8ba5ae24331b",
-        "sha3_256_hash_of_ciphertext": "e8992f7b7b619c03cb9f0c991e3a9c20f91beb707c177ad4e02a5808d10d8769",
-        "shared_secret": "9155619e28de6cc0670ce70e0ad270f0e885e5f5f8d6d38426938ae1036d6ffa"
+        "sha3_256_hash_of_ciphertext": "c3c80130ce1ccb69036c753567b55e2e93df33496228735300b7640f2993c09b",
+        "shared_secret": "56551e57abc7b80a842db9ee65aaf6e65b7c4ca10fc297e9bb0a6364e6255bdb"
     },
     {
         "key_generation_seed": "e1953800acaa85ac02a906c72cb8e8d704e8d27820345f88f71e89c1f549afcc8c64c049c6dfc0f1476cffd520b055756162f7ec94243de6b14ac0b9e5fb366c",
-        "sha3_256_hash_of_public_key": "e3ec3671cc7675a321af8584a0961101c04a432772431e77f5740ba3b2ef488d",
-        "sha3_256_hash_of_secret_key": "93bf696bf0671c3845c4b246f29701a0978eec5b49de81589009e235903061e0",
+        "sha3_256_hash_of_public_key": "bce58a5d05a4840f835b8ce39703f77bb31f20b9ee4fd3795c2e326244208b28",
+        "sha3_256_hash_of_secret_key": "abc33aecf69474343f3848633db85e595a465bcbd408472257e00be338664ecc",
         "encapsulation_seed": "060ea5d2ed1dd88144a9885e79278590821c22917b55a48920f96b53ebe0e689",
-        "sha3_256_hash_of_ciphertext": "6634bd840d2dbb01463cfe5b4e3e54d1eabc081cfbdc14d0bc118911ed8d3cce",
-        "shared_secret": "d1f24383d5b8d0c3c0a6a5f8f7d38ccce13ec179a84b0b09bcda4c9988f3eb4e"
+        "sha3_256_hash_of_ciphertext": "a500aa79a567933c2cb80ea580fff3298a345398243052f2ac292591810328b4",
+        "shared_secret": "30abe054c82a82299e7edd52870f461ff6048daab627b6c848a9d4f1c4641a0f"
     },
     {
         "key_generation_seed": "c719f9b2d16399b7326ce4eca30dabefe8fdaab18e9f6df888b0a134ef355570e40771856eb77e4633504899fcb86c6a3d433d0b8d60e26f07bd61f1d4ed69bd",
-        "sha3_256_hash_of_public_key": "79836213a513bd4cfd42ed281304e3ee4560e4e0c60fa53781f83d5bd2bbea52",
-        "sha3_256_hash_of_secret_key": "65deb55fea451375ef335e7faac73917d32220fc70c95f371fdb16e712beeb26",
+        "sha3_256_hash_of_public_key": "0293675aaefa1219f8794d114bbb004463f9c631729734cb430f26f38886537e",
+        "sha3_256_hash_of_secret_key": "b25401df9f852f7383fc87fa7cbd267b9de2e80bb37946e9fa8d040134a9e31d",
         "encapsulation_seed": "10ef9426f8c4a13b52325c5bb4ead4596ecf2c6b5bd2d37d8350e90d4164fdd9",
-        "sha3_256_hash_of_ciphertext": "ba79883ad64a6f2b256004233d87809a8c390327a23c739334f773507e003aa7",
-        "shared_secret": "d2dab0b39b7f62de3ca9826f9dd15a4201191a0e0c690d3e52b305a9d3af2d0f"
+        "sha3_256_hash_of_ciphertext": "3e0e87ded530c595b63064109c6d64c78253f3bbac5f3bcba552539fa7daa004",
+        "shared_secret": "4b525f467ee0d96c1f4b899a114936343ec21c74738b05555b2bab9a5d0b5513"
     },
     {
         "key_generation_seed": "e9acbb774be970206c3a738e243b420805a509fa59fa902044be2f0d013650d2ded5edaec5de3bf5b4d7c2f2e18e87f499c1968993eff196753db8045e2c8ba8",
-        "sha3_256_hash_of_public_key": "0c2e803c2872400c49e1bb10232946ab939319e84ff32cd354dc15d082cde5a3",
-        "sha3_256_hash_of_secret_key": "d37f172803739d074d71a2be32125eb1ba4250128342e34b882fcba38b259248",
+        "sha3_256_hash_of_public_key": "cadbc64e263f1afdcddf2ad63f2fcd19799a0a8f43ec867477e249ed5fe716f8",
+        "sha3_256_hash_of_secret_key": "ae483cd66ace708eb15d06b55b1414e1ca1cd440d8867932261fe16a41eab8dd",
         "encapsulation_seed": "a4bd30a64cbf29a4e290fa1cc1dfb99e68348713041e4409a1af23c5d80c15c4",
-        "sha3_256_hash_of_ciphertext": "13d437b2fd9d67ca0699a3dacd977fba5d072fa6b482043d63e8a9548ba6a3fb",
-        "shared_secret": "6869ca370a496af2dbaa866265d91ba6be54b9686b1b8dd5714f6ba861b0d1e8"
+        "sha3_256_hash_of_ciphertext": "b4c90f9d9595c242112c963a6f24b6023083a0751e341522eb4460a0eed65f25",
+        "shared_secret": "6cba1b31809b333ea40f2f67bad438226d91bd61b08860357a840cbcc8fabfc5"
     },
     {
         "key_generation_seed": "c1b3cbffad4b306f9af0cdd3028876486dbe858875c9b6497fe20172a986c82b1c96249919cedc2369d8d739ab125e0d2ccb82dfebcd90240a545cdfe07511f2",
-        "sha3_256_hash_of_public_key": "5818ac8d7a38c781e3a0bc43d088e6d391d1d67d9639b260bb6f58a19a57150d",
-        "sha3_256_hash_of_secret_key": "280e4774d1b2401580216fa70fb24c2c214ac5dc7f3841710a42e14d6aa09663",
+        "sha3_256_hash_of_public_key": "5ca1708c7c6e354b69720b4b4a0c358fe9a6ad3febe78bb2a71691658acae21a",
+        "sha3_256_hash_of_secret_key": "eb002a4709c8b95bf166e0942d47453c32b93e32e4273aef846c296d1590d58a",
         "encapsulation_seed": "f4b66a7d3b65b896dfe100b2cad24b175a1168cfd2ae11fd704b835f6bcd311a",
-        "sha3_256_hash_of_ciphertext": "51eb70249a1abebd5159f1069b1acda2304f25fc9cbd9f4a625b58df448b47dc",
-        "shared_secret": "502d92b2a7e1804892ffb8ff009987a58f35baa30c0392c83859fde82105a9aa"
+        "sha3_256_hash_of_ciphertext": "3d21fa1e7c4b9e5b3f68f956afe6fac216d42fd9a3707b7a61932c8ebb5103b3",
+        "shared_secret": "8087b456d37e6aff785a0ca104cb03ef71fa2d6652c52dcd86220cacf878afeb"
     },
     {
         "key_generation_seed": "ff7495b8575b5a98e4fd21fb4c3e58cbb60f14bef21aa74cf8802e3153f14807bdc370460375a778d1a31d01c42b66367ed8d9e8f84551002f552f0e52102b5d",
-        "sha3_256_hash_of_public_key": "172cf4f8dace8a96b8f70da966080a5e3f132873ca7544343377a99b65e8147f",
-        "sha3_256_hash_of_secret_key": "31136804b6c14f3a0a00a3295a5fed8d606369e64d272d432c59d7fe0ccc3e47",
+        "sha3_256_hash_of_public_key": "04f0066489947b572f76e1dfc2e24297b210ed0aaf228788a0b349d11689e064",
+        "sha3_256_hash_of_secret_key": "656696013b36db5535aa376104d5e2beb2c9a708282aa6a5f0ed42cbeefcf98c",
         "encapsulation_seed": "1d7b03d3c5eefb8ae5799dc569aa668f1bcb8c86607b089d3530cf61d6380147",
-        "sha3_256_hash_of_ciphertext": "9b38b66fdfe80acab82bf9577676f6566b4429f78a14f7486b07c96ae7be921b",
-        "shared_secret": "48eb4b840c0d957f28808e434786c02a8f99d3464ccb3caf91cef4a0f8e70c4f"
+        "sha3_256_hash_of_ciphertext": "a29dc0e0107aed03c698c2448cba21940bf9923c2098225ea3421bdb474a8ecd",
+        "shared_secret": "6799d393f4000857868049c19a102e5c04c55a6bfe3a41abeb4fb6d5228cda97"
     },
     {
         "key_generation_seed": "bdc3fba1c32751139fc45bacffb3ea97f26573d804a5f27a459293d95190ed8efd5a08f656a6eb8cd20679930a31caa6a6331c4b133a6838c223ef9f769f6246",
-        "sha3_256_hash_of_public_key": "268b6356f92c57da6dd34494b927e8764adf0ad519612ef0d1b8951e50966c2f",
-        "sha3_256_hash_of_secret_key": "3bf02cee24670ca40b7280d8047fa147b24c5e286dcae9c24bace9465bb19f61",
+        "sha3_256_hash_of_public_key": "67ce6c8abcf3ec4d93505d3be02c039e5a12538e5e59adb5a5d709b9b342938d",
+        "sha3_256_hash_of_secret_key": "b68d06399932cb2d32b2a2aaf12e68568f160092efac36ade3536cfe6fc88d45",
         "encapsulation_seed": "554f3385b382f4a46314de37ee3885addfc5332bd4038785094e0a832e9e8c2c",
-        "sha3_256_hash_of_ciphertext": "fe8c3fcee4be152aff29e55f42f2fb1354ae55ccbe38400bc901ca032ede1ef6",
-        "shared_secret": "f9507f70421be90f21138a1e135329ee8228682cc948a6914ea58624d396df0b"
+        "sha3_256_hash_of_ciphertext": "93a08f27c7cd6ba3d5e6c8b6c833d8c65f05edb2cfd7eaf5bd392cd1563552ca",
+        "shared_secret": "dbbe6f3b6f5a35789697792e209428ba1f53d1b98ac2c0d1893cfee641e40375"
     },
     {
         "key_generation_seed": "447f6076a627bbc5ad7773fbfeb14b4ba9ac43a0f8b99fb6dcd5e452aa3c47ec20a7237801f470fcc2bd9fd7bea8322859b850f7882d362947432913dd068c01",
-        "sha3_256_hash_of_public_key": "4c6d304e0494d88d83b5e3aa5761df3b299551a24f28994d2747b2b08945bead",
-        "sha3_256_hash_of_secret_key": "5de91ca73756eee74da3cac78a1fb329a02f8587f212bb9bc0b29e0e654a5795",
+        "sha3_256_hash_of_public_key": "7fe853da745a27a1462668bb66c4348b7f4bf25c70527b360b2fd104cda48fe5",
+        "sha3_256_hash_of_secret_key": "85a7c0a52f7898df5e3ba9ee378057b9e354dc2108c5f8c60a10fc20c9eda749",
         "encapsulation_seed": "38bf0033b779edf5367d9ebc01c988af90904c560970815837380650e4749eea",
-        "sha3_256_hash_of_ciphertext": "805ce0ab06c568b614cacbfa4cce5e65929e2846932a90e9418513dd48cf3358",
-        "shared_secret": "24caabaafe2063f812eaf57c58b6c0376ed8ff778cec1980ee9c3228801a75a5"
+        "sha3_256_hash_of_ciphertext": "23e8b844258ff739aceecb17073a7f2be2f89030ba7ca699470e4add6f55321b",
+        "shared_secret": "494550faf270431de90c96d2ddcb7c19249d5e85305b3b43626386c30b7aba5f"
     },
     {
         "key_generation_seed": "2d5df64d62cb07fe630310bb801c658dbf3d97993e68626745de39d37fbfc2b27b534537addaba4ecf14f02ab317d36cb9f0f50222ced7cf029dff8a0d3d2fd9",
-        "sha3_256_hash_of_public_key": "72be2f5cd569e6229f00014854633f7b278e90af4ea593411909467a03e29cfb",
-        "sha3_256_hash_of_secret_key": "a68ca31b91491a129af9f280cb4c60c046e7a7ccddf41c9bd98663f8512ca34b",
+        "sha3_256_hash_of_public_key": "65297f711f12a5ff123e6de59d1f16878e93a31612015fb961bc572f3e999cea",
+        "sha3_256_hash_of_secret_key": "f80261900b053c4d1c5e3b445588f1aca6a9959b969b6a60df08f1a12da1b661",
         "encapsulation_seed": "048ea516d0ebbd9f709b47eaac66f344c571cf50f0d01c9466aa061a50b66a24",
-        "sha3_256_hash_of_ciphertext": "d27a36808f09d6165aefc5d253090027eeff0653268c55a0b3de2a751ec765be",
-        "shared_secret": "9f734b15fc7dd99bc10d6cc7de5d2c93ac789a5665e508a95d075dffbad25abb"
+        "sha3_256_hash_of_ciphertext": "7c4f753d71b67d7a6691db0e7d9bf2c2a13f9f48a0d9602be60e080262bf50f1",
+        "shared_secret": "eec9e658edcad5a8a705644ccd35aa3d785cc258666ff749bdbbafae6700f1b9"
     },
     {
         "key_generation_seed": "25056d1b8113bb362dd979d98643d7a7ac9c4f95994c0ba060609b6d07002ff3f48a9254dd40b117941fa35a66bb50296327b725525deef70e128ca8045ec451",
-        "sha3_256_hash_of_public_key": "0831c75b153fa17d336a79ff6e88ddf485daf7b1b0bcf39d8df15319d52ac67e",
-        "sha3_256_hash_of_secret_key": "2b983d7cb50880cff761441b6a2c66b7a41642cfd2a8cc297a5df53f0ed1947f",
+        "sha3_256_hash_of_public_key": "51634cb33a2bc3fc22ff47b58d7879d703bdd661ad3c290a6d812485ef0ce8ff",
+        "sha3_256_hash_of_secret_key": "e9d2895dabc85514f2f1a543440ac0de41d49cf21686327bcc6066d21a2b93a0",
         "encapsulation_seed": "686c921c9db1263e78ae753b1c9c2e7936b8229dca48c0942c56c6bca4f10917",
-        "sha3_256_hash_of_ciphertext": "0892527da24957468b1b8fab49ad2d7dd6d238eca54624fce6a3c2dbbbe8d194",
-        "shared_secret": "d27e55f2a1f9ef336c8537f11da9875e03cc7dde8951d81b0740457609654107"
+        "sha3_256_hash_of_ciphertext": "8d971865b1ec760640db6e480ed27fcac239bb1c36e72054afc530d957672c27",
+        "shared_secret": "d5c5e6657d310b0ccef250c9664a02c846ecb241f2404ca851d8219f93cb0d27"
     },
     {
         "key_generation_seed": "e4d34e12982aeeb1d62fd488d9b9e28557ed3429292239fb4f76fa9098009acae6c45c7fc62329b13c8d29844405db8ff6860de474bf727ecd19e54e6e1a141b",
-        "sha3_256_hash_of_public_key": "b30cedc4316b63d75b641fbad2f33241a3fc47ab8b3ee1a3ed597e5b04f77c68",
-        "sha3_256_hash_of_secret_key": "a49a7533c671e533deec55af218ee511c57014070e138c7059853e08c34b0a78",
+        "sha3_256_hash_of_public_key": "45cccc2997b502ed631257065214ab9afed11f00ca5c18c92c4d6b917165fd1c",
+        "sha3_256_hash_of_secret_key": "3a0f0c13760dfc8bf1bf79bdb1b4f94aa33989529be306bb826b07e089105b47",
         "encapsulation_seed": "2387772e50059cabda53cb93ba24b19ae529496c03b36584169451525c4a0e7e",
-        "sha3_256_hash_of_ciphertext": "390b3b6f9a0f9d97ccd452c83bf47416b22fd06b4d8968c44ee6effa7980e68c",
-        "shared_secret": "ed5903d1cf02861444cad7fc3793b4e1b9b6d0324bf6babfb768bb2f84300086"
+        "sha3_256_hash_of_ciphertext": "c60ba523dc75a1c9f8dd617f1cc775f6d1cee0fd7614da1a5366eee5950b6f10",
+        "shared_secret": "f62460025ebbb273f00207758a1215c3a8053d2ac66cee11c6760aeef7e35d24"
     },
     {
         "key_generation_seed": "cd6a99396eb3539ca663a51e42063a3a262cc1c5a5fce1566f0597b52ad9fa325a3407f591791a5db4578b5972093a95bec3b8e70c1d542c9b5c9789729f8922",
-        "sha3_256_hash_of_public_key": "ee044dbdf6787ff038dbf9c133557169c62fc1ce2580739369aa87df00b49648",
-        "sha3_256_hash_of_secret_key": "9e865967f0d1e7d3f6a49f2bb623ced2a7b1408a945e02adbdca35846b70e7b9",
+        "sha3_256_hash_of_public_key": "89560d4e598328f6302a9762bda2b0f29fa8ee34fe48dc4847810fc6f44cc198",
+        "sha3_256_hash_of_secret_key": "30f40a1a6f4adda2a9e73f3a881f3d10414031a0f5fc0f70ffa4966b29bb1a7f",
         "encapsulation_seed": "155c29c5f0378df0cd0e847a80a07143cf7522fcd880c9229eb9feb1ce340cd2",
-        "sha3_256_hash_of_ciphertext": "6858db6eafd97259e6d775d881f7a877010179d4f827680426946b9ac4571261",
-        "shared_secret": "0d301028c1cb31dedc8a702a9e95b7d3589f68a6a1f600af84ae0f543e625361"
+        "sha3_256_hash_of_ciphertext": "932a09da1c6de03fddf0b45ca31f2446c5c2a3d47af171cde29149167e735cd6",
+        "shared_secret": "74efee46e7b26f5022416ae9bf4a52a3940966b37fab0c3ee2e8fbb24ded6bf8"
     },
     {
         "key_generation_seed": "6c8c53ed6f65e6b2e324b84364e10de42d1c26a106d4d1c99eee79c78586fb55b9402bf02481ce4b27a52e87feb92c4399c7f2988d40e942e7496ad15ad2aa88",
-        "sha3_256_hash_of_public_key": "e965ac6995d525e324e8252d8e2c2da909a29b24baca8b68daa5122cb539a474",
-        "sha3_256_hash_of_secret_key": "91051a381626e9465fc7ab20a1944eca64be461330bda53e7d1838a74597392d",
+        "sha3_256_hash_of_public_key": "878025deeed7dab8e62d43c3d2096e4682692537c70ebab9e1561cba88b05ec0",
+        "sha3_256_hash_of_secret_key": "5469881eca81b37faa66f4d9f63c20ecf61fa8337a095410fc19eeacd774b863",
         "encapsulation_seed": "a9cb9a61a3324b1ea5afe693b32784e2871096b2ca14a11acc9577c52359a241",
-        "sha3_256_hash_of_ciphertext": "42bfb5584610497fbc8080a664139afa534b39a417cb69ab0d2a16c8737eb1cb",
-        "shared_secret": "354d86b389021a3196b75c6582927b3a005fbfee0951f34d9cd5c8f415fa50f9"
+        "sha3_256_hash_of_ciphertext": "0407bedaefe91d921a6442f34fe88c04e62389fc63dafe78a1a2b93723786a10",
+        "shared_secret": "92fd1bb6ea9f1a0a195b3ca29e457f4b3f401fb4521842196d9471f50f5c7249"
     },
     {
         "key_generation_seed": "2107204cd995f1df14314d5381f8c5440f09a347502e161cffc0a2ec3dcfbc7324c3da70fe850e80aa818301d60c70f3038153866dcd5d179e22db59b8991bb4",
-        "sha3_256_hash_of_public_key": "a3d8a85f38cfda38c66ae39b2f9186ef7bc1e0c98e8976a6cbc6c4875d73d7fb",
-        "sha3_256_hash_of_secret_key": "cf7e797f8f7229a08206034737e54fe46645ab2fabdbfc8662b45a2604876b65",
+        "sha3_256_hash_of_public_key": "7d30385f988dc748b843b7b7f569e58ccc9215503e1bc2f28f5019fc72fe6d33",
+        "sha3_256_hash_of_secret_key": "5b425d514afec91db185ec5e84bfd545453da4f3acfef398e7b3548c63f713f9",
         "encapsulation_seed": "e99fbae8a024ebbbdcef32ce213f6aa942e3eca925e5da4c09975d773b33a175",
-        "sha3_256_hash_of_ciphertext": "ce7b65856502b280e02a36d906e018c6a23cae99f27ef6d65762c87ddfedff56",
-        "shared_secret": "3afcfdc446f93a8169024a24fc0383692843cfd6b4854a8e490892fc35aad4cb"
+        "sha3_256_hash_of_ciphertext": "886a86759ae6a21a6dabe37a4b4443bdd358502f0719b5b9178dbb6b9f7e27e6",
+        "shared_secret": "e1a195eb1093af69edf107980f94adb3058378cb79dc807684c26c4ee1308533"
     },
     {
         "key_generation_seed": "63a925685a8ac5bbd918faa33ac397d1ffbcf99135d9da7c3d6ff7aa4c50af3d3afdb8a246a56ee71465591831c371f2eb87467b0559dedd776ba063ee6d2f93",
-        "sha3_256_hash_of_public_key": "aa73b40dedd61e6fdaac86971965c03ab14ae69e8130426fdf830bd57d0974ce",
-        "sha3_256_hash_of_secret_key": "1e7f3f1e5632d1df538b564304f56689742d1f652d8d32f019b45183af68a20e",
+        "sha3_256_hash_of_public_key": "0697d2f9e047e603b8845c9ecb168576f9d8bc7f3c831b6ec15c5fa4f744315d",
+        "sha3_256_hash_of_secret_key": "8b634d3c1e118577cc095a8bc53d05bc8c869f2001f3ef591dffd8cffffea969",
         "encapsulation_seed": "67a216f37d67f5e74f782f1badbce1cc8c80a6130aec305b421899a4faa0a6c3",
-        "sha3_256_hash_of_ciphertext": "b6c40fd53bcd9ee1e70bc6783b402ae34c24dec724e63262d8583c90cd10256b",
-        "shared_secret": "ebba9a8bae936c829c1445c68595da96919041ee3d9b0fe27ca93db691146874"
+        "sha3_256_hash_of_ciphertext": "a9c68747a9697af9d9442e3d5341161afcd1977777bb40dfd8642807d96f3ccb",
+        "shared_secret": "fa8721164f599caeb949141b24a124f2d576b3b58c1914af2b05da26b09bee30"
     },
     {
         "key_generation_seed": "6a1aee5e708c1b47f02bdacce4f56c860f74fc7cfec1ef3b58285b1c8ad7fec2230e05b7114ff0395cc6634db1eae8258072d09c09f291e92d6620b177dc50d7",
-        "sha3_256_hash_of_public_key": "cf754f2ee43694865a09ca7beb0deda9b1328fd0abdf30ca5c338e27e8be04b5",
-        "sha3_256_hash_of_secret_key": "928592604aa44df8f2072f26e9511129f61da0b7f57acb3f6896635a9764ea87",
+        "sha3_256_hash_of_public_key": "d49e426ae85eaa6c911c4dca80caba6e28e5f645a54d8c016de51a2b98241a29",
+        "sha3_256_hash_of_secret_key": "cb272fd45a2a27a517bbe1d77d99c027b8664d596bd77d18c4e861ab9900b0fe",
         "encapsulation_seed": "52b19fea232c9154a3e431e9d69cda40013cf2d485c3cd027ad24e645420420b",
-        "sha3_256_hash_of_ciphertext": "a4b50ad169b436877652a6c64dbbffdd63f53274ddcf58f3c96c3929215aa956",
-        "shared_secret": "f063c0908deb2e61faa0c4c0f5051b2c8af7265060681df14bacb30f0228b3b3"
+        "sha3_256_hash_of_ciphertext": "a569fc93ed9b0342e4090782e82b576632dfef108ece59234c783f80e1862de8",
+        "shared_secret": "d479c2f5e622cf848d921a7155cbbade062d0fb3ce7535d1859eb03e18ac64f1"
     },
     {
         "key_generation_seed": "6396b328b100e4c7f4bcae69875edea1a1982421558c608c13c592bf7b5d0fef1100ced48add211a5c937b8d6079d8e271af3f949edc61f70e60453aef20dea9",
-        "sha3_256_hash_of_public_key": "3a842153dee9e035299d7e268c9492d71188f9fb24bdc2dd20c1ddca647a1523",
-        "sha3_256_hash_of_secret_key": "28ee987bc4ae5a321d2669950dbf87596fc4b35c29f192836005064aa3dadee1",
+        "sha3_256_hash_of_public_key": "903d69da169d8f3f65eec290acf30078fe51bcbd1aeaf412dfe2d31c7b10157c",
+        "sha3_256_hash_of_secret_key": "87b236ca8da0c7a9d38d7714e7ac16e6dad2fb5282a04b846afedbbc0449b395",
         "encapsulation_seed": "64440adb05db3308b189bf999f9ee16e8ee3a6ccbe11eebf0d3ae4b172da7d2f",
-        "sha3_256_hash_of_ciphertext": "126b64a28d82d06ca81f7e86d33f4949634924e04528d1142061320eaadcb841",
-        "shared_secret": "02d2e466e170bf45d3e9d357e2f04c34cda408cf147e9ff7a6e8c715f2c88ace"
+        "sha3_256_hash_of_ciphertext": "d74122c64015ba74b20c9a675bf688952d42ea421aa5c7b6c82eb6dcf0cdc092",
+        "shared_secret": "0dc813eb106eb0d4864ffc38432937a1db0d27745788775a8299e93d1c808f18"
     },
     {
         "key_generation_seed": "a453bcacdd2b0d4646009e5ed451c3c45f08fb827ef733db3c517a9dc1af93e67a3cc8aa3239d4c52ce4c95afdeff6efbfacac10d294edc0e7cf4535059bfdba",
-        "sha3_256_hash_of_public_key": "da43cae3c4da51d69a57eb87094a03cd3a9c3e6b4ed864cc691a60f0509cc646",
-        "sha3_256_hash_of_secret_key": "b204cd1c3122b29a3d99cb77e11427fc102375699928c5a6fe816f96bb212627",
+        "sha3_256_hash_of_public_key": "08cff1967030a528e748b708b0fb783577f249c04ea5536d2da034fd0d15fbac",
+        "sha3_256_hash_of_secret_key": "de3ea809c8eaa873e0aaef44d481d8ae72799a0b746c5847f3d412865871bf63",
         "encapsulation_seed": "c8bb46b3a7344ad170c2052fb042b5a3b62e0590562ee82577b1081f6f114d16",
-        "sha3_256_hash_of_ciphertext": "228dfe300e3fabe4d4e550754ebcbbf72a796209c1d24e7ae93abb79e1cf17dd",
-        "shared_secret": "6a5b0842c122ab6ee251399492b061d2ab3e40843f4dc01c12fbd5bd545c600c"
+        "sha3_256_hash_of_ciphertext": "f0cbdd82f5731bf4177a14a3abfdaaef5fbe94a71ff3f1b7852a010b1d4d7eff",
+        "shared_secret": "c71d65ecbae83e06c622e28a4eff43c10041539d851149dbdf295eb121550d5e"
     },
     {
         "key_generation_seed": "47ca2b77c5b717f423222c2730ca5cb9c856bc951d01b2b2c80bd76ccb5539b78f1481d7cab000e33fa07de8dc9627a85e76fabb4428a3376e66300cf12a0787",
-        "sha3_256_hash_of_public_key": "6533c524a32345eefdadc74a3c6ad7e981832797faf1068955b79f118dff9358",
-        "sha3_256_hash_of_secret_key": "b9dee52055b1f9a2b25a0c1be4d9f30d2ecd7c5a09f0f5294de2d49a55ac9fe0",
+        "sha3_256_hash_of_public_key": "b5ed4c3fb678a44d92486cf091333c7f035541614729496d5dd45ce580f0d263",
+        "sha3_256_hash_of_secret_key": "c313fdffb08de4e928bf32e08a8d0310ea94f9713381f81cdd494a3d4af09553",
         "encapsulation_seed": "2e2b70609f3fe029a14d09d5d659871ac776ce2797a0355f16e2eb68f5613fd1",
-        "sha3_256_hash_of_ciphertext": "2d7e8fbd6f2257b05eaaa2ca1643c452b4e0b623c9ad72027cca8dd8b7b5b91d",
-        "shared_secret": "2486c0a6cf17d9635dbca1f8395784cde54dccb7df10fced92183f983478fac1"
+        "sha3_256_hash_of_ciphertext": "5c266d232b038abc42ac484a721f63094ce50740008e0be68571018d8355099f",
+        "shared_secret": "82360ffb5455f6dfdfc6bfc1a3999eb7453365ca311a0077c9d74968ed27b7a1"
     },
     {
         "key_generation_seed": "aaf6eb40e596a5e3e8218871e708b089240dcbe7fd3641f0e5e41e071ce49107e2f8d320ac3cb0c52efdc753282f092bc39baf4a18783a48ea031a191865eb78",
-        "sha3_256_hash_of_public_key": "e2f60f27da7f318eb94a74b437f8e0bc9513e9bcc38dad99c174c1d75e0145f1",
-        "sha3_256_hash_of_secret_key": "68eaa8143a71bd5f6df29b128781e3f2a5fbc5d20534afb223ddcc64bc767f5a",
+        "sha3_256_hash_of_public_key": "e9037042553968ff3007cdb135e368ecf440e4187e554af9d0ff272911ced339",
+        "sha3_256_hash_of_secret_key": "21dc6c39559081b2ca594cee9e9825ff973158cce0d11b38a51b503952daa372",
         "encapsulation_seed": "4725dd8fb314bfd8ee23731c2341dbe114606d9abe6434c471b5573e7df193bb",
-        "sha3_256_hash_of_ciphertext": "b5b2de55cfaea8fe543f67c4f45a69780c3e2d932e56e0b574d9b40b56ddc1f1",
-        "shared_secret": "85690ee044e4d8e0540ff984775b59bb5134383c4e229e79e37d7d77632fadaa"
+        "sha3_256_hash_of_ciphertext": "525a66ef29f0c8a0f989dae8592e9e00cb7f347915217d53f08a7699c2b912ed",
+        "shared_secret": "77ef6dc5a6c8ff657070e418fdb3eb272c8784a9c38bbef950c8ac1de5ec5578"
     },
     {
         "key_generation_seed": "6500f32c93415cfdbc0bd31d78d5be95cb9060c8cfa2013955b56f8b6868b322393308641a9a4647f230201e1389624a296b55192a9819fcb19ab77c25f95445",
-        "sha3_256_hash_of_public_key": "d4bf608793939ecba27dff5889d4d921c583999a57e20a48085ac549573e6abf",
-        "sha3_256_hash_of_secret_key": "5f9a14a9c41fc228306d79417015408f31bc9c3d97579616bd68a3d3444f9bd2",
+        "sha3_256_hash_of_public_key": "806aea6700e293f433a97e4b2c8485e6b4ac19ad493c4c16a10a2a884d58f5ee",
+        "sha3_256_hash_of_secret_key": "f446ecefbf4c63e8897a89123ff38bee2aece076fc7b268b6379c996999085ac",
         "encapsulation_seed": "818d3bb8ebfb32bf464775f7139bac0a5bddce80ec5798595992f9403002cd5d",
-        "sha3_256_hash_of_ciphertext": "99fb7b7767fa94e74936a6678acfd5a2306b156f90f4608d507768a25403a16f",
-        "shared_secret": "d179d901a0570bd23aa52570c5c233a2240d4724e81d98c9ceedb74187eb75a6"
+        "sha3_256_hash_of_ciphertext": "c7c82e2b3d0d3bcb73c5d9203ca3acc94ae8818794afc7610cf48a21e830c450",
+        "shared_secret": "b0978add3085e1c972bfaf86655a287946f3853cfb372f6fa5813a11b6c4e103"
     },
     {
         "key_generation_seed": "7643cef2d62cc5aaeecf754653ea62294cd2208e5bf3ddeea209e3dc45373d49eac9d531a532770837a854b4f5531f6e0c8d6c10183b30d3435498c2dd142951",
-        "sha3_256_hash_of_public_key": "65f03add3941d22c80d50659f501f8cca1b448d84462ccb93d5f065889484bc0",
-        "sha3_256_hash_of_secret_key": "e4513cfd1dd2153d30d15b023421cb8e8456e6a40e612847e1713e915a29a87c",
+        "sha3_256_hash_of_public_key": "33df23b37987c6b557e4c0f8fa9e466312f19e7e90cd0a67abe6a145cbca9d44",
+        "sha3_256_hash_of_secret_key": "039031ac6171ad5fa8734fa3d60cc5b6590574c09ae0c02564c1907ebc772d3c",
         "encapsulation_seed": "c92aa5fb91c980d9cade9ce99d4c75b2ffa7d6a6ff9bd59def1aa701f2a0992b",
-        "sha3_256_hash_of_ciphertext": "4cd7f0af86623b34c0b137a0516b876daa73ffd65d75871ddc828f86a7e9b224",
-        "shared_secret": "6d574af7fcb241fed8763b2d0a352870baf85ef686e90eea31f8500c35945ef7"
+        "sha3_256_hash_of_ciphertext": "6fc3012eab242c5a3dcf99b82c5e5230fb8a4d45902afc7bb82648298d8a00b3",
+        "shared_secret": "b888ef3a969e162edab17c3d3de9ca682de60a0fd6ac97e1b5a54171dba12a3f"
     },
     {
         "key_generation_seed": "f8ee95521060c03bb8dacc79f7eb7db640f545f315613a35d447a09e504cb4e13fc3d8392cb53f36ed647364a04e37278a0e0a45b720f4a75c580c9920eba98d",
-        "sha3_256_hash_of_public_key": "b8a3b8cf4709204a2fdb19889b0022ea655dfd58ff27e17d530510e1eef45793",
-        "sha3_256_hash_of_secret_key": "1f7cdadf3d4707efe1b7a6173d8f7b8a9f864ab388c3271d79ec424d9da3e896",
+        "sha3_256_hash_of_public_key": "30a5771b76066feb7f606a82cce122964da1be0b6872ee319832214ec677738c",
+        "sha3_256_hash_of_secret_key": "644983542c87680786b41fb07f959451f1507165353080a3789810fdf557f961",
         "encapsulation_seed": "7e8086a01dc5b3bb9eda25bcc45d27f99874841b97237968495800e007696ac5",
-        "sha3_256_hash_of_ciphertext": "1ca889a71a087ccee4ee1a178c3c55ce3649583f3db924e5c1003ccabc44091d",
-        "shared_secret": "b1090cf26276a81c22ef0e4479a4c705fe294d3b892051ddce7eab16495e0783"
+        "sha3_256_hash_of_ciphertext": "6d468584c0336dad723a1c3ea970d53837373372287371eeed8e08ca06e010cc",
+        "shared_secret": "2fc09a1852f458bc7afb58baea4d6e318bf6801e7804b98cfc250b0a1470c598"
     },
     {
         "key_generation_seed": "b8bd0493a882e3a49b4e0f6256fb1fea0912562fd9ba26ec3d6c9cc12c8973abd7e4b5d8021c486b9c3114d7cbbeb7cd49eba8a61bc2bcae1f1bef30a1daf76d",
-        "sha3_256_hash_of_public_key": "46fe6c37136273736ccb11df5b6d55debbc087de802404b72a003c5e8c809719",
-        "sha3_256_hash_of_secret_key": "3177ed170e84ff15fa1e744adc9ce806e431a68f15a7a026c6092bf593dec6a1",
+        "sha3_256_hash_of_public_key": "31fcd120f19fe976236711e58b4ad172d25ce01eb88bc9d6d051c56564a0db11",
+        "sha3_256_hash_of_secret_key": "1502619da09b1bb5e418004fb0263c8f067cb9317053ed502c501c5b5ba4d331",
         "encapsulation_seed": "bb321ef14d44d8698df879fd52450567657f52a2df8d111185dcd7d4f30a72d4",
-        "sha3_256_hash_of_ciphertext": "aa9a0ea1823a84bc84649d26e249899437844827fe7c63d4828a5144929fa00a",
-        "shared_secret": "2fda9fa72321be3a0946d6d914c7ae714b9cc175619ab8abfd1f1fd499e0dc27"
+        "sha3_256_hash_of_ciphertext": "369203e0da6ebef7ae651a3111e67303f89f568b9897ae4c24497b3180e0bcf2",
+        "shared_secret": "930131d3145d5485f06c16a9420a612330843e6524dd74654a85c383e28f2cc1"
     },
     {
         "key_generation_seed": "c0407e41ddf48d333978b89bcf2db01e4613425b456249e76a6f25b8a2827bf5b2dca81e3f5f748d23c9d356a2209f6b2d60247b2e45c9808de497f64f124643",
-        "sha3_256_hash_of_public_key": "a074ed1f76e97d68434ba4af2af0e549204222679e9e643580c35af3cdd247ce",
-        "sha3_256_hash_of_secret_key": "8f9b3f631d0fb04477846ae09aea725f1cc65b2cdefe2108cdb399c36db9b487",
+        "sha3_256_hash_of_public_key": "42f75d6e3755c28f3081ecc9db44f6cc7cec9891756d74093716697781fc8cb5",
+        "sha3_256_hash_of_secret_key": "21b9bc0035097cb2b892a3f4ad5660b160b18973b735181beec815eaf5ba5286",
         "encapsulation_seed": "210a423dadd899b810f011794b79aa7f860823ac1962370e791287d3a1afa384",
-        "sha3_256_hash_of_ciphertext": "a4fb01f55eb2986c1f90cece43330bee1b16d7bda48d617fc94aa14fc540ec4e",
-        "shared_secret": "23798e8b9eaa0b369842cad83a2bc32206f791229c830d7593b9150161168011"
+        "sha3_256_hash_of_ciphertext": "c6d1d905150eb6586eea72b13f7210d9830e8e689f9da7d9c04fa7705f21cf01",
+        "shared_secret": "b276a4fb4cf77eab502dfdf56eae9f8a8ff5e7f5df3f6cfc80614b193c87f08d"
     },
     {
         "key_generation_seed": "334382d39164d1989696a2ff77b25a28af8bead9883b5365eb6fcca7c1781cc9aba5068af837be962f439f233593d193ce5e08f7d66efb3389885927b89d2523",
-        "sha3_256_hash_of_public_key": "26659f74fc9ec372fe18be4ed6aa28b7cd84ad1c0f0115dad011a11d20fda9ed",
-        "sha3_256_hash_of_secret_key": "5e3f83cb08ff80183879af9ade3631bed2a468e429ad027a5afeafd9a6f66362",
+        "sha3_256_hash_of_public_key": "43d6c8562cdec0e87d00c8ca8060da3f031ab663ddb43148eebd67969b7fd490",
+        "sha3_256_hash_of_secret_key": "d3c172cde1f249c0a7fdb003ecc0a189776b616378b188744e407ccc601fea7f",
         "encapsulation_seed": "bc856afe24213e3d14c3d6f9b89223bbcfb2c890722d770fa3492c1e46d1c302",
-        "sha3_256_hash_of_ciphertext": "6a4204db4803d26d7b8a769033e047f3b4cb616bf5451b88a1fb3ff219bba9cd",
-        "shared_secret": "d5c63d2bd297e2d8beb6755d6aefe7234dea8ecfba9acda48e643d89a4b95869"
+        "sha3_256_hash_of_ciphertext": "353cdb064a37df87524874d3f60afdf4077be0ad96e1ab61a9ff1745d1e6e5a3",
+        "shared_secret": "f4924920e64013fae72cfdd1e94b217eebd55a011f6b7542958abb297e4fd180"
     },
     {
         "key_generation_seed": "6995143e8eb8a6e93840f76eec844f67d2b5f75b1839a5040337e61f9806764a0f4dff8e56f68440836a072412a30d851ace2c7c6f02d60e7a8420001a63e6c6",
-        "sha3_256_hash_of_public_key": "2ca3d8ad2dab1dd8a2f4320658fe6eacabf70d907920593919119cf374516336",
-        "sha3_256_hash_of_secret_key": "2798448395f6ae3223550e7d5255e6a605b430229f5809b6efd0683a6b9ca402",
+        "sha3_256_hash_of_public_key": "3cabf1c47e7aaada59ded4fa8ce378ce1d9eba621ebfe8cc96a111aaedc4b6cf",
+        "sha3_256_hash_of_secret_key": "225563503590841152fcf47d4665b7cfc76e2b9de23c0e24b527395549f9f7ff",
         "encapsulation_seed": "5fc00f89563e44b24cd67d0ce684effe5731619fd08e7d72e2406eb016afb66b",
-        "sha3_256_hash_of_ciphertext": "dbd5fc0e1df33ff8af9efd5e281a2b98160f98653803cbd54e3a07292b37fcc7",
-        "shared_secret": "29d6a229adf49a1139794209307b0ca24be5825b2771809232fb718660162475"
+        "sha3_256_hash_of_ciphertext": "f11aa37ffca654d11cb5f9aa294ab734302851b434b57e0f5bb811bb5bafc177",
+        "shared_secret": "412bafc716efe4ff928d9a86ea4665dd841e2f102a8363b994a0faad63251eda"
     },
     {
         "key_generation_seed": "995eff7e0d195c6d0533f3dc194d47e60f9ad14696144cde694d60a95f3e96b4b28f7e7a15a005f92400ce33db073d49b53871594a88fc45e0f94207b5f0f2dc",
-        "sha3_256_hash_of_public_key": "de62eff56f6b49a156d065d85eaf0aa21ca229a20fa4e1372a410ab1c4ab6e7e",
-        "sha3_256_hash_of_secret_key": "6766cef3fe644a233caddf208074b58e6e83f8a78aecd00911c29a08f6f0b0f3",
+        "sha3_256_hash_of_public_key": "2853cbbda86e7039b635d4cc850f494d42b240acb54ab2316791e9ef5b45f1d2",
+        "sha3_256_hash_of_secret_key": "87ffcfe7a504e0dca284d8cf509a92a24f82ed7c46a8c1604d9a2d6d14b1cd11",
         "encapsulation_seed": "ea22a76065db4b565ee1807fbd813b43bde72b0e08407fb867c6a18995025e50",
-        "sha3_256_hash_of_ciphertext": "4c669e33b0227c9c2040cdacdbcb7d22b9984372587985ed8f860ffc8d037e79",
-        "shared_secret": "2a56a7a6d5b4c0500ec00a92e322e69be9e93006240889552072482966c54f56"
+        "sha3_256_hash_of_ciphertext": "ae8fb4bcfc08f8daa486b185540b501680e511f46fe8a628b8fe449d5a51590a",
+        "shared_secret": "c514d4086428200e118c1c297ce5ed865d7452cd7770363961bbb834f56c564a"
     },
     {
         "key_generation_seed": "3e809ec8dd0fec0d911a4e3fac20f70fbb128c5de94dc7184ca7310ae9157a98d8128601c28b1def8d393a0db283229f7c7383152a814e7cefe8ef9d9768c473",
-        "sha3_256_hash_of_public_key": "66f161d27dc34e1a2f4b98b14a2b221d7eae26a593bfe432487d9994cb480656",
-        "sha3_256_hash_of_secret_key": "2237f6cbb452d375878b82c474a7c948ff587a5f3ed02bbba1459fa7ff8ef802",
+        "sha3_256_hash_of_public_key": "2d5680b483287bbd3e61a91839cca9e761429186176b7bc64034ad43f16f65e9",
+        "sha3_256_hash_of_secret_key": "bed74aff196e7ec7bbb4dcaac39ee1a79cfb35140cf4c400b6ef2fdfc53afc6f",
         "encapsulation_seed": "e9602b34fe73ad57f4bf6ead99743d645641553a5b9b9bf2e7016629e3e9bd76",
-        "sha3_256_hash_of_ciphertext": "8a2453a21a031cb8966924607a28882426fab2018826192e9bf833bdd38e0631",
-        "shared_secret": "ecb62b03f640ae4a9d89685fa0070efa93c24dfcff0d555142f9de25b62f861c"
+        "sha3_256_hash_of_ciphertext": "d46f403ce5a0dd92937acc508501305da6bcd32b56ff5d986fd6a07e713ab92c",
+        "shared_secret": "a175feba4c1bab576085bb12683d2bc44e98c75f543cee714c75391c559450ce"
     },
     {
         "key_generation_seed": "dbf1c465fff3d9f783bd9ee61a573715e45691147b8904439b5ffaa64f94ff7bb6d75eac6c76ced1b0a025b40a55440712ad8424672e761e9bc400d63812006f",
-        "sha3_256_hash_of_public_key": "7537e68ccf14e8b7e57090d8f648529dc461ca3950288879e88116acaf57b4a2",
-        "sha3_256_hash_of_secret_key": "bd8e44337eef01251217c4702c99232c001b33870953473d83a7486fd25484cf",
+        "sha3_256_hash_of_public_key": "38635cec71b814aaac223f748d13158dbe8eb902d9125fdc22202c4d59251cbc",
+        "sha3_256_hash_of_secret_key": "f3b87926951408dbb27fc2a4a6c14c40fedc8a1cf5c34ab398d91d554eae344f",
         "encapsulation_seed": "f72b9080a6c051bbdb9b0abc1949034be0f89a9f73fe277ec4d4740c78d04a83",
-        "sha3_256_hash_of_ciphertext": "6077c60641c03aa8b36213dddf938311ce6b7b8801f967d42713e73249fe7c55",
-        "shared_secret": "6cc30699701927e07b559d708f93126ed70af254cf37e9056ec9a8d72bfbfc79"
+        "sha3_256_hash_of_ciphertext": "50350977c400c1318bac5e32925d0f575dd3559587f42d025f4e71648e697218",
+        "shared_secret": "9781578191ebf49b162aa768d093a332b9c849c11e240187cec2ee969d4b3860"
     },
     {
         "key_generation_seed": "1f7cfd2b70863154e8a69d1758532e86c20cfc763d67c758bd10a13b24e759b5273b38bddc18488024ec90e62a4110129a42a16d2a93c45439888e76008604c6",
-        "sha3_256_hash_of_public_key": "82f68b15681cca5c2852c18d6e88bcb102a059c1d21936582adb71790cc0a335",
-        "sha3_256_hash_of_secret_key": "fd483ddc211c5c27f453bca56158e1f8084f075a7b06f5098cc3204427bf8197",
+        "sha3_256_hash_of_public_key": "af97825a77f2f4b6a45ec1a579f9f83e89c025d8d6876db26874f38348604293",
+        "sha3_256_hash_of_secret_key": "b2f08250a2681bbbd3c355e2dc61bda33cfe39f3dbbd2a3f3c41ee2266084cc8",
         "encapsulation_seed": "f1e5542190db8ecf4b8d617a04fd3783ad0df78bf8dab749afb57db8321d151b",
-        "sha3_256_hash_of_ciphertext": "5c6cfa16f63b1aa93a2b5edc2f4b14c9782f286f53deedf3153f329a2ae2d57a",
-        "shared_secret": "250e7f67bb34dd5477471e3a701fb71a8138a1920eb807824380f88a944a6fa3"
+        "sha3_256_hash_of_ciphertext": "33acafd1de1d8d8c7a9ff9a6cd69fd013b46b79e74a9180e99d5fa87805dc0de",
+        "shared_secret": "515dc87c21e6b134a577e4eeccf43a982ba7eac1224d701cf099ad07fee77cb7"
     },
     {
         "key_generation_seed": "3a19577908efd37697b8edc7fdaf47d1bd3ad01a1b77faf794bee5b9c3192a6fa3729672816f3eba84c9638a79676eeac0f22c8a48e0c5d50a26ff0844c66b99",
-        "sha3_256_hash_of_public_key": "104fbf09445794c0ea0654f5caf70ee09d51c8386d4e1f467b10633c710ac2a4",
-        "sha3_256_hash_of_secret_key": "73fb93953ae666a9df1bf933ba56b8655ea9e319c0110c78d49f8480ae1aa3fd",
+        "sha3_256_hash_of_public_key": "8517ab7585926764ec7acff3c747479e837831429b97b7cf49ac3763bd9ebbe0",
+        "sha3_256_hash_of_secret_key": "7e5684a04d59f9166f6b408dbc8ae5daf3ec6678cf5eec1e5a9016392cd6c8db",
         "encapsulation_seed": "74efa414ae171bf60b6f884cb7e5ce12028f49365daccfa23e845d551711660b",
-        "sha3_256_hash_of_ciphertext": "e51772e769f778067916e81a561ba6f64fae6096a2b4d4b945d9117e7c36e2b1",
-        "shared_secret": "0210935a18f1add5ebc2e1107bf40a628ef9cf8f6e7cdac81dc0291bb50a5a3f"
+        "sha3_256_hash_of_ciphertext": "0515c19fb395ed94194a60a6f7883d6351fa61ff18060be4cfe2eb9f81ec0024",
+        "shared_secret": "edc2c0314c7c5b2b071b85e373c06b31fa54dc499168d4b43b15f1d05b8b7ea9"
     },
     {
         "key_generation_seed": "ae0f65e29f38804a6759f70f4d01e2aaff7fe1c91ebc4f892dd0de3ab2e68ea5e03ff73e02a217659f53d8c47556bf3d8c94040f630d63605e2d0f923579370c",
-        "sha3_256_hash_of_public_key": "0f353d6a29813d354471eb8b4c38df93939eb3b1db80ddd1cdd6558a9f2687a3",
-        "sha3_256_hash_of_secret_key": "8a9edd6278707108652f3a5bc244592cb7a82c24634583ed2d3eb6a176b216b8",
+        "sha3_256_hash_of_public_key": "1bb014bb0d6489c14f5411051f9667aabce54da7a8deb73b627e3873d9390a35",
+        "sha3_256_hash_of_secret_key": "b890e330079934f2aac63e5f8d236054fabc8d6a6e057672a7a20150ae08a9a0",
         "encapsulation_seed": "0b4c3cffb2ba4380ead13dc0d8acad2356b448a810da1df29f264c44aab6d24f",
-        "sha3_256_hash_of_ciphertext": "a00c37bd326205575fcbbc100ed54630aa0f2d6dd9e69807d49151ac9a81c429",
-        "shared_secret": "34169fc520e944f94ff1fa3799db802a4c1b26cb2971bf196259a937ab8362ca"
+        "sha3_256_hash_of_ciphertext": "79018c9e998deaec058d73d702b669e10c89dd8285f431aa6e422a948a39cce2",
+        "shared_secret": "b3363e6e6dba3e41ac2c63895c461765bc8a0250880d3dd6e8a4479a7fd3921c"
     },
     {
         "key_generation_seed": "6084a235f79dd093ef6d185b54e69df33dacee73a9bf2f379004421a10e3a79d9f684fb055ece19459eb464e91e126a7a6e3ed11ccee0046da234d964c985110",
-        "sha3_256_hash_of_public_key": "12e89c47142418c26396ef0174c02f69dc00022d56494d31af935490edee6385",
-        "sha3_256_hash_of_secret_key": "bc13b19f01d4cab36dac2154e0fd8fb7d2fa012596363942847f1b0bb3715f90",
+        "sha3_256_hash_of_public_key": "c9a546b5c0a567855039f6c1bca60414684e7bd1f8eeb7913f3a1795ba4bad4c",
+        "sha3_256_hash_of_secret_key": "be5fc57b3efd80d7e82b23f62123814ce04e83ce5c998ba42e7bb978dc70469a",
         "encapsulation_seed": "1c82471dcdfca3a6942061ab4f3d5bf0d197321437c706d9cccccce449447002",
-        "sha3_256_hash_of_ciphertext": "aed1a4ee810b81cb8ee49ee00e94ff4553f0ad2176fe4d27a09f4e68157fcc3b",
-        "shared_secret": "b5901e97eb656a09d2dd132528148ad07a0a89f638717eb53516a9ad19aa36bf"
+        "sha3_256_hash_of_ciphertext": "6c1b69d56c493f6f313d3c996336b8f84b76fac2d5ab5a3d795613b27eb10912",
+        "shared_secret": "8e648593c8f6f6f7a97ce7a2d151ada30fbbc7f3c4fc517d8cbadd71e6a17476"
     },
     {
         "key_generation_seed": "acd1c0217fad5caa4235544dd9de153ab1880ccf4c76f16f236fae4e4bfda04cf03a8abb0a5010f400ae5722a75bdf5a2f6d5b546b34d73857cb1bfc7e587aa7",
-        "sha3_256_hash_of_public_key": "2fac52ca60594e514333ead02cb1bfa5cd1d9ecda4a0b25ccdfc47ad3f632a85",
-        "sha3_256_hash_of_secret_key": "2743b7a9dd83a6b9bb5c2685f28b5629b2e31132ac64788a0929557d3449dfc0",
+        "sha3_256_hash_of_public_key": "8f7bfdde2a7116ff4010cf829cbb18512f7cf44237c02241a1f75fe3ba8d22bf",
+        "sha3_256_hash_of_secret_key": "3f53a0acb384db89ca83d031bf210b072860adcaceecd79c36b4669407c1c227",
         "encapsulation_seed": "46fe60a18124125ab93e0c578f1c02f1bd1301595013001c7f3c2fa56cde294e",
-        "sha3_256_hash_of_ciphertext": "7a039d19c45cc557036189cbbc63445b3504a689db56845ece99d593f165c6af",
-        "shared_secret": "df5117706beedfb521f0f021069fe9650d0844194339033de6997dced05268c8"
+        "sha3_256_hash_of_ciphertext": "cc25f35631396f01cc366e019a7f15034cb2341d6c00924b538d25a227ed181b",
+        "shared_secret": "bcdd6f0d744d2a35147323a4a0451fbfb7d60d73c161c1f8c6a2b5e9f4239c65"
     },
     {
         "key_generation_seed": "241191401a63afa750f05662e354dddbc683c776ce3222beb83e3cf913d7ed7ca59b3bd23b49a95bc1fad20070fec930b6060bd827d742b077092e422268e15d",
-        "sha3_256_hash_of_public_key": "3eb856043b822df9d60b55fccb537afa3cacca9ef50433bde1dd9831e534d192",
-        "sha3_256_hash_of_secret_key": "398ae3423ba5c6bb05920e83e8939a104c3e4ad91647edc7db1667efe438cbfa",
+        "sha3_256_hash_of_public_key": "27b1b921723cedf55fe756ff5fb67d555296c6185d171ed8ba01393d1a735018",
+        "sha3_256_hash_of_secret_key": "40db89fcd941566546d554db0342237611e5ef6fdf8c790f03357091af0648ee",
         "encapsulation_seed": "52fb7cb6a633fd2e83f2892bd9441b48fe59ecee6d026f5246fa7f2a5e55ee3b",
-        "sha3_256_hash_of_ciphertext": "05c9617befed785811fcc44d0fce5ae3a1ec66c4d1217ab42e4b754d0ef6207e",
-        "shared_secret": "eed6ecb831c881508f99ea115745448a7b312a4fa97f65044ebcede172dee2fa"
+        "sha3_256_hash_of_ciphertext": "c5b4844dd10ecf508ea6ed2d96d2328d3f14df6a2a16093bf88ca1283e30f41f",
+        "shared_secret": "072551e254959ce9f2c67657b41122d8a98cde044bb2f60955bdc6e5dbe55277"
     },
     {
         "key_generation_seed": "b9a6b0c05677e957d41a34ba03bd06f2a9092e31f63389397d7e70fde6409d18e99c0e7b82be89bc3c1eaee6680aa4efd394e40c2b3f30523c8117f7c26a8969",
-        "sha3_256_hash_of_public_key": "306aed2a804a1c9bad4ab9e59f6126ad7c8633cdd0c2dd9d4c6f639d312ed47b",
-        "sha3_256_hash_of_secret_key": "88b28cf6fe19424ff82fc2bb096423b71f0cb8cf985af31bc15ceb4ed18a5e62",
+        "sha3_256_hash_of_public_key": "32a2a1197d78798bbeb13ce2e92cd7ed94b410adc37b1b31dc060af11fec8a8b",
+        "sha3_256_hash_of_secret_key": "602bedde695713681a96c94a9a6d35308102ae18d3f3beb92a981e4a3b7704f3",
         "encapsulation_seed": "0f81a5f97082121244403da3feeb734f6084b314b8d94beb11627aa6ad1914e9",
-        "sha3_256_hash_of_ciphertext": "315ef84926802ecbbb437f8f50927d3a391b55ee6e47dbd19aa9adeebb808008",
-        "shared_secret": "d6cb77dc96f9ae4bf8b2fc0e277935b3b7b7a59f749ff2c08ad42659dbce386b"
+        "sha3_256_hash_of_ciphertext": "e4631748f7cba566889ca2c5d90c47bba17000a0d934c4242a9a3d6dfac039e8",
+        "shared_secret": "88c0c1e22b68cd65e1eedd6d6208c36492fb674e26ba4e0d4e55f831a1affc96"
     },
     {
         "key_generation_seed": "28a96c71577ba00c94f99fe965bc595a26db2b3ca6ab5cf8e443cdd8462b17929c35d165453e5fcdc6f9df64526d9de698f2bd3e6bac6c7fdd86601b9ba5f4a5",
-        "sha3_256_hash_of_public_key": "9bb3963cc1c5cf2b2d1c6ca76226328ab765a79999ccc71fe98d5bf3b34f51b1",
-        "sha3_256_hash_of_secret_key": "d8c2492023fb1175a84c19b3ce20f03dd12b1c26b65176d5582c319124bc0e24",
+        "sha3_256_hash_of_public_key": "7cc3f47f319f88da508f841e536a056625f206fe499387d27307257682237f96",
+        "sha3_256_hash_of_secret_key": "064bf50ddc823a97adfc93d52ecbff03a0fd5d94ab38874a5abaedbdaba67309",
         "encapsulation_seed": "31af9345365549ea0360169ed57daf98cc5444799d4c75d9f1f5d615e9df8a91",
-        "sha3_256_hash_of_ciphertext": "ae36e333ece7ca60c9bc2c4ddd01ca88443fd73bab08502656873b703af8925d",
-        "shared_secret": "1592f1413331f1871b41ff298bfa669bca667241790370d81163c9050b8ac365"
+        "sha3_256_hash_of_ciphertext": "b34a0a91afbc9599ae00e67ba4ebf0d8308b3e06efcfa148aed519b0f073ddc8",
+        "shared_secret": "56f717e4baddc2250873d667f73a442b05ca2f8714d4dc4d295f899217c92c9e"
     },
     {
         "key_generation_seed": "c08ba2ef8c3a0a043afad931652d7a19e6e8cb670f840de5f1fa03309b2ca9ec5fe6141a25f7ab9f875f79e0a82d6ea5cde5a017ab637d5fdb7c42646a1d71df",
-        "sha3_256_hash_of_public_key": "6d029bb2121c788b5b6ead7226df664490dae362c4befb615717d81c656b3273",
-        "sha3_256_hash_of_secret_key": "0f2c7bd16d9289c3c27136df0cb6ebc624e80144cb92e6f0c897f58a53617ac3",
+        "sha3_256_hash_of_public_key": "beaeb6ff178f3228defdd117e6ba75a34abb70e86f31fdb16d74d91e6c1b47a7",
+        "sha3_256_hash_of_secret_key": "9cf056be85f240e1ae5b73656c07bfe83ba8ec7212973bac19cffbb80dae7249",
         "encapsulation_seed": "774ae54093d694ef40b63b62c73e6c98295f606feb8699807eda1d030ffb996d",
-        "sha3_256_hash_of_ciphertext": "f8a85f106c6144edf1c7906ec26e292f0390aa9d45a22e67ba2ea018ff565c4d",
-        "shared_secret": "966f35c6bc47b4525d9af1ba350e8f44ea448cd1d90cf4e9c55ae5878920b7cd"
+        "sha3_256_hash_of_ciphertext": "89243e04aa17615c309cae73fbfe985e0716c7fe3b8283b5e84c3caa67b5ad3f",
+        "shared_secret": "35f5517999e15ed842904d53d5b4747639d1165014ab77474c0dbc310e586186"
     },
     {
         "key_generation_seed": "0e3b30e102d707538c2671060f603bb0b8a014103f132d63b09ece07e4a4c75b11eafeca9e810796c34e8cfce9d59342884456007b01ddd12edce6d10ed87e4c",
-        "sha3_256_hash_of_public_key": "64c819d9bf66855f6ae70627f04da8378547e5867e2eb9759fe0971efd601c4a",
-        "sha3_256_hash_of_secret_key": "e85b62236d5c6c691a9076dc58bd5da80999eccc8df973c7d0e7e65d8465ea7d",
+        "sha3_256_hash_of_public_key": "b2b71b8aaccf14842a6d4ecb713612f801a5044147fb9e6987ad3863759de31e",
+        "sha3_256_hash_of_secret_key": "01158ea58361ef89d935c9f845711c7f581322afddaf14e255f71c1dcc9c0024",
         "encapsulation_seed": "9f27a47604ab5146caaf0aafe6d149424f8d66e39ba3baf5e6c73b19221b7e21",
-        "sha3_256_hash_of_ciphertext": "e9149359cc37143b0b565bd413a04f41a7833c5b76012a9263a086ac34071684",
-        "shared_secret": "aa333af0226492126c6985130ac7df2226a64d6d5c5314ce3f7a99add6696d49"
+        "sha3_256_hash_of_ciphertext": "ddf853fbd339780b3f571de2aefb30f760454f2cc1f0fca009bc829afb1f3f7d",
+        "shared_secret": "a7159981a68244549b96b27991e1323013c353bdd9c8d6f583897c35923e87a8"
     },
     {
         "key_generation_seed": "2478f7d3de6041e7e5cd11c5e2ef483d1aa6218eb126444091535f6ae532fa7311136e2681df2ef881b51a092a9badbe72c9772c169808521c47149578621e28",
-        "sha3_256_hash_of_public_key": "db315cafbaec2f8a0142f45affff65289e826c9244ab1cb03f9f65df3e3cbcf7",
-        "sha3_256_hash_of_secret_key": "be98d62e4724c0d960ad4839298d4571f9871033b63bdf10d3b0e589db376ffa",
+        "sha3_256_hash_of_public_key": "a13cb3f23ccbd9ca6a75823d1ba14ef03664560f397133935103ded2d7480b99",
+        "sha3_256_hash_of_secret_key": "710b3a8c8d49ee38390cd2776c42ad74a520c8d6ebd39b514f6fbf28c6c74b45",
         "encapsulation_seed": "90044031b7597b5e60a4f946b713e8996d0426d2cb013243d9b7d8f8ef159a0f",
-        "sha3_256_hash_of_ciphertext": "9f9368ba712cfee95f28a808cb2c23116a0c8da3910c0def2ef4e55947d7101b",
-        "shared_secret": "9535303e6035e30c6605c9e0f10c553dcd73828d8525cb190fea79937e093331"
+        "sha3_256_hash_of_ciphertext": "f5c4738d0ac3b25048186a2049668247c04033cb363e9d23b5d1518f8fa7e70f",
+        "shared_secret": "c4041a29c5b744e9039bf5155cb3ac0b799356829557a7aa3feb4b3585e6cf62"
     },
     {
         "key_generation_seed": "9d405d3ebdaf35fa8722de431b669722acaaea2fd10b814310b17f78b66147d16ceb14f7662be0c42779459f69a145c0e2ce9f0bd9a0cd1bf32ed5694cc9ae32",
-        "sha3_256_hash_of_public_key": "c8d853e65b5b118e28b7cb6f0d5d6f282e0ea20fd72f3690a6b232b20a8a55ec",
-        "sha3_256_hash_of_secret_key": "7a5e854bad628be7b99f524f52a97b0959c0ee67a7a10ad24b970e6e3aeeeb80",
+        "sha3_256_hash_of_public_key": "68302cc5af214ceda67ff8161b29bc300c4be8e1a4139437aead8a9ede3cd4ca",
+        "sha3_256_hash_of_secret_key": "5d6904a6478f0632ec56477321a6d6ec5ccdf299bed0b6ee9f4b32c6b5effec3",
         "encapsulation_seed": "a7a31e140891ea37d2b6424b59b1f84f89220f32dcb73e037eb912b389d34a48",
-        "sha3_256_hash_of_ciphertext": "31b04a4127558df57844413928b29b11547de5afc088d568a962fe080c97f190",
-        "shared_secret": "0caa79e0054182c15e54159fbe36d9fb09481331a560ccd9714fff81db5615c4"
+        "sha3_256_hash_of_ciphertext": "b4ddaeac7b4080e5e9bccdd2cbec4395a1393e61e038bedae9542db78769b923",
+        "shared_secret": "b8441852349193321f466ccbd3afa48bafe903288108312de26e9bf0de9f680c"
     },
     {
         "key_generation_seed": "9a86490f0615f3edf789cb0654066e9ee339cc59f968281f3b89213f83c692edfaeb2ef44d2f608621e831187ce79b2d2f4a20f1568bbe76b0d3d5af36111714",
-        "sha3_256_hash_of_public_key": "f69bd52cb1d071f1cc7720f949d44f66f40c917eb30f3a4b0eb519ecad2d03dc",
-        "sha3_256_hash_of_secret_key": "b6ef04e6acbcd1bb072d1cd28412cdb00ee40d04ce5b39442a2efd6756292167",
+        "sha3_256_hash_of_public_key": "149ca4d94813f81c792060502e09a88ea694c5de863ce6a50516cacb1c3f44bc",
+        "sha3_256_hash_of_secret_key": "8e69c68f8a7a0ad82b033a0bdc94d253d3e7e8516d67e86bb95d219a1090529c",
         "encapsulation_seed": "70eb3f791faa91f1f982fa477dbcddeb2c55691c07f93b04cd31b37544c94b42",
-        "sha3_256_hash_of_ciphertext": "d8fac8ffc3d8dfebe66c219f4189b780d5ba8fe28d5ab79264345639740913b0",
-        "shared_secret": "744ce1aa5a9c515c6571ad6e2f5985df8434e35e9f714cf3659f184b5db4086f"
+        "sha3_256_hash_of_ciphertext": "5fbbb17b2c8ecbb8c74f2cf6259404cb9e0cadd393174e49e88298c6b7a34a22",
+        "shared_secret": "9d0d9ba501da1b46775258f5c0904721906b237c3461da6c31d70da8575fac37"
     },
     {
         "key_generation_seed": "6dfd9b575872560c7bdc2732c4a28dac4db04e535eb8e402c3dffd145c09ce47a2985c1c4d203778597947d710dec806e36b0cd949fe460ef141213bfc525e5b",
-        "sha3_256_hash_of_public_key": "10e01965f9c196d2f5f90ce3ce8f552f8a0d76ba8f5345365392febc50560012",
-        "sha3_256_hash_of_secret_key": "2b5c6d5fe9b09ab5a027522e699401223ae9d304ac912f1b15f0f647dd9a0a7f",
+        "sha3_256_hash_of_public_key": "e5c52e639e5acd0fb97c7eb44df56df5250c6de7d171c467ce6887eaa4ee3d61",
+        "sha3_256_hash_of_secret_key": "6b452ca57379b09ea36746b5b55be3b73df4faf809d7899c5368a51eb4b18cab",
         "encapsulation_seed": "30f4095015ba88b6d969672ca3f438c395dacf7d476ea7a9e805ce932d270a13",
-        "sha3_256_hash_of_ciphertext": "e8b01628c7d63f16c59e67352399a760581f341ed41535013490502e884733be",
-        "shared_secret": "726f7d790df4c860a0b2c40de9d62c85d0ff70c704ce5a1b3f6bf1b3e3f66cd8"
+        "sha3_256_hash_of_ciphertext": "9ec7acd421fd05aeb4440720890cb1ebfba0f0ba3d9b57268b583ea10720a32d",
+        "shared_secret": "188aa07faa2b7a19b6b7bfbd4cbb1ad829a7415d601fdc3b635528db136cac52"
     },
     {
         "key_generation_seed": "6fca9f4e384d8418075cc064c70730801bdb8249899d456a77130d5beeb3662cce7683f8a03d3cf04e46970ff7d6a12494ae12558346dfc8fd9370bf944a0102",
-        "sha3_256_hash_of_public_key": "7c3991fa7983d0dd6e7157cfb152538466e9d5c3998a2b8ed862162b91ca851c",
-        "sha3_256_hash_of_secret_key": "72e786018ae9ab8293fa51cb7ca3ff0435e7cccbd5ae02b4680b92c148590265",
+        "sha3_256_hash_of_public_key": "9a350302631bd506be010a3f42112ae4ea731d515d80c3a21fcce60cc4d945ab",
+        "sha3_256_hash_of_secret_key": "985f528fdd675f3efdbe95a03e071f28e2dd16b425c51651a1e645f6b87eb25e",
         "encapsulation_seed": "cf31220f44de862e1719570e1b26e897790159366a385452334fe24cdcae28ba",
-        "sha3_256_hash_of_ciphertext": "5b2e8a3e38c13b53393c8654e92eeb6251ddbe50de4b3c5203a06977491f2fbc",
-        "shared_secret": "68f3e22d1b2d8c57bff32160e550becfce535fdcb327394aabeb60eede263213"
+        "sha3_256_hash_of_ciphertext": "df8cc2e78b5df8a43e7ae87566452a5df656f13f93a22566116a84c30b786f8c",
+        "shared_secret": "70df7eeecb6ad19b54498071e0840f4957e935a62feba82fe29531f79c2c1651"
     },
     {
         "key_generation_seed": "e58f71bf175c0550a67e00e0f7b3b7fc36bc2707bf0c93044a492626de36301a7f7054814869cf7625e45647bc1547aff288dbb90699b2ad84893f3b755d9722",
-        "sha3_256_hash_of_public_key": "8aacd8940ff6fc27f175342be74d48075f8ae9320cae20a41c879c27c1bf815d",
-        "sha3_256_hash_of_secret_key": "f7399dbf35fcc57a9bff87b0087755faa75267788cd0921b9ebc5cde8b656271",
+        "sha3_256_hash_of_public_key": "866573e536b4017c02e31c8ed7455c841a5ccdb795fc200acaf1da2fb936bb59",
+        "sha3_256_hash_of_secret_key": "e8a4ede82799c3a425b82912df460d5d1e78757b4a917177489839abb92029f2",
         "encapsulation_seed": "bb5e65669a44e5d5c709bafa98c16ccba6ac2c4ae923334f69a11543eda64f5d",
-        "sha3_256_hash_of_ciphertext": "aac868f2299bcd272afacf50f1ab0db3d092d33565cffb5645d8b92271e7e893",
-        "shared_secret": "7f6085840a30c6b1fb9dca782e0c78a2264d54726c04c3127956f131165426c8"
+        "sha3_256_hash_of_ciphertext": "99d967e7c92a7d7e2ed54b1339472d8780e0a7671aa9afb8fa2f19cf96353821",
+        "shared_secret": "8baaf439867c9761e78a64652a383e21682969d18f84dbae0d3a63095948863d"
     },
     {
         "key_generation_seed": "e3fc575ed51513e62aba655d24cd9c8f1c6c848aaffa946c49a53ac3ea59e474d82c2f1bf2e6aebde5660fa73356982e12999d8fdafbb3cb186341d0386dead0",
-        "sha3_256_hash_of_public_key": "149e0b6b49fe8adba1217c2c57c83f2b8c5f1d92f319e502b184a65869214f75",
-        "sha3_256_hash_of_secret_key": "6dfa4d29af6a0e8413d5591339c15d2e2cfac3f502f49acca3efb53b53624666",
+        "sha3_256_hash_of_public_key": "b33387825115cba8b0ae7da0d1aada1ce4ab05bc2479b360b6c56dfa870ca825",
+        "sha3_256_hash_of_secret_key": "7c35640775e31eaba8a119a8e89e1e2180177a55e54391c3fa6675829d721b01",
         "encapsulation_seed": "9ddb3aa9c7905d1a438c93bcf78e3e321813580371ab4e1289e2dbf3701972c2",
-        "sha3_256_hash_of_ciphertext": "ced7a64ce643faebac8ffd39c6a4594732b35f1d6899978ba192b87003d3ad27",
-        "shared_secret": "96e30641ea4280168da37291a3063342ced8e77b33b5415819938c0bd7264ffc"
+        "sha3_256_hash_of_ciphertext": "d42759ad66725175d4d8d3cb6519e9074d6c13d4d183863f1695f0e3b831a10a",
+        "shared_secret": "60b466221ec831f91a91b76ec6bbc29726f65ebcacc96f9e191f57a1399be186"
     },
     {
         "key_generation_seed": "470b4943f0fe7fd0d8ec5185aba0d1db09d112934e4fb4787e2bbc6b88466e7b8b2809fd40008be70a6b184981101724bc3d5ec5e1956b510b82fd5ad0668a5a",
-        "sha3_256_hash_of_public_key": "29b1bff7f12eda28dfedfbf0ac16e27008c9fdc62c35e53b28a312bdc91c40bf",
-        "sha3_256_hash_of_secret_key": "762a61eb847c017ece920f51d5da7a9036ed8b835bfd7793527321ec635e2fd0",
+        "sha3_256_hash_of_public_key": "720fd4f96ab2cac1be382907e8cba0702018ca27b28ea8f93cc19c4809885a3b",
+        "sha3_256_hash_of_secret_key": "c1ec32b739485e2437a6b4dbed289f0cb7dea0ed3b2add99d4c49a3eeda1b0fe",
         "encapsulation_seed": "26d90b190a6c3d0d9a86cf66005154e7086749e966e7187c249ccb9329fd3b8b",
-        "sha3_256_hash_of_ciphertext": "bf49310a35f9ba7994645f12949e658b0dd43d3de76386dc20d08c650522f86c",
-        "shared_secret": "47e54c85cc0e2503629a8bfdcfe038c3cf692d723d462bab733c7c8e0aa37b02"
+        "sha3_256_hash_of_ciphertext": "5fae7a10471d5303e5f6ee5d1e34013528af4945de811ffa1828648986607299",
+        "shared_secret": "6a302778f406082fa285c5ee299d78b048e837c5012f42f9a80e8659b10defda"
     },
     {
         "key_generation_seed": "6df4385db978d27b27d2aa5e452e4152b36f097503d9581ac3390105c5727e7dc95fa08ed106ce84660e8a4c90bd2b22634e40769aa0090a101c5dddad45edc5",
-        "sha3_256_hash_of_public_key": "b990059e901097d00e0ebaf40c5d5dab009c66798489d357e760478ce884cce5",
-        "sha3_256_hash_of_secret_key": "37a044795bd330e4dc60a6d84bc6e99664d1be418b0239661d2ff16d1501573f",
+        "sha3_256_hash_of_public_key": "bfa4b55c7baf2651415d3f28d221b291b175340a07843b299a46e02e22657634",
+        "sha3_256_hash_of_secret_key": "605c4a98f3775c9678804fd5795946c1657311d123b5c7d1544192a205c043d3",
         "encapsulation_seed": "7db6d1a129d6123f1f805b79ad3b413012ea86aed42a05e98e7b1f32f9fbbdec",
-        "sha3_256_hash_of_ciphertext": "329115908d0763110a387c99778e4746861e80367ee90fd821cda9acdb93fd64",
-        "shared_secret": "8569bd042465a2c4af628425cb102b15ed4f5feee16090e2234f3a884a0fa938"
+        "sha3_256_hash_of_ciphertext": "39e07846b4ca91147a0b680f5411c75db937a6855f08939f746ea3d5f9a11d51",
+        "shared_secret": "88a46d35cf07e48c6528b95016aa0c414344e090ee897fd80f26b67bc0451c7f"
     },
     {
         "key_generation_seed": "dbacba825728444921b227cdba54446b3f6881b47be9cd02832f78b023b1bee0e15274a8e2bc08fe818b117ba28c5dfae74d54fcdf6f20052f79be333edc8dde",
-        "sha3_256_hash_of_public_key": "175eb63c3144108548720ce7ee0f43a9ff3f52a9924efe9f2f59318bb93c86b5",
-        "sha3_256_hash_of_secret_key": "1993d7639b79f5e4871a7c58a69fec50f96c1424c2c0ee030ac054ae1b88a56f",
+        "sha3_256_hash_of_public_key": "9675fc6d1e3cc4e0eb62d31b6b4f10022d373d2718f3d20ee1cc00ef6892d9a0",
+        "sha3_256_hash_of_secret_key": "c463b8ab9069814e5308cf9742c6ab6e08c355fa34c0d2e65df1962589eba56e",
         "encapsulation_seed": "1d129b27be7384c359d04311fe5c44917d1fde4bfb57314f483ac617edd5ac49",
-        "sha3_256_hash_of_ciphertext": "8f4225838f2964a986336bacddc40836a98c32cca68c6afcbcf9ef68d9a3760b",
-        "shared_secret": "c184e0b019c2db772e2c1ca6f97f47478d99cf0c4c5ae1406f51d15815022123"
+        "sha3_256_hash_of_ciphertext": "5c7ef87c49f71d3098fe3d33b22bc8191f440bcdf1d04a46f293c5e6b16af12f",
+        "shared_secret": "f3c5586476f4814a2d3728a6f0ceed7d19d076b790d3675e48611c4b8df9702e"
     },
     {
         "key_generation_seed": "690eb71fd7052b906eaec09937a8ed374e0b02afa27c2f14399932be5839fad281c38c2cb5cfafac81b96a810ab749b61806b6d54c9f8cf4bf1be0192423288f",
-        "sha3_256_hash_of_public_key": "9bc32a138a2fb5b6072464172abe0fd97e9eabf357c3fa5391d94a415b53abd3",
-        "sha3_256_hash_of_secret_key": "3db4ab1393cfc8b1c708cf8efdb1c443c975878898b60182c22af66375cba13a",
+        "sha3_256_hash_of_public_key": "9d162fce2f019205a2106acc8e3e3465b6fa3912a06c764e625cbe3b95dea6c8",
+        "sha3_256_hash_of_secret_key": "eeb3bd9d8636b55722f42b3342e415b23df96d1c9b2c5b9c1c2a3e619348ba6f",
         "encapsulation_seed": "bbc773ebd2df42c36ae05952d6a64c63a5dfb82ceb3ef4f8d4df3a30ec8c0467",
-        "sha3_256_hash_of_ciphertext": "f1c85f9530d4471eb1401fcf422a29533738c485a6be25f0b554ebf40b49d49d",
-        "shared_secret": "6d72e23c8a4cc60b2f14adc788a5c480033bbf6eb111070912bc83ad7b89280b"
+        "sha3_256_hash_of_ciphertext": "d482f25e93fd142aa009f2f2569427ebcf04b87aca2bef5e022bcbc1e5972ed1",
+        "shared_secret": "a828fc1446ff04a950e4f551e442aeba279f44de0ec5296fd981bcbe6ee90d8e"
     },
     {
         "key_generation_seed": "32e0ea9089fa928482c0770da545af1bb871a03ce38604138b0d08ea2a10ca2bc06c5bef7b6508409daf847a64c8d30d0974fd3ba7476dc76c46b458a036d884",
-        "sha3_256_hash_of_public_key": "7ef43a72ef04766f1e899d25c9a005009c788b5faf985123cfb3fb97975de26d",
-        "sha3_256_hash_of_secret_key": "77431cb18010a604d56fe5a623bed2ffd028a741f176fa09546e9a45a48caa5e",
+        "sha3_256_hash_of_public_key": "3e834e34f198ab5a3504cfa0c6af6ab78de3a3ef5667e6065e084cf5d2a5bb32",
+        "sha3_256_hash_of_secret_key": "d74767e217cfaaf75adc92927107c76d7267b1d7b3b76f2f8ae5a9044aa290f2",
         "encapsulation_seed": "5b17a6adad541efcbf5ae4b0c0452cd2ce32e4f0f8701801c5b63e197c1fcbf4",
-        "sha3_256_hash_of_ciphertext": "83ddab2e25614544649a1e497b5b21c40a3e154e8a22c270f63cb0c40aa868fd",
-        "shared_secret": "29e6b1edac0a9aa33066c113167e42c64d70215ed04963d8be2d4c2dcd0f6589"
+        "sha3_256_hash_of_ciphertext": "3a41b6054d918e9613e8d4eab83628f7c82b6ef447ecdacd0a74cc21be6b47aa",
+        "shared_secret": "d98b18f7b6717b8f6b3e331d6d8f9d3633eb70f54133a78e2345138420edf89d"
     },
     {
         "key_generation_seed": "6fb2ec719f2a0dea152bf3f64b9d148f8ab8ba88f64e61f5db53e12d59f525574f797c007e4061f95c7d56cfc7ee5c49e849dde3fea8f25e7876df2a18515c34",
-        "sha3_256_hash_of_public_key": "2c0db43f39b672b2cd912f907cf76a0f6fda925eb2d205546431be0b37b20411",
-        "sha3_256_hash_of_secret_key": "09844e203f4d8fa30728ab388b9d654847febbf5c9cd939cdc11c9c9be24ce9c",
+        "sha3_256_hash_of_public_key": "c5e157ff4357d3c26b7c4b45315f0689f135c85d952a64648b0a8cec03741fe0",
+        "sha3_256_hash_of_secret_key": "edc6b8e2036f9ce7ef87dc58d4866ad9f320ffab1aa22371b7b56ec727f77531",
         "encapsulation_seed": "61ab87659525de9656af41246f20e1dbe85c24e335e7ecf9493f46168bc14e94",
-        "sha3_256_hash_of_ciphertext": "a2108ea2c446b566a50c228928893e2e4bde5fafb2184af92eb1314113bde0d6",
-        "shared_secret": "cfd1b82181543656807880f6e2576f0b095bf84629b3367e9bdede24662ee42e"
+        "sha3_256_hash_of_ciphertext": "7324a073d06af373494ecfc7960cfb81484e9ae64bc16e13651b015cdfb73668",
+        "shared_secret": "b7d5919f0bab0e2715a97cab993656831bc8a3dc86c3bd32e64ccb4762f70499"
     },
     {
         "key_generation_seed": "527fb88c8bd9a4d6031dad15e63878abd2b559e7e08d61f69e8e78fca964ee6ae32d432b4f9f751bde0496c580a181ffed762aa35454a02d3f1f47ee0394c89c",
-        "sha3_256_hash_of_public_key": "aae8e61b905723fa092fb95b839f6de3670c39ce0498c27b87d20c24e7f64e22",
-        "sha3_256_hash_of_secret_key": "3880f7ca8fc33575a7a6d8bb46fec86a3f12e0068630507ed245d8bc278fbe5d",
+        "sha3_256_hash_of_public_key": "f5cedd022077b1a6a052f5287219393cd2e0366d0f5531b2f7ea8704d2900ce5",
+        "sha3_256_hash_of_secret_key": "882916ad7b7707feae2885f13bdf19d36931886c4bfd188fd46b6b6adeeb8d78",
         "encapsulation_seed": "eca2adc3da1fb15f34033405ec08ef2f46163df4bfcccf8842c600ce0bc2026c",
-        "sha3_256_hash_of_ciphertext": "ec48b3ec403609a0ce2d1268cadda8184ab9629cc5913135ffdecd420eed1aa9",
-        "shared_secret": "f7331b0a4674969838482b7184fa92e5246f11f5b5e284c3e179effff7eb6329"
+        "sha3_256_hash_of_ciphertext": "84e4fab74ef96f7b3ec50d7afdf69445b4326fe3ad695efcbf56426c0a6df6c8",
+        "shared_secret": "149e4e38a07d18c0b08edf9c47e425b56f7da87b2b9c855bedd29f6f0a8fe5fa"
     },
     {
         "key_generation_seed": "ac6fcfaeeef795b6ef9e062f02bf42975fa01e7d91ba832f74e05269a72684d05aeda108ea4d6c6bc0fb958286850422bc357ca67b83c986048e0d0087fa11ec",
-        "sha3_256_hash_of_public_key": "64e085f67e48f00a7a7f82963e8c67176bff839a54fa1008328c0612f98d83d3",
-        "sha3_256_hash_of_secret_key": "0bfbc25d9df751f4c30907095eb6d9a75ed07fa23218ad0fffc469f0e55553c2",
+        "sha3_256_hash_of_public_key": "a53a20ea03e400a843c8cf4d04bfe0c0a3ce63dde01045e2669f7ae5da790577",
+        "sha3_256_hash_of_secret_key": "9d1e4432908352535074efbfa7cde3e6738e073fd512e04e9601380fb40b7614",
         "encapsulation_seed": "c4f15bec2d7701339d0ade4835193bea3632edcf89e74992620d9eb623a0d0d4",
-        "sha3_256_hash_of_ciphertext": "fb74b727ad120c18915dca475f3082cd34ded7ae20a308106384ffb5caa029d3",
-        "shared_secret": "c89d62938a5caabfd5b30d82ea88aced52ef5f8ec0528e59a654e1f6aff1cc2f"
+        "sha3_256_hash_of_ciphertext": "071204e26ed00e7a1f226d4e971cfb2d9502e17da99f5479235763cb7723ac5d",
+        "shared_secret": "38a1fcaf302905e18940605e49e5f44c747b06e789acc9c395211823598ef516"
     },
     {
         "key_generation_seed": "ba2fb9318d4dbe7488057c33e95e6f054583a2800c41bb83083c330a914a12cfe63f8ffda3565c2424c89b20974b748a65a5aba75133fcb3156dfb6626a83bab",
-        "sha3_256_hash_of_public_key": "8dab879de09b58d0fc7ade140393ffb5343abbddabdc118fad519b14436a964c",
-        "sha3_256_hash_of_secret_key": "7c53072fd98ea7bd8c5e873688b1a5650fe7e11c791407ac8c118b7958cf414b",
+        "sha3_256_hash_of_public_key": "cacca228846450ebb8f04a2a5ef2d919dfa47c4aa265f4cedd10cf74eef3ecc1",
+        "sha3_256_hash_of_secret_key": "a01db77c5983b2472e616dfc04666a2112924dda5ffbf00a989cf1a48578898b",
         "encapsulation_seed": "28878249e2ac2b6263422993923a0c8bd05ce56e385ed13c943b03d226856947",
-        "sha3_256_hash_of_ciphertext": "a1f1579c4ce8eb725e697623321b3d9f55f4b1d0def10b898535ef6614e9923e",
-        "shared_secret": "204d9272682710b52fb39b1176af3ff737848978770310df0c67996f6cb596c3"
+        "sha3_256_hash_of_ciphertext": "dd0b438cb7dcda28762d06e61f1765baef8003d0d86ff48cd4f9788cae8e8618",
+        "shared_secret": "403543b0f8e519ba4ab878c40ab5aed412ea06bfeb2b864baa5ef4b81a42c454"
     },
     {
         "key_generation_seed": "aa6dd1e5799cdf7af9c4fc632b3eb9d51d66e85c8e0a21ec98664fc51ab63c7dfda268813efab5204efa60f78bf81d320d01ac09ac06244f7afbd2d80fd356d9",
-        "sha3_256_hash_of_public_key": "919a696301240cd6129f66be58e19d99b0d827d9932785cd9ea3d92f7ba54463",
-        "sha3_256_hash_of_secret_key": "cb1d7301f15951883cc3f287d4dd8fdf5c9b7022f558dff551c2ade5f5065755",
+        "sha3_256_hash_of_public_key": "4126f5151d1b086e26a88bd9f20710ef06aa0f834722b801f6b79c031f1f9213",
+        "sha3_256_hash_of_secret_key": "9a6c24b5ae556241f3e6b07a7576971173ecfe474be9c6b09fd12ddef8b5f75e",
         "encapsulation_seed": "17fc65f7fbd7c75ceec421dee84dff5a8cb22764a182db17e0ebe857f54d60eb",
-        "sha3_256_hash_of_ciphertext": "f02654803493821dd9c2ed23f9e46a36addd5fca0da706bbeeda87a2df9fec4f",
-        "shared_secret": "76e5f7623e3e867fd12f28dfda4311f7cd90a405b73e994e857f693573fd2b8a"
+        "sha3_256_hash_of_ciphertext": "7c2b9cd82c349fdc534ac30eaa18bf83afd0736b17a4320963571c109451a5b6",
+        "shared_secret": "f7a280462f93b619888b5a72da3749556e53ef4f4440df728c8db1edcc86cea4"
     },
     {
         "key_generation_seed": "195d6c86a3df4c21e3007d7f2768b43c74cb3060e0eca77f0a5d3271542b9a84ae77e0f9f21eabd8c0c6eea7767f4e10fde5c2d79b8400bf96b19014b457ec21",
-        "sha3_256_hash_of_public_key": "cb6d7232426bdbdfdacd373c9190722e7bf342825f7d829185dcc9120588fc76",
-        "sha3_256_hash_of_secret_key": "a85e24cc2eafdfe40d82f46471112e1359628b9955f3feae9955b48d563ac952",
+        "sha3_256_hash_of_public_key": "b6f12914ed31f14f79c652eed4db478de7ebd263fe27052509fee10b50f2d053",
+        "sha3_256_hash_of_secret_key": "1a4de442c4c6db97bfa12227c4423237a869c93154e2c5ca49cacbd0ef730485",
         "encapsulation_seed": "fa0489f3730100609488e951e6aaa15c0f193bc1dbcfcd013bc418d6c507b176",
-        "sha3_256_hash_of_ciphertext": "17336b9ede3a1c26abe725828a5afbe746035a73dfd4a8fbde5040fbabeb2b8d",
-        "shared_secret": "874ac966970f29935db73c231e71a3559b2504e5446151b99c199276617b3824"
+        "sha3_256_hash_of_ciphertext": "41d75dd4690637576652071cb46987cc26321a07bb47a1cfb07f30d2153920c5",
+        "shared_secret": "fef3730b905431d14aa7aa7bb1d253cd912335c590b8d7de1e7aa4e0ff76be04"
     }
 ]

--- a/libcrux-ml-kem/tests/kats/nistkats_mlkem_ipd_1024.json
+++ b/libcrux-ml-kem/tests/kats/nistkats_mlkem_ipd_1024.json
@@ -1,0 +1,802 @@
+[
+    {
+        "key_generation_seed": "7c9935a0b07694aa0c6d10e4db6b1add2fd81a25ccb148032dcd739936737f2d8626ed79d451140800e03b59b956f8210e556067407d13dc90fa9e8b872bfb8f",
+        "sha3_256_hash_of_public_key": "8a39e87d531f3527c207edcc1db7faddcf9628391879b335c707839a0db051a8",
+        "sha3_256_hash_of_secret_key": "ed1f6cb687c37931ea2aa80d9c956f277a9df532649661035c6e2f9872132638",
+        "encapsulation_seed": "147c03f7a5bebba406c8fae1874d7f13c80efe79a3a9a874cc09fe76f6997615",
+        "sha3_256_hash_of_ciphertext": "5ef5d180bf8d4493ef8e8ddc23c22e428840c362a05a25fd306c6c528bd90f8c",
+        "shared_secret": "63a1039074f01f2651213ad9350d6561cb03a60400e74118bb4464d87b9db205"
+    },
+    {
+        "key_generation_seed": "d60b93492a1d8c1c7ba6fc0b733137f3406cee8110a93f170e7a78658af326d9003271531cf27285b8721ed5cb46853043b346a66cba6cf765f1b0eaa40bf672",
+        "sha3_256_hash_of_public_key": "c9ede13be3dbb0edc3ab08226cae11771ff4c0b04a564b64a0d9ff10e373e986",
+        "sha3_256_hash_of_secret_key": "9b5876610793ae42f683d94f736d8d7e0e033bee588bab07a31c9cdb4ab99a5d",
+        "encapsulation_seed": "cde797df8ce67231f6c5d15811843e01eb2ab84c7490931240822adbddd72046",
+        "sha3_256_hash_of_ciphertext": "bef440cb5a14bfa652ff69fc431b59980147a2408df8a893f0fafded11d6cfa3",
+        "shared_secret": "856d56ee09279a13f9abdca14ecbe8ca9968495f09a0758b6d1c8376099365eb"
+    },
+    {
+        "key_generation_seed": "4b622de1350119c45a9f2e2ef3dc5df50a759d138cdfbd64c81cc7cc2f513345e82fcc97ca60ccb27bf6938c975658aeb8b4d37cffbde25d97e561f36c219ade",
+        "sha3_256_hash_of_public_key": "ff2546623aee72025fb6746fba736bae0e80e257e66edbf09d8d4dc11049cda4",
+        "sha3_256_hash_of_secret_key": "57155298b53d3af5d6db214dfa91a9e16f8d5de570bbff5dba5f4cd84098f255",
+        "encapsulation_seed": "f43f68fbd694f0a6d307297110ecd4739876489fdf07eb9b03364e2ed0ff96e9",
+        "sha3_256_hash_of_ciphertext": "28e308a6f91068b01a7065b8579fcb6234ecd9bb8d3172b6dfc5a3a470050ea7",
+        "shared_secret": "c33a4432cc441b7683605c29afdecc81922cf234e02be8c2fbc4e2a7a3b4b078"
+    },
+    {
+        "key_generation_seed": "050d58f9f757edc1e8180e3808b806f5bbb3586db3470b069826d1bb9a4efc2cde950541fd53a8a47aaa8cdfe80d928262a5ef7f8129ec3ef92f78d7cc32ef60",
+        "sha3_256_hash_of_public_key": "25b786a67de17d61b2fc0e85a13924398aab931896b6174089569f08b7260687",
+        "sha3_256_hash_of_secret_key": "d188a2637dfe80dbd0fc25165eb4898923888a82c10f6ff0b8ddb5bf251c0650",
+        "encapsulation_seed": "ea74fbc3c546500ed684bed6fe3c496d3b86d2d6dfaf223969b942e9a8c95e85",
+        "sha3_256_hash_of_ciphertext": "8427a1684769e63ec43e97ecbe7b7e654b6e63433bccd23340849904e02767dd",
+        "shared_secret": "7c14fb353ba421705de44f2a12ddc5ad9b11e30e7b0e163cebebe2da79a7293f"
+    },
+    {
+        "key_generation_seed": "66b79b844e0c2adad694e0478661ac46fe6b6001f6a71ff8e2f034b1fd8833d3be2d3c64d38269a1ee8660b9a2beaeb9f5ac022e8f0a357feebfd13b06813854",
+        "sha3_256_hash_of_public_key": "d35e259a200d16048302df38d8e7f9e1c3352502c43f086fe166325048fdce9c",
+        "sha3_256_hash_of_secret_key": "020ba30e5832867a6db83cdb1e60ddf0b0a88fb33919edb84b246a345d11da6c",
+        "encapsulation_seed": "64efa87a12cb96f98b9b81a7e5128a959c74e5332aaab0444fca7b4a5e5e0216",
+        "sha3_256_hash_of_ciphertext": "b52dc0a41015132b3e7a1ae6f544f12601869bf0673625964e5c4e05cbe656e0",
+        "shared_secret": "35d2a2ab0e91d365a3e2e99bbe3f5121f2eeb528305cc7730f679e10ec1c9b8a"
+    },
+    {
+        "key_generation_seed": "7ec408f52c9aa723d0c41d9987682a5f4ce6c9da7cd0215af60bbaf5484ab353a08ccf451b049fd51d7a9ad77ae14a81569df8c9bd3a8f1ebea86fdcfb823082",
+        "sha3_256_hash_of_public_key": "5a5db7d619be642bd87294527b3f859372b279a1e6074824d9632b5d7f616e42",
+        "sha3_256_hash_of_secret_key": "630f093cb1ff96bff76ede70e970a009a9e5d28fed660e68127d31c3b6dbdb2a",
+        "encapsulation_seed": "8a95d71228acaa5f9ae6f9d9ca8ae55fde296463b41083a39e833e37c4c90f88",
+        "sha3_256_hash_of_ciphertext": "4714a5497351399718258f490da0ce28ce8211aad6975546cb4351c8ebe61917",
+        "shared_secret": "8084cfff3d54b7680e737ed71c37e449f1f9d74bf6735696c46910b13d42d1f1"
+    },
+    {
+        "key_generation_seed": "c121915bfef6abdfc177dae2f5a24218f9abda2559afc6741b08e0e61ab433eb84ef52db5eaa6df8ec3a0bc5ffa730db0dde8c5f38f266d5c680a78d264a7b96",
+        "sha3_256_hash_of_public_key": "f0d1acd4fe1bd3bad938c23ec5a7f320766e01005e32769724abb4ebac578def",
+        "sha3_256_hash_of_secret_key": "664f3632f56ebc5c509931ff3b7e1845265e42a76e20550b683527d7d24e8df8",
+        "encapsulation_seed": "90d79d75d0bbb8921cf70d46bab497022a8e750efdc99e5f1bae653275441c7b",
+        "sha3_256_hash_of_ciphertext": "4ebd3e44b82b03c01ec2aa9e8805e53b8c8022e987fc9eca59c9a5cfcb1c4a84",
+        "shared_secret": "3e94b68a80291e957f9dd0a15b112ad75bfa07951ccb36c2de610e6755a4a0d6"
+    },
+    {
+        "key_generation_seed": "d86634ecf96cc2603761e284c0e36734cedec64e7ff486469e38539c71141c5a99daf37400cfe59841afc412ec97f2929dc84a6f3c36f378ee84ce3e46cd1209",
+        "sha3_256_hash_of_public_key": "7008db565f7ab9c362dc38dcd3e30e5da873c559e9a9222710e8d2e7f6417ce6",
+        "sha3_256_hash_of_secret_key": "9e774cb57c18575de3ec6a9677e40626c2026e47c389c7a3dc5422d8a83b747b",
+        "encapsulation_seed": "be8a32f97b9a8d596382c02fa2a0eeebc15c083e970ddaa4f2622b91d6718663",
+        "sha3_256_hash_of_ciphertext": "1cb3879c49c65c184d605bc6daa22f63affd2a005e145103e6c1ac1ad683d976",
+        "shared_secret": "900649130f9c28082eab5ce3d128593eeaae89667d7fa4da23fcdfc1573995fa"
+    },
+    {
+        "key_generation_seed": "0610678ff4dc3128e1619f915dc192c220f8fad94da1943b90aaec401683a492da1804ddb5aa9b1c6a47a98f8505a49bae2affde5fe75e69e828e546a6771004",
+        "sha3_256_hash_of_public_key": "143b9c53320cdb1b7e8d71efd1f0a1ad5ad1e1ce84dd9fe7c92f19c926388e3c",
+        "sha3_256_hash_of_secret_key": "63707e33c30114732374ac21fd5be61e6dfa7dd85a36eef2e2bae6b3d0599a71",
+        "encapsulation_seed": "da2cfaf69e25b2a89ff2557bbb6f69e01d8e2e7bb27a7a1ce7e40fead16f33b2",
+        "sha3_256_hash_of_ciphertext": "780162548f2d85c00f0276f1db2d6566421cf718679147740d279660fb742544",
+        "shared_secret": "084aafffcc38ac80dfc02548df07f6e7809eb0644385abce0fc569821a907011"
+    },
+    {
+        "key_generation_seed": "d322d56d8ef067ba1f24c92492b9c56df3a6ef54a304adc1b69913766a1ce69756047447b810cc094d400ab204cf9ae71e3afa68b88586ecb6498c68ac0e51b9",
+        "sha3_256_hash_of_public_key": "f2d009cde4abd55a2c7417c9341792e60eaa8e26b53a3aae805746401c4c446f",
+        "sha3_256_hash_of_secret_key": "2a53faa8053fa21b7b07a96ea259c052ef78746c5d53e2857e9f30bd20d3f2b6",
+        "encapsulation_seed": "511c2ab40782322c06111e144e505328c4e5bfc890a5980a2bbc44aeda4c738b",
+        "sha3_256_hash_of_ciphertext": "9b7ead45e0e00c615fce96105720d82ba431692f92e1a73e14b490219c8dda2b",
+        "shared_secret": "a7fd777a337219e1d0ad2cdb47fa18f4685ac343bc537dba6c97326340ab3ebb"
+    },
+    {
+        "key_generation_seed": "2f1d8a3bebb34540324b9485fdf3d5be3b858f544abc3fc641b5728cafab03ba8d6c42e7270ee2b77b6045385f3d175984a0e260363166c73b0c70c971644363",
+        "sha3_256_hash_of_public_key": "1f06190bdfd692cf499be99bacc4beccf048c89926769f1b254cca9a9a44089a",
+        "sha3_256_hash_of_secret_key": "faa641eaff01077bd2fc261ccb91d5c3b468a940e25e8d5d794d564b663315c3",
+        "encapsulation_seed": "dca92dbec9b260dd97e8886f876862d6effc3b91fcf3fbc986cf56ab93ae79a2",
+        "sha3_256_hash_of_ciphertext": "3a22350624e9ffcfeaf0a68c265dc03036e7d5bdbb102474fd2aed257fce04ed",
+        "shared_secret": "17672805d3953f1f374dc8671137dabb0136de43700fea82a2ca23292bd0d562"
+    },
+    {
+        "key_generation_seed": "31beda3462627f601cbc56f3ddf4424e1529c04737ef0ef2af6d7401f653b8a1812083bfa3b670e3eaf9b443702fb6db16ac1197656bbd61a8e25ed523b8d1e5",
+        "sha3_256_hash_of_public_key": "cc20155074cd7cbd43ec2380dc6a71b3a88c9a4bf168ab2bf426a899706fa597",
+        "sha3_256_hash_of_secret_key": "6084f1eb2fe4b9055d6004bfccadad7bd64f623595dd0b5e0c0100d647313279",
+        "encapsulation_seed": "57c170e691d7a914a901b9a11c62b8b569b3806427557a9dbac9faa720ec3641",
+        "sha3_256_hash_of_ciphertext": "43291afa9c1a8098770d5ed9dd4cd71688c52d616e9e68798f8718e4555e0caa",
+        "shared_secret": "8813fdb7bcec5369e6238322be653d920ba26e0aa63a3c3b4e4218c48c1d6dfb"
+    },
+    {
+        "key_generation_seed": "cbdff028766d558af4466ef14043a1a9cf765f7748c63cc09dceb59ab39a4e4d8e9a30597e4b52ffa87a54b83c91d12a5e9c2cd90fcac2c11b3a348240411a4c",
+        "sha3_256_hash_of_public_key": "77fbe004761fc37fe7597638e5dae8b44bd44c8d6efa2893a0a84b104ace6ac4",
+        "sha3_256_hash_of_secret_key": "608099f3fa437094212b3aa2696d592a9ba45f697b9c1020b69ec1d6e178b76c",
+        "encapsulation_seed": "6b5a14e1473abf5a33d44975ca2088bd8fa6fddcb3f80e8fd5c45b9d90c24a5c",
+        "sha3_256_hash_of_ciphertext": "368fcbdfa009642b3ca8fe0261d10d18db5566bc43938e193d9dae45adf2d41e",
+        "shared_secret": "b00167b499d5130ef82a91f83d1f1563185de735e74f89afea0b45ae1b90cea8"
+    },
+    {
+        "key_generation_seed": "4c04310bea66305c6ca8ba6b8f61ca96257a67663afc11761f13fb5c7b324b6b8aec87a9a79204cee2986867a2906eb851b734b8b22b91d6749b1a5f07c44e3b",
+        "sha3_256_hash_of_public_key": "49cbe8daa7dac02d7795e907b037e2ae56624fdc8d7c6320f9e1e69dd0f6286f",
+        "sha3_256_hash_of_secret_key": "de7838a99458b56d0f1de343315d1a7d460269ded85551f70335b1e002742b5f",
+        "encapsulation_seed": "40e593754e6eddb7f9cf176ba2d5fd1087c90ad377556d0b0f686537b1a3165e",
+        "sha3_256_hash_of_ciphertext": "04c5a66da97cec8a22bca38de71927b176310004175b3496c5a2737e91b18e00",
+        "shared_secret": "c55179382eb5d4bbd91e45f4b3dcc5d1022110aa209c002600fe0d55a5b3333d"
+    },
+    {
+        "key_generation_seed": "38a0d5f41d7dc1896efd1b45b0485634cef149828751b96087a0a6dd81b4d58aa2acf359556df4a2abaeb9dcee945829beb71185b4d6bd18b76e5668f253383a",
+        "sha3_256_hash_of_public_key": "a333d474be9bacbea4c301148be2ddf13c3c25d7e4f52447a549a27b6d12710d",
+        "sha3_256_hash_of_secret_key": "731e7c1597fcea477249114301154b9fda1050e71617827da0c9cc149c1cb99b",
+        "encapsulation_seed": "c152523abd8248bed40c3827bcf0f8e8127037a55c780695e2c28ea3e041a44c",
+        "sha3_256_hash_of_ciphertext": "841415e768ab08549533578cdb506a9f72e8d01b472b64746322328c0c035080",
+        "shared_secret": "91c0a23c78351e8f8de8e38c5a10e41e5290ef96266f93839169c05842820e41"
+    },
+    {
+        "key_generation_seed": "97b5665676e59e3538ebadaa8cd50df1f9fda1502d9894c616a946078e56b621df05318b5f655efe36f1b678cf4b875108a18db2fa312261caf839f84bd956c5",
+        "sha3_256_hash_of_public_key": "35d109f57ea2764642ea3473a4f192cedfbe153a37f131cdf447b60e92310eea",
+        "sha3_256_hash_of_secret_key": "0420ee0853629da644872d3e2a9b0a89c9dece1a6748247d2f8f39721af21e12",
+        "encapsulation_seed": "ad6466dd59f26b762fb02b19eedf5f79964da68bce0459b91c3a6ee5a7e01183",
+        "sha3_256_hash_of_ciphertext": "82c120326a2ab109d5c3910a95ec69dc3b1c1c05570728164791870d9c9c1a3f",
+        "shared_secret": "ffd93f9141d4b2abf600c1c258ee78e0f752513bb002677221060cca3ff1e5a6"
+    },
+    {
+        "key_generation_seed": "ef99224a03a85a46ef115474ec5b5d620da6795d6efcca4c9135d19958a9de62df7d92dda83e6b2ef4cce08c9134563063068a196d7b1a1a13623e48ae12528e",
+        "sha3_256_hash_of_public_key": "cd65fd07a78e48c1a02e235ec76fdb509cf9903a4f5a850c51d9d3fda383cc67",
+        "sha3_256_hash_of_secret_key": "951cf21e37dcba710b581e49a6df1c75c65186e9672d647e9cd7239eb4bb975d",
+        "encapsulation_seed": "1a4d5dff5847cfb48333e33bb00ca7301b144aa89dcd412ff5a3b1081d775b7f",
+        "sha3_256_hash_of_ciphertext": "0217f113b6d5786c3995b366adff6984d0c8d91a388f798a9556d7d3a8252b9c",
+        "shared_secret": "550b4e8c00bb5ece74059879fd14f5a0a89073d8a54f8bf1597f1ebf198a61fc"
+    },
+    {
+        "key_generation_seed": "b12f6fd965ea9c5b947db80fc60c83d5e232dca82e7263027c19bd62e5a6ff550f6aa3e88f7fa8a96067f8cdaeceeac90c2d0b5e277e56e9c405ec9420c30252",
+        "sha3_256_hash_of_public_key": "376f022313718aba325ef4c3b720e2c3ab314ace74e983948ba2e43ee3a6ebde",
+        "sha3_256_hash_of_secret_key": "e697899409d15ce13113a2ad86448157a248ff0701b40eec11fb4afac7b9f2fe",
+        "encapsulation_seed": "34f44ec2092eeaf686f2ea170591a98527cbb03a4fa9477a7aef6b41a54feeb2",
+        "sha3_256_hash_of_ciphertext": "26c5a91a627899cf23122c5881bd00b0a4f76e0aaf5de60d1d273e8e635b574e",
+        "shared_secret": "e5b98a3c32a5563c49df725e661a9f44a20390cf83a9779ecf5e7d9f5aff0143"
+    },
+    {
+        "key_generation_seed": "9f52af92ca165fdc38788f2b59ba02e01c8281ff7c1e60504688043a5fe814b04f3029e1be4e1c0258c3a22ff5b50b2674cc094ba7018da2a61569845c17d26f",
+        "sha3_256_hash_of_public_key": "7944e5d79dabf7b7259df5ced02669c81b7dc4590e0b10764729d812f6bd85d7",
+        "sha3_256_hash_of_secret_key": "301fb18a9ec0d975414abc4d41ed0c553e2b9aa2b03bf2765476e3288f760ee7",
+        "encapsulation_seed": "6250c81126572eec2da330271db36ee591f060fc7e53eeefe2e1c476c675fa33",
+        "sha3_256_hash_of_ciphertext": "c7474d6b8d9b3677b39b69030f40415e2234e637e200c689f90d6b37da3c4a8d",
+        "shared_secret": "169929e655f214d7ddca31eae7ecd2e01d9ee0601fd4a2c3a59eb701ed9522ab"
+    },
+    {
+        "key_generation_seed": "851ea90fd3854cbf28fe39fb81f68e4b14345cf0d6eee7ec4ce772513df8410d1c0ec046899a777655233e4e1b5ca44e9afbdc67964bfd5d5e3dbb45e60d03cf",
+        "sha3_256_hash_of_public_key": "692176b38737a053dce0551b63e3eca81884bbf95e1d8975671a2f7f1dfae251",
+        "sha3_256_hash_of_secret_key": "1ae55a55d87ea8d58b51f842c7d6990a1ae6932eccf5c39e97f56bb481a16b7d",
+        "encapsulation_seed": "35d470bcc5880872754810dfb3f2796da2fd7f397537146f6488c27804072b34",
+        "sha3_256_hash_of_ciphertext": "7509dec8c1dd6f29855e08d61a56ade71c6bd9a47102a12b3d4c9784010bc5d0",
+        "shared_secret": "be36ca6f5e0d3da0b5c144ebccd725900a06782fae7b2707ce7c5cb6818c8991"
+    },
+    {
+        "key_generation_seed": "d304c9389cc973477f169788abcb9d511f843219d246a9b587822f422a70c2386590a2e5c7ed86cf2c5c2a898662bc9a81418720bbb632ef9cf0b845ed052d73",
+        "sha3_256_hash_of_public_key": "2f54bedb19919171eca777186dd743b11ec9489aea09534c157faa75adf1c77c",
+        "sha3_256_hash_of_secret_key": "4bea180ffc80875ac731f18365224bd3eefc8d11fad63c7376adc1a37adc67bc",
+        "encapsulation_seed": "8d667921c5db401a86fe1c35dfcf164a6bb2ab7400fd6a0b67eafd4a0ed11940",
+        "sha3_256_hash_of_ciphertext": "def0451ac37ac39a0ef5b94406de4e313b3d12d899d6a4e92f3ee37c84869efe",
+        "shared_secret": "9769b7f3571089f1a086606f3545dcd094097befd492e3c9889f9a97c7b181a4"
+    },
+    {
+        "key_generation_seed": "89a6e3be304a3518fb82b18ca730f0b359cd6ba90664a493fb4f8edaf965b9c3b6591121e25d64010c25a18676033e1d7278ac5f2d0b43a31f3a4156ae710465",
+        "sha3_256_hash_of_public_key": "7a9232085a0222b9c863931ec3bdbdd51be3f16d6cab3009c138e0c8cb692563",
+        "sha3_256_hash_of_secret_key": "a01d03ab913ef4672c49664d2c95fecdd98fcfc19e8d8b839e79a8f6fb9bdf42",
+        "encapsulation_seed": "ec750b3939385a3f8df868119dc76f77ca845567ef068de6ada5478a56bc78b6",
+        "sha3_256_hash_of_ciphertext": "45c35e22eaa9d63a6b57f60ad2e6a35290b290c01761030dea1c9aa7947c965f",
+        "shared_secret": "7a190640b245b6b4de7ac38fa6d4c50e935c0062c2089c926e4e8c31f233fbba"
+    },
+    {
+        "key_generation_seed": "d569b935ce015c85f792f8f7fb0d83c4f53b492959361dd4f75fb764d656450176eae84d11c4528382828f7a689a0d5cff87b8ca0bba97feacb39b935a8788cb",
+        "sha3_256_hash_of_public_key": "1642d52117145ea2956bd5e446b895609be84a9344ff0f5cd1ec62af9ea9e3c0",
+        "sha3_256_hash_of_secret_key": "e2d190c6c423252af301186a3e49892da8c22e4c0fb61586d119119fb7b07447",
+        "encapsulation_seed": "74f1d52af09b12c36eb062ea7528550cb4c18a3ce8e4f4ea9fac43ae383bc925",
+        "sha3_256_hash_of_ciphertext": "0e67bf478bf93c925eee2cdfc285161c1b6dd2ba3a479dfb5fd9203ffdcd3c85",
+        "shared_secret": "5de71ca6710d2d588f53059a15e3a266eab4ed2230502b597f088014fbe9b659"
+    },
+    {
+        "key_generation_seed": "5cbb141c2763425c274f7404fe530d9116e08c33f9f200a20b011cf563a28990fc9ebbe336dc464489861db8253606971bd0a9008a433ed17752d04023781552",
+        "sha3_256_hash_of_public_key": "0163017a26dba83777c4c0f46f31375ba02680ffaba588a9fe91f97ccb99c445",
+        "sha3_256_hash_of_secret_key": "5d101bd4f51fad047a1161e7a95197f6307e7cb88e57fcf9fb28a2be43e9f4a0",
+        "encapsulation_seed": "4b3a70d85f640d1a2a852fb6fe96704af56a7415a8ee4282e9207bc3a2dc116a",
+        "sha3_256_hash_of_ciphertext": "7e38f78738ad21d1015a2e79860e8108e807a3e7070515185ae581345e08f6e4",
+        "shared_secret": "42ffbb3ae86b744b00f36a01f9cb34e8a08916f455c9ea0e5e6ce81bb5042cae"
+    },
+    {
+        "key_generation_seed": "293abb6d1c207927945417cf84883ef010823e11b487ed55239e466e83696d0cff8563038aad865a817cab9ce98846ba75be9363718ecf5fea538aea90b2a558",
+        "sha3_256_hash_of_public_key": "fb21cf5cc9a8a47a07cb2a154f73676d39a98a7d12a4abbd37378595c6332f46",
+        "sha3_256_hash_of_secret_key": "3c5041ff25ab5e854e792eccf12721be4f820020ed7895d5ccb7b1ba4bb7b193",
+        "encapsulation_seed": "26e38ac804fb5b4d59ddf747715e7e6041d875f99c7b638024b4af82d622da60",
+        "sha3_256_hash_of_ciphertext": "e2b8a6842755e5a408a47a32c2093dcf3aa0d32448ddb1f1a154315634f1b701",
+        "shared_secret": "90ca5a797490eb35c3cc24af19fca6dc71d41aa58d68e0061c1bdb8481e691d7"
+    },
+    {
+        "key_generation_seed": "74d87c7556f2671f2d666854a4d6e073e69f35421e6e1a428cccea49c37f972ce1fb7456ac0aa1b97068f452cba64ebdc138bcf5d36b0a0fada2a3b374141eb9",
+        "sha3_256_hash_of_public_key": "591aa9c81277503a34441fbd6cb59c6d1ecd5e00298fa56be9df562576250c52",
+        "sha3_256_hash_of_secret_key": "2e9c26235e0db1383671ad4ef147c1cbe3724bf800be90e356a5a381e3d9aa12",
+        "encapsulation_seed": "a319d2b8f114f1acd866478bcdeba6fd164dc4e37b0adfa8d8034afb3e197376",
+        "sha3_256_hash_of_ciphertext": "02f85b52a3684cab8bc416b74de36ac686cf3a3a495440cd444c1fe7d84b2e07",
+        "shared_secret": "bd58345e9e19483cde256be650975b954e167bd8b0a9036a95c98ebf037e87ec"
+    },
+    {
+        "key_generation_seed": "013bab0212d04ecd54b478daf72748003a25e2cb060ba6cc50bf95c292b8206b9da0c5da5f195b80fbb99c2e8b06926074f3f604b3f6195b5a5b9737876bba72",
+        "sha3_256_hash_of_public_key": "1c6c4009e28f6a20aad0c0b14b7cc0a01aeca507c366913ba5cadefe6656881b",
+        "sha3_256_hash_of_secret_key": "a9d3487d20af12309fb8d12b71a3fc3ad9109a9cc2720a0fa409ec5a491943b4",
+        "encapsulation_seed": "ff646071b2509e6b75790917e08e4f0b0d9f0116ec6291c0b59eaa4b583ad830",
+        "sha3_256_hash_of_ciphertext": "7a5d4cb38e9fb2beefd925d54155ae91d60bd95696db2de45e2307658341f2e7",
+        "shared_secret": "53d22dbfb623f5282ac68ff607b69b9ce559ec3b70aae668c684d90dcbbca13d"
+    },
+    {
+        "key_generation_seed": "ccb073c4b90be0ad746e26fb093b60c70110bd1dcbcddb566a8cffb7b3caf80e71600a8982c350df524cde514431ded7aec23576530894bcbf0ec0bfef0bb64f",
+        "sha3_256_hash_of_public_key": "4576536d1bace29aa7c31f7681222ddd15a3cf6ea6bbd3528d2ec8610d68d134",
+        "sha3_256_hash_of_secret_key": "0f1d74d5cd2fd6a9aa7022a0f06bdb6272a0bc23f115796d6e04692aa44de4ab",
+        "encapsulation_seed": "0584270ec26f3b9818e4af074d17b2d51037cc8dfdcbe3b140fa4fed5deebc54",
+        "sha3_256_hash_of_ciphertext": "8448f623dc438ea4a849544c4fbcf3dc493b18dbacb911b83ed651155a145c53",
+        "shared_secret": "cdca5387453ba0f0fe9f126702ada05c3612388b70185b6c2e69dbf98c2803ec"
+    },
+    {
+        "key_generation_seed": "2e889f44e28901e9ac7ca6b2fffcb124c8979401b17064d7e1d51a7e3c3adbfa0e145e44aae52cfc609e6f47fd7a6f6af877190ff52256d0ac5b05b89c3f449f",
+        "sha3_256_hash_of_public_key": "eea5db7a82254d19c0a0c552ccc92db9c3eef74cd73a9937b7b7298171313f12",
+        "sha3_256_hash_of_secret_key": "d4d3196a516686b8da051e915241f141b04af55e83effb968c52f23a19ccf79d",
+        "encapsulation_seed": "51e05c7b4ca3079781e8293f4eccebeeb2f8c8b4c59468eddb62a21bcb4ab8a3",
+        "sha3_256_hash_of_ciphertext": "84e87b27235041a1815c98ca4cf9ce031d7700a48f602bc9dcc98f876ae50c62",
+        "shared_secret": "b15db77dc79f2d64e13445c4dfa997afb191e0bb2bbf6a210a5d64263b2408f5"
+    },
+    {
+        "key_generation_seed": "174aaa36410566dc15a5e62874218d7abdde0b2c0f30d877bb80b1abd5f5a0a450a7a2354f7e5cefa6f4a4e9a1c411eb9364506e9e1204a8acb3cb77fbd2c4ed",
+        "sha3_256_hash_of_public_key": "72998cc3abc79487ca0a4db5b17514e9961916d30ab9b500430ba748c5c79226",
+        "sha3_256_hash_of_secret_key": "362b40ba4e015b703f639f4c784fa9f114f2cf65de5f6645e8f9d37fb33fd044",
+        "encapsulation_seed": "9eca0fe36c80fc5eba171c3ae66a5b1c923faa50b4521bb055e7bf51005c93df",
+        "sha3_256_hash_of_ciphertext": "44b60f83deff617231e92c5ece08a24243841d3df34de2517c29bdc89ff51400",
+        "shared_secret": "8ca9424860c35214636855849bb039cdcb4c722c5b81ce18ac1a1090034dafc1"
+    },
+    {
+        "key_generation_seed": "351fe4313e2da7fac83d509f3103caf7b4c64a4d458fefdf636785ac361a1390f072d9b5a99f9c7a0a011e4dc10f6b600d611f40bba75071e7bee61d23fd5eda",
+        "sha3_256_hash_of_public_key": "e9631b6d4237dd6884ae3647dd8622fc13d1cc689f3c8ed94ec6bcd4bbdb6980",
+        "sha3_256_hash_of_secret_key": "96736bf10a73d079e56f5812f65e3465957b8228423fdae4059feaf918fba361",
+        "encapsulation_seed": "0c5719261caab51ae66b8c32e21c34e6d86ee4aa127d1b0195663c066497b2e9",
+        "sha3_256_hash_of_ciphertext": "eda93794649d2ba24fb277e8cb0e5788102a4796cb21388caa25eb10bafefc5f",
+        "shared_secret": "b056e2904d66c51dc817acf961f141c2de7d201ca8e52d19564d0fb4e1310aa9"
+    },
+    {
+        "key_generation_seed": "9bc5315580207c6c16dcf3a30c48daf278de12e8c27df6733e62f799068ad23d5a4d0a8a41c4f666854e9b13673071ceb2fd61def9a850c211e7c50071b1ddad",
+        "sha3_256_hash_of_public_key": "847db13de94d97a88d5a3deae31c246f5f04d0c7d7f337859e024764337a08f2",
+        "sha3_256_hash_of_secret_key": "7fc950abb115ea2236036c300c95c76015606539ddd2409ff1b39a99b86a179f",
+        "encapsulation_seed": "0e59f6f9047c784c1f00b24454aa4f1bd32c92ae7e626549972f86fab90e7e89",
+        "sha3_256_hash_of_ciphertext": "af6d97857d131ebccf9d356e78a4fbbb66c7d5ad68fd42d356c3ef14aa756d47",
+        "shared_secret": "663bcd21601942f0ce47640325c9efcfc3eb3b022f0cfaed168893b1b6e5dcfc"
+    },
+    {
+        "key_generation_seed": "d8b907b34d152ff8603b73051f772daa71eb902c47b7e2f070508269d757e02e36b817736cbc5f7b1dd6eef5fe6332fb1a598f3871e5470d440fd2ea631da28a",
+        "sha3_256_hash_of_public_key": "f122b76b83c343de27054985634387fb7138f6f6f105cd4cd3f5b02698a964b0",
+        "sha3_256_hash_of_secret_key": "620b4d0dc53a26e175c69ae7a8f2d749d4adf1d0429852b84839d334e024ab06",
+        "encapsulation_seed": "a3963ade17d69debbc358dda82c7bebe2c39d25b36813058e7a161542e3f8c2b",
+        "sha3_256_hash_of_ciphertext": "51f8a50f2dbcb1255619a7a9868eece507b55d2138707a0550a4113a7e162d5c",
+        "shared_secret": "cad5816f1b2057a410cf917f52040aad9cdef2122ce59211ccef77c4a7c23a6b"
+    },
+    {
+        "key_generation_seed": "684a29e4e5480a5f2533e1526b5fac8cdf5927f3d85087c71f928c59690eb56575d12195ec32a8686d0600e45d4a7f54219b0d7a3826d193a51b9156ecf2edd6",
+        "sha3_256_hash_of_public_key": "4c3182ca7a48afe60eb85790dcb50b8005b568921dbc724130b0ce83f1278454",
+        "sha3_256_hash_of_secret_key": "44b1c2b3487cdda8a8e9205d95dca710093e981e7bf2ea30d1d2502b164375fd",
+        "encapsulation_seed": "97beafabf2c8575586487c7a80e8af5fc50f94b6051c1bc66a5ae9f66be3cea7",
+        "sha3_256_hash_of_ciphertext": "f231d9b8e3cb86e9daddae8d4555779a9125a16a6d2984ef55914a27d7912fbb",
+        "shared_secret": "e8f4dd3d2bb2c2f110bd410b2c37beee6d3bc7c7c4dc477c358234c54bbbd4ca"
+    },
+    {
+        "key_generation_seed": "d76b3573f596eb286ab5231feec7499686b13021be36cb126c7ebeb9d7030daf248c0a21ea0bb6d6f56f12300e8584d8e9a34e0e6f52227281151ae4c305fb8f",
+        "sha3_256_hash_of_public_key": "4359601c371b50b50b5306de33cfd476d3b5f811700dc4918beb345840244e3a",
+        "sha3_256_hash_of_secret_key": "6f2d2c913b4a19bb07b531d74edb549659a35d1330b1ddd62c74dac4bc5f061c",
+        "encapsulation_seed": "75461decd34c50d6a094b4a64fb75e5e9479f8f9250d82bb7d729dedeb2d4b65",
+        "sha3_256_hash_of_ciphertext": "a6130d387a04846c8b920f94f59d6c65b4954b6ced0f0d6a8566a0110c198a08",
+        "shared_secret": "249855eb724db68f7367385c45a3206fa19c521644f8841b7a73f536ca47c26c"
+    },
+    {
+        "key_generation_seed": "b87439fde81c9e39eebe7cf741c685785532c1dd23e8ef868b9ce7a541010f3d1646460817a0fce5836bdfe124a7448e7adf7b8ecc2652ac6d280e986682df71",
+        "sha3_256_hash_of_public_key": "e1f6c5a99a49d6b1b4aa18089439bb4c56ca465785bb36594ef2ebd3af20d564",
+        "sha3_256_hash_of_secret_key": "fcc14cdacdcebc6d1933f1ec9d430c643ff5fdbd78d2fe053a8880e6ee8ef129",
+        "encapsulation_seed": "2607dcf4fd6ca1c614c21b5e37c24981c32b91c8c3e6955777da8a3f5d9c9335",
+        "sha3_256_hash_of_ciphertext": "73a09eadd34a8be74772db44187ab49a2bc086b91848c6ff09f1306c264f6fe4",
+        "shared_secret": "f1be516b31ed89cb70bcf428a2ba2c22b3919f8a9824a59b875ff1e697095ae2"
+    },
+    {
+        "key_generation_seed": "056661b38038da4fdd7426f32a81576c73ed84843b305168a374f934e27a4e1b79238a80dcfd7c992d84b2dffa67493e669243d4fa38c46b090bdf86bc548411",
+        "sha3_256_hash_of_public_key": "b8aa8568431ffc4681caacecd4475c838cf7348402a06413e7a9590ba405ea5e",
+        "sha3_256_hash_of_secret_key": "f1e4bb0178d949637c06e252493235480d3ed16687e9a1c36df0721b29a7573c",
+        "encapsulation_seed": "38c89bbe7145c29e9a831c11431eb9929cb24fb4992db20737e4687d397fd732",
+        "sha3_256_hash_of_ciphertext": "24392701d3f5204f5cad5662bd6526a178567186cc070d951e03593e5722eb46",
+        "shared_secret": "6ec4f71386c0f0c16294e4d76966c69c512d4e5e00a6e05c5aa544e542454225"
+    },
+    {
+        "key_generation_seed": "a1b52d871612a1c611ae0944f9e71858f35d3bd14f20e96a931720668bdf0a6b1f135cf64b6403e103afae34da038613e2853bbfc36baafa3c6a95347193f37c",
+        "sha3_256_hash_of_public_key": "984f4c4ef2371654067ce0f22bbe4648dc9d87eee23842f31affcdc36328e8db",
+        "sha3_256_hash_of_secret_key": "240fe3ab98047b1985b22240622da9669f7ecec81801861ea0859704f3263f6c",
+        "encapsulation_seed": "b2c35e33c72d90182791f0e12a0324f5b216efcab2c8da1bee025dfbe13f4152",
+        "sha3_256_hash_of_ciphertext": "f190fb70fe762db7125e3ba3b459e32bf99775c3c1efb84ae1776b50206db7df",
+        "shared_secret": "464274dd39f2862a97833631ac446642b3c3dd6467c7d2404aaa46a8f5f65b3f"
+    },
+    {
+        "key_generation_seed": "952b49c803d6d6fba69f4375adce8594847a00bcae2179da49af2aed0423250262d7033947ae42ca53522a65fbafe18d3bc3e0cb66164e9a094fe4b44d8977ed",
+        "sha3_256_hash_of_public_key": "74841a59db1202eb2e3744bb36b9c5a229a33cf9eeafca4b3d02d155d870b6bf",
+        "sha3_256_hash_of_secret_key": "e808e7b999c5bedc14a1763428a3f2b3eb9c3f90743f8a1922c87b5874acd79a",
+        "encapsulation_seed": "afb7d6dc2b7eb6d84acc080c1be63c98afe7b07786b5801f716444a3e8e64800",
+        "sha3_256_hash_of_ciphertext": "675ff34f87383d52203c979d1502e2fd35d9da09cc095b44caa073cf58562ba1",
+        "shared_secret": "99dd968e1f5c94c6c4d92e7eee393c802d8ea4a34d39de2048eebfb21a0a4b9c"
+    },
+    {
+        "key_generation_seed": "3c815e57e9233e975fa1630208aab206b71ae0db37a7a8789ac683d9f9b2d29801c8e376fdb140ee343106c093af7cb149b316ba79446ceb4e5e0cedb9b164f9",
+        "sha3_256_hash_of_public_key": "f7243d71bcbb46b9a423431b3b30947eda5fd81b526cce79a36730d8ee1be42c",
+        "sha3_256_hash_of_secret_key": "b1e6993caef04e00ffcf42c81ae97c6d89c5c19bc3b3e1235c48829151f8b4cd",
+        "encapsulation_seed": "28f5e9dbda122b2cf8f3754fe9e0c73a84ad4b0c093522e0b62cf815d60bbc3c",
+        "sha3_256_hash_of_ciphertext": "319744b03f01b7676b3975b70d20698972d5492a2b0c8e0833837de36945c699",
+        "shared_secret": "0642533fe87a2913a37847843f7336a0e4c47f778afe5cc95433948a76ee7ecb"
+    },
+    {
+        "key_generation_seed": "588760826dcfbd36d9abe6ae44a669bb3ebba6a218eab69e30f18a3bd536576e0e860576285483bb5fd36e2f944d32c4317bebc1e441470c1372046a790d79d4",
+        "sha3_256_hash_of_public_key": "4092d5afa2f038f879184f7344800ea49a63543be9600bdc2b18420744588290",
+        "sha3_256_hash_of_secret_key": "18b8bfec268d6e1d6edd376689f2bc5ffbcdc859cee0a26ccf550fb42863d57d",
+        "encapsulation_seed": "b0d713cbef0bb1df70cbb425d1e9373e9f7790fdc7980cc96a240dfc53f1e8e2",
+        "sha3_256_hash_of_ciphertext": "4fb1c5f9a918a9077f822c79ec0697dd6dd7b23ff3cfffafaa272dfb1233bf8a",
+        "shared_secret": "a226b83601ae0e6f76f9f08b0a2f6eb30a3afaa39ecf5c5671e988a354fde9a7"
+    },
+    {
+        "key_generation_seed": "47550e9edacb6ddce3d9ab81f6b61080dd4f2693854acb05e0ccc7a4fb6390fbf89d7d99d5c3e0d10d6ef9af054d842375f695abb28e3b8eb495100f04306e92",
+        "sha3_256_hash_of_public_key": "ad7166f31b2650d125c8ef23b5825fe11afe25d0cda306fa6c7a824b4c2d31d4",
+        "sha3_256_hash_of_secret_key": "0124d8202fcb0c40d7a6cbc1570df65602f376854abd55ea664f66e3923b3d56",
+        "encapsulation_seed": "32bdcdb7059fe27f6409901980c080308951ffd90deffa8317b4d213a5f04495",
+        "sha3_256_hash_of_ciphertext": "74501710705cbe8837e88dc8986d78310ea57196185e3ee3ecc8d17d8cafa7ac",
+        "shared_secret": "3040e7e4eeb844c1385a78dc3c8a6375880ce8fab92827460de1825a4915c3b6"
+    },
+    {
+        "key_generation_seed": "610afb64be8cc1df288cfb016ee2f44c6c07113de7f6fee071fe0c3fe31c6215cd292e4c5f9e1a55e0489bceffb204d672a6215f4f3980a646d9f880817c52dd",
+        "sha3_256_hash_of_public_key": "37933cfd8c0e61085f2ae264d85c4ae05f8bd40bf29976c6d52e4f1c7ff709cc",
+        "sha3_256_hash_of_secret_key": "e9a6c0af326ca00c7f8ee0b6ef5661be3a84c39165ff60fea5510cb219b8f788",
+        "encapsulation_seed": "4ed7c92d83bd03b2a25b567f17ae55542e2f6a4308ec0f3fe69f8ba5ae24331b",
+        "sha3_256_hash_of_ciphertext": "3fc676cfc433cccd2d248824c4f51406491cfd99bd05f863cb4200155ac471c0",
+        "shared_secret": "d990008c5eceab7097524d6755c663ba04599eda80560d59088b21cd73243462"
+    },
+    {
+        "key_generation_seed": "e1953800acaa85ac02a906c72cb8e8d704e8d27820345f88f71e89c1f549afcc8c64c049c6dfc0f1476cffd520b055756162f7ec94243de6b14ac0b9e5fb366c",
+        "sha3_256_hash_of_public_key": "ae96ec4edc7ee08108fe6c0411a96f48731066ae4be12edeb7fc667039c9c1de",
+        "sha3_256_hash_of_secret_key": "7110c8c6d14a3cf5dba3e5f2ecda1ed1490e62b032f798139b779054da20985b",
+        "encapsulation_seed": "060ea5d2ed1dd88144a9885e79278590821c22917b55a48920f96b53ebe0e689",
+        "sha3_256_hash_of_ciphertext": "9b33f0f26252a0e1b92f55f4c0f979efd5ef68ef1ed6f23bf23e5eab1c732ba2",
+        "shared_secret": "bd50423b4ef27559d67532abbfad2a3a388e3dbf4d7b6488c2b48f19cee07ad4"
+    },
+    {
+        "key_generation_seed": "c719f9b2d16399b7326ce4eca30dabefe8fdaab18e9f6df888b0a134ef355570e40771856eb77e4633504899fcb86c6a3d433d0b8d60e26f07bd61f1d4ed69bd",
+        "sha3_256_hash_of_public_key": "4e23909b028699d6677eabe6bac4bc4e8437acbc52b0b17f1df5760c0455c2b5",
+        "sha3_256_hash_of_secret_key": "63ace19297953d106cbc1df1a25143a15772197c05aefb070825ef568eafcf23",
+        "encapsulation_seed": "10ef9426f8c4a13b52325c5bb4ead4596ecf2c6b5bd2d37d8350e90d4164fdd9",
+        "sha3_256_hash_of_ciphertext": "7747110bc34f1a35fea13d10fffb950a85bd6d9247c89b2071afce7544b312bf",
+        "shared_secret": "38e3d97b0547e648b2b722c4844f59ed43dcc4b40fa7dcfe6184c2fe62ab3530"
+    },
+    {
+        "key_generation_seed": "e9acbb774be970206c3a738e243b420805a509fa59fa902044be2f0d013650d2ded5edaec5de3bf5b4d7c2f2e18e87f499c1968993eff196753db8045e2c8ba8",
+        "sha3_256_hash_of_public_key": "513906f5bef81445bd210d63fc4c9b9ef0b61c17b0cd5b229a45908fcbaddcec",
+        "sha3_256_hash_of_secret_key": "11added546dd697edc51e8ed16ca3ccc9da9629c4ce0c8404d04de1aa8b8114c",
+        "encapsulation_seed": "a4bd30a64cbf29a4e290fa1cc1dfb99e68348713041e4409a1af23c5d80c15c4",
+        "sha3_256_hash_of_ciphertext": "569f8e9da2051bde67bd3ff8e81e3b4e749b198586e2ec8d0544e6a8793aa782",
+        "shared_secret": "cca4f1d172212f8c23eb5da77144640d821d2671f66f0b3015d0b46e274e193c"
+    },
+    {
+        "key_generation_seed": "c1b3cbffad4b306f9af0cdd3028876486dbe858875c9b6497fe20172a986c82b1c96249919cedc2369d8d739ab125e0d2ccb82dfebcd90240a545cdfe07511f2",
+        "sha3_256_hash_of_public_key": "4f8b3e9ae47d3b5b95c080d4f18440c24b0691c19f06f5547554697bdfe97b01",
+        "sha3_256_hash_of_secret_key": "cf4be19205cf0c2bd0eb0c1e7aabd40e265792bfc302bb0f28716c406585ca37",
+        "encapsulation_seed": "f4b66a7d3b65b896dfe100b2cad24b175a1168cfd2ae11fd704b835f6bcd311a",
+        "sha3_256_hash_of_ciphertext": "ce6e0b8523fc48a54f1b10be23b1e990a390e4e823d4483681ffbd2ad09f4977",
+        "shared_secret": "dd7816a8a015b2001258e665dc0e576ae19b10dba9704be9c484e4c8ba645522"
+    },
+    {
+        "key_generation_seed": "ff7495b8575b5a98e4fd21fb4c3e58cbb60f14bef21aa74cf8802e3153f14807bdc370460375a778d1a31d01c42b66367ed8d9e8f84551002f552f0e52102b5d",
+        "sha3_256_hash_of_public_key": "c1b4fdc4929c2c7e4501ba7a9feb0be571e27c43fa96f9a7f934636ed9a86110",
+        "sha3_256_hash_of_secret_key": "5b475ff0aeb273c017d1e7d7cd380e41d50e634840e443a762608c09282f3007",
+        "encapsulation_seed": "1d7b03d3c5eefb8ae5799dc569aa668f1bcb8c86607b089d3530cf61d6380147",
+        "sha3_256_hash_of_ciphertext": "556aebca384b3876ec2c00d446239855602625800bd1ecf1b7eb3411d101d442",
+        "shared_secret": "e911f73a4c23637a2708739bd5ef842ccc57d32993f30d6ee1f88acf5093ebcc"
+    },
+    {
+        "key_generation_seed": "bdc3fba1c32751139fc45bacffb3ea97f26573d804a5f27a459293d95190ed8efd5a08f656a6eb8cd20679930a31caa6a6331c4b133a6838c223ef9f769f6246",
+        "sha3_256_hash_of_public_key": "df4f164c11041dbe981d8ff2008757b7e694f564a298b92cd182129ade5e72bc",
+        "sha3_256_hash_of_secret_key": "1f836ed803ea8abe63224c016dc15468719599e06564c11e9f641eeb3634350c",
+        "encapsulation_seed": "554f3385b382f4a46314de37ee3885addfc5332bd4038785094e0a832e9e8c2c",
+        "sha3_256_hash_of_ciphertext": "5dec68120c8c2182ac2b2995eac56b91df2ee9c9bce8e801853e2cee14c0d8a2",
+        "shared_secret": "572994fb967815fe8bf36cf41560dc69aeba8e32b13e1d25128585dbb0e71068"
+    },
+    {
+        "key_generation_seed": "447f6076a627bbc5ad7773fbfeb14b4ba9ac43a0f8b99fb6dcd5e452aa3c47ec20a7237801f470fcc2bd9fd7bea8322859b850f7882d362947432913dd068c01",
+        "sha3_256_hash_of_public_key": "ed722667caf175df48a3a346ec7cb1bcc37d67d3137ff7b7c70a07f202893a33",
+        "sha3_256_hash_of_secret_key": "272df80631771996565e673a4dd92318e87e625097f74fae14c688a24b558216",
+        "encapsulation_seed": "38bf0033b779edf5367d9ebc01c988af90904c560970815837380650e4749eea",
+        "sha3_256_hash_of_ciphertext": "4214ca50c6c732d34dab0b460d7cd9e0ae97346fa50a67386fc35ca0ac8223fe",
+        "shared_secret": "92c63dee4666bfb34fe3095f65cd458654df578f6eac0ec75f5235e5da6a926a"
+    },
+    {
+        "key_generation_seed": "2d5df64d62cb07fe630310bb801c658dbf3d97993e68626745de39d37fbfc2b27b534537addaba4ecf14f02ab317d36cb9f0f50222ced7cf029dff8a0d3d2fd9",
+        "sha3_256_hash_of_public_key": "0c4dc82d723965476a518ea0915c1554bcc61c814c80ff120c37e7e8ed6d5c40",
+        "sha3_256_hash_of_secret_key": "d9e7fabffb14d620ccf618a1e25375d4cf58875c38ecc73587cd09b17621ade4",
+        "encapsulation_seed": "048ea516d0ebbd9f709b47eaac66f344c571cf50f0d01c9466aa061a50b66a24",
+        "sha3_256_hash_of_ciphertext": "651834fb53362a4c4af0b141885056f9db913c4be968c1aed3d7d3f5bd1048ec",
+        "shared_secret": "0e2179fc3d310aca496244699b05da9b7bbb7891ed41b675e5dd48355a586360"
+    },
+    {
+        "key_generation_seed": "25056d1b8113bb362dd979d98643d7a7ac9c4f95994c0ba060609b6d07002ff3f48a9254dd40b117941fa35a66bb50296327b725525deef70e128ca8045ec451",
+        "sha3_256_hash_of_public_key": "c934c11e2eaa7c3c4e764863e436ff12fc9f517c79df6344ab98611f57fe7296",
+        "sha3_256_hash_of_secret_key": "4f502a9abdfece85347362ac4c7e2beedb137e29a4b638c9bfd710de432b5e5a",
+        "encapsulation_seed": "686c921c9db1263e78ae753b1c9c2e7936b8229dca48c0942c56c6bca4f10917",
+        "sha3_256_hash_of_ciphertext": "06786544f2ea24bcbb677092f4602d59f9cc9d2d8211614dbb5b87edc6edc46f",
+        "shared_secret": "573a8fd5e5935badcf974c50cc36e191f0ae2c1458fb00d4117e675424d4e37d"
+    },
+    {
+        "key_generation_seed": "e4d34e12982aeeb1d62fd488d9b9e28557ed3429292239fb4f76fa9098009acae6c45c7fc62329b13c8d29844405db8ff6860de474bf727ecd19e54e6e1a141b",
+        "sha3_256_hash_of_public_key": "5b07c8359e6ec4989c34b31293f4df965b5d95802afa5836beabb001d5cd4dae",
+        "sha3_256_hash_of_secret_key": "73973aaa43538874f8b16d44faefbd26dee5389a05fad2d4f966662ea9eb1df3",
+        "encapsulation_seed": "2387772e50059cabda53cb93ba24b19ae529496c03b36584169451525c4a0e7e",
+        "sha3_256_hash_of_ciphertext": "2d6085e31726d74e2ce2a28088ef3247b68b39d0d51c225df2521ba327bb3154",
+        "shared_secret": "c8d5e0dd64b4f3c6450fd24ed2918887d3ea2806479d3fcd5a19894f4fe401ea"
+    },
+    {
+        "key_generation_seed": "cd6a99396eb3539ca663a51e42063a3a262cc1c5a5fce1566f0597b52ad9fa325a3407f591791a5db4578b5972093a95bec3b8e70c1d542c9b5c9789729f8922",
+        "sha3_256_hash_of_public_key": "37f1d7e636b4ab366dd5725957b9e5d2498e4ee1929f2213f9d05c882d96a106",
+        "sha3_256_hash_of_secret_key": "1b150644ef3edff5c406fc9a85e16fbc87cfcf8a6ac726284483947cc2fffd63",
+        "encapsulation_seed": "155c29c5f0378df0cd0e847a80a07143cf7522fcd880c9229eb9feb1ce340cd2",
+        "sha3_256_hash_of_ciphertext": "37d80e33f5bde211a9a3f634f8505a816e46195616c34a51d62b031822201337",
+        "shared_secret": "f0691ad2fe875e3f0993f25452c70f0c40891b998deb6a7f7aa3c0bacc59bfce"
+    },
+    {
+        "key_generation_seed": "6c8c53ed6f65e6b2e324b84364e10de42d1c26a106d4d1c99eee79c78586fb55b9402bf02481ce4b27a52e87feb92c4399c7f2988d40e942e7496ad15ad2aa88",
+        "sha3_256_hash_of_public_key": "a5383897314d60ae0ab1a8b50d6f5de454a2eb8b0502d57001e6e19223a82ef2",
+        "sha3_256_hash_of_secret_key": "38e8404120bbd346e0483ff7eeb758bd655ed94f6c02e427468f0c5fdbd957f5",
+        "encapsulation_seed": "a9cb9a61a3324b1ea5afe693b32784e2871096b2ca14a11acc9577c52359a241",
+        "sha3_256_hash_of_ciphertext": "3e819dc1fbc939e49bf5935fc8ac8c36d8c16da057091442df74a76fc3125fa0",
+        "shared_secret": "bec215c6bb33e83574319c839db1ca6793931d35a7239bf4ad3c4a493fe5c5ea"
+    },
+    {
+        "key_generation_seed": "2107204cd995f1df14314d5381f8c5440f09a347502e161cffc0a2ec3dcfbc7324c3da70fe850e80aa818301d60c70f3038153866dcd5d179e22db59b8991bb4",
+        "sha3_256_hash_of_public_key": "500dd7b94b28b5b650d90962962bb9a3ae96e70d35723217f3f178cbe5659051",
+        "sha3_256_hash_of_secret_key": "5930b10cb88d66ad1ec117d2b134f921fe4ec980ed9c351951d47d33510585bf",
+        "encapsulation_seed": "e99fbae8a024ebbbdcef32ce213f6aa942e3eca925e5da4c09975d773b33a175",
+        "sha3_256_hash_of_ciphertext": "cb20903e6ba3a41f594cd09056c0a7af4dea86039677761e88dd6818db0d0e88",
+        "shared_secret": "18a505a0543800a93ab6e2fc1d866e22337fc8387d32541008ff82a73ce7dd31"
+    },
+    {
+        "key_generation_seed": "63a925685a8ac5bbd918faa33ac397d1ffbcf99135d9da7c3d6ff7aa4c50af3d3afdb8a246a56ee71465591831c371f2eb87467b0559dedd776ba063ee6d2f93",
+        "sha3_256_hash_of_public_key": "3c4467b507971523509bf97d2bdd733ad9eb94f312e4226d036e8fe827a20533",
+        "sha3_256_hash_of_secret_key": "76e696d5d7ebb4e2035507601f66f38d74db35d3c76b3622678a2c65ec7b0f69",
+        "encapsulation_seed": "67a216f37d67f5e74f782f1badbce1cc8c80a6130aec305b421899a4faa0a6c3",
+        "sha3_256_hash_of_ciphertext": "df6a835ca5253cb64d669990a60fe03b44a4a2229beade86a2f3f2381d33f09b",
+        "shared_secret": "f155d993eadba79e6c2376daeb7f935d39286b10615ab42c5803d43f15960a66"
+    },
+    {
+        "key_generation_seed": "6a1aee5e708c1b47f02bdacce4f56c860f74fc7cfec1ef3b58285b1c8ad7fec2230e05b7114ff0395cc6634db1eae8258072d09c09f291e92d6620b177dc50d7",
+        "sha3_256_hash_of_public_key": "69ffbf2275f12c29cbb69f90a8c881721ce39b49dbba550ab93a2c4c94bfc669",
+        "sha3_256_hash_of_secret_key": "76d6db646c55687ff9eeb3f359093a7105a7ef711bd60a4ef7f1a1bbd70ea24a",
+        "encapsulation_seed": "52b19fea232c9154a3e431e9d69cda40013cf2d485c3cd027ad24e645420420b",
+        "sha3_256_hash_of_ciphertext": "677fe79386a26743faa6fa1c79576e3f898da432af70e1f45a73b582b4c976b9",
+        "shared_secret": "4cc8728603d51b14fca46ebaf01e6b6347ee9c71d192591ee857c206d131886d"
+    },
+    {
+        "key_generation_seed": "6396b328b100e4c7f4bcae69875edea1a1982421558c608c13c592bf7b5d0fef1100ced48add211a5c937b8d6079d8e271af3f949edc61f70e60453aef20dea9",
+        "sha3_256_hash_of_public_key": "41bbd3f5c241a6d65b510dee6662e2a8f35757b0403dcd375e7a15991a7873c2",
+        "sha3_256_hash_of_secret_key": "256673d5b2a0225515bee64da0105c167d031405098819b6992d01c3cc711bdd",
+        "encapsulation_seed": "64440adb05db3308b189bf999f9ee16e8ee3a6ccbe11eebf0d3ae4b172da7d2f",
+        "sha3_256_hash_of_ciphertext": "9306db283ad2a844ad6d266ff6c7bd8e9b4ffddef78d656c9bd06d52cdc52c74",
+        "shared_secret": "fe5dab115160a7200005216d7e6e7dd8527f9c2eec34f60c6710ee21f7f91730"
+    },
+    {
+        "key_generation_seed": "a453bcacdd2b0d4646009e5ed451c3c45f08fb827ef733db3c517a9dc1af93e67a3cc8aa3239d4c52ce4c95afdeff6efbfacac10d294edc0e7cf4535059bfdba",
+        "sha3_256_hash_of_public_key": "290261ff6a1d2fabc75feab002d16cdc44bdbdd0967c728ebef0e9814c60b5e5",
+        "sha3_256_hash_of_secret_key": "beb5d2dc34b1dba8c87e4ca2659ed8ebec2d93be0e2d78285efeb9fd998f5805",
+        "encapsulation_seed": "c8bb46b3a7344ad170c2052fb042b5a3b62e0590562ee82577b1081f6f114d16",
+        "sha3_256_hash_of_ciphertext": "7f94b2d97c0821593745e9b5301a66a81b75e71b15c8c21558c8b8b077d7af5b",
+        "shared_secret": "ba33ea19873105ed9690d40426b2cd24073c822eb86120a4fe8617b5201f9494"
+    },
+    {
+        "key_generation_seed": "47ca2b77c5b717f423222c2730ca5cb9c856bc951d01b2b2c80bd76ccb5539b78f1481d7cab000e33fa07de8dc9627a85e76fabb4428a3376e66300cf12a0787",
+        "sha3_256_hash_of_public_key": "7ffefda144195d79e581c91cdf0247f4346e811f890f54f25226b4ab835871a4",
+        "sha3_256_hash_of_secret_key": "7b85555898660cb43a060e367d9a97112b48e3b8f99d437161cf6ba44b5c6922",
+        "encapsulation_seed": "2e2b70609f3fe029a14d09d5d659871ac776ce2797a0355f16e2eb68f5613fd1",
+        "sha3_256_hash_of_ciphertext": "310c7f22a80995c6e375122f1395604faf5f72fb9fd6819597aba8f370327647",
+        "shared_secret": "2baf80269b225c66a8c35c6f835f15bd6949ae2814cd8c405a0aed313a637701"
+    },
+    {
+        "key_generation_seed": "aaf6eb40e596a5e3e8218871e708b089240dcbe7fd3641f0e5e41e071ce49107e2f8d320ac3cb0c52efdc753282f092bc39baf4a18783a48ea031a191865eb78",
+        "sha3_256_hash_of_public_key": "13dd780ec5347c512cfabf4c2e6a44cb2b17993c7c746f93c1400a5db9f12511",
+        "sha3_256_hash_of_secret_key": "7732b2a074d1c0aa93106ca84711edcb7b8a369f3873cf89fbcebf0d32176f1c",
+        "encapsulation_seed": "4725dd8fb314bfd8ee23731c2341dbe114606d9abe6434c471b5573e7df193bb",
+        "sha3_256_hash_of_ciphertext": "b0003e684b9ce6f284d9a746cb806442e5443430bed95f2e8ad7ee824fb3db2e",
+        "shared_secret": "07318e8edf0ca8f30f49fa906ec814e40ec52922f2c0ace243386ef2bf650000"
+    },
+    {
+        "key_generation_seed": "6500f32c93415cfdbc0bd31d78d5be95cb9060c8cfa2013955b56f8b6868b322393308641a9a4647f230201e1389624a296b55192a9819fcb19ab77c25f95445",
+        "sha3_256_hash_of_public_key": "d5acaf411ccb64500879102d9cdf6d9fcad673d874a4153383806fe174b2fc1e",
+        "sha3_256_hash_of_secret_key": "e5c3fdb9d8e92c42ad48684f0fe13aece244d116f8a6d09a764aaa090b3375f2",
+        "encapsulation_seed": "818d3bb8ebfb32bf464775f7139bac0a5bddce80ec5798595992f9403002cd5d",
+        "sha3_256_hash_of_ciphertext": "9ada65c57d8292e9a999ac102ef855d5da932a54f80f3d976fe1ca834eee5964",
+        "shared_secret": "38b5d71f3a64feb2cd41d6b7a4ac5440707770dc4c472c3ed141165fb7e8818f"
+    },
+    {
+        "key_generation_seed": "7643cef2d62cc5aaeecf754653ea62294cd2208e5bf3ddeea209e3dc45373d49eac9d531a532770837a854b4f5531f6e0c8d6c10183b30d3435498c2dd142951",
+        "sha3_256_hash_of_public_key": "152641a683dd690d4ac3edf0261200cd9244ae7dab962eca2f3d22a554d0802e",
+        "sha3_256_hash_of_secret_key": "7afdb84b3806783db52ef1f5f0ff89ccdb051704cfd19eec3e2f0830c3b27550",
+        "encapsulation_seed": "c92aa5fb91c980d9cade9ce99d4c75b2ffa7d6a6ff9bd59def1aa701f2a0992b",
+        "sha3_256_hash_of_ciphertext": "499ffb9a28fcc692e7d61df4696b538f1bbb205ff82d604512220a9e19d87254",
+        "shared_secret": "368a5e417f4fc728f5080e8fe206ca7558909f6537f1012a58b2d9d45b7c6a8e"
+    },
+    {
+        "key_generation_seed": "f8ee95521060c03bb8dacc79f7eb7db640f545f315613a35d447a09e504cb4e13fc3d8392cb53f36ed647364a04e37278a0e0a45b720f4a75c580c9920eba98d",
+        "sha3_256_hash_of_public_key": "9cc95efe512c84010ccd7118a92522cead44cff28d6e223f76702a47694c8f05",
+        "sha3_256_hash_of_secret_key": "d9a18ebc4b027c9590d0e4eeed88705aaf5d166cc016cf6e0baa07f678f1f0d1",
+        "encapsulation_seed": "7e8086a01dc5b3bb9eda25bcc45d27f99874841b97237968495800e007696ac5",
+        "sha3_256_hash_of_ciphertext": "d202a577a7acba1801e03c446279da6dce6f262a6b1bf06d3c15283bf69fca47",
+        "shared_secret": "7d36e561b501a687939aa880285d32cd6d8b66e2e65b2a076d5aa516cb5b2e6c"
+    },
+    {
+        "key_generation_seed": "b8bd0493a882e3a49b4e0f6256fb1fea0912562fd9ba26ec3d6c9cc12c8973abd7e4b5d8021c486b9c3114d7cbbeb7cd49eba8a61bc2bcae1f1bef30a1daf76d",
+        "sha3_256_hash_of_public_key": "8b12f00bf09aec2b492cf53686beb31c558d0493cc7b2b9a9dc7265fa9edb685",
+        "sha3_256_hash_of_secret_key": "9979de3ecfacdc04e1229773f36d7b4bdfd731ea0f1fc2f9d56ee1d07e9bb075",
+        "encapsulation_seed": "bb321ef14d44d8698df879fd52450567657f52a2df8d111185dcd7d4f30a72d4",
+        "sha3_256_hash_of_ciphertext": "53f97fd2a138ceae2b327344c4947cbee6d6563a48d9bc5d8373c4bac5233a5c",
+        "shared_secret": "6be99cc08c8bf10372f7d5c27bc3ecd17ade8afb967aad41a1b33c0ff848a1be"
+    },
+    {
+        "key_generation_seed": "c0407e41ddf48d333978b89bcf2db01e4613425b456249e76a6f25b8a2827bf5b2dca81e3f5f748d23c9d356a2209f6b2d60247b2e45c9808de497f64f124643",
+        "sha3_256_hash_of_public_key": "3c98fa4af17fd014a60d11ca5e929e4fa2524f7db289ce0947ad90657990c153",
+        "sha3_256_hash_of_secret_key": "2c370afe3301b0481b50ae72e21cbb1be37d2877cd802a1d40e05d9b4e6be502",
+        "encapsulation_seed": "210a423dadd899b810f011794b79aa7f860823ac1962370e791287d3a1afa384",
+        "sha3_256_hash_of_ciphertext": "c134910358575ee3e211603b58b3d6085cebcb91f32a355ff437fe87ee812e3e",
+        "shared_secret": "f6fec6f62257d9a7041f119fff60f734c928e945fe131bf70338f273c0614ae9"
+    },
+    {
+        "key_generation_seed": "334382d39164d1989696a2ff77b25a28af8bead9883b5365eb6fcca7c1781cc9aba5068af837be962f439f233593d193ce5e08f7d66efb3389885927b89d2523",
+        "sha3_256_hash_of_public_key": "091210fb4f6fac00a24167d9bd2761e601db0a3734e3c835d1e9c5865b1e379c",
+        "sha3_256_hash_of_secret_key": "fb4bf08e0cd8d2f31969f75b420578f8d6dcd845824e427a6261931f1e1b820f",
+        "encapsulation_seed": "bc856afe24213e3d14c3d6f9b89223bbcfb2c890722d770fa3492c1e46d1c302",
+        "sha3_256_hash_of_ciphertext": "6076283588ebdb4630d85b2dc6dce53492e11dc8c9445597ec57042bf1e59634",
+        "shared_secret": "9c56f6d91af6741ac13f241f8c960433c0ed4adcc86130877ecc1dbc10573bc5"
+    },
+    {
+        "key_generation_seed": "6995143e8eb8a6e93840f76eec844f67d2b5f75b1839a5040337e61f9806764a0f4dff8e56f68440836a072412a30d851ace2c7c6f02d60e7a8420001a63e6c6",
+        "sha3_256_hash_of_public_key": "6c206507b89f46c6e9cd5e78b6cc78fb3677ee609cc090cf3782c876fd5f941b",
+        "sha3_256_hash_of_secret_key": "c9123a2bac61c5fc4304da90862d8cb544a31da2cc8b8126ca16a71278f461e7",
+        "encapsulation_seed": "5fc00f89563e44b24cd67d0ce684effe5731619fd08e7d72e2406eb016afb66b",
+        "sha3_256_hash_of_ciphertext": "e57f70dde96de9e66ce28b7d1a3014cb095a8ad00d80ae7735fd499d57e2e6f8",
+        "shared_secret": "021b7e80dfd1258695b61aac785b0134ed6e9864d3cdf5ebd4b3ffdd9a5bbf06"
+    },
+    {
+        "key_generation_seed": "995eff7e0d195c6d0533f3dc194d47e60f9ad14696144cde694d60a95f3e96b4b28f7e7a15a005f92400ce33db073d49b53871594a88fc45e0f94207b5f0f2dc",
+        "sha3_256_hash_of_public_key": "0560200b8d070d1db2cbeedf3cb322ebbab3edb80cf474b4178633c210b2fc74",
+        "sha3_256_hash_of_secret_key": "a2424d9992c7e999a5b18e638a22d65e1e5d5029e5fac62a5091095897b3543c",
+        "encapsulation_seed": "ea22a76065db4b565ee1807fbd813b43bde72b0e08407fb867c6a18995025e50",
+        "sha3_256_hash_of_ciphertext": "b5928a28fea0e5b0321439f9df86c6f10fa6203bcdac0cc94da7f7d6764d543d",
+        "shared_secret": "2c876ef4c2bd6464c5e4274d5360e210ff389325c1da4bda5495294d7cd126be"
+    },
+    {
+        "key_generation_seed": "3e809ec8dd0fec0d911a4e3fac20f70fbb128c5de94dc7184ca7310ae9157a98d8128601c28b1def8d393a0db283229f7c7383152a814e7cefe8ef9d9768c473",
+        "sha3_256_hash_of_public_key": "3a2484828bce833f9262405b562bcade9ff04877838558409d2b60f1b689d137",
+        "sha3_256_hash_of_secret_key": "610db3251ec079ce8003a49d64ec03dd49d89e82ae9f12d26d50938f4a3992d9",
+        "encapsulation_seed": "e9602b34fe73ad57f4bf6ead99743d645641553a5b9b9bf2e7016629e3e9bd76",
+        "sha3_256_hash_of_ciphertext": "723bebfc2e4e934fc9e35383c7f150d31d832e1516c66f8bb2effb449fefda23",
+        "shared_secret": "909b047e7f0fac27df2787ae406fdd66893a98d98e38a9f5b67bb5c8431a77c4"
+    },
+    {
+        "key_generation_seed": "dbf1c465fff3d9f783bd9ee61a573715e45691147b8904439b5ffaa64f94ff7bb6d75eac6c76ced1b0a025b40a55440712ad8424672e761e9bc400d63812006f",
+        "sha3_256_hash_of_public_key": "bb8615509158b63be5f5e51a0e690f2ad6fd0c56fa886bd85902abd52598bc81",
+        "sha3_256_hash_of_secret_key": "3a4a1360d366376a56362fee0aa22756122e3c40226c770797c0baa82192bfa5",
+        "encapsulation_seed": "f72b9080a6c051bbdb9b0abc1949034be0f89a9f73fe277ec4d4740c78d04a83",
+        "sha3_256_hash_of_ciphertext": "47cead6dc9f155f4e61afb233c6a8519f016c6f2bf7b1668ed9333daac257507",
+        "shared_secret": "dff8310ce364ba5686b9d42a17922b8d5e9259a176e38d39687a5269455939f7"
+    },
+    {
+        "key_generation_seed": "1f7cfd2b70863154e8a69d1758532e86c20cfc763d67c758bd10a13b24e759b5273b38bddc18488024ec90e62a4110129a42a16d2a93c45439888e76008604c6",
+        "sha3_256_hash_of_public_key": "5cf14252096e4988d8ecc4ac6d29ff09c55d666865863d03a68db523728910a8",
+        "sha3_256_hash_of_secret_key": "404e6febba9802464a188007c2137fc25a4c437611babc8fa8248a0e42e45357",
+        "encapsulation_seed": "f1e5542190db8ecf4b8d617a04fd3783ad0df78bf8dab749afb57db8321d151b",
+        "sha3_256_hash_of_ciphertext": "84765944d4602d3fca6333b699d98e4c8c9b3bc1570d428398a29cc5a7fb96c7",
+        "shared_secret": "faa9833781a7a41691f236feefa0c743bc141f458ecbba98eac4a51ee1ca001c"
+    },
+    {
+        "key_generation_seed": "3a19577908efd37697b8edc7fdaf47d1bd3ad01a1b77faf794bee5b9c3192a6fa3729672816f3eba84c9638a79676eeac0f22c8a48e0c5d50a26ff0844c66b99",
+        "sha3_256_hash_of_public_key": "345118a7b9bcc773f0ec10c3e353eb4365d2bbff3b812df4635d5c8265b5d8c5",
+        "sha3_256_hash_of_secret_key": "2eff0ff04aa2f95d9d2a877d2c3b4a09255fed2413da76e63506d0def33f42ff",
+        "encapsulation_seed": "74efa414ae171bf60b6f884cb7e5ce12028f49365daccfa23e845d551711660b",
+        "sha3_256_hash_of_ciphertext": "602b3893213ac6168e24c7c20d22a9c9126a9f70b918df134860f394795836a6",
+        "shared_secret": "0f47139a8b007c4ba77c91ee885435dfcd38d38c0aa4f57fc147f08b4751aa44"
+    },
+    {
+        "key_generation_seed": "ae0f65e29f38804a6759f70f4d01e2aaff7fe1c91ebc4f892dd0de3ab2e68ea5e03ff73e02a217659f53d8c47556bf3d8c94040f630d63605e2d0f923579370c",
+        "sha3_256_hash_of_public_key": "772f50f7047714627bf76bc098e0b919145fcd8df6922ebac383e5c556738390",
+        "sha3_256_hash_of_secret_key": "c48cd8eced0093133d3d083baae0f69ebc3e239c373a41db9557c1a46a40d480",
+        "encapsulation_seed": "0b4c3cffb2ba4380ead13dc0d8acad2356b448a810da1df29f264c44aab6d24f",
+        "sha3_256_hash_of_ciphertext": "84f212f6cac0f0e7a6a27630c0c33f98063bd57243b26fa086d6a37161d75f81",
+        "shared_secret": "182d34d0e83216d26a9d13301fe75a3aeb15ab145433965996255120cc9a5f86"
+    },
+    {
+        "key_generation_seed": "6084a235f79dd093ef6d185b54e69df33dacee73a9bf2f379004421a10e3a79d9f684fb055ece19459eb464e91e126a7a6e3ed11ccee0046da234d964c985110",
+        "sha3_256_hash_of_public_key": "a9f015f625356a6bacbb5e565c70184940891589309a571b7166c2ee713b8fbb",
+        "sha3_256_hash_of_secret_key": "924859759e33e4100a02afca0ad0f0e631eeef3b4a70444267e921b0b6eb334d",
+        "encapsulation_seed": "1c82471dcdfca3a6942061ab4f3d5bf0d197321437c706d9cccccce449447002",
+        "sha3_256_hash_of_ciphertext": "935ed1ee90431bb81d67fa4c620c973f7354aa5dab63b51686501882e65a3961",
+        "shared_secret": "62a14f68d726235fc16e0ac57ad4ae0eb3fc029abb18567a4ee574b44924693b"
+    },
+    {
+        "key_generation_seed": "acd1c0217fad5caa4235544dd9de153ab1880ccf4c76f16f236fae4e4bfda04cf03a8abb0a5010f400ae5722a75bdf5a2f6d5b546b34d73857cb1bfc7e587aa7",
+        "sha3_256_hash_of_public_key": "655d6f749b0a013bec99e017f5e13bff76680a2f9386f2ac6938d7950d5fa1f9",
+        "sha3_256_hash_of_secret_key": "0511490e76eaba3b276ebadd300c394490589dec54468855977e96a33025e06f",
+        "encapsulation_seed": "46fe60a18124125ab93e0c578f1c02f1bd1301595013001c7f3c2fa56cde294e",
+        "sha3_256_hash_of_ciphertext": "c28eea97d0767b408e58bbadfdff091ba468c26b585f22bde6f3eeb1fc7bb631",
+        "shared_secret": "4ceda11055991ce1e5d910a240981e39a6a903b20ea6ae6a21d9d56d0935efa8"
+    },
+    {
+        "key_generation_seed": "241191401a63afa750f05662e354dddbc683c776ce3222beb83e3cf913d7ed7ca59b3bd23b49a95bc1fad20070fec930b6060bd827d742b077092e422268e15d",
+        "sha3_256_hash_of_public_key": "1c3c2aed0ff6944819c93f9a9fe77d14a16a385f644de118099fd4f7f57db9a0",
+        "sha3_256_hash_of_secret_key": "0fb711641d1830a3eb4ae1a4bc2fc610ea9a811fdc5274488dd31f9cf52ec04e",
+        "encapsulation_seed": "52fb7cb6a633fd2e83f2892bd9441b48fe59ecee6d026f5246fa7f2a5e55ee3b",
+        "sha3_256_hash_of_ciphertext": "9fae0ef351454fb5c87cff7ed880d32dcc2f0654ab8c5a5b66b1e85d8e6feb06",
+        "shared_secret": "8d8257f05a4e76ad11783f7f6850c4f1c34017bf5ab47f89eae202132ada42ff"
+    },
+    {
+        "key_generation_seed": "b9a6b0c05677e957d41a34ba03bd06f2a9092e31f63389397d7e70fde6409d18e99c0e7b82be89bc3c1eaee6680aa4efd394e40c2b3f30523c8117f7c26a8969",
+        "sha3_256_hash_of_public_key": "357d61586f671648188f070899d2eb3408158adf5e8056ef37ab6d8817cd8275",
+        "sha3_256_hash_of_secret_key": "b22e39d960d7079015d70fba54ae860285f3c182bd5fc8d84c255f5e0f86f800",
+        "encapsulation_seed": "0f81a5f97082121244403da3feeb734f6084b314b8d94beb11627aa6ad1914e9",
+        "sha3_256_hash_of_ciphertext": "388d730604d16fff83eaa4e21a540b2ed8b3138f81b4c1c4cd7bb863325344eb",
+        "shared_secret": "08a60196adf66426b4e7b90be90160e196944d012cc34a524e1e73ca125ba407"
+    },
+    {
+        "key_generation_seed": "28a96c71577ba00c94f99fe965bc595a26db2b3ca6ab5cf8e443cdd8462b17929c35d165453e5fcdc6f9df64526d9de698f2bd3e6bac6c7fdd86601b9ba5f4a5",
+        "sha3_256_hash_of_public_key": "ef07b1f4886b895a3246241ddc084379eeb0f0ed84bdcd318fe72c9b546413be",
+        "sha3_256_hash_of_secret_key": "132633e3d33bcbc61ff70504e34bb033c92db5086bd924eab4ecbb8e4be983d5",
+        "encapsulation_seed": "31af9345365549ea0360169ed57daf98cc5444799d4c75d9f1f5d615e9df8a91",
+        "sha3_256_hash_of_ciphertext": "ea130b782f8d0167bd57d1cbead18c1a5a65ac27681847b85d8e09030dee8738",
+        "shared_secret": "13f3b79bb1e5d20ed95c7165a610e122b5de6cb02444cc66e0f1f9ec44c27485"
+    },
+    {
+        "key_generation_seed": "c08ba2ef8c3a0a043afad931652d7a19e6e8cb670f840de5f1fa03309b2ca9ec5fe6141a25f7ab9f875f79e0a82d6ea5cde5a017ab637d5fdb7c42646a1d71df",
+        "sha3_256_hash_of_public_key": "1a2d9ea0d2280249d9d756975c6979a8770bf4b5f6addbd76d045a816bc1be38",
+        "sha3_256_hash_of_secret_key": "23678549b4e6e050b57ed1ad078705d33fe76ac976a9f70312b9cb45be554b0c",
+        "encapsulation_seed": "774ae54093d694ef40b63b62c73e6c98295f606feb8699807eda1d030ffb996d",
+        "sha3_256_hash_of_ciphertext": "254058fc10c3327f551dfa143d17dcf4dc4319419050cb5e6841a8d5cb6ce9cb",
+        "shared_secret": "fcf4227a487e719499f86e44ff74a5339870e4238c20731e0c85f00229f2a1b4"
+    },
+    {
+        "key_generation_seed": "0e3b30e102d707538c2671060f603bb0b8a014103f132d63b09ece07e4a4c75b11eafeca9e810796c34e8cfce9d59342884456007b01ddd12edce6d10ed87e4c",
+        "sha3_256_hash_of_public_key": "a57b333a2f41fda2ea72ea11d8bd642d911f6afe90e60492ebeefdc17a932192",
+        "sha3_256_hash_of_secret_key": "b59171816497ec0c34b963be3ef6366eb051cdebdb145fe445e16b72aa37356f",
+        "encapsulation_seed": "9f27a47604ab5146caaf0aafe6d149424f8d66e39ba3baf5e6c73b19221b7e21",
+        "sha3_256_hash_of_ciphertext": "4bb877beb1b9dbe916e61f9d6d7442deb7483128b6db494a0724e081be74ded6",
+        "shared_secret": "3f8cf35d0ba76d75dec611e5fb059db5197862b7e5cc6b116a730734932441f3"
+    },
+    {
+        "key_generation_seed": "2478f7d3de6041e7e5cd11c5e2ef483d1aa6218eb126444091535f6ae532fa7311136e2681df2ef881b51a092a9badbe72c9772c169808521c47149578621e28",
+        "sha3_256_hash_of_public_key": "d3cd2febe168b1ddf776b954e96085a7d475e3c8cbde68f7c80ffc9fa46b0d43",
+        "sha3_256_hash_of_secret_key": "b41a159ad0a89e7a771ef11e68efc9d79e6add05b261d0e40620a6b667a6c6bd",
+        "encapsulation_seed": "90044031b7597b5e60a4f946b713e8996d0426d2cb013243d9b7d8f8ef159a0f",
+        "sha3_256_hash_of_ciphertext": "62de1efed6f92fc50d8fdef1ff217cb04faf53196e5af3a7507cb6ea5f822e2d",
+        "shared_secret": "d48544c1ac452c0b821e080e02c9c83e95252fb033617ce270f58e2974679fc6"
+    },
+    {
+        "key_generation_seed": "9d405d3ebdaf35fa8722de431b669722acaaea2fd10b814310b17f78b66147d16ceb14f7662be0c42779459f69a145c0e2ce9f0bd9a0cd1bf32ed5694cc9ae32",
+        "sha3_256_hash_of_public_key": "9499c1b006a0ec2c299c41c3f728c3bb7848957fb2bbbcd05b65233b89a2b1b1",
+        "sha3_256_hash_of_secret_key": "bdf5c3beb39ae62a6e29e858962c322fe525a307a163d68f765779b7848bec3f",
+        "encapsulation_seed": "a7a31e140891ea37d2b6424b59b1f84f89220f32dcb73e037eb912b389d34a48",
+        "sha3_256_hash_of_ciphertext": "3a0a1742b1e27f14001e3457a00748f232f550687a232fa409c2098f97e72bb5",
+        "shared_secret": "6b8f4cbb3c4fda3c067d7ba48bf24e24258ca7e26bfaf918b784d01ae74ec57c"
+    },
+    {
+        "key_generation_seed": "9a86490f0615f3edf789cb0654066e9ee339cc59f968281f3b89213f83c692edfaeb2ef44d2f608621e831187ce79b2d2f4a20f1568bbe76b0d3d5af36111714",
+        "sha3_256_hash_of_public_key": "aa14ea531df0a7f93225de1c75ace0d2692bc750b1b538cfd0d860ae9c5a8c13",
+        "sha3_256_hash_of_secret_key": "155cff081ef58459a00ae63a6ee0ed2698bdbd99c67b4c9dd09f8b0fc3de0120",
+        "encapsulation_seed": "70eb3f791faa91f1f982fa477dbcddeb2c55691c07f93b04cd31b37544c94b42",
+        "sha3_256_hash_of_ciphertext": "8753aea7979a0d3f7aa35b9fab1b320d1b0965899bd51bfc8c1f6de79ff7d92f",
+        "shared_secret": "aa9878a81dd8165350b880c4af6a2adb9e50a48b9e0709f069c02184d3785181"
+    },
+    {
+        "key_generation_seed": "6dfd9b575872560c7bdc2732c4a28dac4db04e535eb8e402c3dffd145c09ce47a2985c1c4d203778597947d710dec806e36b0cd949fe460ef141213bfc525e5b",
+        "sha3_256_hash_of_public_key": "e0013ff7eb7b8266ee94659f3372f5981ce1d87584cb1f0e80da2c0c95c16b4e",
+        "sha3_256_hash_of_secret_key": "7eece78f3f97759d0cfc8a69481271a425c56e540704b2fdaab8b2d920d19e21",
+        "encapsulation_seed": "30f4095015ba88b6d969672ca3f438c395dacf7d476ea7a9e805ce932d270a13",
+        "sha3_256_hash_of_ciphertext": "777253af58f65c8a85f3feca46f8d32eb5d3d5d0664ea59cfdf47b89be9f005d",
+        "shared_secret": "5a23296c84df3d660e7c2a973c4e6bddad3fd814e158028ff92b234cffb1afa4"
+    },
+    {
+        "key_generation_seed": "6fca9f4e384d8418075cc064c70730801bdb8249899d456a77130d5beeb3662cce7683f8a03d3cf04e46970ff7d6a12494ae12558346dfc8fd9370bf944a0102",
+        "sha3_256_hash_of_public_key": "b503f8ec36d39fc7b4b8ada1cbb933b9db9ee118bf081ed75dd5dba7590f6c8c",
+        "sha3_256_hash_of_secret_key": "65d28565658fe991b77136b89255ec2d1cf65368e06f2b30bcedab87ffe39550",
+        "encapsulation_seed": "cf31220f44de862e1719570e1b26e897790159366a385452334fe24cdcae28ba",
+        "sha3_256_hash_of_ciphertext": "a7302707d52fc49f3e3637a742826bc8c8267e89c1fdf95b2ab7a0d8f1003c8f",
+        "shared_secret": "d790ec546719fb05125841bda9dd361e162ca4241e2b489a0f948b612309b649"
+    },
+    {
+        "key_generation_seed": "e58f71bf175c0550a67e00e0f7b3b7fc36bc2707bf0c93044a492626de36301a7f7054814869cf7625e45647bc1547aff288dbb90699b2ad84893f3b755d9722",
+        "sha3_256_hash_of_public_key": "03341657b159925cedc8967872a45a3c1f0122979af87a878a2019b3f17c8ba6",
+        "sha3_256_hash_of_secret_key": "6bb236b9c7a818f9edec1e5da339755dcb7ca1b663a5a208c38c75e7ad7dc12d",
+        "encapsulation_seed": "bb5e65669a44e5d5c709bafa98c16ccba6ac2c4ae923334f69a11543eda64f5d",
+        "sha3_256_hash_of_ciphertext": "9a9301ca946909c3ee5d2171bc36322179ab4bfa825ffc0b826517accbc78298",
+        "shared_secret": "10086d1a59c41f84a089c239fcd8f8eea3b22c7796f9c1f9b1867b709cb77704"
+    },
+    {
+        "key_generation_seed": "e3fc575ed51513e62aba655d24cd9c8f1c6c848aaffa946c49a53ac3ea59e474d82c2f1bf2e6aebde5660fa73356982e12999d8fdafbb3cb186341d0386dead0",
+        "sha3_256_hash_of_public_key": "60c001172c4734a620c248654c58f1c10135657083de776116a6acf8a55f3610",
+        "sha3_256_hash_of_secret_key": "b10663e90392d6387c16dcad565bbe1fbc05f32495cf9878706bd0d61d289147",
+        "encapsulation_seed": "9ddb3aa9c7905d1a438c93bcf78e3e321813580371ab4e1289e2dbf3701972c2",
+        "sha3_256_hash_of_ciphertext": "e4b3ce9e19c204a884f8a5adbe41acca97a22f1f5f2a13f1185021a8a36a131f",
+        "shared_secret": "82ad68065774eabcd6e78c027286ca7c7120987c4984e56f52abeb1ccc7a273b"
+    },
+    {
+        "key_generation_seed": "470b4943f0fe7fd0d8ec5185aba0d1db09d112934e4fb4787e2bbc6b88466e7b8b2809fd40008be70a6b184981101724bc3d5ec5e1956b510b82fd5ad0668a5a",
+        "sha3_256_hash_of_public_key": "647a136f20b22c63afd2b88d14fe7677cf5c2b78223a587068377021f6edfe9b",
+        "sha3_256_hash_of_secret_key": "e70be83a7585618e7b91bc9930a581625e2441962c823a27eda9f6dfff8528ee",
+        "encapsulation_seed": "26d90b190a6c3d0d9a86cf66005154e7086749e966e7187c249ccb9329fd3b8b",
+        "sha3_256_hash_of_ciphertext": "6287ca7c4d1eb3afb6ecfc456a4ca9ef5776177dbd5115165424c66e2db061d8",
+        "shared_secret": "2d56c88020d399532bada6516f9a1acc28a565cf252bafd40043879bcd6de1cd"
+    },
+    {
+        "key_generation_seed": "6df4385db978d27b27d2aa5e452e4152b36f097503d9581ac3390105c5727e7dc95fa08ed106ce84660e8a4c90bd2b22634e40769aa0090a101c5dddad45edc5",
+        "sha3_256_hash_of_public_key": "1cde599b2dfc69d59036434cc0423337513fb9506452bd8f42bb82661ad0065a",
+        "sha3_256_hash_of_secret_key": "aa80a266176a7ef8fb22fe21fcf3d3762cfc36734d8b6db3c6e1d4df1eecc1a3",
+        "encapsulation_seed": "7db6d1a129d6123f1f805b79ad3b413012ea86aed42a05e98e7b1f32f9fbbdec",
+        "sha3_256_hash_of_ciphertext": "31c85544389bc3163e6893d9298d947a6cd189b045eadf8dcc265e4b5c750fcf",
+        "shared_secret": "44052d0cc62801e0d9717c65ddcb560246cd901f104b4252eeaef903f7c26af2"
+    },
+    {
+        "key_generation_seed": "dbacba825728444921b227cdba54446b3f6881b47be9cd02832f78b023b1bee0e15274a8e2bc08fe818b117ba28c5dfae74d54fcdf6f20052f79be333edc8dde",
+        "sha3_256_hash_of_public_key": "2a50c7a070b3dc7e107eb1e8b96d62305c13327d729bf9d97c69f1fe6eed2b52",
+        "sha3_256_hash_of_secret_key": "6df052019662b83b16b4da0a85b17f2fe56ad269b294438c8ad298d2e2269d2f",
+        "encapsulation_seed": "1d129b27be7384c359d04311fe5c44917d1fde4bfb57314f483ac617edd5ac49",
+        "sha3_256_hash_of_ciphertext": "c485c6e392c29c231c9eb04861fefff1fc27544443ebb316c74f9d4d7d9be68c",
+        "shared_secret": "2e95f47543ff640e6384d65cede004c4fc47e9e2f05649e694c18c7faf975987"
+    },
+    {
+        "key_generation_seed": "690eb71fd7052b906eaec09937a8ed374e0b02afa27c2f14399932be5839fad281c38c2cb5cfafac81b96a810ab749b61806b6d54c9f8cf4bf1be0192423288f",
+        "sha3_256_hash_of_public_key": "5f166082ad3ab0c739cbf0a6bbe2707741d9b5f53a0e16199280a2376c9e5a17",
+        "sha3_256_hash_of_secret_key": "391b71e679b9a0a23a1aeba042ec7df439fa0a18c6442dbfe2bbe05d4fdb5fd6",
+        "encapsulation_seed": "bbc773ebd2df42c36ae05952d6a64c63a5dfb82ceb3ef4f8d4df3a30ec8c0467",
+        "sha3_256_hash_of_ciphertext": "499c37f74e94c6c724e218f339b8d60ab65190e0a56e39a6b4cf619db98bb57d",
+        "shared_secret": "42f1442e384b4e747794c944f4df154cde33cdff32bf35c2c5234919762030ca"
+    },
+    {
+        "key_generation_seed": "32e0ea9089fa928482c0770da545af1bb871a03ce38604138b0d08ea2a10ca2bc06c5bef7b6508409daf847a64c8d30d0974fd3ba7476dc76c46b458a036d884",
+        "sha3_256_hash_of_public_key": "40b3a72c164432e6ca838693ef25b30013e5cf56c1e6142828107a10cabdd169",
+        "sha3_256_hash_of_secret_key": "6f970259ae97422f8698120bfa8e53f4f89589773243db6e7a1859c94181a3f6",
+        "encapsulation_seed": "5b17a6adad541efcbf5ae4b0c0452cd2ce32e4f0f8701801c5b63e197c1fcbf4",
+        "sha3_256_hash_of_ciphertext": "55e508c96b8b7c06cc9a88b4c9f974abd3e2cdd96ba6f0cf330ccaa3641fbd29",
+        "shared_secret": "a50a07f6b01ee4429848806031637c8ef8da23f253874124452e3771ef98b6e0"
+    },
+    {
+        "key_generation_seed": "6fb2ec719f2a0dea152bf3f64b9d148f8ab8ba88f64e61f5db53e12d59f525574f797c007e4061f95c7d56cfc7ee5c49e849dde3fea8f25e7876df2a18515c34",
+        "sha3_256_hash_of_public_key": "f475da2ec982c47d91b24bb5ec6c51910530eec26f38541b173b38927d23c568",
+        "sha3_256_hash_of_secret_key": "f8c836ce8a42d6d07f1ff40e2dbf16d264bb6ecd1cc0227ebf792a6bacd327ec",
+        "encapsulation_seed": "61ab87659525de9656af41246f20e1dbe85c24e335e7ecf9493f46168bc14e94",
+        "sha3_256_hash_of_ciphertext": "d63a88547104683878df29e59de826821fa3a95bdd668e5e838e08a671d887ee",
+        "shared_secret": "c299f650b03170f5cdef5da81e52c2a094b11aaf58426e8c41e06a26c7d5ccc1"
+    },
+    {
+        "key_generation_seed": "527fb88c8bd9a4d6031dad15e63878abd2b559e7e08d61f69e8e78fca964ee6ae32d432b4f9f751bde0496c580a181ffed762aa35454a02d3f1f47ee0394c89c",
+        "sha3_256_hash_of_public_key": "2b22f73a770cbdb80da84f97f27a14c5df5b3372d52503d3a20c3cb2bea8b404",
+        "sha3_256_hash_of_secret_key": "a111bb1797a3baeecc223e4fc4accf093d2e069cfd40d45346d2aefc09acb358",
+        "encapsulation_seed": "eca2adc3da1fb15f34033405ec08ef2f46163df4bfcccf8842c600ce0bc2026c",
+        "sha3_256_hash_of_ciphertext": "e9c030db90931ef3d2a61077dc33529aad87535e809d1a255fb5b5925f202893",
+        "shared_secret": "5e1ac468279cfe354c4d0df6ead070071b19c9707338158ff7dc133684afe2ba"
+    },
+    {
+        "key_generation_seed": "ac6fcfaeeef795b6ef9e062f02bf42975fa01e7d91ba832f74e05269a72684d05aeda108ea4d6c6bc0fb958286850422bc357ca67b83c986048e0d0087fa11ec",
+        "sha3_256_hash_of_public_key": "3d8fe8354d81146fd65af657da08926bd3a6ecbc2f81cb58d1aaacfe5b6e686f",
+        "sha3_256_hash_of_secret_key": "d1c524a715b2d05abc8e8729204b620f4551815cdeb00662b487d58e99c0ac7e",
+        "encapsulation_seed": "c4f15bec2d7701339d0ade4835193bea3632edcf89e74992620d9eb623a0d0d4",
+        "sha3_256_hash_of_ciphertext": "c256150127c8119ae42a62b90ac9a7119a3faa5442f058bbe5844d29c99c4eee",
+        "shared_secret": "7841501410e4158cf04f92b9d65d0cec732984ea66809130aeb594156829dd39"
+    },
+    {
+        "key_generation_seed": "ba2fb9318d4dbe7488057c33e95e6f054583a2800c41bb83083c330a914a12cfe63f8ffda3565c2424c89b20974b748a65a5aba75133fcb3156dfb6626a83bab",
+        "sha3_256_hash_of_public_key": "36fc15e2340175a2a64ca1cf31a4b38ed5f797aaa8acb0c3d2ed9c19c7099f27",
+        "sha3_256_hash_of_secret_key": "0741ce5533316ef689bd966721b1ee57a272d5eb557dfa6fab6de770a2e7afa0",
+        "encapsulation_seed": "28878249e2ac2b6263422993923a0c8bd05ce56e385ed13c943b03d226856947",
+        "sha3_256_hash_of_ciphertext": "0c6a7cce80da6e6a3c17b46959124b8c26a8a74b5068f707f582cb5b811e282e",
+        "shared_secret": "6b3fe0dd082bf384c3e08497d380516e78ca778de627c112d02dc8c393334d11"
+    },
+    {
+        "key_generation_seed": "aa6dd1e5799cdf7af9c4fc632b3eb9d51d66e85c8e0a21ec98664fc51ab63c7dfda268813efab5204efa60f78bf81d320d01ac09ac06244f7afbd2d80fd356d9",
+        "sha3_256_hash_of_public_key": "26a1b77ae8a807e9de16a9ede5da5aec3ca5f23f5ea00e455d4a091467e6ac6d",
+        "sha3_256_hash_of_secret_key": "2bb0f5318208eba32bfba206dfe174f976431dc12421bc7b3705fc7c0b4a06cd",
+        "encapsulation_seed": "17fc65f7fbd7c75ceec421dee84dff5a8cb22764a182db17e0ebe857f54d60eb",
+        "sha3_256_hash_of_ciphertext": "ba2e94ce526ee4bdcd818855708af8173acac373696df4f910720fb296bc1076",
+        "shared_secret": "cb15c306ba8d5f4f8b723db93bfbcfd4fa02ef32ed8e39c2aeb706a463d9a40f"
+    },
+    {
+        "key_generation_seed": "195d6c86a3df4c21e3007d7f2768b43c74cb3060e0eca77f0a5d3271542b9a84ae77e0f9f21eabd8c0c6eea7767f4e10fde5c2d79b8400bf96b19014b457ec21",
+        "sha3_256_hash_of_public_key": "2460170e6cf1da1e7b92037f51b4e7674d9abf74f5c225c5c6ce16a971691284",
+        "sha3_256_hash_of_secret_key": "a364a1f435a2d2a341b59a1886af0d0f3580e56306869bbab819de741ac9f642",
+        "encapsulation_seed": "fa0489f3730100609488e951e6aaa15c0f193bc1dbcfcd013bc418d6c507b176",
+        "sha3_256_hash_of_ciphertext": "ff21fac2cb15307ebb70ec04904f636bfac9ba968e86984b4a55dcac70430c1e",
+        "shared_secret": "8dc8bc55a907bcbad27aafbba2cbd957c30794e3770d0984a6323b641e5fe53d"
+    }
+]

--- a/libcrux-ml-kem/tests/kats/nistkats_mlkem_ipd_512.json
+++ b/libcrux-ml-kem/tests/kats/nistkats_mlkem_ipd_512.json
@@ -1,0 +1,802 @@
+[
+    {
+        "key_generation_seed": "7c9935a0b07694aa0c6d10e4db6b1add2fd81a25ccb148032dcd739936737f2d8626ed79d451140800e03b59b956f8210e556067407d13dc90fa9e8b872bfb8f",
+        "sha3_256_hash_of_public_key": "7ffad1bc8af73b7e874956b81c2a2ef0bfabe8dc93d77b2fbc9e0c64efa01e84",
+        "sha3_256_hash_of_secret_key": "26e1b5ea0f48b3c87d7ce87113b6a93a49d9f7ede7c5cb15b41382bd3243715a",
+        "encapsulation_seed": "147c03f7a5bebba406c8fae1874d7f13c80efe79a3a9a874cc09fe76f6997615",
+        "sha3_256_hash_of_ciphertext": "a3856ee9fb112b154b397c91398576dda45391b89742603436588d81ce6d1b50",
+        "shared_secret": "c608777086ed9ffdf92cd4f1c999aedd0b42e5e8ef6732f4111246481e260463"
+    },
+    {
+        "key_generation_seed": "d60b93492a1d8c1c7ba6fc0b733137f3406cee8110a93f170e7a78658af326d9003271531cf27285b8721ed5cb46853043b346a66cba6cf765f1b0eaa40bf672",
+        "sha3_256_hash_of_public_key": "13f0970c03d32967b06cca4cf58e87559128d14cb3f876a1ed10eadfe03fc1a9",
+        "sha3_256_hash_of_secret_key": "9c613d0d3313af8169e65295e8c4f21f0b5d3e78de031e78a12ec864d71b6548",
+        "encapsulation_seed": "cde797df8ce67231f6c5d15811843e01eb2ab84c7490931240822adbddd72046",
+        "sha3_256_hash_of_ciphertext": "557c682bda01552173367f40bd2b2c1ed64aae3f083c80ce2f812d0b60acfacc",
+        "shared_secret": "9401f92689a452b5e58c35cf06690596faa4ec0937a04493a359b59ab3b0fdee"
+    },
+    {
+        "key_generation_seed": "4b622de1350119c45a9f2e2ef3dc5df50a759d138cdfbd64c81cc7cc2f513345e82fcc97ca60ccb27bf6938c975658aeb8b4d37cffbde25d97e561f36c219ade",
+        "sha3_256_hash_of_public_key": "083553153f7d65cd5cbe201e681245eda61e1ec2c7ee6b91a9ccdeb6b76943b7",
+        "sha3_256_hash_of_secret_key": "b4148d4bba0430ddca173618456704ddf440b9b5bdfd61ee46bd79590dd78ff3",
+        "encapsulation_seed": "f43f68fbd694f0a6d307297110ecd4739876489fdf07eb9b03364e2ed0ff96e9",
+        "sha3_256_hash_of_ciphertext": "7b7b882320575a3cfa5f0ca2165ed39383921da042f7bce896896fa90fef2aef",
+        "shared_secret": "f2c689c7a8180baf27a4573d3e6154d4f2bff7b3f34d44576e777e2ac1249e8c"
+    },
+    {
+        "key_generation_seed": "050d58f9f757edc1e8180e3808b806f5bbb3586db3470b069826d1bb9a4efc2cde950541fd53a8a47aaa8cdfe80d928262a5ef7f8129ec3ef92f78d7cc32ef60",
+        "sha3_256_hash_of_public_key": "9df5746a44b10c1886f62b068d18152a85792781160e1a1a19a25b5ca00555f4",
+        "sha3_256_hash_of_secret_key": "75a93307372e001d4fb028125dad61c4412ac864bf7eac7a213ad3dca6599981",
+        "encapsulation_seed": "ea74fbc3c546500ed684bed6fe3c496d3b86d2d6dfaf223969b942e9a8c95e85",
+        "sha3_256_hash_of_ciphertext": "72782e8ee6fe4e4442723e727b5d415f66fda7c363fe6dc7be22d9b8741852f2",
+        "shared_secret": "1dac4f6f8d96ffd931f67b03cee8c4e4bcb42eb8bbda5cb702dadde8340d1524"
+    },
+    {
+        "key_generation_seed": "66b79b844e0c2adad694e0478661ac46fe6b6001f6a71ff8e2f034b1fd8833d3be2d3c64d38269a1ee8660b9a2beaeb9f5ac022e8f0a357feebfd13b06813854",
+        "sha3_256_hash_of_public_key": "9415ce164fadececacd75fdad3284af20c52fa576699029d6e0ce77bf347d520",
+        "sha3_256_hash_of_secret_key": "97f1f85233dba2a50848add15f8f0e60f4ccf3542dc6da5f59e06f6b27c59c67",
+        "encapsulation_seed": "64efa87a12cb96f98b9b81a7e5128a959c74e5332aaab0444fca7b4a5e5e0216",
+        "sha3_256_hash_of_ciphertext": "80f49e8f6f8d442a7678f2c33881a5264b58a5998b7d9a8e10b2febf59ba868d",
+        "shared_secret": "01adaecc8cd981e7f00187622defc0cbb8934464ca4675d86bc7d9b69148c85f"
+    },
+    {
+        "key_generation_seed": "7ec408f52c9aa723d0c41d9987682a5f4ce6c9da7cd0215af60bbaf5484ab353a08ccf451b049fd51d7a9ad77ae14a81569df8c9bd3a8f1ebea86fdcfb823082",
+        "sha3_256_hash_of_public_key": "ca2232297ba8b986dacd401896cb6239f557720d91a2cfb7a73274bac7a0f6de",
+        "sha3_256_hash_of_secret_key": "17446e8436a68423ba4e22a57135d470c7e91fbe0a4da065bdc34897fda89b2f",
+        "encapsulation_seed": "8a95d71228acaa5f9ae6f9d9ca8ae55fde296463b41083a39e833e37c4c90f88",
+        "sha3_256_hash_of_ciphertext": "a08cfd7a6374d902e153b862449efdee9f912234f3e7a7d2697ebf1909f59dfc",
+        "shared_secret": "6f13bdb1452d9e672c8fedaf9450c436e5fa77e8d58ce83300b8e539f20e9dfa"
+    },
+    {
+        "key_generation_seed": "c121915bfef6abdfc177dae2f5a24218f9abda2559afc6741b08e0e61ab433eb84ef52db5eaa6df8ec3a0bc5ffa730db0dde8c5f38f266d5c680a78d264a7b96",
+        "sha3_256_hash_of_public_key": "34486689b387ba25dd0e9aedbc53034924ea4ef9497b5772f10ca4d091e9e846",
+        "sha3_256_hash_of_secret_key": "94419fc5d865a97586b71a3414721f04473d4d30e5a8d6a1c438752f19504209",
+        "encapsulation_seed": "90d79d75d0bbb8921cf70d46bab497022a8e750efdc99e5f1bae653275441c7b",
+        "sha3_256_hash_of_ciphertext": "6b930dced8da8c0353569fe807e383e2d04836680fb78881ffc6974802131eca",
+        "shared_secret": "c81a637f63a802a5d2b336dd960175176b2b838ffb6de5adc501bef984fed26d"
+    },
+    {
+        "key_generation_seed": "d86634ecf96cc2603761e284c0e36734cedec64e7ff486469e38539c71141c5a99daf37400cfe59841afc412ec97f2929dc84a6f3c36f378ee84ce3e46cd1209",
+        "sha3_256_hash_of_public_key": "39d1850f7acb36ed2a35e9af6f94a06c31afadaae3545a069f892ecd8929f766",
+        "sha3_256_hash_of_secret_key": "98a2ef35596f2fbc7e462d5ee536f30d8bc3a5272d78cb14c0ce816fbb180396",
+        "encapsulation_seed": "be8a32f97b9a8d596382c02fa2a0eeebc15c083e970ddaa4f2622b91d6718663",
+        "sha3_256_hash_of_ciphertext": "2d277dbc8b03bbec796e778c74b4c3f408f3e47835398039236d7cd861762a9f",
+        "shared_secret": "3031994f1365446186b4a4d6190ac89f928f6706d08c6316d6f522cd7605adfd"
+    },
+    {
+        "key_generation_seed": "0610678ff4dc3128e1619f915dc192c220f8fad94da1943b90aaec401683a492da1804ddb5aa9b1c6a47a98f8505a49bae2affde5fe75e69e828e546a6771004",
+        "sha3_256_hash_of_public_key": "edc8db1ca35744a75ca14516abe07472d0d1b723f70ca8cf0e5c9341fd2e8c26",
+        "sha3_256_hash_of_secret_key": "fa6de16f50b0c04b8be10d3262005227715f69de5089f0f6bafc1fe26603e525",
+        "encapsulation_seed": "da2cfaf69e25b2a89ff2557bbb6f69e01d8e2e7bb27a7a1ce7e40fead16f33b2",
+        "sha3_256_hash_of_ciphertext": "c20e526b8837092f1847b40f9b5fda528dfb72780aceb510635b490acb5f7686",
+        "shared_secret": "61419eeacf26714b028d2f7e1e3769ae2f181a7e9311f3312911ead00486bcd5"
+    },
+    {
+        "key_generation_seed": "d322d56d8ef067ba1f24c92492b9c56df3a6ef54a304adc1b69913766a1ce69756047447b810cc094d400ab204cf9ae71e3afa68b88586ecb6498c68ac0e51b9",
+        "sha3_256_hash_of_public_key": "b1eef6e8c88ff8da9cc4a9b01d4c08b6b585beb5bb9e084c6c47a717b51feea3",
+        "sha3_256_hash_of_secret_key": "bce9d6b2e45918ea5798910aa9baf289b04d8a5bcfa7e08235dccfc8b9479f55",
+        "encapsulation_seed": "511c2ab40782322c06111e144e505328c4e5bfc890a5980a2bbc44aeda4c738b",
+        "sha3_256_hash_of_ciphertext": "811bf647ebaad03c81a84c6a82b4cab108267b1e9c1add3dff1803623471f9bc",
+        "shared_secret": "3871c9637cbea04a2ccd3b62c9399b0a7277a31caba8a8f015d59b0fed845bb1"
+    },
+    {
+        "key_generation_seed": "2f1d8a3bebb34540324b9485fdf3d5be3b858f544abc3fc641b5728cafab03ba8d6c42e7270ee2b77b6045385f3d175984a0e260363166c73b0c70c971644363",
+        "sha3_256_hash_of_public_key": "f581c2fec9055830b38cb68fb506aa927443b1afd1b2b6faa6f92a325985c6ce",
+        "sha3_256_hash_of_secret_key": "9567f27ef67c3ada92a02cf25d8ee4a6db69744d3f6de5a0026dac023d04f37c",
+        "encapsulation_seed": "dca92dbec9b260dd97e8886f876862d6effc3b91fcf3fbc986cf56ab93ae79a2",
+        "sha3_256_hash_of_ciphertext": "c855f0a4521640b9136035b5d02770dbe864b85a6f54f422ccf2b512e1c07b33",
+        "shared_secret": "3775b12681d854b7ff2eec05cd4ac2db91bf06f3c14db2eb35287129a960ab03"
+    },
+    {
+        "key_generation_seed": "31beda3462627f601cbc56f3ddf4424e1529c04737ef0ef2af6d7401f653b8a1812083bfa3b670e3eaf9b443702fb6db16ac1197656bbd61a8e25ed523b8d1e5",
+        "sha3_256_hash_of_public_key": "f12f3ecad62bd327f1c44ae86c0be6e7f15112b7f6f6d5ec7b13f4dfab718965",
+        "sha3_256_hash_of_secret_key": "32a666c02a41f7b9408c570a3304a80e947a1be650f5f164e376b8b34b72254b",
+        "encapsulation_seed": "57c170e691d7a914a901b9a11c62b8b569b3806427557a9dbac9faa720ec3641",
+        "sha3_256_hash_of_ciphertext": "632b389d951d4a4e570d2fee62dd87c3aa2cf0c036dc63462f3ee7e4543ef8b7",
+        "shared_secret": "87662dcdee8b176e2dc60d079be188f63501274bde0829f3595c99d1e564c2d0"
+    },
+    {
+        "key_generation_seed": "cbdff028766d558af4466ef14043a1a9cf765f7748c63cc09dceb59ab39a4e4d8e9a30597e4b52ffa87a54b83c91d12a5e9c2cd90fcac2c11b3a348240411a4c",
+        "sha3_256_hash_of_public_key": "4cae8b58e0434fb1475312355a8b40145043bed4b269aaddd654d2e562324bc7",
+        "sha3_256_hash_of_secret_key": "53793d47a6e9e527f109b7611f33063dbe0b8a1423ac02178934f59c3d47ddb2",
+        "encapsulation_seed": "6b5a14e1473abf5a33d44975ca2088bd8fa6fddcb3f80e8fd5c45b9d90c24a5c",
+        "sha3_256_hash_of_ciphertext": "6f88eea1ec597548ec3c0d22c60a92ac4b0c3e17e332983d01a0bdda1157ecf6",
+        "shared_secret": "c5676cf0cc81871d677bd7f5982e6493aa3ea4dffbb30dbaf59e90e4977d2f12"
+    },
+    {
+        "key_generation_seed": "4c04310bea66305c6ca8ba6b8f61ca96257a67663afc11761f13fb5c7b324b6b8aec87a9a79204cee2986867a2906eb851b734b8b22b91d6749b1a5f07c44e3b",
+        "sha3_256_hash_of_public_key": "b899475c1802b1dd76a9783d93b4225dc558eea558ddc598cdc45a898b7bbfb3",
+        "sha3_256_hash_of_secret_key": "278b448b48a14a9be1ed211228cfab37d07e5f1e502478e3ad059c83a7c83894",
+        "encapsulation_seed": "40e593754e6eddb7f9cf176ba2d5fd1087c90ad377556d0b0f686537b1a3165e",
+        "sha3_256_hash_of_ciphertext": "36f6daad6b98df3f8e26456d06f112ca69231333e4ebd86e04fe7b8fd8c1bf26",
+        "shared_secret": "c5b03a417c10715a53f3a1efc044a81e266b40a1b16c87aa1f754146ac39b80e"
+    },
+    {
+        "key_generation_seed": "38a0d5f41d7dc1896efd1b45b0485634cef149828751b96087a0a6dd81b4d58aa2acf359556df4a2abaeb9dcee945829beb71185b4d6bd18b76e5668f253383a",
+        "sha3_256_hash_of_public_key": "1a7e0760c345cb5875303e20e4c72076c794e56ab75231750a190b45f374d979",
+        "sha3_256_hash_of_secret_key": "eb53a36a9f50baac64b4c7bcb97fecae54d3f66b8311b5a67c5daaefaa63f209",
+        "encapsulation_seed": "c152523abd8248bed40c3827bcf0f8e8127037a55c780695e2c28ea3e041a44c",
+        "sha3_256_hash_of_ciphertext": "1b4728ec7c6e90ad99dbee3b83438050df88887de2e6d7a6ec55e7a2f7f1bbc3",
+        "shared_secret": "38daf9348e4d89149e4968131370ce3d38a4028727fb85d27f87a95b341340fd"
+    },
+    {
+        "key_generation_seed": "97b5665676e59e3538ebadaa8cd50df1f9fda1502d9894c616a946078e56b621df05318b5f655efe36f1b678cf4b875108a18db2fa312261caf839f84bd956c5",
+        "sha3_256_hash_of_public_key": "0f96fb9e146a1c22cc5d23e9108af0dc5e13b7810b8f5598bbd5f8d4b54c8af7",
+        "sha3_256_hash_of_secret_key": "d494ee913886be1398be54856ebc83eb8cd7aab4268b976583be2e097edc2d64",
+        "encapsulation_seed": "ad6466dd59f26b762fb02b19eedf5f79964da68bce0459b91c3a6ee5a7e01183",
+        "sha3_256_hash_of_ciphertext": "3934a38f7c11d237b46c9d93a8ab8d3dfc76b3e020b5cfcd0344eae35a333e45",
+        "shared_secret": "60bc23845c0b116208c0ea02849cea3d8025a7220337c617c4bd304aedcdc1af"
+    },
+    {
+        "key_generation_seed": "ef99224a03a85a46ef115474ec5b5d620da6795d6efcca4c9135d19958a9de62df7d92dda83e6b2ef4cce08c9134563063068a196d7b1a1a13623e48ae12528e",
+        "sha3_256_hash_of_public_key": "0bb63b48b8cdd1c7242bd4f017c519b43502656e23817bfd683150488f8b0b44",
+        "sha3_256_hash_of_secret_key": "195207c9e44942d5cfbf338fb9f20317d3ae8be85dac5f10dd60abd802a3caa9",
+        "encapsulation_seed": "1a4d5dff5847cfb48333e33bb00ca7301b144aa89dcd412ff5a3b1081d775b7f",
+        "sha3_256_hash_of_ciphertext": "ddcc4d878447ee699abdb85f1463b113784be6d4e42c46379b31c02715243f17",
+        "shared_secret": "2eb03b010e291fca1bb6ed09d22d50b9c7bec93c556f1f273e57048c9c56bb3c"
+    },
+    {
+        "key_generation_seed": "b12f6fd965ea9c5b947db80fc60c83d5e232dca82e7263027c19bd62e5a6ff550f6aa3e88f7fa8a96067f8cdaeceeac90c2d0b5e277e56e9c405ec9420c30252",
+        "sha3_256_hash_of_public_key": "2d19bf7937eeab0d2a7570d43cf965547542a519be85bdd4921f7d710747ec6f",
+        "sha3_256_hash_of_secret_key": "cd59ca5c7954d87bc8d025683563aab0f9272d6c12cc03914220aa6ee392e6b3",
+        "encapsulation_seed": "34f44ec2092eeaf686f2ea170591a98527cbb03a4fa9477a7aef6b41a54feeb2",
+        "sha3_256_hash_of_ciphertext": "86184bc66edef41a25ca3350698277f4e49713b821fd0745d276fe490ac636d9",
+        "shared_secret": "be892649db60b2ce07ef18c4a709714933542ab94ee3250cea6e7c6f5eee5d5f"
+    },
+    {
+        "key_generation_seed": "9f52af92ca165fdc38788f2b59ba02e01c8281ff7c1e60504688043a5fe814b04f3029e1be4e1c0258c3a22ff5b50b2674cc094ba7018da2a61569845c17d26f",
+        "sha3_256_hash_of_public_key": "6907e1096410ab332e10f37c93d86d9b4657159eac1faffcd1688d182d127844",
+        "sha3_256_hash_of_secret_key": "250d27ac4dc4447520c4c1193ac57d239857ecbeac2b1009dc08dca2114299ed",
+        "encapsulation_seed": "6250c81126572eec2da330271db36ee591f060fc7e53eeefe2e1c476c675fa33",
+        "sha3_256_hash_of_ciphertext": "51c6ca6d7536a183416b16b1716cecd3d994dba4b5ba019bced87bb51f9cef0a",
+        "shared_secret": "75556d5854c44805ca5c4bb927c837ff635feaae939220592d89caf74592a0be"
+    },
+    {
+        "key_generation_seed": "851ea90fd3854cbf28fe39fb81f68e4b14345cf0d6eee7ec4ce772513df8410d1c0ec046899a777655233e4e1b5ca44e9afbdc67964bfd5d5e3dbb45e60d03cf",
+        "sha3_256_hash_of_public_key": "379c9176059f3a7ddfe021041301bcebbc91e997a0d5bf2ed1d9d125a7129834",
+        "sha3_256_hash_of_secret_key": "57df17dd8b9b1411af66d82f61dd61c4f5235f48d503c164ad0da02a598a69b2",
+        "encapsulation_seed": "35d470bcc5880872754810dfb3f2796da2fd7f397537146f6488c27804072b34",
+        "sha3_256_hash_of_ciphertext": "a5773e0569d9e26225b05bd61591d1722c4c1396789ce3156ef749c115949ace",
+        "shared_secret": "469d60c303b10f517a932d9fc090e61802003e9cba3630224f2c43a4727230e1"
+    },
+    {
+        "key_generation_seed": "d304c9389cc973477f169788abcb9d511f843219d246a9b587822f422a70c2386590a2e5c7ed86cf2c5c2a898662bc9a81418720bbb632ef9cf0b845ed052d73",
+        "sha3_256_hash_of_public_key": "f5515b23187af5dac6d1d090bc7bc01df34ec781561e3d3b8b62164f74946802",
+        "sha3_256_hash_of_secret_key": "2ab40ea093450e534152efb278b45038f1f2cccf13a654f1c5c27b8c389f6129",
+        "encapsulation_seed": "8d667921c5db401a86fe1c35dfcf164a6bb2ab7400fd6a0b67eafd4a0ed11940",
+        "sha3_256_hash_of_ciphertext": "d1b469613c872181c4428440cec1ccf87b82303e4979de6eddd437decd8afecd",
+        "shared_secret": "b545dc066355b91cef05e65107fa11070c455209c55573cc549cd053c8e4155a"
+    },
+    {
+        "key_generation_seed": "89a6e3be304a3518fb82b18ca730f0b359cd6ba90664a493fb4f8edaf965b9c3b6591121e25d64010c25a18676033e1d7278ac5f2d0b43a31f3a4156ae710465",
+        "sha3_256_hash_of_public_key": "9dc0d69094efe63d751e6f9c1e92d2107a7b45fabb820222d30b11595c351643",
+        "sha3_256_hash_of_secret_key": "00f4a04ab804f2fa3ed80a0fa4530fd45ebff8afadf5f5b7d46a672c690ac3ac",
+        "encapsulation_seed": "ec750b3939385a3f8df868119dc76f77ca845567ef068de6ada5478a56bc78b6",
+        "sha3_256_hash_of_ciphertext": "774abc2c6dc9570eb781a39f79f49f2cc6870a43e8812559d89d1c59bb1aa5ef",
+        "shared_secret": "2c42bc4a172c928bc6ec7480785d63f7281a9e5acfd3f94335d6d7fe5fb9c5d4"
+    },
+    {
+        "key_generation_seed": "d569b935ce015c85f792f8f7fb0d83c4f53b492959361dd4f75fb764d656450176eae84d11c4528382828f7a689a0d5cff87b8ca0bba97feacb39b935a8788cb",
+        "sha3_256_hash_of_public_key": "16829a8aa9f8c4e949d4e6388448c2c4ec6a977f8c5fb80bd75d93a723bc9bbe",
+        "sha3_256_hash_of_secret_key": "659cb66f989532fdf5a741fd03862fb142a05a0fb43ae20bffc5116de1a66d57",
+        "encapsulation_seed": "74f1d52af09b12c36eb062ea7528550cb4c18a3ce8e4f4ea9fac43ae383bc925",
+        "sha3_256_hash_of_ciphertext": "ff53eb11ffac30f45bc8327d7e7d518f1c2d71bae0052ce8e15903c8d14978e7",
+        "shared_secret": "230a69c53e2192eed6c9b876d6b228fb666b19448e0a2ef8601910d624bc173f"
+    },
+    {
+        "key_generation_seed": "5cbb141c2763425c274f7404fe530d9116e08c33f9f200a20b011cf563a28990fc9ebbe336dc464489861db8253606971bd0a9008a433ed17752d04023781552",
+        "sha3_256_hash_of_public_key": "90fe22b38a4fafc045cdbe0c9689745fb45760cb2f0f94f7d13cf8c834c4df3c",
+        "sha3_256_hash_of_secret_key": "10a89c990c7676890a65e1c776cf892ef1431d56fc115ef3115c0b8f91db0690",
+        "encapsulation_seed": "4b3a70d85f640d1a2a852fb6fe96704af56a7415a8ee4282e9207bc3a2dc116a",
+        "sha3_256_hash_of_ciphertext": "3d1fa5720670ea284567d32beaca2e56853f7b6268e32af381034f13e4cd4853",
+        "shared_secret": "327c548d7df90d813f3b3c92e908c4c55fe4c7277f91b6fa2271c0f149dfb273"
+    },
+    {
+        "key_generation_seed": "293abb6d1c207927945417cf84883ef010823e11b487ed55239e466e83696d0cff8563038aad865a817cab9ce98846ba75be9363718ecf5fea538aea90b2a558",
+        "sha3_256_hash_of_public_key": "c277a9588d9a781ddff6aa9ea8d259e5599d0adaba2f459598ebd5bc72786023",
+        "sha3_256_hash_of_secret_key": "40609cf26d205ce694ca8baa097bc1342d2462a26678eab90893da147e389d3e",
+        "encapsulation_seed": "26e38ac804fb5b4d59ddf747715e7e6041d875f99c7b638024b4af82d622da60",
+        "sha3_256_hash_of_ciphertext": "bd274d905deacefc3d90a9ed76d59af4e814cfc06c118ec17662afa4f6b4fdd6",
+        "shared_secret": "0d95796efa11ef2b4f05d0cd9e1d8db26f3e5839fbba7cd84e00d468decc088c"
+    },
+    {
+        "key_generation_seed": "74d87c7556f2671f2d666854a4d6e073e69f35421e6e1a428cccea49c37f972ce1fb7456ac0aa1b97068f452cba64ebdc138bcf5d36b0a0fada2a3b374141eb9",
+        "sha3_256_hash_of_public_key": "d3c8cc315c4054d09deac08c6d5d364fd5d47a3c09041bee42c561f978e2d98f",
+        "sha3_256_hash_of_secret_key": "3e1b23ca9dc111c4a3cb0a585c7f4e5d1f27a71533eaa5347e285c7c35e81990",
+        "encapsulation_seed": "a319d2b8f114f1acd866478bcdeba6fd164dc4e37b0adfa8d8034afb3e197376",
+        "sha3_256_hash_of_ciphertext": "c866f33265de001b3308ec41682803d46dc61d423d61565aa5ab2f1367c93e3d",
+        "shared_secret": "cc047c6cad36dd056b84e6b9a4fb6b1b349d593e104ba94a67b107b291ca4633"
+    },
+    {
+        "key_generation_seed": "013bab0212d04ecd54b478daf72748003a25e2cb060ba6cc50bf95c292b8206b9da0c5da5f195b80fbb99c2e8b06926074f3f604b3f6195b5a5b9737876bba72",
+        "sha3_256_hash_of_public_key": "dd1a07043fa0c6452500249601f25de742ab44213e2718cf0ddc5ff6a2a9aa6a",
+        "sha3_256_hash_of_secret_key": "2cfeaf5c1b4195f0374256027d3a888e9a093de8ff9181296d5b1b94048de38a",
+        "encapsulation_seed": "ff646071b2509e6b75790917e08e4f0b0d9f0116ec6291c0b59eaa4b583ad830",
+        "sha3_256_hash_of_ciphertext": "6dad2899c49ef32329180b6b8749c28a24e070fe989027061dea25f0b05490b3",
+        "shared_secret": "2faf2dd50be618b025cd2b53365221f5258e175e4a445cf053c66b3d3a998c8a"
+    },
+    {
+        "key_generation_seed": "ccb073c4b90be0ad746e26fb093b60c70110bd1dcbcddb566a8cffb7b3caf80e71600a8982c350df524cde514431ded7aec23576530894bcbf0ec0bfef0bb64f",
+        "sha3_256_hash_of_public_key": "f2a8cad42c743eb61aa338049ce917616899c803358541de1e58cbbdcf3c6328",
+        "sha3_256_hash_of_secret_key": "7a9ebb792c7193ffefe6e4760ebd0dec6f67c3f3b0fddb5abb4b7e931ee827e6",
+        "encapsulation_seed": "0584270ec26f3b9818e4af074d17b2d51037cc8dfdcbe3b140fa4fed5deebc54",
+        "sha3_256_hash_of_ciphertext": "125f7da90bdf4bbeecc54e47e065b221a6ce42d0569530c136ce2c9415b17e79",
+        "shared_secret": "cd890d2eee7f747441ca9448c7192bcc274e8b0c3c80005cb6fdb4691186d85d"
+    },
+    {
+        "key_generation_seed": "2e889f44e28901e9ac7ca6b2fffcb124c8979401b17064d7e1d51a7e3c3adbfa0e145e44aae52cfc609e6f47fd7a6f6af877190ff52256d0ac5b05b89c3f449f",
+        "sha3_256_hash_of_public_key": "3394e8401245fd6348bfa697f6990b6671577ec7b35a45b0101730a801942643",
+        "sha3_256_hash_of_secret_key": "3ecbb219e90e2250ad5ba87f53975439cacc030c3e1641b87ba8c5b3d89a4aba",
+        "encapsulation_seed": "51e05c7b4ca3079781e8293f4eccebeeb2f8c8b4c59468eddb62a21bcb4ab8a3",
+        "sha3_256_hash_of_ciphertext": "6cd30cb202554c18809da0819ced4cfe83021874fa9c48c3374b7544e3256f5b",
+        "shared_secret": "e7942359dfb015d5022b790b5e777a93a5963260ae352567d3fb7e27b2ef0bab"
+    },
+    {
+        "key_generation_seed": "174aaa36410566dc15a5e62874218d7abdde0b2c0f30d877bb80b1abd5f5a0a450a7a2354f7e5cefa6f4a4e9a1c411eb9364506e9e1204a8acb3cb77fbd2c4ed",
+        "sha3_256_hash_of_public_key": "ec9c0d68c84cf3804f14e8daffdd1e28c28d3d55ee782c98c498b0d9bd4ebb23",
+        "sha3_256_hash_of_secret_key": "24a2b3c3efd979a1406e92d5c504d5004079965b5fd0492469f1b4250f7023ff",
+        "encapsulation_seed": "9eca0fe36c80fc5eba171c3ae66a5b1c923faa50b4521bb055e7bf51005c93df",
+        "sha3_256_hash_of_ciphertext": "a2c6cfb957639661086b02d9a312e7483150fae87d84f21f56e48850af7e3b62",
+        "shared_secret": "5d7b6ecaadbae69fbaa9e004634ea609df6ec80801bbe73671f4e52169cc9683"
+    },
+    {
+        "key_generation_seed": "351fe4313e2da7fac83d509f3103caf7b4c64a4d458fefdf636785ac361a1390f072d9b5a99f9c7a0a011e4dc10f6b600d611f40bba75071e7bee61d23fd5eda",
+        "sha3_256_hash_of_public_key": "a9d7d5a52aa2dc226832f6e4603322f60b1dc21207e3360712f9c6445d37e64d",
+        "sha3_256_hash_of_secret_key": "2e5342a1c2f58a48e044a26673799c63f88656f6d350a0d7e57bbf8811b2a5e9",
+        "encapsulation_seed": "0c5719261caab51ae66b8c32e21c34e6d86ee4aa127d1b0195663c066497b2e9",
+        "sha3_256_hash_of_ciphertext": "b79a2fbd2e63aa66a526fbb42440224fad7ce91206df3684d1deb4a3e57bfafa",
+        "shared_secret": "547666f6c72c97a8f06fbd7cda4279165dc82489aba2119416e0dc46795bc464"
+    },
+    {
+        "key_generation_seed": "9bc5315580207c6c16dcf3a30c48daf278de12e8c27df6733e62f799068ad23d5a4d0a8a41c4f666854e9b13673071ceb2fd61def9a850c211e7c50071b1ddad",
+        "sha3_256_hash_of_public_key": "fa7ba132b5dfa2e3ce67b64bc72d551f3290d428cfbd45ec026f44c8dc28334d",
+        "sha3_256_hash_of_secret_key": "34306d06720216257691fc65054ed32decd609312f5c5f061e7763ae73fe0aba",
+        "encapsulation_seed": "0e59f6f9047c784c1f00b24454aa4f1bd32c92ae7e626549972f86fab90e7e89",
+        "sha3_256_hash_of_ciphertext": "acd7944297fc3b0d2daa3b0cbc999a43de7e9f948d39b9c6a4746873e285f8a8",
+        "shared_secret": "88c80381cde3db2c1d40aedf8cf923b79b18cf76efe0e46edc3e25e17c7cd8c6"
+    },
+    {
+        "key_generation_seed": "d8b907b34d152ff8603b73051f772daa71eb902c47b7e2f070508269d757e02e36b817736cbc5f7b1dd6eef5fe6332fb1a598f3871e5470d440fd2ea631da28a",
+        "sha3_256_hash_of_public_key": "29f8a01ba71d04d6831c03d1ff294fb58ef6f4041772cc071074829c32a3ac9d",
+        "sha3_256_hash_of_secret_key": "95f9b4063bf05f89ca9f99e393b11c0f2105eafe40abb313f345b58e10519955",
+        "encapsulation_seed": "a3963ade17d69debbc358dda82c7bebe2c39d25b36813058e7a161542e3f8c2b",
+        "sha3_256_hash_of_ciphertext": "096f7946c01dc61a13dac8b85d9c377f9c86aaf8ddc02163a74169854046a1b0",
+        "shared_secret": "ccda9f28bb09dc0017a1df8e1796a3489c66afd2c3898a39027c843cf022b790"
+    },
+    {
+        "key_generation_seed": "684a29e4e5480a5f2533e1526b5fac8cdf5927f3d85087c71f928c59690eb56575d12195ec32a8686d0600e45d4a7f54219b0d7a3826d193a51b9156ecf2edd6",
+        "sha3_256_hash_of_public_key": "357376de9843d74252466888727f9dc1ef48d028c0f52c902aa0dfc3de374c83",
+        "sha3_256_hash_of_secret_key": "b8d675ce213c73f9792f328448850047f4410fc500212939ab2e234b619c9104",
+        "encapsulation_seed": "97beafabf2c8575586487c7a80e8af5fc50f94b6051c1bc66a5ae9f66be3cea7",
+        "sha3_256_hash_of_ciphertext": "a0810d28d2dec44499bc47d48ae22984c17728547c3ff0cc859702d2a6962f88",
+        "shared_secret": "caea7e78e6f80e126a9f41ddc0ae5946a80cdf617635934b22c9097c5090ce59"
+    },
+    {
+        "key_generation_seed": "d76b3573f596eb286ab5231feec7499686b13021be36cb126c7ebeb9d7030daf248c0a21ea0bb6d6f56f12300e8584d8e9a34e0e6f52227281151ae4c305fb8f",
+        "sha3_256_hash_of_public_key": "30382cb59feee1b6b0fc129fecb8c74034da92987249bc20cc8ad4a2cfc1bfe0",
+        "sha3_256_hash_of_secret_key": "2600203271549828d0979adea52e2e976b7d9f85bfa6931d6c79e14137fad51c",
+        "encapsulation_seed": "75461decd34c50d6a094b4a64fb75e5e9479f8f9250d82bb7d729dedeb2d4b65",
+        "sha3_256_hash_of_ciphertext": "4d20b7665cdea726a3240782143beb60585d4ae39bf18f4ab5343d4f44c7acd6",
+        "shared_secret": "431bba421ea89647d815a16f440d47f1604b67d9a2d33f2dcd21dae7e65bd5ce"
+    },
+    {
+        "key_generation_seed": "b87439fde81c9e39eebe7cf741c685785532c1dd23e8ef868b9ce7a541010f3d1646460817a0fce5836bdfe124a7448e7adf7b8ecc2652ac6d280e986682df71",
+        "sha3_256_hash_of_public_key": "f4e474fd64a6d945e85eb4ee7509cc99fd4054de99f819fdbbb05c54ca6e36da",
+        "sha3_256_hash_of_secret_key": "d8a3a0edc73fee057281add9e7cb328566fb22c5082978c69088d76e98ffff90",
+        "encapsulation_seed": "2607dcf4fd6ca1c614c21b5e37c24981c32b91c8c3e6955777da8a3f5d9c9335",
+        "sha3_256_hash_of_ciphertext": "0f18bede2f42d6fdf32dcd2cf8937ee8d2909eef0aaca8586c3892d608712a98",
+        "shared_secret": "cc0a7809cf6787a4587e090249709f694b709ec8475a42b4705bd1ba312c098e"
+    },
+    {
+        "key_generation_seed": "056661b38038da4fdd7426f32a81576c73ed84843b305168a374f934e27a4e1b79238a80dcfd7c992d84b2dffa67493e669243d4fa38c46b090bdf86bc548411",
+        "sha3_256_hash_of_public_key": "50688de263a82386f39a7b82592247bf5499f1836a3a941413c75f6331ce4031",
+        "sha3_256_hash_of_secret_key": "ff207007724ca5d696ba44cb106f525858111d55323c9fc0fb98d64d4f8de8d8",
+        "encapsulation_seed": "38c89bbe7145c29e9a831c11431eb9929cb24fb4992db20737e4687d397fd732",
+        "sha3_256_hash_of_ciphertext": "9dcc43fabf94918ed4f7936960d8c732deb2209090d1303d62d5ba591b51a142",
+        "shared_secret": "cf21da86b3e09c38ce5799637b1492a1a268dbf0ac716499c68bac11a774f41c"
+    },
+    {
+        "key_generation_seed": "a1b52d871612a1c611ae0944f9e71858f35d3bd14f20e96a931720668bdf0a6b1f135cf64b6403e103afae34da038613e2853bbfc36baafa3c6a95347193f37c",
+        "sha3_256_hash_of_public_key": "1a29c0f2dc4089a85db6865ec90faf2f4ddd25f210eb56e49741866bbca8cf81",
+        "sha3_256_hash_of_secret_key": "477dbc28e4f21587f274e7a3b673f743840da1501c35f0e9ceb8972970de6f86",
+        "encapsulation_seed": "b2c35e33c72d90182791f0e12a0324f5b216efcab2c8da1bee025dfbe13f4152",
+        "sha3_256_hash_of_ciphertext": "877f477beda55ed2a7c34408c04b4a90596b4d94ac1830bc04a0ac9b73761ffe",
+        "shared_secret": "b56f557eb758ae10d22b5d65847cd811475b96f5a46b0ed3bc2f1b9b371fef0f"
+    },
+    {
+        "key_generation_seed": "952b49c803d6d6fba69f4375adce8594847a00bcae2179da49af2aed0423250262d7033947ae42ca53522a65fbafe18d3bc3e0cb66164e9a094fe4b44d8977ed",
+        "sha3_256_hash_of_public_key": "3fffc419d3d8a887ff789eb661b2af1ee5b32a302ca267b33eac2ea7e3340b97",
+        "sha3_256_hash_of_secret_key": "0f42068d2885e1a44b2ce4042675118f4fa35f58c1206b965b57ccb52c4f25f8",
+        "encapsulation_seed": "afb7d6dc2b7eb6d84acc080c1be63c98afe7b07786b5801f716444a3e8e64800",
+        "sha3_256_hash_of_ciphertext": "d8f7b4a0047c18a84ed13e3057e240cb578cdd2ac1e57dbbd6253eca9208d6df",
+        "shared_secret": "aec1264f12ddd2ee8e51b71d703ca5c2718dbd79858240635f9b076c749a5ffb"
+    },
+    {
+        "key_generation_seed": "3c815e57e9233e975fa1630208aab206b71ae0db37a7a8789ac683d9f9b2d29801c8e376fdb140ee343106c093af7cb149b316ba79446ceb4e5e0cedb9b164f9",
+        "sha3_256_hash_of_public_key": "f1de70b1072881eb659a5e890a92c9313c7378d2e960a060b9c918260d4c2458",
+        "sha3_256_hash_of_secret_key": "ecd9d757d80352b4fb51c71976d7b2ddeb927052f9f7a7cc61fa67662d4dc86f",
+        "encapsulation_seed": "28f5e9dbda122b2cf8f3754fe9e0c73a84ad4b0c093522e0b62cf815d60bbc3c",
+        "sha3_256_hash_of_ciphertext": "10b2b1dfe168aace0dce3776456c2e2605f99fdeaadfa3ff5e7a81f6bafcb76d",
+        "shared_secret": "6514a3b97760070116c64014c5695df60d0345b29ada92fe24b672586f5bf06e"
+    },
+    {
+        "key_generation_seed": "588760826dcfbd36d9abe6ae44a669bb3ebba6a218eab69e30f18a3bd536576e0e860576285483bb5fd36e2f944d32c4317bebc1e441470c1372046a790d79d4",
+        "sha3_256_hash_of_public_key": "b0c77b5407577a9a9cd8864efb80974aae107fa2801b6ccaf341d5456a86621f",
+        "sha3_256_hash_of_secret_key": "0feade68babcf09673bf843c59379520c19081f2bc33940a8dfcee07832ec66d",
+        "encapsulation_seed": "b0d713cbef0bb1df70cbb425d1e9373e9f7790fdc7980cc96a240dfc53f1e8e2",
+        "sha3_256_hash_of_ciphertext": "b204aa70efa18e31a11b6b92e6c7dab4b2f4766ec5d302a0e93e4feb05fe4843",
+        "shared_secret": "52344e5e173fc6088c9dc555cc90d8e5de19bdfa0d657ad8de1a3c24ea679bb3"
+    },
+    {
+        "key_generation_seed": "47550e9edacb6ddce3d9ab81f6b61080dd4f2693854acb05e0ccc7a4fb6390fbf89d7d99d5c3e0d10d6ef9af054d842375f695abb28e3b8eb495100f04306e92",
+        "sha3_256_hash_of_public_key": "255d2e2fe01c87cf70bc30703644fc255f83fb47cc5cc5ae2c0e49d6198cae03",
+        "sha3_256_hash_of_secret_key": "1b1050f38bdb785ed43daa264b60c7946d93f135c65e93c95c39fd1f2d7b5311",
+        "encapsulation_seed": "32bdcdb7059fe27f6409901980c080308951ffd90deffa8317b4d213a5f04495",
+        "sha3_256_hash_of_ciphertext": "55165f35498250256c30d0f0fba6ec57db352a6ebc05ac42eaa8982b2d48af5c",
+        "shared_secret": "ce80f65731c8fac072f7153bbdc425f76189d01bacee8462060c62dfeddfaf64"
+    },
+    {
+        "key_generation_seed": "610afb64be8cc1df288cfb016ee2f44c6c07113de7f6fee071fe0c3fe31c6215cd292e4c5f9e1a55e0489bceffb204d672a6215f4f3980a646d9f880817c52dd",
+        "sha3_256_hash_of_public_key": "63b304a19162abdc4234e6046109f99f955695580a8b782017e107e45575bd78",
+        "sha3_256_hash_of_secret_key": "19aba21e57d4b3aca7209fd5cbd15f9e7cb9f6777960d9452fed866e9e9234f0",
+        "encapsulation_seed": "4ed7c92d83bd03b2a25b567f17ae55542e2f6a4308ec0f3fe69f8ba5ae24331b",
+        "sha3_256_hash_of_ciphertext": "5eddd27af25f9553e3a5b20e4de86280c65eb689ffa7773dbb5d24640bf51248",
+        "shared_secret": "3b23a3cfe57897fa9cb691ee9805739f40d2bf22930ca9ee48ebb7163cd66bb0"
+    },
+    {
+        "key_generation_seed": "e1953800acaa85ac02a906c72cb8e8d704e8d27820345f88f71e89c1f549afcc8c64c049c6dfc0f1476cffd520b055756162f7ec94243de6b14ac0b9e5fb366c",
+        "sha3_256_hash_of_public_key": "3c598a48b06d7474da19ca85aff6b2b3303b5d25b96088c52a08cc7f1e87c5fd",
+        "sha3_256_hash_of_secret_key": "03c563426eb21d277421a30ca8980d4de86f7aedead9ab9aefb3d7362104ec50",
+        "encapsulation_seed": "060ea5d2ed1dd88144a9885e79278590821c22917b55a48920f96b53ebe0e689",
+        "sha3_256_hash_of_ciphertext": "244dfd0105b643caafe35fdc184b8e23c7538370d545e6f08357e83f413de258",
+        "shared_secret": "272ecae17c3d107a8b008f60c8844ac01e09b8bee17eb4972f5f71774af2d54c"
+    },
+    {
+        "key_generation_seed": "c719f9b2d16399b7326ce4eca30dabefe8fdaab18e9f6df888b0a134ef355570e40771856eb77e4633504899fcb86c6a3d433d0b8d60e26f07bd61f1d4ed69bd",
+        "sha3_256_hash_of_public_key": "9911b6283fc6dee66e16d411fe39bbc9f53c30bb54f05044b96c740ca051c61c",
+        "sha3_256_hash_of_secret_key": "06751acd0a50beca92428cf8c803af429068d4e5c4f74cc59e6d3275ea6da737",
+        "encapsulation_seed": "10ef9426f8c4a13b52325c5bb4ead4596ecf2c6b5bd2d37d8350e90d4164fdd9",
+        "sha3_256_hash_of_ciphertext": "dc8797dfa40479e4edee48d320320ca4a84c55789c94c34ce4f0a4be83ae0568",
+        "shared_secret": "eb456d8919c7e96c4e18d7a0ae27d47996e4f94c46c60b4649b327903acdc0c0"
+    },
+    {
+        "key_generation_seed": "e9acbb774be970206c3a738e243b420805a509fa59fa902044be2f0d013650d2ded5edaec5de3bf5b4d7c2f2e18e87f499c1968993eff196753db8045e2c8ba8",
+        "sha3_256_hash_of_public_key": "e78d350d2836d1d17e6ec375a0cbe0d6b2afe1ac036272dd41f8aa769c9d0668",
+        "sha3_256_hash_of_secret_key": "f74b8f9343146c1551a3cf9fb3d4e88febba4e98db745f36678d854230a8d7f2",
+        "encapsulation_seed": "a4bd30a64cbf29a4e290fa1cc1dfb99e68348713041e4409a1af23c5d80c15c4",
+        "sha3_256_hash_of_ciphertext": "400cda4e51c1eb539625bbe6679fc13b009e72cd442a1385759e7090e54d31bc",
+        "shared_secret": "3f92ab2eb867d4e2e658917fe95b19042cd768dbbcd895e83b7bfda621fc428b"
+    },
+    {
+        "key_generation_seed": "c1b3cbffad4b306f9af0cdd3028876486dbe858875c9b6497fe20172a986c82b1c96249919cedc2369d8d739ab125e0d2ccb82dfebcd90240a545cdfe07511f2",
+        "sha3_256_hash_of_public_key": "5820c7564d087683c0a4864844335bcbd62afa1ee542c3c1dcd8b72c80824b50",
+        "sha3_256_hash_of_secret_key": "11212a895ad32958d25d2ad32e917bd5bfda9dfcf08e316f733b74479469f9b2",
+        "encapsulation_seed": "f4b66a7d3b65b896dfe100b2cad24b175a1168cfd2ae11fd704b835f6bcd311a",
+        "sha3_256_hash_of_ciphertext": "fad3a5efa62eabac076fd38f84e91f3c20f7b263408366c476695a9665972ddc",
+        "shared_secret": "5890e86b38f7fb11708a63f5e98ad65d10db5916e6669e1b0161142e6d30d017"
+    },
+    {
+        "key_generation_seed": "ff7495b8575b5a98e4fd21fb4c3e58cbb60f14bef21aa74cf8802e3153f14807bdc370460375a778d1a31d01c42b66367ed8d9e8f84551002f552f0e52102b5d",
+        "sha3_256_hash_of_public_key": "c56eb5880e9d9d0fe7901747f75eca1996c722ac47b76f34a4dbaaee0ef8a611",
+        "sha3_256_hash_of_secret_key": "8a90ed45b5910904e2e9f6a6e410d4caf024ef6436fbb75fdd179eaf09f6f362",
+        "encapsulation_seed": "1d7b03d3c5eefb8ae5799dc569aa668f1bcb8c86607b089d3530cf61d6380147",
+        "sha3_256_hash_of_ciphertext": "16f18c8dfcb9aa496f8c6f8a76af4cf2405407e0f0467deb4adb7049595b0df6",
+        "shared_secret": "3b09c4579ad60b17eba6029141a6d9765e1abae72ec32f1b329a5e2af761a087"
+    },
+    {
+        "key_generation_seed": "bdc3fba1c32751139fc45bacffb3ea97f26573d804a5f27a459293d95190ed8efd5a08f656a6eb8cd20679930a31caa6a6331c4b133a6838c223ef9f769f6246",
+        "sha3_256_hash_of_public_key": "717823f0b58cdfacafc795aea529561d11374f02964cf635c27848671043766c",
+        "sha3_256_hash_of_secret_key": "f3c47ab6b2f2a0962faf49bbc31f3101d6f4b867952aa3bbee32408c1b88ee82",
+        "encapsulation_seed": "554f3385b382f4a46314de37ee3885addfc5332bd4038785094e0a832e9e8c2c",
+        "sha3_256_hash_of_ciphertext": "fd6a149b033707358fc07243d95b0256153c30e65cbc9479ce05ad2f96204a37",
+        "shared_secret": "f15864351fe8e878ad66b402f012668e8bdf21525f09d5bcf4a4dad656d2e480"
+    },
+    {
+        "key_generation_seed": "447f6076a627bbc5ad7773fbfeb14b4ba9ac43a0f8b99fb6dcd5e452aa3c47ec20a7237801f470fcc2bd9fd7bea8322859b850f7882d362947432913dd068c01",
+        "sha3_256_hash_of_public_key": "7a13afefbba39ad59c088825380398f43f1251b83b0ca9debba0102f902d7190",
+        "sha3_256_hash_of_secret_key": "da94e15b824e73150a408df01cf1c5e4128739524831a4c2f45d0724144010fa",
+        "encapsulation_seed": "38bf0033b779edf5367d9ebc01c988af90904c560970815837380650e4749eea",
+        "sha3_256_hash_of_ciphertext": "9193450ad037d38d8e85a46a522d4f6562ef7c7aa1372a2ebbc7ecefd1286bfc",
+        "shared_secret": "1f1a7f0d0d86a52a6679c431c322263b185b0c90ce40db054928be438f38d47f"
+    },
+    {
+        "key_generation_seed": "2d5df64d62cb07fe630310bb801c658dbf3d97993e68626745de39d37fbfc2b27b534537addaba4ecf14f02ab317d36cb9f0f50222ced7cf029dff8a0d3d2fd9",
+        "sha3_256_hash_of_public_key": "dd4cfbc29de3568663a3a044c3f897714363b0fdd3b6ee55f796292d34c7c79b",
+        "sha3_256_hash_of_secret_key": "6142d02fd4501c7bffac124bb8f26813009d2bfb91023a3fadea9506a40e1467",
+        "encapsulation_seed": "048ea516d0ebbd9f709b47eaac66f344c571cf50f0d01c9466aa061a50b66a24",
+        "sha3_256_hash_of_ciphertext": "bb6e0249218f8bb4712d60e59f51cde2dfecfc1f828eff42f2707aa59f12164c",
+        "shared_secret": "aae9ca8c35deddcfd7dbaa7780fe31c102aa90cc594eb56edc782fdc4eb53b41"
+    },
+    {
+        "key_generation_seed": "25056d1b8113bb362dd979d98643d7a7ac9c4f95994c0ba060609b6d07002ff3f48a9254dd40b117941fa35a66bb50296327b725525deef70e128ca8045ec451",
+        "sha3_256_hash_of_public_key": "9ca90d64e28a5bbc54c36053ed333c530f72549c2afd77b10c2944fc833408fa",
+        "sha3_256_hash_of_secret_key": "510f84cae4d4307d7848f4c9665061657ae81526139a8b6a4076ad3df919abfb",
+        "encapsulation_seed": "686c921c9db1263e78ae753b1c9c2e7936b8229dca48c0942c56c6bca4f10917",
+        "sha3_256_hash_of_ciphertext": "36b3567939ee624d5088c4daa597c73349270a754d3c272ec3ca5e08bf896fec",
+        "shared_secret": "970fe36e57a253e88cc80c9da6867dd66fd8da1dc15c85a480a1a45eed708ff5"
+    },
+    {
+        "key_generation_seed": "e4d34e12982aeeb1d62fd488d9b9e28557ed3429292239fb4f76fa9098009acae6c45c7fc62329b13c8d29844405db8ff6860de474bf727ecd19e54e6e1a141b",
+        "sha3_256_hash_of_public_key": "da073c98794493ec169c78eb75a39c1594ccfa635b8707325e0ab6cb8576e30c",
+        "sha3_256_hash_of_secret_key": "7829ef884941abc63f66889c3d44381f5450de1b95c6b6f79f909d74b27125a3",
+        "encapsulation_seed": "2387772e50059cabda53cb93ba24b19ae529496c03b36584169451525c4a0e7e",
+        "sha3_256_hash_of_ciphertext": "43f8a2c466c09c915fdbf0d0dc5069ae5333790e7efce86c163d360dd0fdc0cd",
+        "shared_secret": "8eb310431276a31c1913cfa2e2d6b0dedc8a208c7470251daebc5b1bb6ee78ec"
+    },
+    {
+        "key_generation_seed": "cd6a99396eb3539ca663a51e42063a3a262cc1c5a5fce1566f0597b52ad9fa325a3407f591791a5db4578b5972093a95bec3b8e70c1d542c9b5c9789729f8922",
+        "sha3_256_hash_of_public_key": "c2aa254714dac09b9e712572b24154be391063afd3cd8cf4cc4ed8ef21f0cfe5",
+        "sha3_256_hash_of_secret_key": "2e552fd01c00cf43110aacac37d01c02e5f59c87133e3769d3b2bf0fd2e4431d",
+        "encapsulation_seed": "155c29c5f0378df0cd0e847a80a07143cf7522fcd880c9229eb9feb1ce340cd2",
+        "sha3_256_hash_of_ciphertext": "854806aa3266473aa5fa6097095d5f21707ab4df857d927e8848146bc4cc2bb2",
+        "shared_secret": "425a88aa4cbb6b6de122f1730aee536f1cdb8fc84751fc6eb2b42bcde5febcb1"
+    },
+    {
+        "key_generation_seed": "6c8c53ed6f65e6b2e324b84364e10de42d1c26a106d4d1c99eee79c78586fb55b9402bf02481ce4b27a52e87feb92c4399c7f2988d40e942e7496ad15ad2aa88",
+        "sha3_256_hash_of_public_key": "8aaca951e0573f28d50831960a28dd11126f0eb080afc55f394e8eaf6379f6eb",
+        "sha3_256_hash_of_secret_key": "45592f0d94666d8201247fad4d0acdfdb4635a5e4fa85b7e25b2391639451bdf",
+        "encapsulation_seed": "a9cb9a61a3324b1ea5afe693b32784e2871096b2ca14a11acc9577c52359a241",
+        "sha3_256_hash_of_ciphertext": "035223323ac02f2a52f9c19da46b31a7e189073fd5ef5ceee6ab8dd1b062b6d7",
+        "shared_secret": "457efc40f2e99aa599ac1ef92f9efbfc93d17fcd793837857f6a5c91a8dd7da2"
+    },
+    {
+        "key_generation_seed": "2107204cd995f1df14314d5381f8c5440f09a347502e161cffc0a2ec3dcfbc7324c3da70fe850e80aa818301d60c70f3038153866dcd5d179e22db59b8991bb4",
+        "sha3_256_hash_of_public_key": "f15a8fc937b12ff78c54fc273fcd7dd5611e5835472ed377652ae64495f9cf52",
+        "sha3_256_hash_of_secret_key": "dcdb853d17884fb04396dc10d34bc84d594343ceadda564fcdfa9b4d47dd4e3b",
+        "encapsulation_seed": "e99fbae8a024ebbbdcef32ce213f6aa942e3eca925e5da4c09975d773b33a175",
+        "sha3_256_hash_of_ciphertext": "a94ff1a0c62792c0e1dbe578210ba5a7f3cf8a9f9763a16362d66a3082e4753e",
+        "shared_secret": "99b58031465868d0617fa795e6be1c33a870a1e154a85a2bf61346f7c55f3b76"
+    },
+    {
+        "key_generation_seed": "63a925685a8ac5bbd918faa33ac397d1ffbcf99135d9da7c3d6ff7aa4c50af3d3afdb8a246a56ee71465591831c371f2eb87467b0559dedd776ba063ee6d2f93",
+        "sha3_256_hash_of_public_key": "ef7ef8d7d81aa907fece4c1920c7ca9dda3bb9d57f09193487bb89d6422f10cb",
+        "sha3_256_hash_of_secret_key": "2bef3558b547044290d1232a580a6a473cfcd8d87ced6305f996d4db4f46e6af",
+        "encapsulation_seed": "67a216f37d67f5e74f782f1badbce1cc8c80a6130aec305b421899a4faa0a6c3",
+        "sha3_256_hash_of_ciphertext": "0b60d83d562b66153e07bffb5bb05b7d268351377381b04f1e59201f961f1907",
+        "shared_secret": "387705c2ed600492a0b06f5587ae3c40be55e6d5592597e57cb8015de9e9271b"
+    },
+    {
+        "key_generation_seed": "6a1aee5e708c1b47f02bdacce4f56c860f74fc7cfec1ef3b58285b1c8ad7fec2230e05b7114ff0395cc6634db1eae8258072d09c09f291e92d6620b177dc50d7",
+        "sha3_256_hash_of_public_key": "99b151aa6b4654589afc36b8343fcbdc09a3e5255b378d6ee5629cd8b3cfd555",
+        "sha3_256_hash_of_secret_key": "b7a7d95034017d523ae23e29fc400e9a0b320f9778ba1587b69dd012f2aa47bd",
+        "encapsulation_seed": "52b19fea232c9154a3e431e9d69cda40013cf2d485c3cd027ad24e645420420b",
+        "sha3_256_hash_of_ciphertext": "3a4ba04bec2aee99c5e4e2459f1aec52fc950ab67b61570d57a17c4f3d9031d5",
+        "shared_secret": "2a426534e3c23e28a237047aec83d24abcef8c7f77d85d8b27aedd7c50263010"
+    },
+    {
+        "key_generation_seed": "6396b328b100e4c7f4bcae69875edea1a1982421558c608c13c592bf7b5d0fef1100ced48add211a5c937b8d6079d8e271af3f949edc61f70e60453aef20dea9",
+        "sha3_256_hash_of_public_key": "339ba63f705606d8c7fbbd6e66dadbf23f532d5423802c836f2105a636e9e6da",
+        "sha3_256_hash_of_secret_key": "60aa684e7cbf79e9c70504608a4c0f2cf8dc207f71b1d0ef5e3a99013ee866cc",
+        "encapsulation_seed": "64440adb05db3308b189bf999f9ee16e8ee3a6ccbe11eebf0d3ae4b172da7d2f",
+        "sha3_256_hash_of_ciphertext": "f5d1973f7c10d3ff7cdb66195ce52e182f40ce5b9f16ef67e31ce8632cf617e8",
+        "shared_secret": "ffaf18d4fdb39a4aedc80c7985843f6b87a02e36c69dcb00f3cb01a619a77779"
+    },
+    {
+        "key_generation_seed": "a453bcacdd2b0d4646009e5ed451c3c45f08fb827ef733db3c517a9dc1af93e67a3cc8aa3239d4c52ce4c95afdeff6efbfacac10d294edc0e7cf4535059bfdba",
+        "sha3_256_hash_of_public_key": "1f9e26333b637ef9beb8881c63f9412b07c47a276af0e242062a54026bcee2bd",
+        "sha3_256_hash_of_secret_key": "f7f38ae2caba6d7e87b7bee8b127a9aecbc0b795345952d65bb4435e3720f89d",
+        "encapsulation_seed": "c8bb46b3a7344ad170c2052fb042b5a3b62e0590562ee82577b1081f6f114d16",
+        "sha3_256_hash_of_ciphertext": "c42f9beac87086ca603d95377c5e539735752eee043653fbacef0d2824b91d86",
+        "shared_secret": "1b37c256820ae408a0005a1fe7461d54e53813e6e7ad58ca3dde46a53a44590c"
+    },
+    {
+        "key_generation_seed": "47ca2b77c5b717f423222c2730ca5cb9c856bc951d01b2b2c80bd76ccb5539b78f1481d7cab000e33fa07de8dc9627a85e76fabb4428a3376e66300cf12a0787",
+        "sha3_256_hash_of_public_key": "64b9f8198bab9b3b2f2a1704cd4ddf6b3cbc216ddc0f062a72ef40115917fd21",
+        "sha3_256_hash_of_secret_key": "a3cf5841bedd9be95061b910333190834063e5cbcf0fd32673f8cf3f6b548d17",
+        "encapsulation_seed": "2e2b70609f3fe029a14d09d5d659871ac776ce2797a0355f16e2eb68f5613fd1",
+        "sha3_256_hash_of_ciphertext": "056998cb46e48667cb4bda6dfcff9321219b13fb1a682e90bfba6ca025bbe6df",
+        "shared_secret": "12871c83c35db351c2c0b4afe0f0ce9fe1f21fdfbe8c18a485d5c1292faa531c"
+    },
+    {
+        "key_generation_seed": "aaf6eb40e596a5e3e8218871e708b089240dcbe7fd3641f0e5e41e071ce49107e2f8d320ac3cb0c52efdc753282f092bc39baf4a18783a48ea031a191865eb78",
+        "sha3_256_hash_of_public_key": "de4ce515b882c849717a1ab34f2ac0238c868f415630c1155bcfb302d346dc91",
+        "sha3_256_hash_of_secret_key": "4b917d9daddcdc932fe0448063a24a592edbb0e6e40b5b53812f20a4cff7a0a3",
+        "encapsulation_seed": "4725dd8fb314bfd8ee23731c2341dbe114606d9abe6434c471b5573e7df193bb",
+        "sha3_256_hash_of_ciphertext": "e4eec4f31749692984bee94c59e2947afc769197fc18b20d2e34ec92e7d15ae1",
+        "shared_secret": "adf49431dcdeb29f729459cbf3c2b94151005c7b841eac921a71262d65dcff99"
+    },
+    {
+        "key_generation_seed": "6500f32c93415cfdbc0bd31d78d5be95cb9060c8cfa2013955b56f8b6868b322393308641a9a4647f230201e1389624a296b55192a9819fcb19ab77c25f95445",
+        "sha3_256_hash_of_public_key": "93b60f0d00c09af885b5a0cbe942fde6afc4841428104710823bdcc12319eb35",
+        "sha3_256_hash_of_secret_key": "953ab28bf8cf18e86b8c80efae0bb47582d720e787fd2af27d9789c1ffb7ea1c",
+        "encapsulation_seed": "818d3bb8ebfb32bf464775f7139bac0a5bddce80ec5798595992f9403002cd5d",
+        "sha3_256_hash_of_ciphertext": "ed5b2ff1ee4222029e7c0d858da6ff1a1417a74a501b80d1b5b6a4941329e892",
+        "shared_secret": "35e1521271e7ab9931b2c25d75f0f09a89b3f83a6bb62ceb99e8e00c5cf78afb"
+    },
+    {
+        "key_generation_seed": "7643cef2d62cc5aaeecf754653ea62294cd2208e5bf3ddeea209e3dc45373d49eac9d531a532770837a854b4f5531f6e0c8d6c10183b30d3435498c2dd142951",
+        "sha3_256_hash_of_public_key": "167a2fec4d72cac2ffd844246eebabdac0c074e4f984433744e31d299faa389c",
+        "sha3_256_hash_of_secret_key": "9afc4ddea68ca10e36d9b12d3c34595912eaafed49d8ffce01cbed09501f7527",
+        "encapsulation_seed": "c92aa5fb91c980d9cade9ce99d4c75b2ffa7d6a6ff9bd59def1aa701f2a0992b",
+        "sha3_256_hash_of_ciphertext": "a076b58fa98a7282c2cedc1e93c1473dd15b15c1ecef192955d8a813180b3217",
+        "shared_secret": "715519f07b29bbecfc0776e35417558e3bc50c76b8da6fd4c99391b7bc7873cf"
+    },
+    {
+        "key_generation_seed": "f8ee95521060c03bb8dacc79f7eb7db640f545f315613a35d447a09e504cb4e13fc3d8392cb53f36ed647364a04e37278a0e0a45b720f4a75c580c9920eba98d",
+        "sha3_256_hash_of_public_key": "955468734662471c953fa516b35b3a53053ff396b7e2798fe07a2ecd549d6c06",
+        "sha3_256_hash_of_secret_key": "8bbc886fcb7516e7888880921abfaa72823ace9d50cf0afc2f68c4a7c3dd2e53",
+        "encapsulation_seed": "7e8086a01dc5b3bb9eda25bcc45d27f99874841b97237968495800e007696ac5",
+        "sha3_256_hash_of_ciphertext": "87914dbce6a365f7335188d83f2394b0fdafc9b0676c022608401cd93d294f36",
+        "shared_secret": "5a4ba3737140bf227c0e618f74191b3de1c1b8e24b032036942de66a13ef5a91"
+    },
+    {
+        "key_generation_seed": "b8bd0493a882e3a49b4e0f6256fb1fea0912562fd9ba26ec3d6c9cc12c8973abd7e4b5d8021c486b9c3114d7cbbeb7cd49eba8a61bc2bcae1f1bef30a1daf76d",
+        "sha3_256_hash_of_public_key": "f7310c0531060051469ffcd2f88e3200bec6c721bca1fa4c9e7bf1773d7ccb19",
+        "sha3_256_hash_of_secret_key": "16c976495bbd05ee6715f30a9323aa41ecc320e2e63479148ab3a51132afd7b5",
+        "encapsulation_seed": "bb321ef14d44d8698df879fd52450567657f52a2df8d111185dcd7d4f30a72d4",
+        "sha3_256_hash_of_ciphertext": "37ff2acef57d0665358cc5ec7f489160d602d41c21cbb3332670f3cf0044fc39",
+        "shared_secret": "87528a4a961de06d5856004eba20a44590a1bd88318fcd1ae1dbfbfd41f152b0"
+    },
+    {
+        "key_generation_seed": "c0407e41ddf48d333978b89bcf2db01e4613425b456249e76a6f25b8a2827bf5b2dca81e3f5f748d23c9d356a2209f6b2d60247b2e45c9808de497f64f124643",
+        "sha3_256_hash_of_public_key": "152c13a9a4dfbade0f98e8a5136358f69c93f0722addc008952cf72e1bf350b1",
+        "sha3_256_hash_of_secret_key": "b93c3fb9dbddaa560dd52c6a1c37f6aeb2111e46b7b746419e3c27fa43a27211",
+        "encapsulation_seed": "210a423dadd899b810f011794b79aa7f860823ac1962370e791287d3a1afa384",
+        "sha3_256_hash_of_ciphertext": "b62ee0b20daf3a87406f7f8428d6dac79ad5f95c225956a564f896658ed51eee",
+        "shared_secret": "3652a13e36459a324958a2c45328fe4ca6163ba833400e643b0a6e51bbc594fe"
+    },
+    {
+        "key_generation_seed": "334382d39164d1989696a2ff77b25a28af8bead9883b5365eb6fcca7c1781cc9aba5068af837be962f439f233593d193ce5e08f7d66efb3389885927b89d2523",
+        "sha3_256_hash_of_public_key": "97e5b18cff525ef46fd8a6aa6e5e4b8d953fe1e67b5771d1b99ff18e754553be",
+        "sha3_256_hash_of_secret_key": "55102f3a620209b46e41531919a1b6f091c86bbcc5bdcb52b18f9a070680bd66",
+        "encapsulation_seed": "bc856afe24213e3d14c3d6f9b89223bbcfb2c890722d770fa3492c1e46d1c302",
+        "sha3_256_hash_of_ciphertext": "6d20fbb0cf418e91e295f391160df696348b3fa99542d12584c0da554b96153d",
+        "shared_secret": "c07d965e4a87e89e9fd5db44cdf225b20157a6842e2862ecb4f72d8aac933c2b"
+    },
+    {
+        "key_generation_seed": "6995143e8eb8a6e93840f76eec844f67d2b5f75b1839a5040337e61f9806764a0f4dff8e56f68440836a072412a30d851ace2c7c6f02d60e7a8420001a63e6c6",
+        "sha3_256_hash_of_public_key": "7b5c67fa6e0ff374f691540fff0b4d14d4ed8a8a8c48b14b2a35facb413a5ee6",
+        "sha3_256_hash_of_secret_key": "449e7b1644520512fa25ea48f468ce9f866ea08178e814f11561efd4e4aad792",
+        "encapsulation_seed": "5fc00f89563e44b24cd67d0ce684effe5731619fd08e7d72e2406eb016afb66b",
+        "sha3_256_hash_of_ciphertext": "e4f728484e23e99dcd35c5d3ca6d62e3a829e60a784faec5dd9fbb2d0cfa8bd7",
+        "shared_secret": "a502041eee317af1e9e6f9a9c12cc98415b358ff179d4d64ba5b7463a1f33b0d"
+    },
+    {
+        "key_generation_seed": "995eff7e0d195c6d0533f3dc194d47e60f9ad14696144cde694d60a95f3e96b4b28f7e7a15a005f92400ce33db073d49b53871594a88fc45e0f94207b5f0f2dc",
+        "sha3_256_hash_of_public_key": "8e49b73bae3b0285bbe1676eb6fad2641e7354e4c0a4feb0b74bb16708b01351",
+        "sha3_256_hash_of_secret_key": "23a598fad0141bdf07257c662d22549343a01d75eea9c1ebcdeb4a138c6e215c",
+        "encapsulation_seed": "ea22a76065db4b565ee1807fbd813b43bde72b0e08407fb867c6a18995025e50",
+        "sha3_256_hash_of_ciphertext": "cb2c217f6ad9c504c9fec4750db44d2c339017542da415ad81094290006e9273",
+        "shared_secret": "a354e870cd600e5a5951aad3491c31a80b0545c1662f830d7f0b6d144ed3733b"
+    },
+    {
+        "key_generation_seed": "3e809ec8dd0fec0d911a4e3fac20f70fbb128c5de94dc7184ca7310ae9157a98d8128601c28b1def8d393a0db283229f7c7383152a814e7cefe8ef9d9768c473",
+        "sha3_256_hash_of_public_key": "f5de62d662f480d4ed8ba235b4aaa4bfff19edebbbfbd96e5a9b7c4e89365c3e",
+        "sha3_256_hash_of_secret_key": "583ad55aa14bd6a4310d3ab7aa619cf59c93906251f5721a0bf880a866517f70",
+        "encapsulation_seed": "e9602b34fe73ad57f4bf6ead99743d645641553a5b9b9bf2e7016629e3e9bd76",
+        "sha3_256_hash_of_ciphertext": "a9f97b3e253dcb15c8ef4c5576786d967e504e8f76c0bf46e051b8f123fce22d",
+        "shared_secret": "cd98ddb938549cc7c4fe56cda7f3ef213f1aea49fed4fb81b940c7e894be1e54"
+    },
+    {
+        "key_generation_seed": "dbf1c465fff3d9f783bd9ee61a573715e45691147b8904439b5ffaa64f94ff7bb6d75eac6c76ced1b0a025b40a55440712ad8424672e761e9bc400d63812006f",
+        "sha3_256_hash_of_public_key": "ec2fc5834e128c5e1460d8cb0c35ab340d706a6c8b52070a7e41a6405fada53f",
+        "sha3_256_hash_of_secret_key": "954a43f78ef0b5a279c0d020c08d930cc5e83a385c09afed508f9ef6f1a27920",
+        "encapsulation_seed": "f72b9080a6c051bbdb9b0abc1949034be0f89a9f73fe277ec4d4740c78d04a83",
+        "sha3_256_hash_of_ciphertext": "f137abde6208e2c014a5a7eb1aac7b910a21df3a7dff68dcc40cba4f34b839d1",
+        "shared_secret": "e0d0d574b1287716bd7e0a44feea36ec28469bd36713fa8a53b0a104f322016f"
+    },
+    {
+        "key_generation_seed": "1f7cfd2b70863154e8a69d1758532e86c20cfc763d67c758bd10a13b24e759b5273b38bddc18488024ec90e62a4110129a42a16d2a93c45439888e76008604c6",
+        "sha3_256_hash_of_public_key": "5e7f49b87bb2319dba8d3485fe814aedb0b43173bc48f3a793554c3e8bf90c17",
+        "sha3_256_hash_of_secret_key": "74eb7c05fedc78406453b8f021f8a71cce4b3ad0c4d38bc8d581000a38908574",
+        "encapsulation_seed": "f1e5542190db8ecf4b8d617a04fd3783ad0df78bf8dab749afb57db8321d151b",
+        "sha3_256_hash_of_ciphertext": "2018b7eddcf255f6a171af914ef44153fd60976c5c7368998a218b1d81e34e33",
+        "shared_secret": "bd97eac1e35a06536e713a2ca5e71e35277b948172cafef0c35e1558efb61676"
+    },
+    {
+        "key_generation_seed": "3a19577908efd37697b8edc7fdaf47d1bd3ad01a1b77faf794bee5b9c3192a6fa3729672816f3eba84c9638a79676eeac0f22c8a48e0c5d50a26ff0844c66b99",
+        "sha3_256_hash_of_public_key": "e3f73c56254fac37209f5a59818fbaabf5abff3320b0b3ee00e20679b5728c12",
+        "sha3_256_hash_of_secret_key": "1e1cff1c4e09318bdc174bff8ef0817d6e7414355adf930bb35e71a7a0b95abf",
+        "encapsulation_seed": "74efa414ae171bf60b6f884cb7e5ce12028f49365daccfa23e845d551711660b",
+        "sha3_256_hash_of_ciphertext": "d641fde487a3659350dc41f329e0d41741bd4389346da9270eda4f5829ce9ee3",
+        "shared_secret": "2ed540764a77b17c6b9608bf86d8d8703f80718044d52dc79cbc1838f91fdd7a"
+    },
+    {
+        "key_generation_seed": "ae0f65e29f38804a6759f70f4d01e2aaff7fe1c91ebc4f892dd0de3ab2e68ea5e03ff73e02a217659f53d8c47556bf3d8c94040f630d63605e2d0f923579370c",
+        "sha3_256_hash_of_public_key": "bc0a40ba03d27bbbfb91654fdcfab2dfb3e94d9607b99c1d7da1f2663bfa2598",
+        "sha3_256_hash_of_secret_key": "dd55c195b92ff410b9ea37577ddba0385bbf067b3053b0a678e8106c07b98c9e",
+        "encapsulation_seed": "0b4c3cffb2ba4380ead13dc0d8acad2356b448a810da1df29f264c44aab6d24f",
+        "sha3_256_hash_of_ciphertext": "7387b045cefcf3d2c659171ee41acf3857b9f63f1ba20c3f0832cfe41a26ef75",
+        "shared_secret": "1e5ba1b64fa8ad0494c96ba27e288ee2b479c24634285f8919e58e9b9c8be78b"
+    },
+    {
+        "key_generation_seed": "6084a235f79dd093ef6d185b54e69df33dacee73a9bf2f379004421a10e3a79d9f684fb055ece19459eb464e91e126a7a6e3ed11ccee0046da234d964c985110",
+        "sha3_256_hash_of_public_key": "e16da7f99bb7bceb75a6468a921ab9fe53aab2972ca616ee10697c204df1e350",
+        "sha3_256_hash_of_secret_key": "2db70f5bb4e8927fd7696a4d802817fa58c43f9b2618ed27c7584cce8acf3506",
+        "encapsulation_seed": "1c82471dcdfca3a6942061ab4f3d5bf0d197321437c706d9cccccce449447002",
+        "sha3_256_hash_of_ciphertext": "0159f5e60336eec1fda83aeffbee92eddfcac6f92b0fef7a4a38fb20d1a771ca",
+        "shared_secret": "96ba12c7f8a0d864ce1434b789c09753c2d1f7ade6a5a0e679ce2ea0b6d66c83"
+    },
+    {
+        "key_generation_seed": "acd1c0217fad5caa4235544dd9de153ab1880ccf4c76f16f236fae4e4bfda04cf03a8abb0a5010f400ae5722a75bdf5a2f6d5b546b34d73857cb1bfc7e587aa7",
+        "sha3_256_hash_of_public_key": "fb80edf4f67823ff4e53a8963a9c9937fa9f8e014b750e11b4c4bb1a361d6484",
+        "sha3_256_hash_of_secret_key": "fe67beff69ea75d4953d71c038559591b2a0349ddcdfeaf7596dcd02f57db2b9",
+        "encapsulation_seed": "46fe60a18124125ab93e0c578f1c02f1bd1301595013001c7f3c2fa56cde294e",
+        "sha3_256_hash_of_ciphertext": "6e68fe27fe416c12819fa8a48eb29351d1d74a9200c408b55294ea374046c3d3",
+        "shared_secret": "07dfc04ebbb7ae537b594210a9180f647d3d385d1c1bb56abb8174111eb246df"
+    },
+    {
+        "key_generation_seed": "241191401a63afa750f05662e354dddbc683c776ce3222beb83e3cf913d7ed7ca59b3bd23b49a95bc1fad20070fec930b6060bd827d742b077092e422268e15d",
+        "sha3_256_hash_of_public_key": "d9f630c3838eb161374710d9f01bc70d4ef928fcb1c38bed93e30f3633a05e01",
+        "sha3_256_hash_of_secret_key": "ca4a4ab954c3a4c8b960fdfb7dd7cf5e8d103f7936f31e720e5043010926829f",
+        "encapsulation_seed": "52fb7cb6a633fd2e83f2892bd9441b48fe59ecee6d026f5246fa7f2a5e55ee3b",
+        "sha3_256_hash_of_ciphertext": "3b6a1f5d06cd55c98ce6f4dc5b17fce8cb05b33b1d89b618a027e4478d8b5e69",
+        "shared_secret": "81fdb9267988ad39ab57e2fc8d4c280e0000dac3471b0936083aec68b49fd92b"
+    },
+    {
+        "key_generation_seed": "b9a6b0c05677e957d41a34ba03bd06f2a9092e31f63389397d7e70fde6409d18e99c0e7b82be89bc3c1eaee6680aa4efd394e40c2b3f30523c8117f7c26a8969",
+        "sha3_256_hash_of_public_key": "5c27fa929adc826f98fbf0a7fdce33c8f215b34e70450da0767240741894ffa4",
+        "sha3_256_hash_of_secret_key": "0116eb35f3138aa7371a058661a92a4bde258f823747b70ad40767c27d7bc7f4",
+        "encapsulation_seed": "0f81a5f97082121244403da3feeb734f6084b314b8d94beb11627aa6ad1914e9",
+        "sha3_256_hash_of_ciphertext": "83f17a1e23402e14a58a32343e1083434eb10b90a8080d01ba112b83ba15f7f4",
+        "shared_secret": "703958ce09d7d6a5bb09e88de8df95c8ee2598544d50193be50534947530fa37"
+    },
+    {
+        "key_generation_seed": "28a96c71577ba00c94f99fe965bc595a26db2b3ca6ab5cf8e443cdd8462b17929c35d165453e5fcdc6f9df64526d9de698f2bd3e6bac6c7fdd86601b9ba5f4a5",
+        "sha3_256_hash_of_public_key": "dd8aa653122eb5e3a4c3c877e95e8ecfcfef1ac9e0e6af92cce8ee89d09188fa",
+        "sha3_256_hash_of_secret_key": "8a5fbb715cf44c86b736227e56b53d91ebbea432fb1f1d6d7cafe42da8457b2c",
+        "encapsulation_seed": "31af9345365549ea0360169ed57daf98cc5444799d4c75d9f1f5d615e9df8a91",
+        "sha3_256_hash_of_ciphertext": "862f660f11fb4252070e948ea2c141202246d5117ec151e6d5fcd0783bd76bb9",
+        "shared_secret": "c86d221cbc5ff6a994d9111acbfff23f7dc0cd934412b17d89f0f27e3cbd1a15"
+    },
+    {
+        "key_generation_seed": "c08ba2ef8c3a0a043afad931652d7a19e6e8cb670f840de5f1fa03309b2ca9ec5fe6141a25f7ab9f875f79e0a82d6ea5cde5a017ab637d5fdb7c42646a1d71df",
+        "sha3_256_hash_of_public_key": "b7c80e434104e9838cb08529592a5f81b0e8ead186663db8facc569b09e75c9a",
+        "sha3_256_hash_of_secret_key": "c5f84c36f3b8af4b4d90a040d929b116b402840f487d437f9b330f6ff3ec36fc",
+        "encapsulation_seed": "774ae54093d694ef40b63b62c73e6c98295f606feb8699807eda1d030ffb996d",
+        "sha3_256_hash_of_ciphertext": "a372aefe804077da915a423dad55b76ff08a58d222aa66305599ff301128ae13",
+        "shared_secret": "c0146ba47b3d4178919879721f69ac896d6911d6e86de1e8f05797d467053222"
+    },
+    {
+        "key_generation_seed": "0e3b30e102d707538c2671060f603bb0b8a014103f132d63b09ece07e4a4c75b11eafeca9e810796c34e8cfce9d59342884456007b01ddd12edce6d10ed87e4c",
+        "sha3_256_hash_of_public_key": "e619285c692532735f1582d227b9a9e77b1eae4aab9eaa79f6ce7ac2fcac8318",
+        "sha3_256_hash_of_secret_key": "2d4ae4f98c61bd104fbc1ef512b946202f95ecaa0ad7353a686141be5fe18116",
+        "encapsulation_seed": "9f27a47604ab5146caaf0aafe6d149424f8d66e39ba3baf5e6c73b19221b7e21",
+        "sha3_256_hash_of_ciphertext": "462b78ef50b2c1ce761fa7750ab5ed2a7315e474a92ddae74bd23013b0d9ad0a",
+        "shared_secret": "a33f72941e0947735925e5be668b3481e0cece75ef48ae6db0d66f0fb2ec428e"
+    },
+    {
+        "key_generation_seed": "2478f7d3de6041e7e5cd11c5e2ef483d1aa6218eb126444091535f6ae532fa7311136e2681df2ef881b51a092a9badbe72c9772c169808521c47149578621e28",
+        "sha3_256_hash_of_public_key": "dd3761c0e96678a959f30997e96d6a59858528c5e10234398e2da2e50ffcc517",
+        "sha3_256_hash_of_secret_key": "c6f5f9285f93d2ee6d180353799df5fea713870ca06de901e9c12e8a01ead6b6",
+        "encapsulation_seed": "90044031b7597b5e60a4f946b713e8996d0426d2cb013243d9b7d8f8ef159a0f",
+        "sha3_256_hash_of_ciphertext": "2e552ce25fe0771bfa135939d85bd68ed07959709da470df50be36aa8ab2890d",
+        "shared_secret": "3d77b9b4ade74443fc573c393b82c0cfd2bc2769327f273c14e66eab9f8d9ebc"
+    },
+    {
+        "key_generation_seed": "9d405d3ebdaf35fa8722de431b669722acaaea2fd10b814310b17f78b66147d16ceb14f7662be0c42779459f69a145c0e2ce9f0bd9a0cd1bf32ed5694cc9ae32",
+        "sha3_256_hash_of_public_key": "6d9e513a7cd137583507ad7256844bcb9775ca82ef5f411331a7c37ce451181f",
+        "sha3_256_hash_of_secret_key": "1dd2623a7413ff14549690b642fe90ce16ebe7acea38be795a4936b8d86b93aa",
+        "encapsulation_seed": "a7a31e140891ea37d2b6424b59b1f84f89220f32dcb73e037eb912b389d34a48",
+        "sha3_256_hash_of_ciphertext": "b4c64b73ba056f9ee7c3587ba0825bcc7172a6da749cdd86c1ef60cf84515883",
+        "shared_secret": "812d6c4becfdd4a95f234e8fcae1d9b316266d1c519545bbb7fab8a19f3519e0"
+    },
+    {
+        "key_generation_seed": "9a86490f0615f3edf789cb0654066e9ee339cc59f968281f3b89213f83c692edfaeb2ef44d2f608621e831187ce79b2d2f4a20f1568bbe76b0d3d5af36111714",
+        "sha3_256_hash_of_public_key": "b252e5abf757e116a92518eb72df9f9ce66b07edf4d31be225585a6a827a35b8",
+        "sha3_256_hash_of_secret_key": "45ac74f2a699f1e3559e2d1442638290029688cec3da96c58ea697e1ed1d4178",
+        "encapsulation_seed": "70eb3f791faa91f1f982fa477dbcddeb2c55691c07f93b04cd31b37544c94b42",
+        "sha3_256_hash_of_ciphertext": "4dae8b2d08afb311ef727118966c6c17652f1464e6cdd26ac23551d31b013415",
+        "shared_secret": "c8757f45a1e334ad99a0d2adf12e79ef2bcb96ea1876bc29a4ec5cd660923d82"
+    },
+    {
+        "key_generation_seed": "6dfd9b575872560c7bdc2732c4a28dac4db04e535eb8e402c3dffd145c09ce47a2985c1c4d203778597947d710dec806e36b0cd949fe460ef141213bfc525e5b",
+        "sha3_256_hash_of_public_key": "18c081231277f424c5f3f1f6b4db91958611fa28bcf09ccb2573da64547e1958",
+        "sha3_256_hash_of_secret_key": "f32167b39e19dbc0db58a5eb79e735337ffe154c75b0f2c091e009d0cec366d2",
+        "encapsulation_seed": "30f4095015ba88b6d969672ca3f438c395dacf7d476ea7a9e805ce932d270a13",
+        "sha3_256_hash_of_ciphertext": "3a246e10c7c20d77a9e4bd6d3a90d73ae456501dc989210c798293d0b449852c",
+        "shared_secret": "be765dc236062da9d3fef68c645b9a8a5494c351d37790c1e7cd1089d97971b3"
+    },
+    {
+        "key_generation_seed": "6fca9f4e384d8418075cc064c70730801bdb8249899d456a77130d5beeb3662cce7683f8a03d3cf04e46970ff7d6a12494ae12558346dfc8fd9370bf944a0102",
+        "sha3_256_hash_of_public_key": "0ac7db13184d6ae6e21a14a63a2ab3d6d5d1ee7f4a6011413a0295b752fd2c28",
+        "sha3_256_hash_of_secret_key": "f69bacdf5992e64369aa4325b70af9f0e8a399cadafe48d854c288cc4eec627e",
+        "encapsulation_seed": "cf31220f44de862e1719570e1b26e897790159366a385452334fe24cdcae28ba",
+        "sha3_256_hash_of_ciphertext": "d4200c5ed5cb4e30e8e74a5c8c30eacd48014d326ae72f73618c5680f04999d8",
+        "shared_secret": "e72888e8dc5fe30f0a9c01e2e4599a7046147a81da280c393a48bee1b43bbb5b"
+    },
+    {
+        "key_generation_seed": "e58f71bf175c0550a67e00e0f7b3b7fc36bc2707bf0c93044a492626de36301a7f7054814869cf7625e45647bc1547aff288dbb90699b2ad84893f3b755d9722",
+        "sha3_256_hash_of_public_key": "27ea5a76294070ab10a6edc502d82be3d240672e5fa61377e73e5e19d11f64a3",
+        "sha3_256_hash_of_secret_key": "33161a2b269ff022ff4699b05ac7fac1374d733e46800447164d3e528ff89dc4",
+        "encapsulation_seed": "bb5e65669a44e5d5c709bafa98c16ccba6ac2c4ae923334f69a11543eda64f5d",
+        "sha3_256_hash_of_ciphertext": "8995a8a9b59bd5adbe1fa10cc20da5348737cce9088be7eb0ba1f6215d68b9a9",
+        "shared_secret": "e3f13c77fa9eb329c218e1bd5823d6e07249fa1b455770ae57b2a00aa8c69c5d"
+    },
+    {
+        "key_generation_seed": "e3fc575ed51513e62aba655d24cd9c8f1c6c848aaffa946c49a53ac3ea59e474d82c2f1bf2e6aebde5660fa73356982e12999d8fdafbb3cb186341d0386dead0",
+        "sha3_256_hash_of_public_key": "9898462f05bea461adb40faacdfdde363c06f58bc756f0a8417df63a66d3a544",
+        "sha3_256_hash_of_secret_key": "e10192b72796b2da465303c0bbe16f1e23e08f9680ba92fc22d568ac84352113",
+        "encapsulation_seed": "9ddb3aa9c7905d1a438c93bcf78e3e321813580371ab4e1289e2dbf3701972c2",
+        "sha3_256_hash_of_ciphertext": "573aa757ef6fa5110ba7b948c325718f87c6bc9ccd596debff4e6c7dac1fa8f5",
+        "shared_secret": "a8498502e012b5cd006e77fcbb9fab801dc3748a0da37587dcd41310fa945e09"
+    },
+    {
+        "key_generation_seed": "470b4943f0fe7fd0d8ec5185aba0d1db09d112934e4fb4787e2bbc6b88466e7b8b2809fd40008be70a6b184981101724bc3d5ec5e1956b510b82fd5ad0668a5a",
+        "sha3_256_hash_of_public_key": "a24e6203d9b1aa5cd06c44f048da7225e33952617f12b4289494b3969857c2ff",
+        "sha3_256_hash_of_secret_key": "61f1e3b3a9ce59d25480d88dac106cebc81272c0c9449c9b22048f67419d940a",
+        "encapsulation_seed": "26d90b190a6c3d0d9a86cf66005154e7086749e966e7187c249ccb9329fd3b8b",
+        "sha3_256_hash_of_ciphertext": "7f92312ab16635c5e90a6d41ac65e594e37754359331b0814e09da9c7eb945e7",
+        "shared_secret": "780b2d0ea585a6ea41dcf43197b9ca4648454e30a3057f0d47f6e79a2bbc365e"
+    },
+    {
+        "key_generation_seed": "6df4385db978d27b27d2aa5e452e4152b36f097503d9581ac3390105c5727e7dc95fa08ed106ce84660e8a4c90bd2b22634e40769aa0090a101c5dddad45edc5",
+        "sha3_256_hash_of_public_key": "cb2e9159ab5225a75d02268af2dac89a0afb33fe83a45f552e2bf542868c0683",
+        "sha3_256_hash_of_secret_key": "d2ce7cdfbe3ac715b2c87b1231fe46d5385a77caab367570a955bb562d23183c",
+        "encapsulation_seed": "7db6d1a129d6123f1f805b79ad3b413012ea86aed42a05e98e7b1f32f9fbbdec",
+        "sha3_256_hash_of_ciphertext": "1113b9a38ec4629ad20ecb594b64ba242a5a4db7bdf32914f9eb34ecc76c4a1c",
+        "shared_secret": "7832b351d71984cb60e6e548e5b4edeedf9749f8b3bc96fd208b6bb557251de8"
+    },
+    {
+        "key_generation_seed": "dbacba825728444921b227cdba54446b3f6881b47be9cd02832f78b023b1bee0e15274a8e2bc08fe818b117ba28c5dfae74d54fcdf6f20052f79be333edc8dde",
+        "sha3_256_hash_of_public_key": "7f8d36076b3a8aa13b633650726f7e907806a0573402ef3af129f611def1a813",
+        "sha3_256_hash_of_secret_key": "0b38e04daf35259696487ffaad947f481756bc3e94dd1a73b81bf8a6da4a43c3",
+        "encapsulation_seed": "1d129b27be7384c359d04311fe5c44917d1fde4bfb57314f483ac617edd5ac49",
+        "sha3_256_hash_of_ciphertext": "eefa4d255cbd39fb5686d14a6a574d4c75c6b138a45a09cec12287c281cc00e8",
+        "shared_secret": "468ee020867cb766cd0a9ce1bfe9e7dbb56ae66c131a4540f211837c1779e11f"
+    },
+    {
+        "key_generation_seed": "690eb71fd7052b906eaec09937a8ed374e0b02afa27c2f14399932be5839fad281c38c2cb5cfafac81b96a810ab749b61806b6d54c9f8cf4bf1be0192423288f",
+        "sha3_256_hash_of_public_key": "ff2044ee6a3bfd4f7033dc4bbd6283b534cd3fbbf1c4af072fea1ba37d3262d5",
+        "sha3_256_hash_of_secret_key": "ed62dbd78c007d385c786f2607715a69a44804c4e88111861d175875bc0b09ee",
+        "encapsulation_seed": "bbc773ebd2df42c36ae05952d6a64c63a5dfb82ceb3ef4f8d4df3a30ec8c0467",
+        "sha3_256_hash_of_ciphertext": "d16b23897beae9fb1a6ca746d3c15ef52c8ac454cd518d5a90a561cb588a0260",
+        "shared_secret": "f04a17a3737285f2257a6374a0057776ea24bd731724851d12ac2e06e959fa26"
+    },
+    {
+        "key_generation_seed": "32e0ea9089fa928482c0770da545af1bb871a03ce38604138b0d08ea2a10ca2bc06c5bef7b6508409daf847a64c8d30d0974fd3ba7476dc76c46b458a036d884",
+        "sha3_256_hash_of_public_key": "c7ca6ebbe17f30f8ce49e15c40c1ea5456f43624148eaecc9f3018f7beb96bdf",
+        "sha3_256_hash_of_secret_key": "7886dadfd208ab926afd2376dc11a004d8b793d7a30623df27109f9a4d4b0916",
+        "encapsulation_seed": "5b17a6adad541efcbf5ae4b0c0452cd2ce32e4f0f8701801c5b63e197c1fcbf4",
+        "sha3_256_hash_of_ciphertext": "4fdbbb522c23abd8a69c583c2c68ddc28fa4da85a6bf208a22d19e7ef40d98b3",
+        "shared_secret": "fcfab6cb3daf0c64b4ce007499f097f6421e00905fd4daca7da7a29b9c8f6325"
+    },
+    {
+        "key_generation_seed": "6fb2ec719f2a0dea152bf3f64b9d148f8ab8ba88f64e61f5db53e12d59f525574f797c007e4061f95c7d56cfc7ee5c49e849dde3fea8f25e7876df2a18515c34",
+        "sha3_256_hash_of_public_key": "61fb6cfc0f388e34fb28ed783c2733453005eea03d3fee4b01bb6364abc01c30",
+        "sha3_256_hash_of_secret_key": "b724f25cf64bdaab1cd29c9cd1f8ee6cf4104c26fa3caf53b77d61cb5c35222e",
+        "encapsulation_seed": "61ab87659525de9656af41246f20e1dbe85c24e335e7ecf9493f46168bc14e94",
+        "sha3_256_hash_of_ciphertext": "5ce7558ab39d932fd35fc346aaea5aff4bc90e65c17b5760996e84687dcb5402",
+        "shared_secret": "dbf4cd1f5cddf15322449ddfe147ae0605d0315ff9da6421069b47c3a67a65c4"
+    },
+    {
+        "key_generation_seed": "527fb88c8bd9a4d6031dad15e63878abd2b559e7e08d61f69e8e78fca964ee6ae32d432b4f9f751bde0496c580a181ffed762aa35454a02d3f1f47ee0394c89c",
+        "sha3_256_hash_of_public_key": "9333445958cf50f9cfba453f058f562158bc253e535e4e2f07715531a1c6289e",
+        "sha3_256_hash_of_secret_key": "9bb80f6928e0d09847b4c7e77ba6bf2cd0f75bdd147e884b92d3c3f2e9d839d6",
+        "encapsulation_seed": "eca2adc3da1fb15f34033405ec08ef2f46163df4bfcccf8842c600ce0bc2026c",
+        "sha3_256_hash_of_ciphertext": "57651b24ece777c321c6e59ba774951e2a3c4720d370e3af928238ff60c9565d",
+        "shared_secret": "3f4848a2de1cdd8a0403da22f609809a20c2cfc0ae619be0cac350897fead710"
+    },
+    {
+        "key_generation_seed": "ac6fcfaeeef795b6ef9e062f02bf42975fa01e7d91ba832f74e05269a72684d05aeda108ea4d6c6bc0fb958286850422bc357ca67b83c986048e0d0087fa11ec",
+        "sha3_256_hash_of_public_key": "ee6cb12a54341aeedc99f1040b01603c35f07c5487ffac7b4fc1925f49026916",
+        "sha3_256_hash_of_secret_key": "4e498a0606b1f9cd72b9d2493428730712bdaa4a7fed8099b15d9e2873bbdf7e",
+        "encapsulation_seed": "c4f15bec2d7701339d0ade4835193bea3632edcf89e74992620d9eb623a0d0d4",
+        "sha3_256_hash_of_ciphertext": "1fb55bc4e6d95931087b23945ce9448207fbbc14bd284f6bcda65fcf31d68fdc",
+        "shared_secret": "eed5b71764da1763a01184a1eb51dedb4eaa9dae7890b1c7dbc7e7132c30e737"
+    },
+    {
+        "key_generation_seed": "ba2fb9318d4dbe7488057c33e95e6f054583a2800c41bb83083c330a914a12cfe63f8ffda3565c2424c89b20974b748a65a5aba75133fcb3156dfb6626a83bab",
+        "sha3_256_hash_of_public_key": "42ad42d6d3b13c72b16287909bc4c0da04900536a1e48a1a28db4f5ee2d2e771",
+        "sha3_256_hash_of_secret_key": "d6f909b6679487a8718c843c4b894785ee046c4d86ad2794c22ee912113dad1f",
+        "encapsulation_seed": "28878249e2ac2b6263422993923a0c8bd05ce56e385ed13c943b03d226856947",
+        "sha3_256_hash_of_ciphertext": "54043d4b2be7ecb264847dd0bcde9076523e798aeee942be82d61d51ef0253c1",
+        "shared_secret": "4218fc9abb402e67ac946c7a7c6f9029108f67de469e1a9987d570f011b685c3"
+    },
+    {
+        "key_generation_seed": "aa6dd1e5799cdf7af9c4fc632b3eb9d51d66e85c8e0a21ec98664fc51ab63c7dfda268813efab5204efa60f78bf81d320d01ac09ac06244f7afbd2d80fd356d9",
+        "sha3_256_hash_of_public_key": "5b70c5bb1b7af3b643588aa7c20567d4259dbe6abd7617a61b48185de8f21e1c",
+        "sha3_256_hash_of_secret_key": "f03297b8577b131e39946a288f7ca9070e70c1e00e6ff126543556f60dbafead",
+        "encapsulation_seed": "17fc65f7fbd7c75ceec421dee84dff5a8cb22764a182db17e0ebe857f54d60eb",
+        "sha3_256_hash_of_ciphertext": "c3d51c14b28feb48ee67945a2f9e2ababb8682a839ca1148ddc99f909e8c0bc1",
+        "shared_secret": "95a33968866dadc1fd8748768a99f6bb444e3d76a65ec5fee0c8a833978d4585"
+    },
+    {
+        "key_generation_seed": "195d6c86a3df4c21e3007d7f2768b43c74cb3060e0eca77f0a5d3271542b9a84ae77e0f9f21eabd8c0c6eea7767f4e10fde5c2d79b8400bf96b19014b457ec21",
+        "sha3_256_hash_of_public_key": "01782fce09e644e310c9286f1e381be9ea8c54a1804e61f2958c1f975aec185a",
+        "sha3_256_hash_of_secret_key": "3d1b220e747de4ca99a9882a00860ed00abcf2e6eea60cba5194977f97c87770",
+        "encapsulation_seed": "fa0489f3730100609488e951e6aaa15c0f193bc1dbcfcd013bc418d6c507b176",
+        "sha3_256_hash_of_ciphertext": "8dbc778809c9cb1de5301be5bce766f1acd7d8f74ecf30619c398250def57d74",
+        "shared_secret": "c9423277519ab439fca3f5fab4c29c8123a55eaf37d94d70e27afffeec1b3b9b"
+    }
+]

--- a/libcrux-ml-kem/tests/kats/nistkats_mlkem_ipd_768.json
+++ b/libcrux-ml-kem/tests/kats/nistkats_mlkem_ipd_768.json
@@ -1,0 +1,802 @@
+[
+    {
+        "key_generation_seed": "7c9935a0b07694aa0c6d10e4db6b1add2fd81a25ccb148032dcd739936737f2d8626ed79d451140800e03b59b956f8210e556067407d13dc90fa9e8b872bfb8f",
+        "sha3_256_hash_of_public_key": "d4ec143b50f01423b177895edee22bb739f647ecf85f50bc25ef7b5a725dee86",
+        "sha3_256_hash_of_secret_key": "245bc1d8cdd4893e4c471e8fccfa7019df0fd10f2d5375f36b4af5f4222aca6a",
+        "encapsulation_seed": "147c03f7a5bebba406c8fae1874d7f13c80efe79a3a9a874cc09fe76f6997615",
+        "sha3_256_hash_of_ciphertext": "bb62281b4aacc5a90a5ccdc5cd3dbe3867c502e8e6ec963ab329a9da0a20a75a",
+        "shared_secret": "729fa06ac93c5efdfbf1272a96cef167a393947ab7dc2d11ed7de8ac3c947fa8"
+    },
+    {
+        "key_generation_seed": "d60b93492a1d8c1c7ba6fc0b733137f3406cee8110a93f170e7a78658af326d9003271531cf27285b8721ed5cb46853043b346a66cba6cf765f1b0eaa40bf672",
+        "sha3_256_hash_of_public_key": "2cedad700b675e98641bea57b936bd8befce2d5161e0ef4ef8406e70f1e2c27c",
+        "sha3_256_hash_of_secret_key": "0a84cc895da138b944accbef3ff1a0004b8a0d8af5d426d2b82ea4c0e585cc6a",
+        "encapsulation_seed": "cde797df8ce67231f6c5d15811843e01eb2ab84c7490931240822adbddd72046",
+        "sha3_256_hash_of_ciphertext": "c15158a536d89bf3bafaea44cd442827a82f6eb772849015f3fec68a29d589dc",
+        "shared_secret": "c00e4ede0a4fa212980e6736686bf73585a0adf8d38fec212c860a0d3d055d1c"
+    },
+    {
+        "key_generation_seed": "4b622de1350119c45a9f2e2ef3dc5df50a759d138cdfbd64c81cc7cc2f513345e82fcc97ca60ccb27bf6938c975658aeb8b4d37cffbde25d97e561f36c219ade",
+        "sha3_256_hash_of_public_key": "3dbc65b722a8982d058e27d409f04f744551ecde9015b62607cf67bb8ececbb8",
+        "sha3_256_hash_of_secret_key": "0ffced333b5d13fff22b81e66d57b6e2a6dba0285fe2a82d5537df51a8d3eac3",
+        "encapsulation_seed": "f43f68fbd694f0a6d307297110ecd4739876489fdf07eb9b03364e2ed0ff96e9",
+        "sha3_256_hash_of_ciphertext": "aec80e6fe21e2616352b4c148f9fa0e30986541fb0969df7873b1336b23a8de0",
+        "shared_secret": "8f50401bc9b1f857fd870902d4065f6cec8cb825db3eb22573c6167442b6e19b"
+    },
+    {
+        "key_generation_seed": "050d58f9f757edc1e8180e3808b806f5bbb3586db3470b069826d1bb9a4efc2cde950541fd53a8a47aaa8cdfe80d928262a5ef7f8129ec3ef92f78d7cc32ef60",
+        "sha3_256_hash_of_public_key": "94391b7a41175a41c15cd995ebc69c83b29e4bcea6c186611dc4a79578e37f4c",
+        "sha3_256_hash_of_secret_key": "e3904266e186b34a397014c95f6d314cd6e1c813348b02e977d0fd21d9bb681b",
+        "encapsulation_seed": "ea74fbc3c546500ed684bed6fe3c496d3b86d2d6dfaf223969b942e9a8c95e85",
+        "sha3_256_hash_of_ciphertext": "39fa8e1d0a5e4bb987618734ee4903771886030b2d8bea4b5a9b0cb672ebb279",
+        "shared_secret": "3221d7b046caccbded38e369625f69bac60c2d7efacad8f24170b10c5d222830"
+    },
+    {
+        "key_generation_seed": "66b79b844e0c2adad694e0478661ac46fe6b6001f6a71ff8e2f034b1fd8833d3be2d3c64d38269a1ee8660b9a2beaeb9f5ac022e8f0a357feebfd13b06813854",
+        "sha3_256_hash_of_public_key": "c5dbd68b3a8c148b2e7ac049bb986e14dd1cebfa1cbf3edd6bae85a4d2dda082",
+        "sha3_256_hash_of_secret_key": "b3fa7958f4b7ccb68712ae948c3f08740c8b89a69e53ad4e9959234e6869d8fe",
+        "encapsulation_seed": "64efa87a12cb96f98b9b81a7e5128a959c74e5332aaab0444fca7b4a5e5e0216",
+        "sha3_256_hash_of_ciphertext": "ca9f95c38dc95f51b6b62ec709539f0d1e9fa64e49ce4ad10bbe62868f35cfc5",
+        "shared_secret": "1d746afc4160c75aaa6c6967f4eee941e09546a039027f05f0f8a483710ac334"
+    },
+    {
+        "key_generation_seed": "7ec408f52c9aa723d0c41d9987682a5f4ce6c9da7cd0215af60bbaf5484ab353a08ccf451b049fd51d7a9ad77ae14a81569df8c9bd3a8f1ebea86fdcfb823082",
+        "sha3_256_hash_of_public_key": "62e0447f7b5ae8a806b741ca5c302230b555c3786c11f3eb43894a8f45e3f7b1",
+        "sha3_256_hash_of_secret_key": "1a3249c268754c86d2e02ba9d87c2b60b220bf2406b71037cfaf6b089477ffb4",
+        "encapsulation_seed": "8a95d71228acaa5f9ae6f9d9ca8ae55fde296463b41083a39e833e37c4c90f88",
+        "sha3_256_hash_of_ciphertext": "ec7bb1327a69aeaf626a76d344be1156eac160262128a64477a194805b926233",
+        "shared_secret": "722fccef7142c46f74eb57a10b13e420d6554e9d18507f660bd1be96d3cebbcc"
+    },
+    {
+        "key_generation_seed": "c121915bfef6abdfc177dae2f5a24218f9abda2559afc6741b08e0e61ab433eb84ef52db5eaa6df8ec3a0bc5ffa730db0dde8c5f38f266d5c680a78d264a7b96",
+        "sha3_256_hash_of_public_key": "0c1d832af7b7282d8bd81a2237107ee60d81e28eb64d6a153ae0eaa1a25797c2",
+        "sha3_256_hash_of_secret_key": "fd6b5d3f120ca009871ca24552a6118917ea882f12f30dc8097f6614d9d36080",
+        "encapsulation_seed": "90d79d75d0bbb8921cf70d46bab497022a8e750efdc99e5f1bae653275441c7b",
+        "sha3_256_hash_of_ciphertext": "da36cb6137a777acb4afbc0932811f75ef1d6732031309ae7e2de1543aaf5c2c",
+        "shared_secret": "ee7c5fb6a63ace944e1eae1bd4b182263d918754c33753b904853551b2b46cb8"
+    },
+    {
+        "key_generation_seed": "d86634ecf96cc2603761e284c0e36734cedec64e7ff486469e38539c71141c5a99daf37400cfe59841afc412ec97f2929dc84a6f3c36f378ee84ce3e46cd1209",
+        "sha3_256_hash_of_public_key": "2b757ac0425152bef72ed852ab1eb44f4359499407bb6a020ff843a31657c5fe",
+        "sha3_256_hash_of_secret_key": "27dbbc7918c31e9ab57808f439c4f4189cc318a62422457f4fed733be959c816",
+        "encapsulation_seed": "be8a32f97b9a8d596382c02fa2a0eeebc15c083e970ddaa4f2622b91d6718663",
+        "sha3_256_hash_of_ciphertext": "85efbfd0b096fa921711ea66b17bcf7c9a6240711b38a88830dbd9d716f07195",
+        "shared_secret": "77cfbdae47854e9e10765cf397eca9ab2bf2b7522817152b22e18b6e09795016"
+    },
+    {
+        "key_generation_seed": "0610678ff4dc3128e1619f915dc192c220f8fad94da1943b90aaec401683a492da1804ddb5aa9b1c6a47a98f8505a49bae2affde5fe75e69e828e546a6771004",
+        "sha3_256_hash_of_public_key": "53b9d62e64f9069d9fb94ea2c0806459b201531f4fddd708d162981cc1fb3757",
+        "sha3_256_hash_of_secret_key": "f4b964b7ab3e09fdf3d91527da06a4d29ef28344709a41739ef56f18bd5b984b",
+        "encapsulation_seed": "da2cfaf69e25b2a89ff2557bbb6f69e01d8e2e7bb27a7a1ce7e40fead16f33b2",
+        "sha3_256_hash_of_ciphertext": "379a57a8f19110d5e0d747a2c184877d71f00fea95cd815b4c0e8782b12bec6f",
+        "shared_secret": "8be7a417efbdd3587c6f82ddd1d29956789d28c2413b8383590c5b80cc53e04a"
+    },
+    {
+        "key_generation_seed": "d322d56d8ef067ba1f24c92492b9c56df3a6ef54a304adc1b69913766a1ce69756047447b810cc094d400ab204cf9ae71e3afa68b88586ecb6498c68ac0e51b9",
+        "sha3_256_hash_of_public_key": "9cfeca12dfe978bf0b7ad7271487cf61b2b8f7c60f389f33fc18439a95bcbb63",
+        "sha3_256_hash_of_secret_key": "a2e37a55c9b80fb423f40585180b011f32402d0320259285b6e278df6c20ba60",
+        "encapsulation_seed": "511c2ab40782322c06111e144e505328c4e5bfc890a5980a2bbc44aeda4c738b",
+        "sha3_256_hash_of_ciphertext": "44053f01ecb88811b9ee7a9ddd4234f94507c7cf64b6803b28c54bc605ec4e31",
+        "shared_secret": "79fcd201101e7e277c1b6cdc4475d63ea1dbc42ab94cf873bf0163c2aab0b5ff"
+    },
+    {
+        "key_generation_seed": "2f1d8a3bebb34540324b9485fdf3d5be3b858f544abc3fc641b5728cafab03ba8d6c42e7270ee2b77b6045385f3d175984a0e260363166c73b0c70c971644363",
+        "sha3_256_hash_of_public_key": "9aa64a30bed5aa8300772066ef577f79bf4813e3315a15f2c28b2665e4dc7e2f",
+        "sha3_256_hash_of_secret_key": "837eb6ce037f235273d7686fd9d01bea14026e0a0f5f943884f18409cc4bc70a",
+        "encapsulation_seed": "dca92dbec9b260dd97e8886f876862d6effc3b91fcf3fbc986cf56ab93ae79a2",
+        "sha3_256_hash_of_ciphertext": "02798b5af1a76a2b478ee05c630e62618e5e2d7ee0c411a82ed2bf888706fe28",
+        "shared_secret": "6c4484b6d7b0a376f52abb1811c712368a9f34bd108ffe7ca31c36a6ec8140f3"
+    },
+    {
+        "key_generation_seed": "31beda3462627f601cbc56f3ddf4424e1529c04737ef0ef2af6d7401f653b8a1812083bfa3b670e3eaf9b443702fb6db16ac1197656bbd61a8e25ed523b8d1e5",
+        "sha3_256_hash_of_public_key": "241e5c7b836862d7482d507973ae3fd8dae96eec4ecebcedb68fbda75e04b401",
+        "sha3_256_hash_of_secret_key": "95c79c2a867b3e8a4e4e545ff626cd49893b8e87eb188ed1516b159a24736c97",
+        "encapsulation_seed": "57c170e691d7a914a901b9a11c62b8b569b3806427557a9dbac9faa720ec3641",
+        "sha3_256_hash_of_ciphertext": "cf3b2e2dc822949eb13638299fc2d5102c7132aa6cd54dd7834b13f05a4dece2",
+        "shared_secret": "8554d6af350f13471cfd45c23882e43dc81d8a094f6299e2ad33ef4c01a32058"
+    },
+    {
+        "key_generation_seed": "cbdff028766d558af4466ef14043a1a9cf765f7748c63cc09dceb59ab39a4e4d8e9a30597e4b52ffa87a54b83c91d12a5e9c2cd90fcac2c11b3a348240411a4c",
+        "sha3_256_hash_of_public_key": "6ad1d739f1598a16c608a240cd13dfaf8263d74866315e2898a3431cf19e4685",
+        "sha3_256_hash_of_secret_key": "1ef733faa4f2cb53cb5d8975aa6797b5f37fd918aeda02178a40584475cdf667",
+        "encapsulation_seed": "6b5a14e1473abf5a33d44975ca2088bd8fa6fddcb3f80e8fd5c45b9d90c24a5c",
+        "sha3_256_hash_of_ciphertext": "1706e6983032950b47cb6c8586178b42d515ce929c1434c1a8c9e36d8b4db7a3",
+        "shared_secret": "f9646f73de3d93d8e5dc5beeaa65a30d8f3a1f8d6392190ee66ff28693fbadfa"
+    },
+    {
+        "key_generation_seed": "4c04310bea66305c6ca8ba6b8f61ca96257a67663afc11761f13fb5c7b324b6b8aec87a9a79204cee2986867a2906eb851b734b8b22b91d6749b1a5f07c44e3b",
+        "sha3_256_hash_of_public_key": "9510a2a0b4fcbd414fc61aff04a8df579660d14b13c40ec0470c45f639b65a58",
+        "sha3_256_hash_of_secret_key": "0bcfa8078582f60e218047d0016437601da8431f34ae6da12921f53958f32819",
+        "encapsulation_seed": "40e593754e6eddb7f9cf176ba2d5fd1087c90ad377556d0b0f686537b1a3165e",
+        "sha3_256_hash_of_ciphertext": "f9341d26e39b38a88ddef1708c96ee2068f569a59a4010745730d8290d637718",
+        "shared_secret": "1ee252e97b69445f7f109187645cd2879f55e10eb8361ab43b3492ff51f01815"
+    },
+    {
+        "key_generation_seed": "38a0d5f41d7dc1896efd1b45b0485634cef149828751b96087a0a6dd81b4d58aa2acf359556df4a2abaeb9dcee945829beb71185b4d6bd18b76e5668f253383a",
+        "sha3_256_hash_of_public_key": "cfbe9649d9d1c384baad67b91b2f3e21f2fadd6bb582a0b9cb016051dd82c75a",
+        "sha3_256_hash_of_secret_key": "09b118f7c4d059baf27284d127d4e85d55b84e4c92bf3127eeb318d2f5765401",
+        "encapsulation_seed": "c152523abd8248bed40c3827bcf0f8e8127037a55c780695e2c28ea3e041a44c",
+        "sha3_256_hash_of_ciphertext": "94a8c287238191a107e74e31ec099086d83f198e6b0f3321da4d8f46ce01a0b2",
+        "shared_secret": "1e1ea5d6a18873c5c7fc8da79093f6d3db5b28fdd0aaa42726ad130c78e9bb88"
+    },
+    {
+        "key_generation_seed": "97b5665676e59e3538ebadaa8cd50df1f9fda1502d9894c616a946078e56b621df05318b5f655efe36f1b678cf4b875108a18db2fa312261caf839f84bd956c5",
+        "sha3_256_hash_of_public_key": "a19c2c9c907b129d01cc44a95949121c39534cc98b6d105e60fe519a000cc2ae",
+        "sha3_256_hash_of_secret_key": "f1c00070780a7a2ac5b57ff3ff765ca75278bb661d1635cac92792f9454fe8ba",
+        "encapsulation_seed": "ad6466dd59f26b762fb02b19eedf5f79964da68bce0459b91c3a6ee5a7e01183",
+        "sha3_256_hash_of_ciphertext": "56e0b8ab3b302fae682938a45d9931e092d78877d1f8834bb43cd5c85582a205",
+        "shared_secret": "24619bb17c912fc992bd8272969cd5b6fd6b030122ee5af9365cac8b38e569fc"
+    },
+    {
+        "key_generation_seed": "ef99224a03a85a46ef115474ec5b5d620da6795d6efcca4c9135d19958a9de62df7d92dda83e6b2ef4cce08c9134563063068a196d7b1a1a13623e48ae12528e",
+        "sha3_256_hash_of_public_key": "e4174b6e7542fbe80ab2bc06dfb802f691aff147ff90332d5ea739216c18d872",
+        "sha3_256_hash_of_secret_key": "f3f3a292f5cf01d6f7266461c9e8cd44bfc8f17e16035ab8d10af8177f389b86",
+        "encapsulation_seed": "1a4d5dff5847cfb48333e33bb00ca7301b144aa89dcd412ff5a3b1081d775b7f",
+        "sha3_256_hash_of_ciphertext": "5f878ca21c8c27ae9c41c43aaf1f3a2af62c73296e165c08b88c5b22592867be",
+        "shared_secret": "a990af801ddcf2009c82fe657fe3f068bae7e6bfc661e3e588354ba7d1b176e6"
+    },
+    {
+        "key_generation_seed": "b12f6fd965ea9c5b947db80fc60c83d5e232dca82e7263027c19bd62e5a6ff550f6aa3e88f7fa8a96067f8cdaeceeac90c2d0b5e277e56e9c405ec9420c30252",
+        "sha3_256_hash_of_public_key": "2006a70fa33ff4a65b00553734c5bd8cca0a65eb3a115d96b8aa90f8fdc5f8f4",
+        "sha3_256_hash_of_secret_key": "7334d4a1755e1e639b3e9eadb5996cd910b55d1de5790469f229231d3bfb1528",
+        "encapsulation_seed": "34f44ec2092eeaf686f2ea170591a98527cbb03a4fa9477a7aef6b41a54feeb2",
+        "sha3_256_hash_of_ciphertext": "c2079637916c089b2afb9d6e9c6fa51308ab7720d5c2fca484c34ce614a14fc0",
+        "shared_secret": "11a2ceaa0c77f0602c4b2be3499e6df6b0339d9de90d04b2b12829f4758afaa5"
+    },
+    {
+        "key_generation_seed": "9f52af92ca165fdc38788f2b59ba02e01c8281ff7c1e60504688043a5fe814b04f3029e1be4e1c0258c3a22ff5b50b2674cc094ba7018da2a61569845c17d26f",
+        "sha3_256_hash_of_public_key": "631e1de2556ae65d57e600c21e8e355a4ed586d667177ca0b7545cb5a23d669f",
+        "sha3_256_hash_of_secret_key": "3d4d2c680a1e6aa83861ad95043ded260e720ae80060320feffa309b4281ba3d",
+        "encapsulation_seed": "6250c81126572eec2da330271db36ee591f060fc7e53eeefe2e1c476c675fa33",
+        "sha3_256_hash_of_ciphertext": "2e9d6551050e32e204d7c062a4c18b8abdb91346e9f2c2708776827e0be4c514",
+        "shared_secret": "7571990ef1ef7e15cc920318fb75fd38c4ceb9abf7a4b1adc2175f99d1a0a275"
+    },
+    {
+        "key_generation_seed": "851ea90fd3854cbf28fe39fb81f68e4b14345cf0d6eee7ec4ce772513df8410d1c0ec046899a777655233e4e1b5ca44e9afbdc67964bfd5d5e3dbb45e60d03cf",
+        "sha3_256_hash_of_public_key": "87f3829eff562789b3e19fafec92e4b5f95b45f3786f12d9c24915ca484a49ce",
+        "sha3_256_hash_of_secret_key": "9aa6c0546cf02085e2b3af65a7d7fd32d0f6d8080e1e7fbff6c39bcf3086ece4",
+        "encapsulation_seed": "35d470bcc5880872754810dfb3f2796da2fd7f397537146f6488c27804072b34",
+        "sha3_256_hash_of_ciphertext": "14da42e207477f4383faf4004e58675f0380e7d621421b3c36b877acf3a45d5a",
+        "shared_secret": "27ba4cb50ae44cd938585e0a4905d76053dd851e5b6af4fd787446079aa5a4ab"
+    },
+    {
+        "key_generation_seed": "d304c9389cc973477f169788abcb9d511f843219d246a9b587822f422a70c2386590a2e5c7ed86cf2c5c2a898662bc9a81418720bbb632ef9cf0b845ed052d73",
+        "sha3_256_hash_of_public_key": "699fb2f061a75f111f4a7a60195d9045dc01716b6502cc107cbcedf122e8f619",
+        "sha3_256_hash_of_secret_key": "421f16805b1ceffcd64128b1296521ef812d3a8f4c5e3875a049f8de456b021a",
+        "encapsulation_seed": "8d667921c5db401a86fe1c35dfcf164a6bb2ab7400fd6a0b67eafd4a0ed11940",
+        "sha3_256_hash_of_ciphertext": "b2485ef56c39d468193e387e72794e0ddc9b5404c1a6d90c3b94a5f3e13ba7b4",
+        "shared_secret": "d17b2738213a98f29ee46747c93308ee7000fa404b9a0c1acf3f89654ca2446e"
+    },
+    {
+        "key_generation_seed": "89a6e3be304a3518fb82b18ca730f0b359cd6ba90664a493fb4f8edaf965b9c3b6591121e25d64010c25a18676033e1d7278ac5f2d0b43a31f3a4156ae710465",
+        "sha3_256_hash_of_public_key": "d3413880d082f26986fcf452a84a8da934ed06198b290ada1789e74d9081a9e7",
+        "sha3_256_hash_of_secret_key": "7b546a42ffe6b65cd9c5b8857c2518f4f8e0bf835c894a68d1743691fc9aad9d",
+        "encapsulation_seed": "ec750b3939385a3f8df868119dc76f77ca845567ef068de6ada5478a56bc78b6",
+        "sha3_256_hash_of_ciphertext": "8290f3c4bec7c3b93f3d26e0be3b3fbfdd9c3f5806188fcf0fa1339133f29c7d",
+        "shared_secret": "954af53b4add522514b34cd2ab96669a76ca13f82aa2fd70826bc8ee790ccefb"
+    },
+    {
+        "key_generation_seed": "d569b935ce015c85f792f8f7fb0d83c4f53b492959361dd4f75fb764d656450176eae84d11c4528382828f7a689a0d5cff87b8ca0bba97feacb39b935a8788cb",
+        "sha3_256_hash_of_public_key": "e6eec2929feac2a86c9dacfa6214e2e353fda2d547c3829f5678025ff8418a1a",
+        "sha3_256_hash_of_secret_key": "5fac243c82807d7357a61023226a7c270525d96932162ca5c09fc8f7b9ec6cb3",
+        "encapsulation_seed": "74f1d52af09b12c36eb062ea7528550cb4c18a3ce8e4f4ea9fac43ae383bc925",
+        "sha3_256_hash_of_ciphertext": "f1b10c800a42ae606c72eaad76accf059cccc02299fbd78a5d091f183f6c3f0e",
+        "shared_secret": "d0bbc576fb1aa43b6e76db0e87bc4ee3fa057c31642b37f3339217a1b041b521"
+    },
+    {
+        "key_generation_seed": "5cbb141c2763425c274f7404fe530d9116e08c33f9f200a20b011cf563a28990fc9ebbe336dc464489861db8253606971bd0a9008a433ed17752d04023781552",
+        "sha3_256_hash_of_public_key": "c74f3b7fa6e2ef8ce99508c89cf3c71d666ab065a262581a5fb01b2c9b9444fa",
+        "sha3_256_hash_of_secret_key": "5c6998a20960109a4c9808f8f8575697b2b8d18c44c7e9dff97585ae43e6004c",
+        "encapsulation_seed": "4b3a70d85f640d1a2a852fb6fe96704af56a7415a8ee4282e9207bc3a2dc116a",
+        "sha3_256_hash_of_ciphertext": "e9ef0852ee47744b8c3e12cd728d9017465014eef51edf83a4502cb5218cee20",
+        "shared_secret": "91fbc37d4749ec6175c12f0d8eb6b6a8621e693c79f85f5cd2f557cafec5e7e9"
+    },
+    {
+        "key_generation_seed": "293abb6d1c207927945417cf84883ef010823e11b487ed55239e466e83696d0cff8563038aad865a817cab9ce98846ba75be9363718ecf5fea538aea90b2a558",
+        "sha3_256_hash_of_public_key": "7378ef967195c977d43a50d03205044006715a6a8a8263d717f40170b49e6bd0",
+        "sha3_256_hash_of_secret_key": "30bd5f16c3f242248a4c4cddc43508bf54535958657bda4dcf105216ddf47eb0",
+        "encapsulation_seed": "26e38ac804fb5b4d59ddf747715e7e6041d875f99c7b638024b4af82d622da60",
+        "sha3_256_hash_of_ciphertext": "37843616c8a4f7ea9480740b6624f41650da2bb1664cf228d85d6d71a0624528",
+        "shared_secret": "d586b441b8eaf7d053cc96b6835f093426677a7c3acc51aaa3ddbb66dd14a623"
+    },
+    {
+        "key_generation_seed": "74d87c7556f2671f2d666854a4d6e073e69f35421e6e1a428cccea49c37f972ce1fb7456ac0aa1b97068f452cba64ebdc138bcf5d36b0a0fada2a3b374141eb9",
+        "sha3_256_hash_of_public_key": "16fe956be4601573d72306a251f69bc2181253e2417e178341fd6553303ac189",
+        "sha3_256_hash_of_secret_key": "873c94f8bee9fe37265d5dc0c5d3bc1c706057c7efb3cd2cd5ca9ba45498d0d1",
+        "encapsulation_seed": "a319d2b8f114f1acd866478bcdeba6fd164dc4e37b0adfa8d8034afb3e197376",
+        "sha3_256_hash_of_ciphertext": "cc677a81c73ea5139eed8d85782978d06192715933bc5aef560e737f6d57d0a7",
+        "shared_secret": "409bfd9102bd4632c6b5d3610eb349fe3e3bc51e73acc78a8e994a070e20e10c"
+    },
+    {
+        "key_generation_seed": "013bab0212d04ecd54b478daf72748003a25e2cb060ba6cc50bf95c292b8206b9da0c5da5f195b80fbb99c2e8b06926074f3f604b3f6195b5a5b9737876bba72",
+        "sha3_256_hash_of_public_key": "633bee89571e8fc16151491ea71234ab83289426559f90c67903a36e4afaa6f4",
+        "sha3_256_hash_of_secret_key": "3c3cff5f49a802cec693efbfc264f6a385210b1eed20f7bc5b07b51839961d14",
+        "encapsulation_seed": "ff646071b2509e6b75790917e08e4f0b0d9f0116ec6291c0b59eaa4b583ad830",
+        "sha3_256_hash_of_ciphertext": "6d94a31cff4761e3993308cb3e812a4a7f04f64d02ed3b46b418c2fc16189dfa",
+        "shared_secret": "5dd151a8015c0b16d79822832ff4cc0da7fd38eb73b7da59bc519d4d2374b808"
+    },
+    {
+        "key_generation_seed": "ccb073c4b90be0ad746e26fb093b60c70110bd1dcbcddb566a8cffb7b3caf80e71600a8982c350df524cde514431ded7aec23576530894bcbf0ec0bfef0bb64f",
+        "sha3_256_hash_of_public_key": "3217d034b472a846cd317681c0f36feea187bd40e546dc4ad69c2e67fd9d8303",
+        "sha3_256_hash_of_secret_key": "1503bc141825d523c9505d34f50dc0a01d7bc91cdaee6b99f4a85a24ce800496",
+        "encapsulation_seed": "0584270ec26f3b9818e4af074d17b2d51037cc8dfdcbe3b140fa4fed5deebc54",
+        "sha3_256_hash_of_ciphertext": "a63613ccfd2ecf8aa3adf0103ddd9eeedbde3282443bcf02513b4ab87360cabb",
+        "shared_secret": "1c729b8e580e124e715f19ea6f2409fc6de741afa3d9919b2b8bf3e54c053b51"
+    },
+    {
+        "key_generation_seed": "2e889f44e28901e9ac7ca6b2fffcb124c8979401b17064d7e1d51a7e3c3adbfa0e145e44aae52cfc609e6f47fd7a6f6af877190ff52256d0ac5b05b89c3f449f",
+        "sha3_256_hash_of_public_key": "d1756ecfaeb695001ac490f36c4638151bee98d367fb7adf0e06a470844068af",
+        "sha3_256_hash_of_secret_key": "a21acea0fd4354eb0c78d47caaf93c9f2434f1cf2d6b2194871ccd98f9522ced",
+        "encapsulation_seed": "51e05c7b4ca3079781e8293f4eccebeeb2f8c8b4c59468eddb62a21bcb4ab8a3",
+        "sha3_256_hash_of_ciphertext": "3b322134b37fe8f5d7268fb74d1634ab8b35d456a973f7b0b427fb40a93b6db2",
+        "shared_secret": "b95ac8b73c703ab1154152b3ac73f054596ed23d3be328fbe20f936ea95fa926"
+    },
+    {
+        "key_generation_seed": "174aaa36410566dc15a5e62874218d7abdde0b2c0f30d877bb80b1abd5f5a0a450a7a2354f7e5cefa6f4a4e9a1c411eb9364506e9e1204a8acb3cb77fbd2c4ed",
+        "sha3_256_hash_of_public_key": "1b1b0a8682caf72df2e0a48513a7358edbc77a615d6be6fe2a7145be66b7c509",
+        "sha3_256_hash_of_secret_key": "3e214f25fbf4d1bb670a87367399e1b2a9da3491cac5a22a2c18dcc44f3f1bae",
+        "encapsulation_seed": "9eca0fe36c80fc5eba171c3ae66a5b1c923faa50b4521bb055e7bf51005c93df",
+        "sha3_256_hash_of_ciphertext": "a2cd589c24c4c75bc0a3864dc84a85a7f0f3ac11c8578757f8e94054a7c186aa",
+        "shared_secret": "8c3851393e5c5997cc95f06da96300f6dd85c041343c98db2e742aaa5f78b298"
+    },
+    {
+        "key_generation_seed": "351fe4313e2da7fac83d509f3103caf7b4c64a4d458fefdf636785ac361a1390f072d9b5a99f9c7a0a011e4dc10f6b600d611f40bba75071e7bee61d23fd5eda",
+        "sha3_256_hash_of_public_key": "2c54df6e9020e1e44b11b471dea97a382a2fe8d1042565bcd51ef21cc0884d68",
+        "sha3_256_hash_of_secret_key": "c6bc9c9e797a02684d3ad8de47919b8d8fdbee09258d084c7a9dc963c80401ac",
+        "encapsulation_seed": "0c5719261caab51ae66b8c32e21c34e6d86ee4aa127d1b0195663c066497b2e9",
+        "sha3_256_hash_of_ciphertext": "0cd687f1c3e0d67c46cebf93c1217ddc972ad8662dd05830db350e1292542c1c",
+        "shared_secret": "4b681fff6a755e1dda908d070f0d9ac610d85c73079c1022fc67d255e36f1f71"
+    },
+    {
+        "key_generation_seed": "9bc5315580207c6c16dcf3a30c48daf278de12e8c27df6733e62f799068ad23d5a4d0a8a41c4f666854e9b13673071ceb2fd61def9a850c211e7c50071b1ddad",
+        "sha3_256_hash_of_public_key": "bdcaf7b417da8b8933279b33068f6fda313826c2eec500b224cbe046abeb37a7",
+        "sha3_256_hash_of_secret_key": "c96e176b19f4135add434d0dd219024587d49fdb649bf470e84d9518bbfa2879",
+        "encapsulation_seed": "0e59f6f9047c784c1f00b24454aa4f1bd32c92ae7e626549972f86fab90e7e89",
+        "sha3_256_hash_of_ciphertext": "b38711e358893a864b475f35328b2450fffd5087d631844f7ab0995de2b8310d",
+        "shared_secret": "bbaa67f1dad879f2fb33bd4ead45aec354bc8f05c7cbea1e433509faac022edf"
+    },
+    {
+        "key_generation_seed": "d8b907b34d152ff8603b73051f772daa71eb902c47b7e2f070508269d757e02e36b817736cbc5f7b1dd6eef5fe6332fb1a598f3871e5470d440fd2ea631da28a",
+        "sha3_256_hash_of_public_key": "61e27e954728e2e2e230c94ff009417d7372938e2c29c38af22184eed530fa1f",
+        "sha3_256_hash_of_secret_key": "8baa58b1d3fab8ec5cee8841c9012506cad40bf58a677adac88f1a6400506d40",
+        "encapsulation_seed": "a3963ade17d69debbc358dda82c7bebe2c39d25b36813058e7a161542e3f8c2b",
+        "sha3_256_hash_of_ciphertext": "7d47a21d95483a5845a4fddbb07b3435c29a56b5cf26f5d0abfa21bc39a2f2e6",
+        "shared_secret": "2c7b983d66978be80250c12bf723eb0300a744e80ad075c903fce95fae9e41a2"
+    },
+    {
+        "key_generation_seed": "684a29e4e5480a5f2533e1526b5fac8cdf5927f3d85087c71f928c59690eb56575d12195ec32a8686d0600e45d4a7f54219b0d7a3826d193a51b9156ecf2edd6",
+        "sha3_256_hash_of_public_key": "672e53b28d579974d268132187e7bd72238639c6f2ca154d50d98c74096ec330",
+        "sha3_256_hash_of_secret_key": "4c72f0a7ef5c3274c49365cca5e6770bc709ef12bdbd4fd7c2eb5faa296cdfe8",
+        "encapsulation_seed": "97beafabf2c8575586487c7a80e8af5fc50f94b6051c1bc66a5ae9f66be3cea7",
+        "sha3_256_hash_of_ciphertext": "167b4e8b7517cad82ae0f49795918c4d33c79137a9c3e16000c4c55b30b1d382",
+        "shared_secret": "bbc58d06cc14f9e96a10acb1789d93b93933f1429cc53a1735b3cd995f086ce7"
+    },
+    {
+        "key_generation_seed": "d76b3573f596eb286ab5231feec7499686b13021be36cb126c7ebeb9d7030daf248c0a21ea0bb6d6f56f12300e8584d8e9a34e0e6f52227281151ae4c305fb8f",
+        "sha3_256_hash_of_public_key": "b86d5b13bb8b72a9fb81245ab712f0d10f0e2e09b222143c420e3f2c3acea27b",
+        "sha3_256_hash_of_secret_key": "c25f2e16a0e6fbf0729e5ee89fbbdd71f00ff9a1abbb00cb47f26e9989eaf678",
+        "encapsulation_seed": "75461decd34c50d6a094b4a64fb75e5e9479f8f9250d82bb7d729dedeb2d4b65",
+        "sha3_256_hash_of_ciphertext": "8919940aeb732930c496fa9832b0c09382663accda45be1ee22930c545eb3a37",
+        "shared_secret": "e045e0391e15a66d6208467078f2ba5e429cc586c410ca6c5f3c032c21761955"
+    },
+    {
+        "key_generation_seed": "b87439fde81c9e39eebe7cf741c685785532c1dd23e8ef868b9ce7a541010f3d1646460817a0fce5836bdfe124a7448e7adf7b8ecc2652ac6d280e986682df71",
+        "sha3_256_hash_of_public_key": "85441cbd71c18717e9de7359b920a9a3bb7f32e619806f4e4718c585085be624",
+        "sha3_256_hash_of_secret_key": "93b65d2df33d3e3ab0d53c1d0a21f3752e2c5962f7d960b888b2a8c495b1b133",
+        "encapsulation_seed": "2607dcf4fd6ca1c614c21b5e37c24981c32b91c8c3e6955777da8a3f5d9c9335",
+        "sha3_256_hash_of_ciphertext": "422509b01b8fff9468e867a2b5ebe5d3e27314de5c058b2c79a61ccf464f4df7",
+        "shared_secret": "0b8584b75838e084839d58c89cb1749e82ec06a0e85464c7546dd96870547d29"
+    },
+    {
+        "key_generation_seed": "056661b38038da4fdd7426f32a81576c73ed84843b305168a374f934e27a4e1b79238a80dcfd7c992d84b2dffa67493e669243d4fa38c46b090bdf86bc548411",
+        "sha3_256_hash_of_public_key": "065fb6156acaac591f1bf3ce71c4a046be8c6c55eb9a84d29569bd2b144c73e2",
+        "sha3_256_hash_of_secret_key": "0121afcc6aeb8be9f1c5b06d5b65cc1c03e9366ed7b85fc511d853c5eee230cc",
+        "encapsulation_seed": "38c89bbe7145c29e9a831c11431eb9929cb24fb4992db20737e4687d397fd732",
+        "sha3_256_hash_of_ciphertext": "f1d3b745d86f860e508ad8b6d5c8a72ef833c280ec11e99516f4ead3c42509be",
+        "shared_secret": "3547a15b5748990a5436bdc4db283738eb7d64bdb6ff566c96f7edec607ccc9b"
+    },
+    {
+        "key_generation_seed": "a1b52d871612a1c611ae0944f9e71858f35d3bd14f20e96a931720668bdf0a6b1f135cf64b6403e103afae34da038613e2853bbfc36baafa3c6a95347193f37c",
+        "sha3_256_hash_of_public_key": "ced77d358342759291c2bd225b0bd82d659d28a24bbc5eda8f47975b780cd129",
+        "sha3_256_hash_of_secret_key": "16e06287bd8d71c78f1657bbd6d5d12c22f6bad7658e68dd849d7751da950860",
+        "encapsulation_seed": "b2c35e33c72d90182791f0e12a0324f5b216efcab2c8da1bee025dfbe13f4152",
+        "sha3_256_hash_of_ciphertext": "fdfd351fbb15c92843b44489fee162d40ce2eea4856059731490afda1268b985",
+        "shared_secret": "852ba9be42763c5a74a75778eb839a3738a8ceed1520b0588f9dccdd91907228"
+    },
+    {
+        "key_generation_seed": "952b49c803d6d6fba69f4375adce8594847a00bcae2179da49af2aed0423250262d7033947ae42ca53522a65fbafe18d3bc3e0cb66164e9a094fe4b44d8977ed",
+        "sha3_256_hash_of_public_key": "2fdb7c7e39ce1625c20a13a1c91aa5909d8b03b064d00877dce2415020370c72",
+        "sha3_256_hash_of_secret_key": "ffdb52b23a9ca4b71ec882031ebcb33a0ecc6731c13c817b24f3a06e48273778",
+        "encapsulation_seed": "afb7d6dc2b7eb6d84acc080c1be63c98afe7b07786b5801f716444a3e8e64800",
+        "sha3_256_hash_of_ciphertext": "215d83f872221c5fd4ee4da557e17299dc102c52dba1fc4bc3f8c16805da7f1e",
+        "shared_secret": "618a8496b8850609c09dd1d18798ee2bfff3ed7ef6f8b8034fffcec98f291d69"
+    },
+    {
+        "key_generation_seed": "3c815e57e9233e975fa1630208aab206b71ae0db37a7a8789ac683d9f9b2d29801c8e376fdb140ee343106c093af7cb149b316ba79446ceb4e5e0cedb9b164f9",
+        "sha3_256_hash_of_public_key": "86bb11e7d9c1368fbba34ce3a2f169c2464ef5fbc11f73843c456467b6cdbd4e",
+        "sha3_256_hash_of_secret_key": "5d46659798d268f1314ad1e7c1735c480301f5877773403966e928bc3fd33d1b",
+        "encapsulation_seed": "28f5e9dbda122b2cf8f3754fe9e0c73a84ad4b0c093522e0b62cf815d60bbc3c",
+        "sha3_256_hash_of_ciphertext": "5ff5d6bdb110bac57e58a4e288d056a1384f9823606a42daef2ae82e0b7574b2",
+        "shared_secret": "cbb8b7a05f48b47d163cf8c2fad32bc586f47f2c2e0911da349f29b1e3286c22"
+    },
+    {
+        "key_generation_seed": "588760826dcfbd36d9abe6ae44a669bb3ebba6a218eab69e30f18a3bd536576e0e860576285483bb5fd36e2f944d32c4317bebc1e441470c1372046a790d79d4",
+        "sha3_256_hash_of_public_key": "29253478090cb4d580bc2a912645bc685061e5d4437b3811eda69c865ea9923c",
+        "sha3_256_hash_of_secret_key": "aadce411f3708e9727e4a7e4e198781e1ef5e8f4c4c14add1e25f5758649e265",
+        "encapsulation_seed": "b0d713cbef0bb1df70cbb425d1e9373e9f7790fdc7980cc96a240dfc53f1e8e2",
+        "sha3_256_hash_of_ciphertext": "675039d66fcb631a050a8b24415b50f331350bd6697f9c977eef15c15d4cacca",
+        "shared_secret": "1eef87404f318351413d52ba8a07cfa5e72f235d6f91afd7fb8ad3e683ce0a55"
+    },
+    {
+        "key_generation_seed": "47550e9edacb6ddce3d9ab81f6b61080dd4f2693854acb05e0ccc7a4fb6390fbf89d7d99d5c3e0d10d6ef9af054d842375f695abb28e3b8eb495100f04306e92",
+        "sha3_256_hash_of_public_key": "286de7dc142efe935e84b0aeebbd32d050fd9d8b008a94e59454b19ea401611d",
+        "sha3_256_hash_of_secret_key": "a6b53edf9efd7fa67a478456a5b6a379876c248f623ea45f4b541a8db00c524e",
+        "encapsulation_seed": "32bdcdb7059fe27f6409901980c080308951ffd90deffa8317b4d213a5f04495",
+        "sha3_256_hash_of_ciphertext": "f03d44bd9bdf3bfd486919fec2177b8b685a9981de4cbc2a9e98b7e9b0a528fd",
+        "shared_secret": "ca2c0bba56645e4fce4b7e38a7bb4b839e754bf2834a302a2614377eddd6ae60"
+    },
+    {
+        "key_generation_seed": "610afb64be8cc1df288cfb016ee2f44c6c07113de7f6fee071fe0c3fe31c6215cd292e4c5f9e1a55e0489bceffb204d672a6215f4f3980a646d9f880817c52dd",
+        "sha3_256_hash_of_public_key": "029a2e12c3e6aa668afb5be8a82576813fac7b8e61c5a88aff94ecc2770c585e",
+        "sha3_256_hash_of_secret_key": "413ae41ee83e17b74ac654c2aca57abe8f8ed0409acf7cc8b301e3d6bb049cfe",
+        "encapsulation_seed": "4ed7c92d83bd03b2a25b567f17ae55542e2f6a4308ec0f3fe69f8ba5ae24331b",
+        "sha3_256_hash_of_ciphertext": "e8992f7b7b619c03cb9f0c991e3a9c20f91beb707c177ad4e02a5808d10d8769",
+        "shared_secret": "9155619e28de6cc0670ce70e0ad270f0e885e5f5f8d6d38426938ae1036d6ffa"
+    },
+    {
+        "key_generation_seed": "e1953800acaa85ac02a906c72cb8e8d704e8d27820345f88f71e89c1f549afcc8c64c049c6dfc0f1476cffd520b055756162f7ec94243de6b14ac0b9e5fb366c",
+        "sha3_256_hash_of_public_key": "e3ec3671cc7675a321af8584a0961101c04a432772431e77f5740ba3b2ef488d",
+        "sha3_256_hash_of_secret_key": "93bf696bf0671c3845c4b246f29701a0978eec5b49de81589009e235903061e0",
+        "encapsulation_seed": "060ea5d2ed1dd88144a9885e79278590821c22917b55a48920f96b53ebe0e689",
+        "sha3_256_hash_of_ciphertext": "6634bd840d2dbb01463cfe5b4e3e54d1eabc081cfbdc14d0bc118911ed8d3cce",
+        "shared_secret": "d1f24383d5b8d0c3c0a6a5f8f7d38ccce13ec179a84b0b09bcda4c9988f3eb4e"
+    },
+    {
+        "key_generation_seed": "c719f9b2d16399b7326ce4eca30dabefe8fdaab18e9f6df888b0a134ef355570e40771856eb77e4633504899fcb86c6a3d433d0b8d60e26f07bd61f1d4ed69bd",
+        "sha3_256_hash_of_public_key": "79836213a513bd4cfd42ed281304e3ee4560e4e0c60fa53781f83d5bd2bbea52",
+        "sha3_256_hash_of_secret_key": "65deb55fea451375ef335e7faac73917d32220fc70c95f371fdb16e712beeb26",
+        "encapsulation_seed": "10ef9426f8c4a13b52325c5bb4ead4596ecf2c6b5bd2d37d8350e90d4164fdd9",
+        "sha3_256_hash_of_ciphertext": "ba79883ad64a6f2b256004233d87809a8c390327a23c739334f773507e003aa7",
+        "shared_secret": "d2dab0b39b7f62de3ca9826f9dd15a4201191a0e0c690d3e52b305a9d3af2d0f"
+    },
+    {
+        "key_generation_seed": "e9acbb774be970206c3a738e243b420805a509fa59fa902044be2f0d013650d2ded5edaec5de3bf5b4d7c2f2e18e87f499c1968993eff196753db8045e2c8ba8",
+        "sha3_256_hash_of_public_key": "0c2e803c2872400c49e1bb10232946ab939319e84ff32cd354dc15d082cde5a3",
+        "sha3_256_hash_of_secret_key": "d37f172803739d074d71a2be32125eb1ba4250128342e34b882fcba38b259248",
+        "encapsulation_seed": "a4bd30a64cbf29a4e290fa1cc1dfb99e68348713041e4409a1af23c5d80c15c4",
+        "sha3_256_hash_of_ciphertext": "13d437b2fd9d67ca0699a3dacd977fba5d072fa6b482043d63e8a9548ba6a3fb",
+        "shared_secret": "6869ca370a496af2dbaa866265d91ba6be54b9686b1b8dd5714f6ba861b0d1e8"
+    },
+    {
+        "key_generation_seed": "c1b3cbffad4b306f9af0cdd3028876486dbe858875c9b6497fe20172a986c82b1c96249919cedc2369d8d739ab125e0d2ccb82dfebcd90240a545cdfe07511f2",
+        "sha3_256_hash_of_public_key": "5818ac8d7a38c781e3a0bc43d088e6d391d1d67d9639b260bb6f58a19a57150d",
+        "sha3_256_hash_of_secret_key": "280e4774d1b2401580216fa70fb24c2c214ac5dc7f3841710a42e14d6aa09663",
+        "encapsulation_seed": "f4b66a7d3b65b896dfe100b2cad24b175a1168cfd2ae11fd704b835f6bcd311a",
+        "sha3_256_hash_of_ciphertext": "51eb70249a1abebd5159f1069b1acda2304f25fc9cbd9f4a625b58df448b47dc",
+        "shared_secret": "502d92b2a7e1804892ffb8ff009987a58f35baa30c0392c83859fde82105a9aa"
+    },
+    {
+        "key_generation_seed": "ff7495b8575b5a98e4fd21fb4c3e58cbb60f14bef21aa74cf8802e3153f14807bdc370460375a778d1a31d01c42b66367ed8d9e8f84551002f552f0e52102b5d",
+        "sha3_256_hash_of_public_key": "172cf4f8dace8a96b8f70da966080a5e3f132873ca7544343377a99b65e8147f",
+        "sha3_256_hash_of_secret_key": "31136804b6c14f3a0a00a3295a5fed8d606369e64d272d432c59d7fe0ccc3e47",
+        "encapsulation_seed": "1d7b03d3c5eefb8ae5799dc569aa668f1bcb8c86607b089d3530cf61d6380147",
+        "sha3_256_hash_of_ciphertext": "9b38b66fdfe80acab82bf9577676f6566b4429f78a14f7486b07c96ae7be921b",
+        "shared_secret": "48eb4b840c0d957f28808e434786c02a8f99d3464ccb3caf91cef4a0f8e70c4f"
+    },
+    {
+        "key_generation_seed": "bdc3fba1c32751139fc45bacffb3ea97f26573d804a5f27a459293d95190ed8efd5a08f656a6eb8cd20679930a31caa6a6331c4b133a6838c223ef9f769f6246",
+        "sha3_256_hash_of_public_key": "268b6356f92c57da6dd34494b927e8764adf0ad519612ef0d1b8951e50966c2f",
+        "sha3_256_hash_of_secret_key": "3bf02cee24670ca40b7280d8047fa147b24c5e286dcae9c24bace9465bb19f61",
+        "encapsulation_seed": "554f3385b382f4a46314de37ee3885addfc5332bd4038785094e0a832e9e8c2c",
+        "sha3_256_hash_of_ciphertext": "fe8c3fcee4be152aff29e55f42f2fb1354ae55ccbe38400bc901ca032ede1ef6",
+        "shared_secret": "f9507f70421be90f21138a1e135329ee8228682cc948a6914ea58624d396df0b"
+    },
+    {
+        "key_generation_seed": "447f6076a627bbc5ad7773fbfeb14b4ba9ac43a0f8b99fb6dcd5e452aa3c47ec20a7237801f470fcc2bd9fd7bea8322859b850f7882d362947432913dd068c01",
+        "sha3_256_hash_of_public_key": "4c6d304e0494d88d83b5e3aa5761df3b299551a24f28994d2747b2b08945bead",
+        "sha3_256_hash_of_secret_key": "5de91ca73756eee74da3cac78a1fb329a02f8587f212bb9bc0b29e0e654a5795",
+        "encapsulation_seed": "38bf0033b779edf5367d9ebc01c988af90904c560970815837380650e4749eea",
+        "sha3_256_hash_of_ciphertext": "805ce0ab06c568b614cacbfa4cce5e65929e2846932a90e9418513dd48cf3358",
+        "shared_secret": "24caabaafe2063f812eaf57c58b6c0376ed8ff778cec1980ee9c3228801a75a5"
+    },
+    {
+        "key_generation_seed": "2d5df64d62cb07fe630310bb801c658dbf3d97993e68626745de39d37fbfc2b27b534537addaba4ecf14f02ab317d36cb9f0f50222ced7cf029dff8a0d3d2fd9",
+        "sha3_256_hash_of_public_key": "72be2f5cd569e6229f00014854633f7b278e90af4ea593411909467a03e29cfb",
+        "sha3_256_hash_of_secret_key": "a68ca31b91491a129af9f280cb4c60c046e7a7ccddf41c9bd98663f8512ca34b",
+        "encapsulation_seed": "048ea516d0ebbd9f709b47eaac66f344c571cf50f0d01c9466aa061a50b66a24",
+        "sha3_256_hash_of_ciphertext": "d27a36808f09d6165aefc5d253090027eeff0653268c55a0b3de2a751ec765be",
+        "shared_secret": "9f734b15fc7dd99bc10d6cc7de5d2c93ac789a5665e508a95d075dffbad25abb"
+    },
+    {
+        "key_generation_seed": "25056d1b8113bb362dd979d98643d7a7ac9c4f95994c0ba060609b6d07002ff3f48a9254dd40b117941fa35a66bb50296327b725525deef70e128ca8045ec451",
+        "sha3_256_hash_of_public_key": "0831c75b153fa17d336a79ff6e88ddf485daf7b1b0bcf39d8df15319d52ac67e",
+        "sha3_256_hash_of_secret_key": "2b983d7cb50880cff761441b6a2c66b7a41642cfd2a8cc297a5df53f0ed1947f",
+        "encapsulation_seed": "686c921c9db1263e78ae753b1c9c2e7936b8229dca48c0942c56c6bca4f10917",
+        "sha3_256_hash_of_ciphertext": "0892527da24957468b1b8fab49ad2d7dd6d238eca54624fce6a3c2dbbbe8d194",
+        "shared_secret": "d27e55f2a1f9ef336c8537f11da9875e03cc7dde8951d81b0740457609654107"
+    },
+    {
+        "key_generation_seed": "e4d34e12982aeeb1d62fd488d9b9e28557ed3429292239fb4f76fa9098009acae6c45c7fc62329b13c8d29844405db8ff6860de474bf727ecd19e54e6e1a141b",
+        "sha3_256_hash_of_public_key": "b30cedc4316b63d75b641fbad2f33241a3fc47ab8b3ee1a3ed597e5b04f77c68",
+        "sha3_256_hash_of_secret_key": "a49a7533c671e533deec55af218ee511c57014070e138c7059853e08c34b0a78",
+        "encapsulation_seed": "2387772e50059cabda53cb93ba24b19ae529496c03b36584169451525c4a0e7e",
+        "sha3_256_hash_of_ciphertext": "390b3b6f9a0f9d97ccd452c83bf47416b22fd06b4d8968c44ee6effa7980e68c",
+        "shared_secret": "ed5903d1cf02861444cad7fc3793b4e1b9b6d0324bf6babfb768bb2f84300086"
+    },
+    {
+        "key_generation_seed": "cd6a99396eb3539ca663a51e42063a3a262cc1c5a5fce1566f0597b52ad9fa325a3407f591791a5db4578b5972093a95bec3b8e70c1d542c9b5c9789729f8922",
+        "sha3_256_hash_of_public_key": "ee044dbdf6787ff038dbf9c133557169c62fc1ce2580739369aa87df00b49648",
+        "sha3_256_hash_of_secret_key": "9e865967f0d1e7d3f6a49f2bb623ced2a7b1408a945e02adbdca35846b70e7b9",
+        "encapsulation_seed": "155c29c5f0378df0cd0e847a80a07143cf7522fcd880c9229eb9feb1ce340cd2",
+        "sha3_256_hash_of_ciphertext": "6858db6eafd97259e6d775d881f7a877010179d4f827680426946b9ac4571261",
+        "shared_secret": "0d301028c1cb31dedc8a702a9e95b7d3589f68a6a1f600af84ae0f543e625361"
+    },
+    {
+        "key_generation_seed": "6c8c53ed6f65e6b2e324b84364e10de42d1c26a106d4d1c99eee79c78586fb55b9402bf02481ce4b27a52e87feb92c4399c7f2988d40e942e7496ad15ad2aa88",
+        "sha3_256_hash_of_public_key": "e965ac6995d525e324e8252d8e2c2da909a29b24baca8b68daa5122cb539a474",
+        "sha3_256_hash_of_secret_key": "91051a381626e9465fc7ab20a1944eca64be461330bda53e7d1838a74597392d",
+        "encapsulation_seed": "a9cb9a61a3324b1ea5afe693b32784e2871096b2ca14a11acc9577c52359a241",
+        "sha3_256_hash_of_ciphertext": "42bfb5584610497fbc8080a664139afa534b39a417cb69ab0d2a16c8737eb1cb",
+        "shared_secret": "354d86b389021a3196b75c6582927b3a005fbfee0951f34d9cd5c8f415fa50f9"
+    },
+    {
+        "key_generation_seed": "2107204cd995f1df14314d5381f8c5440f09a347502e161cffc0a2ec3dcfbc7324c3da70fe850e80aa818301d60c70f3038153866dcd5d179e22db59b8991bb4",
+        "sha3_256_hash_of_public_key": "a3d8a85f38cfda38c66ae39b2f9186ef7bc1e0c98e8976a6cbc6c4875d73d7fb",
+        "sha3_256_hash_of_secret_key": "cf7e797f8f7229a08206034737e54fe46645ab2fabdbfc8662b45a2604876b65",
+        "encapsulation_seed": "e99fbae8a024ebbbdcef32ce213f6aa942e3eca925e5da4c09975d773b33a175",
+        "sha3_256_hash_of_ciphertext": "ce7b65856502b280e02a36d906e018c6a23cae99f27ef6d65762c87ddfedff56",
+        "shared_secret": "3afcfdc446f93a8169024a24fc0383692843cfd6b4854a8e490892fc35aad4cb"
+    },
+    {
+        "key_generation_seed": "63a925685a8ac5bbd918faa33ac397d1ffbcf99135d9da7c3d6ff7aa4c50af3d3afdb8a246a56ee71465591831c371f2eb87467b0559dedd776ba063ee6d2f93",
+        "sha3_256_hash_of_public_key": "aa73b40dedd61e6fdaac86971965c03ab14ae69e8130426fdf830bd57d0974ce",
+        "sha3_256_hash_of_secret_key": "1e7f3f1e5632d1df538b564304f56689742d1f652d8d32f019b45183af68a20e",
+        "encapsulation_seed": "67a216f37d67f5e74f782f1badbce1cc8c80a6130aec305b421899a4faa0a6c3",
+        "sha3_256_hash_of_ciphertext": "b6c40fd53bcd9ee1e70bc6783b402ae34c24dec724e63262d8583c90cd10256b",
+        "shared_secret": "ebba9a8bae936c829c1445c68595da96919041ee3d9b0fe27ca93db691146874"
+    },
+    {
+        "key_generation_seed": "6a1aee5e708c1b47f02bdacce4f56c860f74fc7cfec1ef3b58285b1c8ad7fec2230e05b7114ff0395cc6634db1eae8258072d09c09f291e92d6620b177dc50d7",
+        "sha3_256_hash_of_public_key": "cf754f2ee43694865a09ca7beb0deda9b1328fd0abdf30ca5c338e27e8be04b5",
+        "sha3_256_hash_of_secret_key": "928592604aa44df8f2072f26e9511129f61da0b7f57acb3f6896635a9764ea87",
+        "encapsulation_seed": "52b19fea232c9154a3e431e9d69cda40013cf2d485c3cd027ad24e645420420b",
+        "sha3_256_hash_of_ciphertext": "a4b50ad169b436877652a6c64dbbffdd63f53274ddcf58f3c96c3929215aa956",
+        "shared_secret": "f063c0908deb2e61faa0c4c0f5051b2c8af7265060681df14bacb30f0228b3b3"
+    },
+    {
+        "key_generation_seed": "6396b328b100e4c7f4bcae69875edea1a1982421558c608c13c592bf7b5d0fef1100ced48add211a5c937b8d6079d8e271af3f949edc61f70e60453aef20dea9",
+        "sha3_256_hash_of_public_key": "3a842153dee9e035299d7e268c9492d71188f9fb24bdc2dd20c1ddca647a1523",
+        "sha3_256_hash_of_secret_key": "28ee987bc4ae5a321d2669950dbf87596fc4b35c29f192836005064aa3dadee1",
+        "encapsulation_seed": "64440adb05db3308b189bf999f9ee16e8ee3a6ccbe11eebf0d3ae4b172da7d2f",
+        "sha3_256_hash_of_ciphertext": "126b64a28d82d06ca81f7e86d33f4949634924e04528d1142061320eaadcb841",
+        "shared_secret": "02d2e466e170bf45d3e9d357e2f04c34cda408cf147e9ff7a6e8c715f2c88ace"
+    },
+    {
+        "key_generation_seed": "a453bcacdd2b0d4646009e5ed451c3c45f08fb827ef733db3c517a9dc1af93e67a3cc8aa3239d4c52ce4c95afdeff6efbfacac10d294edc0e7cf4535059bfdba",
+        "sha3_256_hash_of_public_key": "da43cae3c4da51d69a57eb87094a03cd3a9c3e6b4ed864cc691a60f0509cc646",
+        "sha3_256_hash_of_secret_key": "b204cd1c3122b29a3d99cb77e11427fc102375699928c5a6fe816f96bb212627",
+        "encapsulation_seed": "c8bb46b3a7344ad170c2052fb042b5a3b62e0590562ee82577b1081f6f114d16",
+        "sha3_256_hash_of_ciphertext": "228dfe300e3fabe4d4e550754ebcbbf72a796209c1d24e7ae93abb79e1cf17dd",
+        "shared_secret": "6a5b0842c122ab6ee251399492b061d2ab3e40843f4dc01c12fbd5bd545c600c"
+    },
+    {
+        "key_generation_seed": "47ca2b77c5b717f423222c2730ca5cb9c856bc951d01b2b2c80bd76ccb5539b78f1481d7cab000e33fa07de8dc9627a85e76fabb4428a3376e66300cf12a0787",
+        "sha3_256_hash_of_public_key": "6533c524a32345eefdadc74a3c6ad7e981832797faf1068955b79f118dff9358",
+        "sha3_256_hash_of_secret_key": "b9dee52055b1f9a2b25a0c1be4d9f30d2ecd7c5a09f0f5294de2d49a55ac9fe0",
+        "encapsulation_seed": "2e2b70609f3fe029a14d09d5d659871ac776ce2797a0355f16e2eb68f5613fd1",
+        "sha3_256_hash_of_ciphertext": "2d7e8fbd6f2257b05eaaa2ca1643c452b4e0b623c9ad72027cca8dd8b7b5b91d",
+        "shared_secret": "2486c0a6cf17d9635dbca1f8395784cde54dccb7df10fced92183f983478fac1"
+    },
+    {
+        "key_generation_seed": "aaf6eb40e596a5e3e8218871e708b089240dcbe7fd3641f0e5e41e071ce49107e2f8d320ac3cb0c52efdc753282f092bc39baf4a18783a48ea031a191865eb78",
+        "sha3_256_hash_of_public_key": "e2f60f27da7f318eb94a74b437f8e0bc9513e9bcc38dad99c174c1d75e0145f1",
+        "sha3_256_hash_of_secret_key": "68eaa8143a71bd5f6df29b128781e3f2a5fbc5d20534afb223ddcc64bc767f5a",
+        "encapsulation_seed": "4725dd8fb314bfd8ee23731c2341dbe114606d9abe6434c471b5573e7df193bb",
+        "sha3_256_hash_of_ciphertext": "b5b2de55cfaea8fe543f67c4f45a69780c3e2d932e56e0b574d9b40b56ddc1f1",
+        "shared_secret": "85690ee044e4d8e0540ff984775b59bb5134383c4e229e79e37d7d77632fadaa"
+    },
+    {
+        "key_generation_seed": "6500f32c93415cfdbc0bd31d78d5be95cb9060c8cfa2013955b56f8b6868b322393308641a9a4647f230201e1389624a296b55192a9819fcb19ab77c25f95445",
+        "sha3_256_hash_of_public_key": "d4bf608793939ecba27dff5889d4d921c583999a57e20a48085ac549573e6abf",
+        "sha3_256_hash_of_secret_key": "5f9a14a9c41fc228306d79417015408f31bc9c3d97579616bd68a3d3444f9bd2",
+        "encapsulation_seed": "818d3bb8ebfb32bf464775f7139bac0a5bddce80ec5798595992f9403002cd5d",
+        "sha3_256_hash_of_ciphertext": "99fb7b7767fa94e74936a6678acfd5a2306b156f90f4608d507768a25403a16f",
+        "shared_secret": "d179d901a0570bd23aa52570c5c233a2240d4724e81d98c9ceedb74187eb75a6"
+    },
+    {
+        "key_generation_seed": "7643cef2d62cc5aaeecf754653ea62294cd2208e5bf3ddeea209e3dc45373d49eac9d531a532770837a854b4f5531f6e0c8d6c10183b30d3435498c2dd142951",
+        "sha3_256_hash_of_public_key": "65f03add3941d22c80d50659f501f8cca1b448d84462ccb93d5f065889484bc0",
+        "sha3_256_hash_of_secret_key": "e4513cfd1dd2153d30d15b023421cb8e8456e6a40e612847e1713e915a29a87c",
+        "encapsulation_seed": "c92aa5fb91c980d9cade9ce99d4c75b2ffa7d6a6ff9bd59def1aa701f2a0992b",
+        "sha3_256_hash_of_ciphertext": "4cd7f0af86623b34c0b137a0516b876daa73ffd65d75871ddc828f86a7e9b224",
+        "shared_secret": "6d574af7fcb241fed8763b2d0a352870baf85ef686e90eea31f8500c35945ef7"
+    },
+    {
+        "key_generation_seed": "f8ee95521060c03bb8dacc79f7eb7db640f545f315613a35d447a09e504cb4e13fc3d8392cb53f36ed647364a04e37278a0e0a45b720f4a75c580c9920eba98d",
+        "sha3_256_hash_of_public_key": "b8a3b8cf4709204a2fdb19889b0022ea655dfd58ff27e17d530510e1eef45793",
+        "sha3_256_hash_of_secret_key": "1f7cdadf3d4707efe1b7a6173d8f7b8a9f864ab388c3271d79ec424d9da3e896",
+        "encapsulation_seed": "7e8086a01dc5b3bb9eda25bcc45d27f99874841b97237968495800e007696ac5",
+        "sha3_256_hash_of_ciphertext": "1ca889a71a087ccee4ee1a178c3c55ce3649583f3db924e5c1003ccabc44091d",
+        "shared_secret": "b1090cf26276a81c22ef0e4479a4c705fe294d3b892051ddce7eab16495e0783"
+    },
+    {
+        "key_generation_seed": "b8bd0493a882e3a49b4e0f6256fb1fea0912562fd9ba26ec3d6c9cc12c8973abd7e4b5d8021c486b9c3114d7cbbeb7cd49eba8a61bc2bcae1f1bef30a1daf76d",
+        "sha3_256_hash_of_public_key": "46fe6c37136273736ccb11df5b6d55debbc087de802404b72a003c5e8c809719",
+        "sha3_256_hash_of_secret_key": "3177ed170e84ff15fa1e744adc9ce806e431a68f15a7a026c6092bf593dec6a1",
+        "encapsulation_seed": "bb321ef14d44d8698df879fd52450567657f52a2df8d111185dcd7d4f30a72d4",
+        "sha3_256_hash_of_ciphertext": "aa9a0ea1823a84bc84649d26e249899437844827fe7c63d4828a5144929fa00a",
+        "shared_secret": "2fda9fa72321be3a0946d6d914c7ae714b9cc175619ab8abfd1f1fd499e0dc27"
+    },
+    {
+        "key_generation_seed": "c0407e41ddf48d333978b89bcf2db01e4613425b456249e76a6f25b8a2827bf5b2dca81e3f5f748d23c9d356a2209f6b2d60247b2e45c9808de497f64f124643",
+        "sha3_256_hash_of_public_key": "a074ed1f76e97d68434ba4af2af0e549204222679e9e643580c35af3cdd247ce",
+        "sha3_256_hash_of_secret_key": "8f9b3f631d0fb04477846ae09aea725f1cc65b2cdefe2108cdb399c36db9b487",
+        "encapsulation_seed": "210a423dadd899b810f011794b79aa7f860823ac1962370e791287d3a1afa384",
+        "sha3_256_hash_of_ciphertext": "a4fb01f55eb2986c1f90cece43330bee1b16d7bda48d617fc94aa14fc540ec4e",
+        "shared_secret": "23798e8b9eaa0b369842cad83a2bc32206f791229c830d7593b9150161168011"
+    },
+    {
+        "key_generation_seed": "334382d39164d1989696a2ff77b25a28af8bead9883b5365eb6fcca7c1781cc9aba5068af837be962f439f233593d193ce5e08f7d66efb3389885927b89d2523",
+        "sha3_256_hash_of_public_key": "26659f74fc9ec372fe18be4ed6aa28b7cd84ad1c0f0115dad011a11d20fda9ed",
+        "sha3_256_hash_of_secret_key": "5e3f83cb08ff80183879af9ade3631bed2a468e429ad027a5afeafd9a6f66362",
+        "encapsulation_seed": "bc856afe24213e3d14c3d6f9b89223bbcfb2c890722d770fa3492c1e46d1c302",
+        "sha3_256_hash_of_ciphertext": "6a4204db4803d26d7b8a769033e047f3b4cb616bf5451b88a1fb3ff219bba9cd",
+        "shared_secret": "d5c63d2bd297e2d8beb6755d6aefe7234dea8ecfba9acda48e643d89a4b95869"
+    },
+    {
+        "key_generation_seed": "6995143e8eb8a6e93840f76eec844f67d2b5f75b1839a5040337e61f9806764a0f4dff8e56f68440836a072412a30d851ace2c7c6f02d60e7a8420001a63e6c6",
+        "sha3_256_hash_of_public_key": "2ca3d8ad2dab1dd8a2f4320658fe6eacabf70d907920593919119cf374516336",
+        "sha3_256_hash_of_secret_key": "2798448395f6ae3223550e7d5255e6a605b430229f5809b6efd0683a6b9ca402",
+        "encapsulation_seed": "5fc00f89563e44b24cd67d0ce684effe5731619fd08e7d72e2406eb016afb66b",
+        "sha3_256_hash_of_ciphertext": "dbd5fc0e1df33ff8af9efd5e281a2b98160f98653803cbd54e3a07292b37fcc7",
+        "shared_secret": "29d6a229adf49a1139794209307b0ca24be5825b2771809232fb718660162475"
+    },
+    {
+        "key_generation_seed": "995eff7e0d195c6d0533f3dc194d47e60f9ad14696144cde694d60a95f3e96b4b28f7e7a15a005f92400ce33db073d49b53871594a88fc45e0f94207b5f0f2dc",
+        "sha3_256_hash_of_public_key": "de62eff56f6b49a156d065d85eaf0aa21ca229a20fa4e1372a410ab1c4ab6e7e",
+        "sha3_256_hash_of_secret_key": "6766cef3fe644a233caddf208074b58e6e83f8a78aecd00911c29a08f6f0b0f3",
+        "encapsulation_seed": "ea22a76065db4b565ee1807fbd813b43bde72b0e08407fb867c6a18995025e50",
+        "sha3_256_hash_of_ciphertext": "4c669e33b0227c9c2040cdacdbcb7d22b9984372587985ed8f860ffc8d037e79",
+        "shared_secret": "2a56a7a6d5b4c0500ec00a92e322e69be9e93006240889552072482966c54f56"
+    },
+    {
+        "key_generation_seed": "3e809ec8dd0fec0d911a4e3fac20f70fbb128c5de94dc7184ca7310ae9157a98d8128601c28b1def8d393a0db283229f7c7383152a814e7cefe8ef9d9768c473",
+        "sha3_256_hash_of_public_key": "66f161d27dc34e1a2f4b98b14a2b221d7eae26a593bfe432487d9994cb480656",
+        "sha3_256_hash_of_secret_key": "2237f6cbb452d375878b82c474a7c948ff587a5f3ed02bbba1459fa7ff8ef802",
+        "encapsulation_seed": "e9602b34fe73ad57f4bf6ead99743d645641553a5b9b9bf2e7016629e3e9bd76",
+        "sha3_256_hash_of_ciphertext": "8a2453a21a031cb8966924607a28882426fab2018826192e9bf833bdd38e0631",
+        "shared_secret": "ecb62b03f640ae4a9d89685fa0070efa93c24dfcff0d555142f9de25b62f861c"
+    },
+    {
+        "key_generation_seed": "dbf1c465fff3d9f783bd9ee61a573715e45691147b8904439b5ffaa64f94ff7bb6d75eac6c76ced1b0a025b40a55440712ad8424672e761e9bc400d63812006f",
+        "sha3_256_hash_of_public_key": "7537e68ccf14e8b7e57090d8f648529dc461ca3950288879e88116acaf57b4a2",
+        "sha3_256_hash_of_secret_key": "bd8e44337eef01251217c4702c99232c001b33870953473d83a7486fd25484cf",
+        "encapsulation_seed": "f72b9080a6c051bbdb9b0abc1949034be0f89a9f73fe277ec4d4740c78d04a83",
+        "sha3_256_hash_of_ciphertext": "6077c60641c03aa8b36213dddf938311ce6b7b8801f967d42713e73249fe7c55",
+        "shared_secret": "6cc30699701927e07b559d708f93126ed70af254cf37e9056ec9a8d72bfbfc79"
+    },
+    {
+        "key_generation_seed": "1f7cfd2b70863154e8a69d1758532e86c20cfc763d67c758bd10a13b24e759b5273b38bddc18488024ec90e62a4110129a42a16d2a93c45439888e76008604c6",
+        "sha3_256_hash_of_public_key": "82f68b15681cca5c2852c18d6e88bcb102a059c1d21936582adb71790cc0a335",
+        "sha3_256_hash_of_secret_key": "fd483ddc211c5c27f453bca56158e1f8084f075a7b06f5098cc3204427bf8197",
+        "encapsulation_seed": "f1e5542190db8ecf4b8d617a04fd3783ad0df78bf8dab749afb57db8321d151b",
+        "sha3_256_hash_of_ciphertext": "5c6cfa16f63b1aa93a2b5edc2f4b14c9782f286f53deedf3153f329a2ae2d57a",
+        "shared_secret": "250e7f67bb34dd5477471e3a701fb71a8138a1920eb807824380f88a944a6fa3"
+    },
+    {
+        "key_generation_seed": "3a19577908efd37697b8edc7fdaf47d1bd3ad01a1b77faf794bee5b9c3192a6fa3729672816f3eba84c9638a79676eeac0f22c8a48e0c5d50a26ff0844c66b99",
+        "sha3_256_hash_of_public_key": "104fbf09445794c0ea0654f5caf70ee09d51c8386d4e1f467b10633c710ac2a4",
+        "sha3_256_hash_of_secret_key": "73fb93953ae666a9df1bf933ba56b8655ea9e319c0110c78d49f8480ae1aa3fd",
+        "encapsulation_seed": "74efa414ae171bf60b6f884cb7e5ce12028f49365daccfa23e845d551711660b",
+        "sha3_256_hash_of_ciphertext": "e51772e769f778067916e81a561ba6f64fae6096a2b4d4b945d9117e7c36e2b1",
+        "shared_secret": "0210935a18f1add5ebc2e1107bf40a628ef9cf8f6e7cdac81dc0291bb50a5a3f"
+    },
+    {
+        "key_generation_seed": "ae0f65e29f38804a6759f70f4d01e2aaff7fe1c91ebc4f892dd0de3ab2e68ea5e03ff73e02a217659f53d8c47556bf3d8c94040f630d63605e2d0f923579370c",
+        "sha3_256_hash_of_public_key": "0f353d6a29813d354471eb8b4c38df93939eb3b1db80ddd1cdd6558a9f2687a3",
+        "sha3_256_hash_of_secret_key": "8a9edd6278707108652f3a5bc244592cb7a82c24634583ed2d3eb6a176b216b8",
+        "encapsulation_seed": "0b4c3cffb2ba4380ead13dc0d8acad2356b448a810da1df29f264c44aab6d24f",
+        "sha3_256_hash_of_ciphertext": "a00c37bd326205575fcbbc100ed54630aa0f2d6dd9e69807d49151ac9a81c429",
+        "shared_secret": "34169fc520e944f94ff1fa3799db802a4c1b26cb2971bf196259a937ab8362ca"
+    },
+    {
+        "key_generation_seed": "6084a235f79dd093ef6d185b54e69df33dacee73a9bf2f379004421a10e3a79d9f684fb055ece19459eb464e91e126a7a6e3ed11ccee0046da234d964c985110",
+        "sha3_256_hash_of_public_key": "12e89c47142418c26396ef0174c02f69dc00022d56494d31af935490edee6385",
+        "sha3_256_hash_of_secret_key": "bc13b19f01d4cab36dac2154e0fd8fb7d2fa012596363942847f1b0bb3715f90",
+        "encapsulation_seed": "1c82471dcdfca3a6942061ab4f3d5bf0d197321437c706d9cccccce449447002",
+        "sha3_256_hash_of_ciphertext": "aed1a4ee810b81cb8ee49ee00e94ff4553f0ad2176fe4d27a09f4e68157fcc3b",
+        "shared_secret": "b5901e97eb656a09d2dd132528148ad07a0a89f638717eb53516a9ad19aa36bf"
+    },
+    {
+        "key_generation_seed": "acd1c0217fad5caa4235544dd9de153ab1880ccf4c76f16f236fae4e4bfda04cf03a8abb0a5010f400ae5722a75bdf5a2f6d5b546b34d73857cb1bfc7e587aa7",
+        "sha3_256_hash_of_public_key": "2fac52ca60594e514333ead02cb1bfa5cd1d9ecda4a0b25ccdfc47ad3f632a85",
+        "sha3_256_hash_of_secret_key": "2743b7a9dd83a6b9bb5c2685f28b5629b2e31132ac64788a0929557d3449dfc0",
+        "encapsulation_seed": "46fe60a18124125ab93e0c578f1c02f1bd1301595013001c7f3c2fa56cde294e",
+        "sha3_256_hash_of_ciphertext": "7a039d19c45cc557036189cbbc63445b3504a689db56845ece99d593f165c6af",
+        "shared_secret": "df5117706beedfb521f0f021069fe9650d0844194339033de6997dced05268c8"
+    },
+    {
+        "key_generation_seed": "241191401a63afa750f05662e354dddbc683c776ce3222beb83e3cf913d7ed7ca59b3bd23b49a95bc1fad20070fec930b6060bd827d742b077092e422268e15d",
+        "sha3_256_hash_of_public_key": "3eb856043b822df9d60b55fccb537afa3cacca9ef50433bde1dd9831e534d192",
+        "sha3_256_hash_of_secret_key": "398ae3423ba5c6bb05920e83e8939a104c3e4ad91647edc7db1667efe438cbfa",
+        "encapsulation_seed": "52fb7cb6a633fd2e83f2892bd9441b48fe59ecee6d026f5246fa7f2a5e55ee3b",
+        "sha3_256_hash_of_ciphertext": "05c9617befed785811fcc44d0fce5ae3a1ec66c4d1217ab42e4b754d0ef6207e",
+        "shared_secret": "eed6ecb831c881508f99ea115745448a7b312a4fa97f65044ebcede172dee2fa"
+    },
+    {
+        "key_generation_seed": "b9a6b0c05677e957d41a34ba03bd06f2a9092e31f63389397d7e70fde6409d18e99c0e7b82be89bc3c1eaee6680aa4efd394e40c2b3f30523c8117f7c26a8969",
+        "sha3_256_hash_of_public_key": "306aed2a804a1c9bad4ab9e59f6126ad7c8633cdd0c2dd9d4c6f639d312ed47b",
+        "sha3_256_hash_of_secret_key": "88b28cf6fe19424ff82fc2bb096423b71f0cb8cf985af31bc15ceb4ed18a5e62",
+        "encapsulation_seed": "0f81a5f97082121244403da3feeb734f6084b314b8d94beb11627aa6ad1914e9",
+        "sha3_256_hash_of_ciphertext": "315ef84926802ecbbb437f8f50927d3a391b55ee6e47dbd19aa9adeebb808008",
+        "shared_secret": "d6cb77dc96f9ae4bf8b2fc0e277935b3b7b7a59f749ff2c08ad42659dbce386b"
+    },
+    {
+        "key_generation_seed": "28a96c71577ba00c94f99fe965bc595a26db2b3ca6ab5cf8e443cdd8462b17929c35d165453e5fcdc6f9df64526d9de698f2bd3e6bac6c7fdd86601b9ba5f4a5",
+        "sha3_256_hash_of_public_key": "9bb3963cc1c5cf2b2d1c6ca76226328ab765a79999ccc71fe98d5bf3b34f51b1",
+        "sha3_256_hash_of_secret_key": "d8c2492023fb1175a84c19b3ce20f03dd12b1c26b65176d5582c319124bc0e24",
+        "encapsulation_seed": "31af9345365549ea0360169ed57daf98cc5444799d4c75d9f1f5d615e9df8a91",
+        "sha3_256_hash_of_ciphertext": "ae36e333ece7ca60c9bc2c4ddd01ca88443fd73bab08502656873b703af8925d",
+        "shared_secret": "1592f1413331f1871b41ff298bfa669bca667241790370d81163c9050b8ac365"
+    },
+    {
+        "key_generation_seed": "c08ba2ef8c3a0a043afad931652d7a19e6e8cb670f840de5f1fa03309b2ca9ec5fe6141a25f7ab9f875f79e0a82d6ea5cde5a017ab637d5fdb7c42646a1d71df",
+        "sha3_256_hash_of_public_key": "6d029bb2121c788b5b6ead7226df664490dae362c4befb615717d81c656b3273",
+        "sha3_256_hash_of_secret_key": "0f2c7bd16d9289c3c27136df0cb6ebc624e80144cb92e6f0c897f58a53617ac3",
+        "encapsulation_seed": "774ae54093d694ef40b63b62c73e6c98295f606feb8699807eda1d030ffb996d",
+        "sha3_256_hash_of_ciphertext": "f8a85f106c6144edf1c7906ec26e292f0390aa9d45a22e67ba2ea018ff565c4d",
+        "shared_secret": "966f35c6bc47b4525d9af1ba350e8f44ea448cd1d90cf4e9c55ae5878920b7cd"
+    },
+    {
+        "key_generation_seed": "0e3b30e102d707538c2671060f603bb0b8a014103f132d63b09ece07e4a4c75b11eafeca9e810796c34e8cfce9d59342884456007b01ddd12edce6d10ed87e4c",
+        "sha3_256_hash_of_public_key": "64c819d9bf66855f6ae70627f04da8378547e5867e2eb9759fe0971efd601c4a",
+        "sha3_256_hash_of_secret_key": "e85b62236d5c6c691a9076dc58bd5da80999eccc8df973c7d0e7e65d8465ea7d",
+        "encapsulation_seed": "9f27a47604ab5146caaf0aafe6d149424f8d66e39ba3baf5e6c73b19221b7e21",
+        "sha3_256_hash_of_ciphertext": "e9149359cc37143b0b565bd413a04f41a7833c5b76012a9263a086ac34071684",
+        "shared_secret": "aa333af0226492126c6985130ac7df2226a64d6d5c5314ce3f7a99add6696d49"
+    },
+    {
+        "key_generation_seed": "2478f7d3de6041e7e5cd11c5e2ef483d1aa6218eb126444091535f6ae532fa7311136e2681df2ef881b51a092a9badbe72c9772c169808521c47149578621e28",
+        "sha3_256_hash_of_public_key": "db315cafbaec2f8a0142f45affff65289e826c9244ab1cb03f9f65df3e3cbcf7",
+        "sha3_256_hash_of_secret_key": "be98d62e4724c0d960ad4839298d4571f9871033b63bdf10d3b0e589db376ffa",
+        "encapsulation_seed": "90044031b7597b5e60a4f946b713e8996d0426d2cb013243d9b7d8f8ef159a0f",
+        "sha3_256_hash_of_ciphertext": "9f9368ba712cfee95f28a808cb2c23116a0c8da3910c0def2ef4e55947d7101b",
+        "shared_secret": "9535303e6035e30c6605c9e0f10c553dcd73828d8525cb190fea79937e093331"
+    },
+    {
+        "key_generation_seed": "9d405d3ebdaf35fa8722de431b669722acaaea2fd10b814310b17f78b66147d16ceb14f7662be0c42779459f69a145c0e2ce9f0bd9a0cd1bf32ed5694cc9ae32",
+        "sha3_256_hash_of_public_key": "c8d853e65b5b118e28b7cb6f0d5d6f282e0ea20fd72f3690a6b232b20a8a55ec",
+        "sha3_256_hash_of_secret_key": "7a5e854bad628be7b99f524f52a97b0959c0ee67a7a10ad24b970e6e3aeeeb80",
+        "encapsulation_seed": "a7a31e140891ea37d2b6424b59b1f84f89220f32dcb73e037eb912b389d34a48",
+        "sha3_256_hash_of_ciphertext": "31b04a4127558df57844413928b29b11547de5afc088d568a962fe080c97f190",
+        "shared_secret": "0caa79e0054182c15e54159fbe36d9fb09481331a560ccd9714fff81db5615c4"
+    },
+    {
+        "key_generation_seed": "9a86490f0615f3edf789cb0654066e9ee339cc59f968281f3b89213f83c692edfaeb2ef44d2f608621e831187ce79b2d2f4a20f1568bbe76b0d3d5af36111714",
+        "sha3_256_hash_of_public_key": "f69bd52cb1d071f1cc7720f949d44f66f40c917eb30f3a4b0eb519ecad2d03dc",
+        "sha3_256_hash_of_secret_key": "b6ef04e6acbcd1bb072d1cd28412cdb00ee40d04ce5b39442a2efd6756292167",
+        "encapsulation_seed": "70eb3f791faa91f1f982fa477dbcddeb2c55691c07f93b04cd31b37544c94b42",
+        "sha3_256_hash_of_ciphertext": "d8fac8ffc3d8dfebe66c219f4189b780d5ba8fe28d5ab79264345639740913b0",
+        "shared_secret": "744ce1aa5a9c515c6571ad6e2f5985df8434e35e9f714cf3659f184b5db4086f"
+    },
+    {
+        "key_generation_seed": "6dfd9b575872560c7bdc2732c4a28dac4db04e535eb8e402c3dffd145c09ce47a2985c1c4d203778597947d710dec806e36b0cd949fe460ef141213bfc525e5b",
+        "sha3_256_hash_of_public_key": "10e01965f9c196d2f5f90ce3ce8f552f8a0d76ba8f5345365392febc50560012",
+        "sha3_256_hash_of_secret_key": "2b5c6d5fe9b09ab5a027522e699401223ae9d304ac912f1b15f0f647dd9a0a7f",
+        "encapsulation_seed": "30f4095015ba88b6d969672ca3f438c395dacf7d476ea7a9e805ce932d270a13",
+        "sha3_256_hash_of_ciphertext": "e8b01628c7d63f16c59e67352399a760581f341ed41535013490502e884733be",
+        "shared_secret": "726f7d790df4c860a0b2c40de9d62c85d0ff70c704ce5a1b3f6bf1b3e3f66cd8"
+    },
+    {
+        "key_generation_seed": "6fca9f4e384d8418075cc064c70730801bdb8249899d456a77130d5beeb3662cce7683f8a03d3cf04e46970ff7d6a12494ae12558346dfc8fd9370bf944a0102",
+        "sha3_256_hash_of_public_key": "7c3991fa7983d0dd6e7157cfb152538466e9d5c3998a2b8ed862162b91ca851c",
+        "sha3_256_hash_of_secret_key": "72e786018ae9ab8293fa51cb7ca3ff0435e7cccbd5ae02b4680b92c148590265",
+        "encapsulation_seed": "cf31220f44de862e1719570e1b26e897790159366a385452334fe24cdcae28ba",
+        "sha3_256_hash_of_ciphertext": "5b2e8a3e38c13b53393c8654e92eeb6251ddbe50de4b3c5203a06977491f2fbc",
+        "shared_secret": "68f3e22d1b2d8c57bff32160e550becfce535fdcb327394aabeb60eede263213"
+    },
+    {
+        "key_generation_seed": "e58f71bf175c0550a67e00e0f7b3b7fc36bc2707bf0c93044a492626de36301a7f7054814869cf7625e45647bc1547aff288dbb90699b2ad84893f3b755d9722",
+        "sha3_256_hash_of_public_key": "8aacd8940ff6fc27f175342be74d48075f8ae9320cae20a41c879c27c1bf815d",
+        "sha3_256_hash_of_secret_key": "f7399dbf35fcc57a9bff87b0087755faa75267788cd0921b9ebc5cde8b656271",
+        "encapsulation_seed": "bb5e65669a44e5d5c709bafa98c16ccba6ac2c4ae923334f69a11543eda64f5d",
+        "sha3_256_hash_of_ciphertext": "aac868f2299bcd272afacf50f1ab0db3d092d33565cffb5645d8b92271e7e893",
+        "shared_secret": "7f6085840a30c6b1fb9dca782e0c78a2264d54726c04c3127956f131165426c8"
+    },
+    {
+        "key_generation_seed": "e3fc575ed51513e62aba655d24cd9c8f1c6c848aaffa946c49a53ac3ea59e474d82c2f1bf2e6aebde5660fa73356982e12999d8fdafbb3cb186341d0386dead0",
+        "sha3_256_hash_of_public_key": "149e0b6b49fe8adba1217c2c57c83f2b8c5f1d92f319e502b184a65869214f75",
+        "sha3_256_hash_of_secret_key": "6dfa4d29af6a0e8413d5591339c15d2e2cfac3f502f49acca3efb53b53624666",
+        "encapsulation_seed": "9ddb3aa9c7905d1a438c93bcf78e3e321813580371ab4e1289e2dbf3701972c2",
+        "sha3_256_hash_of_ciphertext": "ced7a64ce643faebac8ffd39c6a4594732b35f1d6899978ba192b87003d3ad27",
+        "shared_secret": "96e30641ea4280168da37291a3063342ced8e77b33b5415819938c0bd7264ffc"
+    },
+    {
+        "key_generation_seed": "470b4943f0fe7fd0d8ec5185aba0d1db09d112934e4fb4787e2bbc6b88466e7b8b2809fd40008be70a6b184981101724bc3d5ec5e1956b510b82fd5ad0668a5a",
+        "sha3_256_hash_of_public_key": "29b1bff7f12eda28dfedfbf0ac16e27008c9fdc62c35e53b28a312bdc91c40bf",
+        "sha3_256_hash_of_secret_key": "762a61eb847c017ece920f51d5da7a9036ed8b835bfd7793527321ec635e2fd0",
+        "encapsulation_seed": "26d90b190a6c3d0d9a86cf66005154e7086749e966e7187c249ccb9329fd3b8b",
+        "sha3_256_hash_of_ciphertext": "bf49310a35f9ba7994645f12949e658b0dd43d3de76386dc20d08c650522f86c",
+        "shared_secret": "47e54c85cc0e2503629a8bfdcfe038c3cf692d723d462bab733c7c8e0aa37b02"
+    },
+    {
+        "key_generation_seed": "6df4385db978d27b27d2aa5e452e4152b36f097503d9581ac3390105c5727e7dc95fa08ed106ce84660e8a4c90bd2b22634e40769aa0090a101c5dddad45edc5",
+        "sha3_256_hash_of_public_key": "b990059e901097d00e0ebaf40c5d5dab009c66798489d357e760478ce884cce5",
+        "sha3_256_hash_of_secret_key": "37a044795bd330e4dc60a6d84bc6e99664d1be418b0239661d2ff16d1501573f",
+        "encapsulation_seed": "7db6d1a129d6123f1f805b79ad3b413012ea86aed42a05e98e7b1f32f9fbbdec",
+        "sha3_256_hash_of_ciphertext": "329115908d0763110a387c99778e4746861e80367ee90fd821cda9acdb93fd64",
+        "shared_secret": "8569bd042465a2c4af628425cb102b15ed4f5feee16090e2234f3a884a0fa938"
+    },
+    {
+        "key_generation_seed": "dbacba825728444921b227cdba54446b3f6881b47be9cd02832f78b023b1bee0e15274a8e2bc08fe818b117ba28c5dfae74d54fcdf6f20052f79be333edc8dde",
+        "sha3_256_hash_of_public_key": "175eb63c3144108548720ce7ee0f43a9ff3f52a9924efe9f2f59318bb93c86b5",
+        "sha3_256_hash_of_secret_key": "1993d7639b79f5e4871a7c58a69fec50f96c1424c2c0ee030ac054ae1b88a56f",
+        "encapsulation_seed": "1d129b27be7384c359d04311fe5c44917d1fde4bfb57314f483ac617edd5ac49",
+        "sha3_256_hash_of_ciphertext": "8f4225838f2964a986336bacddc40836a98c32cca68c6afcbcf9ef68d9a3760b",
+        "shared_secret": "c184e0b019c2db772e2c1ca6f97f47478d99cf0c4c5ae1406f51d15815022123"
+    },
+    {
+        "key_generation_seed": "690eb71fd7052b906eaec09937a8ed374e0b02afa27c2f14399932be5839fad281c38c2cb5cfafac81b96a810ab749b61806b6d54c9f8cf4bf1be0192423288f",
+        "sha3_256_hash_of_public_key": "9bc32a138a2fb5b6072464172abe0fd97e9eabf357c3fa5391d94a415b53abd3",
+        "sha3_256_hash_of_secret_key": "3db4ab1393cfc8b1c708cf8efdb1c443c975878898b60182c22af66375cba13a",
+        "encapsulation_seed": "bbc773ebd2df42c36ae05952d6a64c63a5dfb82ceb3ef4f8d4df3a30ec8c0467",
+        "sha3_256_hash_of_ciphertext": "f1c85f9530d4471eb1401fcf422a29533738c485a6be25f0b554ebf40b49d49d",
+        "shared_secret": "6d72e23c8a4cc60b2f14adc788a5c480033bbf6eb111070912bc83ad7b89280b"
+    },
+    {
+        "key_generation_seed": "32e0ea9089fa928482c0770da545af1bb871a03ce38604138b0d08ea2a10ca2bc06c5bef7b6508409daf847a64c8d30d0974fd3ba7476dc76c46b458a036d884",
+        "sha3_256_hash_of_public_key": "7ef43a72ef04766f1e899d25c9a005009c788b5faf985123cfb3fb97975de26d",
+        "sha3_256_hash_of_secret_key": "77431cb18010a604d56fe5a623bed2ffd028a741f176fa09546e9a45a48caa5e",
+        "encapsulation_seed": "5b17a6adad541efcbf5ae4b0c0452cd2ce32e4f0f8701801c5b63e197c1fcbf4",
+        "sha3_256_hash_of_ciphertext": "83ddab2e25614544649a1e497b5b21c40a3e154e8a22c270f63cb0c40aa868fd",
+        "shared_secret": "29e6b1edac0a9aa33066c113167e42c64d70215ed04963d8be2d4c2dcd0f6589"
+    },
+    {
+        "key_generation_seed": "6fb2ec719f2a0dea152bf3f64b9d148f8ab8ba88f64e61f5db53e12d59f525574f797c007e4061f95c7d56cfc7ee5c49e849dde3fea8f25e7876df2a18515c34",
+        "sha3_256_hash_of_public_key": "2c0db43f39b672b2cd912f907cf76a0f6fda925eb2d205546431be0b37b20411",
+        "sha3_256_hash_of_secret_key": "09844e203f4d8fa30728ab388b9d654847febbf5c9cd939cdc11c9c9be24ce9c",
+        "encapsulation_seed": "61ab87659525de9656af41246f20e1dbe85c24e335e7ecf9493f46168bc14e94",
+        "sha3_256_hash_of_ciphertext": "a2108ea2c446b566a50c228928893e2e4bde5fafb2184af92eb1314113bde0d6",
+        "shared_secret": "cfd1b82181543656807880f6e2576f0b095bf84629b3367e9bdede24662ee42e"
+    },
+    {
+        "key_generation_seed": "527fb88c8bd9a4d6031dad15e63878abd2b559e7e08d61f69e8e78fca964ee6ae32d432b4f9f751bde0496c580a181ffed762aa35454a02d3f1f47ee0394c89c",
+        "sha3_256_hash_of_public_key": "aae8e61b905723fa092fb95b839f6de3670c39ce0498c27b87d20c24e7f64e22",
+        "sha3_256_hash_of_secret_key": "3880f7ca8fc33575a7a6d8bb46fec86a3f12e0068630507ed245d8bc278fbe5d",
+        "encapsulation_seed": "eca2adc3da1fb15f34033405ec08ef2f46163df4bfcccf8842c600ce0bc2026c",
+        "sha3_256_hash_of_ciphertext": "ec48b3ec403609a0ce2d1268cadda8184ab9629cc5913135ffdecd420eed1aa9",
+        "shared_secret": "f7331b0a4674969838482b7184fa92e5246f11f5b5e284c3e179effff7eb6329"
+    },
+    {
+        "key_generation_seed": "ac6fcfaeeef795b6ef9e062f02bf42975fa01e7d91ba832f74e05269a72684d05aeda108ea4d6c6bc0fb958286850422bc357ca67b83c986048e0d0087fa11ec",
+        "sha3_256_hash_of_public_key": "64e085f67e48f00a7a7f82963e8c67176bff839a54fa1008328c0612f98d83d3",
+        "sha3_256_hash_of_secret_key": "0bfbc25d9df751f4c30907095eb6d9a75ed07fa23218ad0fffc469f0e55553c2",
+        "encapsulation_seed": "c4f15bec2d7701339d0ade4835193bea3632edcf89e74992620d9eb623a0d0d4",
+        "sha3_256_hash_of_ciphertext": "fb74b727ad120c18915dca475f3082cd34ded7ae20a308106384ffb5caa029d3",
+        "shared_secret": "c89d62938a5caabfd5b30d82ea88aced52ef5f8ec0528e59a654e1f6aff1cc2f"
+    },
+    {
+        "key_generation_seed": "ba2fb9318d4dbe7488057c33e95e6f054583a2800c41bb83083c330a914a12cfe63f8ffda3565c2424c89b20974b748a65a5aba75133fcb3156dfb6626a83bab",
+        "sha3_256_hash_of_public_key": "8dab879de09b58d0fc7ade140393ffb5343abbddabdc118fad519b14436a964c",
+        "sha3_256_hash_of_secret_key": "7c53072fd98ea7bd8c5e873688b1a5650fe7e11c791407ac8c118b7958cf414b",
+        "encapsulation_seed": "28878249e2ac2b6263422993923a0c8bd05ce56e385ed13c943b03d226856947",
+        "sha3_256_hash_of_ciphertext": "a1f1579c4ce8eb725e697623321b3d9f55f4b1d0def10b898535ef6614e9923e",
+        "shared_secret": "204d9272682710b52fb39b1176af3ff737848978770310df0c67996f6cb596c3"
+    },
+    {
+        "key_generation_seed": "aa6dd1e5799cdf7af9c4fc632b3eb9d51d66e85c8e0a21ec98664fc51ab63c7dfda268813efab5204efa60f78bf81d320d01ac09ac06244f7afbd2d80fd356d9",
+        "sha3_256_hash_of_public_key": "919a696301240cd6129f66be58e19d99b0d827d9932785cd9ea3d92f7ba54463",
+        "sha3_256_hash_of_secret_key": "cb1d7301f15951883cc3f287d4dd8fdf5c9b7022f558dff551c2ade5f5065755",
+        "encapsulation_seed": "17fc65f7fbd7c75ceec421dee84dff5a8cb22764a182db17e0ebe857f54d60eb",
+        "sha3_256_hash_of_ciphertext": "f02654803493821dd9c2ed23f9e46a36addd5fca0da706bbeeda87a2df9fec4f",
+        "shared_secret": "76e5f7623e3e867fd12f28dfda4311f7cd90a405b73e994e857f693573fd2b8a"
+    },
+    {
+        "key_generation_seed": "195d6c86a3df4c21e3007d7f2768b43c74cb3060e0eca77f0a5d3271542b9a84ae77e0f9f21eabd8c0c6eea7767f4e10fde5c2d79b8400bf96b19014b457ec21",
+        "sha3_256_hash_of_public_key": "cb6d7232426bdbdfdacd373c9190722e7bf342825f7d829185dcc9120588fc76",
+        "sha3_256_hash_of_secret_key": "a85e24cc2eafdfe40d82f46471112e1359628b9955f3feae9955b48d563ac952",
+        "encapsulation_seed": "fa0489f3730100609488e951e6aaa15c0f193bc1dbcfcd013bc418d6c507b176",
+        "sha3_256_hash_of_ciphertext": "17336b9ede3a1c26abe725828a5afbe746035a73dfd4a8fbde5040fbabeb2b8d",
+        "shared_secret": "874ac966970f29935db73c231e71a3559b2504e5446151b99c199276617b3824"
+    }
+]

--- a/libcrux-ml-kem/tests/nistkats.rs
+++ b/libcrux-ml-kem/tests/nistkats.rs
@@ -61,7 +61,7 @@ macro_rules! impl_nist_known_answer_tests {
         }
     };
 }
-#[cfg(feature = "mlkem512")]
+#[cfg(all(not(feature = "pre-verification"), feature = "mlkem512"))]
 impl_nist_known_answer_tests!(
     mlkem512_nist_known_answer_tests,
     "mlkem_ipd",
@@ -70,7 +70,8 @@ impl_nist_known_answer_tests!(
     libcrux_ml_kem::mlkem512::encapsulate,
     libcrux_ml_kem::mlkem512::decapsulate
 );
-#[cfg(feature = "mlkem768")]
+
+#[cfg(all(not(feature = "pre-verification"), feature = "mlkem768"))]
 impl_nist_known_answer_tests!(
     mlkem768_nist_known_answer_tests,
     "mlkem_ipd",
@@ -80,7 +81,7 @@ impl_nist_known_answer_tests!(
     libcrux_ml_kem::mlkem768::decapsulate
 );
 
-#[cfg(feature = "mlkem1024")]
+#[cfg(all(not(feature = "pre-verification"), feature = "mlkem1024"))]
 impl_nist_known_answer_tests!(
     mlkem1024_nist_known_answer_tests,
     "mlkem_ipd",

--- a/libcrux-ml-kem/tests/nistkats.rs
+++ b/libcrux-ml-kem/tests/nistkats.rs
@@ -64,7 +64,7 @@ macro_rules! impl_nist_known_answer_tests {
 #[cfg(feature = "mlkem512")]
 impl_nist_known_answer_tests!(
     mlkem512_nist_known_answer_tests,
-    "mlkem",
+    "mlkem_ipd",
     512,
     libcrux_ml_kem::mlkem512::generate_key_pair,
     libcrux_ml_kem::mlkem512::encapsulate,
@@ -73,7 +73,7 @@ impl_nist_known_answer_tests!(
 #[cfg(feature = "mlkem768")]
 impl_nist_known_answer_tests!(
     mlkem768_nist_known_answer_tests,
-    "mlkem",
+    "mlkem_ipd",
     768,
     libcrux_ml_kem::mlkem768::generate_key_pair,
     libcrux_ml_kem::mlkem768::encapsulate,
@@ -83,7 +83,7 @@ impl_nist_known_answer_tests!(
 #[cfg(feature = "mlkem1024")]
 impl_nist_known_answer_tests!(
     mlkem1024_nist_known_answer_tests,
-    "mlkem",
+    "mlkem_ipd",
     1024,
     libcrux_ml_kem::mlkem1024::generate_key_pair,
     libcrux_ml_kem::mlkem1024::encapsulate,


### PR DESCRIPTION
This PR addresses
- [x] domain separation for CPA key generation seed. Fixes #492 
- [x] Indices are already in the right order. Fixes #493 
- [x] regeneration of test vectors. Fixes #494 

I also noticed that we weren't actually testing Kyber on CI, but the verified ML-KEM code (since we only had `--features kyber` in the workflow, not `--features pre-verification,kyber`). In addition, I've separated out testing of the old verified version (which is the FIPS 203 IPD), while we still have that.