### PR TITLE
Add lemmas for Portable serialize/deserialize functions

### DIFF
--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Serialize.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Serialize.fst
@@ -1,7 +1,9 @@
 module Libcrux_ml_kem.Vector.Portable.Serialize
-#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 1500"
 open Core
 open FStar.Mul
+
+#push-options "--admit_smt_queries true"
 
 let deserialize_10_int (bytes: t_Slice u8) =
   let r0:i16 =
@@ -36,12 +38,7 @@ let deserialize_10_int (bytes: t_Slice u8) =
     ((cast (bytes.[ sz 9 ] <: u8) <: i16) <<! 2l <: i16) |.
     ((cast (bytes.[ sz 8 ] <: u8) <: i16) >>! 6l <: i16)
   in
-  let _:Prims.unit = BitVecEq.bit_vec_equal_intro_principle () in
-  let result:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    r0, r1, r2, r3, r4, r5, r6, r7 <: (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
-  in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  r0, r1, r2, r3, r4, r5, r6, r7 <: (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
 
 let deserialize_11_int (bytes: t_Slice u8) =
   let r0:i16 =
@@ -82,12 +79,7 @@ let deserialize_11_int (bytes: t_Slice u8) =
     ((cast (bytes.[ sz 10 ] <: u8) <: i16) <<! 3l <: i16) |.
     ((cast (bytes.[ sz 9 ] <: u8) <: i16) >>! 5l <: i16)
   in
-  let _:Prims.unit = BitVecEq.bit_vec_equal_intro_principle () in
-  let result:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    r0, r1, r2, r3, r4, r5, r6, r7 <: (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
-  in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  r0, r1, r2, r3, r4, r5, r6, r7 <: (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
 
 let deserialize_12_int (bytes: t_Slice u8) =
   let byte0:i16 = cast (bytes.[ sz 0 ] <: u8) <: i16 in
@@ -95,10 +87,7 @@ let deserialize_12_int (bytes: t_Slice u8) =
   let byte2:i16 = cast (bytes.[ sz 2 ] <: u8) <: i16 in
   let r0:i16 = ((byte1 &. 15s <: i16) <<! 8l <: i16) |. (byte0 &. 255s <: i16) in
   let r1:i16 = (byte2 <<! 4l <: i16) |. ((byte1 >>! 4l <: i16) &. 15s <: i16) in
-  let _:Prims.unit = BitVecEq.bit_vec_equal_intro_principle () in
-  let result:(i16 & i16) = r0, r1 <: (i16 & i16) in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  r0, r1 <: (i16 & i16)
 
 let deserialize_4_int (bytes: t_Slice u8) =
   let v0:i16 = cast ((bytes.[ sz 0 ] <: u8) &. 15uy <: u8) <: i16 in
@@ -109,12 +98,7 @@ let deserialize_4_int (bytes: t_Slice u8) =
   let v5:i16 = cast (((bytes.[ sz 2 ] <: u8) >>! 4l <: u8) &. 15uy <: u8) <: i16 in
   let v6:i16 = cast ((bytes.[ sz 3 ] <: u8) &. 15uy <: u8) <: i16 in
   let v7:i16 = cast (((bytes.[ sz 3 ] <: u8) >>! 4l <: u8) &. 15uy <: u8) <: i16 in
-  let _:Prims.unit = BitVecEq.bit_vec_equal_intro_principle () in
-  let result:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    v0, v1, v2, v3, v4, v5, v6, v7 <: (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
-  in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  v0, v1, v2, v3, v4, v5, v6, v7 <: (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
 
 let deserialize_5_int (bytes: t_Slice u8) =
   let v0:i16 = cast ((bytes.[ sz 0 ] <: u8) &. 31uy <: u8) <: i16 in
@@ -153,13 +137,7 @@ let deserialize_5_int (bytes: t_Slice u8) =
     i16
   in
   let v7:i16 = cast ((bytes.[ sz 4 ] <: u8) >>! 3l <: u8) <: i16 in
-  let result:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    v0, v1, v2, v3, v4, v5, v6, v7 <: (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
-  in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
-
-#push-options "--z3rlimit 480 --split_queries always"
+  v0, v1, v2, v3, v4, v5, v6, v7 <: (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
 
 let serialize_10_int (v: t_Slice i16) =
   let r0:u8 = cast ((v.[ sz 0 ] <: i16) &. 255s <: i16) <: u8 in
@@ -176,12 +154,7 @@ let serialize_10_int (v: t_Slice i16) =
     (cast (((v.[ sz 2 ] <: i16) >>! 4l <: i16) &. 63s <: i16) <: u8)
   in
   let r4:u8 = cast (((v.[ sz 3 ] <: i16) >>! 2l <: i16) &. 255s <: i16) <: u8 in
-  let _:Prims.unit = BitVecEq.bit_vec_equal_intro_principle () in
-  let result:(u8 & u8 & u8 & u8 & u8) = r0, r1, r2, r3, r4 <: (u8 & u8 & u8 & u8 & u8) in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
-
-#pop-options
+  r0, r1, r2, r3, r4 <: (u8 & u8 & u8 & u8 & u8)
 
 let serialize_11_int (v: t_Slice i16) =
   let r0:u8 = cast (v.[ sz 0 ] <: i16) <: u8 in
@@ -216,14 +189,9 @@ let serialize_11_int (v: t_Slice i16) =
     (cast ((v.[ sz 6 ] <: i16) >>! 6l <: i16) <: u8)
   in
   let r10:u8 = cast ((v.[ sz 7 ] <: i16) >>! 3l <: i16) <: u8 in
-  let _:Prims.unit = BitVecEq.bit_vec_equal_intro_principle () in
-  let result:(u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8) =
-    r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10
-    <:
-    (u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8)
-  in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10
+  <:
+  (u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8)
 
 let serialize_12_int (v: t_Slice i16) =
   let r0:u8 = cast ((v.[ sz 0 ] <: i16) &. 255s <: i16) <: u8 in
@@ -235,10 +203,7 @@ let serialize_12_int (v: t_Slice i16) =
     u8
   in
   let r2:u8 = cast (((v.[ sz 1 ] <: i16) >>! 4l <: i16) &. 255s <: i16) <: u8 in
-  let _:Prims.unit = BitVecEq.bit_vec_equal_intro_principle () in
-  let result:(u8 & u8 & u8) = r0, r1, r2 <: (u8 & u8 & u8) in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  r0, r1, r2 <: (u8 & u8 & u8)
 
 let serialize_4_int (v: t_Slice i16) =
   let result0:u8 =
@@ -253,20 +218,7 @@ let serialize_4_int (v: t_Slice i16) =
   let result3:u8 =
     ((cast (v.[ sz 7 ] <: i16) <: u8) <<! 4l <: u8) |. (cast (v.[ sz 6 ] <: i16) <: u8)
   in
-  let _:Prims.unit = BitVecEq.bit_vec_equal_intro_principle () in
-  let result:(u8 & u8 & u8 & u8) = result0, result1, result2, result3 <: (u8 & u8 & u8 & u8) in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
-
-let serialize_4_int_lemma (inputs: t_Array i16 (sz 8))
-   (_: squash (forall i. Rust_primitives.bounded (Seq.index inputs i) 4))
-   : squash (
-     let outputs = serialize_4_int inputs in
-     let outputs = MkSeq.create4 outputs in
-     let inputs = bit_vec_of_int_t_array inputs 4 in
-     let outputs = bit_vec_of_int_t_array outputs 8 in
-     (forall (i: nat {i < 32}). inputs i == outputs i)
-   ) = _ by (Tactics.GetBit.prove_bit_vector_equality ())
+  result0, result1, result2, result3 <: (u8 & u8 & u8 & u8)
 
 let serialize_5_int (v: t_Slice i16) =
   let r0:u8 = cast ((v.[ sz 0 ] <: i16) |. ((v.[ sz 1 ] <: i16) <<! 5l <: i16) <: i16) <: u8 in
@@ -292,65 +244,81 @@ let serialize_5_int (v: t_Slice i16) =
   let r4:u8 =
     cast (((v.[ sz 6 ] <: i16) >>! 2l <: i16) |. ((v.[ sz 7 ] <: i16) <<! 3l <: i16) <: i16) <: u8
   in
-  let result:(u8 & u8 & u8 & u8 & u8) = r0, r1, r2, r3, r4 <: (u8 & u8 & u8 & u8 & u8) in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  r0, r1, r2, r3, r4 <: (u8 & u8 & u8 & u8 & u8)
 
-#push-options "--admit_smt_queries true"
+let deserialize_4_ (bytes: t_Slice u8) =
+  let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
+    deserialize_4_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 4 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v8_15_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
+    deserialize_4_int (bytes.[ { Core.Ops.Range.f_start = sz 4; Core.Ops.Range.f_end = sz 8 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  {
+    Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+    =
+    let list =
+      [
+        v0_7_._1; v0_7_._2; v0_7_._3; v0_7_._4; v0_7_._5; v0_7_._6; v0_7_._7; v0_7_._8; v8_15_._1;
+        v8_15_._2; v8_15_._3; v8_15_._4; v8_15_._5; v8_15_._6; v8_15_._7; v8_15_._8
+      ]
+    in
+    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 16);
+    Rust_primitives.Hax.array_of_list 16 list
+  }
+  <:
+  Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
 
 let serialize_1_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
-  let result:t_Array u8 (sz 2) = Rust_primitives.Hax.repeat 0uy (sz 2) in
-  let result:t_Array u8 (sz 2) =
+  let result0:u8 = 0uy in
+  let result1:u8 = 0uy in
+  let result0:u8 =
     Rust_primitives.Hax.Folds.fold_range (sz 0)
       (sz 8)
-      (fun result temp_1_ ->
-          let result:t_Array u8 (sz 2) = result in
+      (fun result0 temp_1_ ->
+          let result0:u8 = result0 in
           let _:usize = temp_1_ in
           true)
-      result
-      (fun result i ->
-          let result:t_Array u8 (sz 2) = result in
+      result0
+      (fun result0 i ->
+          let result0:u8 = result0 in
           let i:usize = i in
-          Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
-            (sz 0)
-            ((result.[ sz 0 ] <: u8) |.
-              ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) <: u8) <<!
-                i
-                <:
-                u8)
-              <:
-              u8)
+          result0 |.
+          ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) <: u8) <<! i
+            <:
+            u8)
           <:
-          t_Array u8 (sz 2))
+          u8)
   in
-  let result:t_Array u8 (sz 2) =
+  let result1:u8 =
     Rust_primitives.Hax.Folds.fold_range (sz 8)
       (sz 16)
-      (fun result temp_1_ ->
-          let result:t_Array u8 (sz 2) = result in
+      (fun result1 temp_1_ ->
+          let result1:u8 = result1 in
           let _:usize = temp_1_ in
           true)
-      result
-      (fun result i ->
-          let result:t_Array u8 (sz 2) = result in
+      result1
+      (fun result1 i ->
+          let result1:u8 = result1 in
           let i:usize = i in
-          Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
-            (sz 1)
-            ((result.[ sz 1 ] <: u8) |.
-              ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) <: u8) <<!
-                (i -! sz 8 <: usize)
-                <:
-                u8)
-              <:
-              u8)
+          result1 |.
+          ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) <: u8) <<!
+            (i -! sz 8 <: usize)
+            <:
+            u8)
           <:
-          t_Array u8 (sz 2))
+          u8)
   in
-  result
-
-#pop-options
-
-#push-options "--admit_smt_queries true"
+  let list = [result0; result1] in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+  Rust_primitives.Hax.array_of_list 2 list
 
 let serialize_10_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
   let r0_4_:(u8 & u8 & u8 & u8 & u8) =
@@ -403,10 +371,6 @@ let serialize_10_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVecto
   FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 20);
   Rust_primitives.Hax.array_of_list 20 list
 
-#pop-options
-
-#push-options "--admit_smt_queries true"
-
 let serialize_11_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
   let r0_10_:(u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8) =
     serialize_11_int (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ {
@@ -428,78 +392,17 @@ let serialize_11_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVecto
         <:
         t_Slice i16)
   in
-  let result:t_Array u8 (sz 22) = Rust_primitives.Hax.repeat 0uy (sz 22) in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 0) r0_10_._1
+  let list =
+    [
+      r0_10_._1; r0_10_._2; r0_10_._3; r0_10_._4; r0_10_._5; r0_10_._6; r0_10_._7; r0_10_._8;
+      r0_10_._9; r0_10_._10; r0_10_._11; r11_21_._1; r11_21_._2; r11_21_._3; r11_21_._4; r11_21_._5;
+      r11_21_._6; r11_21_._7; r11_21_._8; r11_21_._9; r11_21_._10; r11_21_._11
+    ]
   in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 1) r0_10_._2
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 2) r0_10_._3
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 3) r0_10_._4
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 4) r0_10_._5
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 5) r0_10_._6
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 6) r0_10_._7
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 7) r0_10_._8
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 8) r0_10_._9
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 9) r0_10_._10
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 10) r0_10_._11
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 11) r11_21_._1
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 12) r11_21_._2
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 13) r11_21_._3
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 14) r11_21_._4
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 15) r11_21_._5
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 16) r11_21_._6
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 17) r11_21_._7
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 18) r11_21_._8
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 19) r11_21_._9
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 20) r11_21_._10
-  in
-  let result:t_Array u8 (sz 22) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 21) r11_21_._11
-  in
-  result
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 22);
+  Rust_primitives.Hax.array_of_list 22 list
 
 #pop-options
-
-#push-options "--admit_smt_queries true"
 
 let serialize_12_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
   let r0_2_:(u8 & u8 & u8) =
@@ -582,84 +485,28 @@ let serialize_12_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVecto
         <:
         t_Slice i16)
   in
-  let result:t_Array u8 (sz 24) = Rust_primitives.Hax.repeat 0uy (sz 24) in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 0) r0_2_._1
+  let list =
+    [
+      r0_2_._1; r0_2_._2; r0_2_._3; r3_5_._1; r3_5_._2; r3_5_._3; r6_8_._1; r6_8_._2; r6_8_._3;
+      r9_11_._1; r9_11_._2; r9_11_._3; r12_14_._1; r12_14_._2; r12_14_._3; r15_17_._1; r15_17_._2;
+      r15_17_._3; r18_20_._1; r18_20_._2; r18_20_._3; r21_23_._1; r21_23_._2; r21_23_._3
+    ]
   in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 1) r0_2_._2
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 2) r0_2_._3
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 3) r3_5_._1
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 4) r3_5_._2
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 5) r3_5_._3
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 6) r6_8_._1
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 7) r6_8_._2
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 8) r6_8_._3
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 9) r9_11_._1
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 10) r9_11_._2
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 11) r9_11_._3
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 12) r12_14_._1
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 13) r12_14_._2
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 14) r12_14_._3
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 15) r15_17_._1
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 16) r15_17_._2
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 17) r15_17_._3
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 18) r18_20_._1
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 19) r18_20_._2
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 20) r18_20_._3
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 21) r21_23_._1
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 22) r21_23_._2
-  in
-  let result:t_Array u8 (sz 24) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 23) r21_23_._3
-  in
-  result
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 24);
+  Rust_primitives.Hax.array_of_list 24 list
+
+#push-options "--compat_pre_core 2"
+
+let serialize_12_bit_vec_lemma (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+  (_: squash (forall i. Rust_primitives.bounded (Seq.index v.f_elements i) 12))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v.f_elements 12 in
+     let outputs = bit_vec_of_int_t_array (serialize_12_ v) 8 in
+     (forall (i: nat {i < 192}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
 
 #pop-options
-
-#push-options "--admit_smt_queries true"
 
 let serialize_4_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
   let result0_3_:(u8 & u8 & u8 & u8) =
@@ -682,36 +529,20 @@ let serialize_4_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
         <:
         t_Slice i16)
   in
-  let result:t_Array u8 (sz 8) = Rust_primitives.Hax.repeat 0uy (sz 8) in
-  let result:t_Array u8 (sz 8) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 0) result0_3_._1
+  let list =
+    [
+      result0_3_._1;
+      result0_3_._2;
+      result0_3_._3;
+      result0_3_._4;
+      result4_7_._1;
+      result4_7_._2;
+      result4_7_._3;
+      result4_7_._4
+    ]
   in
-  let result:t_Array u8 (sz 8) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 1) result0_3_._2
-  in
-  let result:t_Array u8 (sz 8) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 2) result0_3_._3
-  in
-  let result:t_Array u8 (sz 8) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 3) result0_3_._4
-  in
-  let result:t_Array u8 (sz 8) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 4) result4_7_._1
-  in
-  let result:t_Array u8 (sz 8) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 5) result4_7_._2
-  in
-  let result:t_Array u8 (sz 8) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 6) result4_7_._3
-  in
-  let result:t_Array u8 (sz 8) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 7) result4_7_._4
-  in
-  result
-
-#pop-options
-
-#push-options "--admit_smt_queries true"
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 8);
+  Rust_primitives.Hax.array_of_list 8 list
 
 let serialize_5_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
   let r0_4_:(u8 & u8 & u8 & u8 & u8) =
@@ -766,10 +597,6 @@ let serialize_5_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
     Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 9) r5_9_._5
   in
   result
-
-#pop-options
-
-#push-options "--admit_smt_queries true"
 
 let deserialize_1_ (v: t_Slice u8) =
   let result:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
@@ -826,10 +653,6 @@ let deserialize_1_ (v: t_Slice u8) =
           Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
   in
   result
-
-#pop-options
-
-#push-options "--admit_smt_queries true"
 
 let deserialize_10_ (bytes: t_Slice u8) =
   let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
@@ -1059,10 +882,6 @@ let deserialize_10_ (bytes: t_Slice u8) =
   in
   v
 
-#pop-options
-
-#push-options "--admit_smt_queries true"
-
 let deserialize_11_ (bytes: t_Slice u8) =
   let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
     deserialize_11_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 11 }
@@ -1290,10 +1109,6 @@ let deserialize_11_ (bytes: t_Slice u8) =
     Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
   in
   v
-
-#pop-options
-
-#push-options "--admit_smt_queries true"
 
 let deserialize_12_ (bytes: t_Slice u8) =
   let v0_1_:(i16 & i16) =
@@ -1565,242 +1380,6 @@ let deserialize_12_ (bytes: t_Slice u8) =
   in
   re
 
-#pop-options
-
-#push-options "--admit_smt_queries true"
-
-let deserialize_4_ (bytes: t_Slice u8) =
-  let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    deserialize_4_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 4 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v8_15_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    deserialize_4_int (bytes.[ { Core.Ops.Range.f_start = sz 4; Core.Ops.Range.f_end = sz 8 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    Libcrux_ml_kem.Vector.Portable.Vector_type.zero ()
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 0)
-        v0_7_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 1)
-        v0_7_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 2)
-        v0_7_._3
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 3)
-        v0_7_._4
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 4)
-        v0_7_._5
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 5)
-        v0_7_._6
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 6)
-        v0_7_._7
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 7)
-        v0_7_._8
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 8)
-        v8_15_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 9)
-        v8_15_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 10)
-        v8_15_._3
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 11)
-        v8_15_._4
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 12)
-        v8_15_._5
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 13)
-        v8_15_._6
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 14)
-        v8_15_._7
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 15)
-        v8_15_._8
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  v
-
-#pop-options
-
-#push-options "--admit_smt_queries true"
-
 let deserialize_5_ (bytes: t_Slice u8) =
   let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
     deserialize_5_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 5 }
@@ -2028,5 +1607,3 @@ let deserialize_5_ (bytes: t_Slice u8) =
     Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
   in
   v
-
-#pop-options

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Serialize.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Serialize.fst
@@ -1,9 +1,7 @@
 module Libcrux_ml_kem.Vector.Portable.Serialize
-#set-options "--fuel 0 --ifuel 1 --z3rlimit 1500"
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
 open Core
 open FStar.Mul
-
-#push-options "--admit_smt_queries true"
 
 let deserialize_10_int (bytes: t_Slice u8) =
   let r0:i16 =
@@ -246,6 +244,233 @@ let serialize_5_int (v: t_Slice i16) =
   in
   r0, r1, r2, r3, r4 <: (u8 & u8 & u8 & u8 & u8)
 
+let deserialize_1_ (v: t_Slice u8) =
+  let result0:i16 = cast ((v.[ sz 0 ] <: u8) &. 1uy <: u8) <: i16 in
+  let result1:i16 = cast (((v.[ sz 0 ] <: u8) >>! 1l <: u8) &. 1uy <: u8) <: i16 in
+  let result2:i16 = cast (((v.[ sz 0 ] <: u8) >>! 2l <: u8) &. 1uy <: u8) <: i16 in
+  let result3:i16 = cast (((v.[ sz 0 ] <: u8) >>! 3l <: u8) &. 1uy <: u8) <: i16 in
+  let result4:i16 = cast (((v.[ sz 0 ] <: u8) >>! 4l <: u8) &. 1uy <: u8) <: i16 in
+  let result5:i16 = cast (((v.[ sz 0 ] <: u8) >>! 5l <: u8) &. 1uy <: u8) <: i16 in
+  let result6:i16 = cast (((v.[ sz 0 ] <: u8) >>! 6l <: u8) &. 1uy <: u8) <: i16 in
+  let result7:i16 = cast (((v.[ sz 0 ] <: u8) >>! 7l <: u8) &. 1uy <: u8) <: i16 in
+  let result8:i16 = cast ((v.[ sz 1 ] <: u8) &. 1uy <: u8) <: i16 in
+  let result9:i16 = cast (((v.[ sz 1 ] <: u8) >>! 1l <: u8) &. 1uy <: u8) <: i16 in
+  let result10:i16 = cast (((v.[ sz 1 ] <: u8) >>! 2l <: u8) &. 1uy <: u8) <: i16 in
+  let result11:i16 = cast (((v.[ sz 1 ] <: u8) >>! 3l <: u8) &. 1uy <: u8) <: i16 in
+  let result12:i16 = cast (((v.[ sz 1 ] <: u8) >>! 4l <: u8) &. 1uy <: u8) <: i16 in
+  let result13:i16 = cast (((v.[ sz 1 ] <: u8) >>! 5l <: u8) &. 1uy <: u8) <: i16 in
+  let result14:i16 = cast (((v.[ sz 1 ] <: u8) >>! 6l <: u8) &. 1uy <: u8) <: i16 in
+  let result15:i16 = cast (((v.[ sz 1 ] <: u8) >>! 7l <: u8) &. 1uy <: u8) <: i16 in
+  {
+    Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+    =
+    let list =
+      [
+        result0; result1; result2; result3; result4; result5; result6; result7; result8; result9;
+        result10; result11; result12; result13; result14; result15
+      ]
+    in
+    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 16);
+    Rust_primitives.Hax.array_of_list 16 list
+  }
+  <:
+  Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+
+#push-options "--compat_pre_core 2 --z3rlimit 300"
+
+let deserialize_1_bit_vec_lemma (v: t_Array u8 (sz 2))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 8 in
+     let outputs = bit_vec_of_int_t_array (deserialize_1_ v).f_elements 1 in
+     (forall (i: nat {i < 16}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+
+#push-options "--z3rlimit 300"
+
+let deserialize_1_lemma inputs =
+  deserialize_1_bit_vec_lemma inputs;
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (deserialize_1_ inputs).f_elements 1) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs 8))
+
+#pop-options
+
+let deserialize_10_ (bytes: t_Slice u8) =
+  let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
+    deserialize_10_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 10 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v8_15_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
+    deserialize_10_int (bytes.[ { Core.Ops.Range.f_start = sz 10; Core.Ops.Range.f_end = sz 20 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  {
+    Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+    =
+    let list =
+      [
+        v0_7_._1; v0_7_._2; v0_7_._3; v0_7_._4; v0_7_._5; v0_7_._6; v0_7_._7; v0_7_._8; v8_15_._1;
+        v8_15_._2; v8_15_._3; v8_15_._4; v8_15_._5; v8_15_._6; v8_15_._7; v8_15_._8
+      ]
+    in
+    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 16);
+    Rust_primitives.Hax.array_of_list 16 list
+  }
+  <:
+  Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+
+#push-options "--compat_pre_core 2 --z3rlimit 300"
+
+let deserialize_10_bit_vec_lemma (v: t_Array u8 (sz 20))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 8 in
+     let outputs = bit_vec_of_int_t_array (deserialize_10_ v).f_elements 10 in
+     (forall (i: nat {i < 160}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+
+#push-options "--z3rlimit 300"
+
+let deserialize_10_lemma inputs =
+  deserialize_10_bit_vec_lemma inputs;
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (deserialize_10_ inputs).f_elements 10) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs 8))
+
+#pop-options
+
+let deserialize_11_ (bytes: t_Slice u8) =
+  let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
+    deserialize_11_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 11 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v8_15_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
+    deserialize_11_int (bytes.[ { Core.Ops.Range.f_start = sz 11; Core.Ops.Range.f_end = sz 22 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  {
+    Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+    =
+    let list =
+      [
+        v0_7_._1; v0_7_._2; v0_7_._3; v0_7_._4; v0_7_._5; v0_7_._6; v0_7_._7; v0_7_._8; v8_15_._1;
+        v8_15_._2; v8_15_._3; v8_15_._4; v8_15_._5; v8_15_._6; v8_15_._7; v8_15_._8
+      ]
+    in
+    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 16);
+    Rust_primitives.Hax.array_of_list 16 list
+  }
+  <:
+  Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+
+let deserialize_12_ (bytes: t_Slice u8) =
+  let v0_1_:(i16 & i16) =
+    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 3 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v2_3_:(i16 & i16) =
+    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 3; Core.Ops.Range.f_end = sz 6 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v4_5_:(i16 & i16) =
+    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 6; Core.Ops.Range.f_end = sz 9 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v6_7_:(i16 & i16) =
+    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 9; Core.Ops.Range.f_end = sz 12 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v8_9_:(i16 & i16) =
+    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 12; Core.Ops.Range.f_end = sz 15 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v10_11_:(i16 & i16) =
+    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 15; Core.Ops.Range.f_end = sz 18 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v12_13_:(i16 & i16) =
+    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 18; Core.Ops.Range.f_end = sz 21 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v14_15_:(i16 & i16) =
+    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 21; Core.Ops.Range.f_end = sz 24 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  {
+    Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+    =
+    let list =
+      [
+        v0_1_._1; v0_1_._2; v2_3_._1; v2_3_._2; v4_5_._1; v4_5_._2; v6_7_._1; v6_7_._2; v8_9_._1;
+        v8_9_._2; v10_11_._1; v10_11_._2; v12_13_._1; v12_13_._2; v14_15_._1; v14_15_._2
+      ]
+    in
+    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 16);
+    Rust_primitives.Hax.array_of_list 16 list
+  }
+  <:
+  Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+
+#push-options "--compat_pre_core 2 --z3rlimit 300"
+
+let deserialize_12_bit_vec_lemma (v: t_Array u8 (sz 24))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 8 in
+     let outputs = bit_vec_of_int_t_array (deserialize_12_ v).f_elements 12 in
+     (forall (i: nat {i < 192}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+
+#push-options "--z3rlimit 300"
+
+let deserialize_12_lemma inputs =
+  deserialize_12_bit_vec_lemma inputs;
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (deserialize_12_ inputs).f_elements 12) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs 8))
+
+#pop-options
+
 let deserialize_4_ (bytes: t_Slice u8) =
   let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
     deserialize_4_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 4 }
@@ -276,49 +501,173 @@ let deserialize_4_ (bytes: t_Slice u8) =
   <:
   Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
 
+#push-options "--compat_pre_core 2 --z3rlimit 300"
+
+let deserialize_4_bit_vec_lemma (v: t_Array u8 (sz 8))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 8 in
+     let outputs = bit_vec_of_int_t_array (deserialize_4_ v).f_elements 4 in
+     (forall (i: nat {i < 64}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+
+#push-options "--z3rlimit 300"
+
+let deserialize_4_lemma inputs =
+  deserialize_4_bit_vec_lemma inputs;
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (deserialize_4_ inputs).f_elements 4) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs 8))
+
+#pop-options
+
+let deserialize_5_ (bytes: t_Slice u8) =
+  let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
+    deserialize_5_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 5 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  let v8_15_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
+    deserialize_5_int (bytes.[ { Core.Ops.Range.f_start = sz 5; Core.Ops.Range.f_end = sz 10 }
+          <:
+          Core.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  {
+    Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
+    =
+    let list =
+      [
+        v0_7_._1; v0_7_._2; v0_7_._3; v0_7_._4; v0_7_._5; v0_7_._6; v0_7_._7; v0_7_._8; v8_15_._1;
+        v8_15_._2; v8_15_._3; v8_15_._4; v8_15_._5; v8_15_._6; v8_15_._7; v8_15_._8
+      ]
+    in
+    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 16);
+    Rust_primitives.Hax.array_of_list 16 list
+  }
+  <:
+  Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+
 let serialize_1_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
-  let result0:u8 = 0uy in
-  let result1:u8 = 0uy in
   let result0:u8 =
-    Rust_primitives.Hax.Folds.fold_range (sz 0)
-      (sz 8)
-      (fun result0 temp_1_ ->
-          let result0:u8 = result0 in
-          let _:usize = temp_1_ in
-          true)
-      result0
-      (fun result0 i ->
-          let result0:u8 = result0 in
-          let i:usize = i in
-          result0 |.
-          ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) <: u8) <<! i
+    (((((((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 0 ] <: i16) <: u8) |.
+                ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 1 ] <: i16)
+                    <:
+                    u8) <<!
+                  1l
+                  <:
+                  u8)
+                <:
+                u8) |.
+              ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 2 ] <: i16) <: u8
+                ) <<!
+                2l
+                <:
+                u8)
+              <:
+              u8) |.
+            ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 3 ] <: i16) <: u8) <<!
+              3l
+              <:
+              u8)
+            <:
+            u8) |.
+          ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 4 ] <: i16) <: u8) <<!
+            4l
             <:
             u8)
           <:
+          u8) |.
+        ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 5 ] <: i16) <: u8) <<!
+          5l
+          <:
           u8)
+        <:
+        u8) |.
+      ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 6 ] <: i16) <: u8) <<! 6l
+        <:
+        u8)
+      <:
+      u8) |.
+    ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 7 ] <: i16) <: u8) <<! 7l
+      <:
+      u8)
   in
   let result1:u8 =
-    Rust_primitives.Hax.Folds.fold_range (sz 8)
-      (sz 16)
-      (fun result1 temp_1_ ->
-          let result1:u8 = result1 in
-          let _:usize = temp_1_ in
-          true)
-      result1
-      (fun result1 i ->
-          let result1:u8 = result1 in
-          let i:usize = i in
-          result1 |.
-          ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ i ] <: i16) <: u8) <<!
-            (i -! sz 8 <: usize)
+    (((((((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 8 ] <: i16) <: u8) |.
+                ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 9 ] <: i16)
+                    <:
+                    u8) <<!
+                  1l
+                  <:
+                  u8)
+                <:
+                u8) |.
+              ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 10 ] <: i16)
+                  <:
+                  u8) <<!
+                2l
+                <:
+                u8)
+              <:
+              u8) |.
+            ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 11 ] <: i16) <: u8) <<!
+              3l
+              <:
+              u8)
+            <:
+            u8) |.
+          ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 12 ] <: i16) <: u8) <<!
+            4l
             <:
             u8)
           <:
+          u8) |.
+        ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 13 ] <: i16) <: u8) <<!
+          5l
+          <:
           u8)
+        <:
+        u8) |.
+      ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 14 ] <: i16) <: u8) <<!
+        6l
+        <:
+        u8)
+      <:
+      u8) |.
+    ((cast (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ sz 15 ] <: i16) <: u8) <<! 7l
+      <:
+      u8)
   in
   let list = [result0; result1] in
   FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
   Rust_primitives.Hax.array_of_list 2 list
+
+#push-options "--compat_pre_core 2 --z3rlimit 300"
+
+let serialize_1_bit_vec_lemma (v: t_Array i16 (sz 16))
+  (_: squash (forall i. Rust_primitives.bounded (Seq.index v i) 1))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 1 in
+     let outputs = bit_vec_of_int_t_array (serialize_1_ ({ f_elements = v })) 8 in
+     (forall (i: nat {i < 16}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+
+#push-options "--z3rlimit 300"
+
+let serialize_1_lemma inputs =
+  serialize_1_bit_vec_lemma inputs.f_elements ();
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (serialize_1_ inputs) 8) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs.f_elements 1))
+
+#pop-options
 
 let serialize_10_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
   let r0_4_:(u8 & u8 & u8 & u8 & u8) =
@@ -371,6 +720,28 @@ let serialize_10_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVecto
   FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 20);
   Rust_primitives.Hax.array_of_list 20 list
 
+#push-options "--compat_pre_core 2 --z3rlimit 300"
+
+let serialize_10_bit_vec_lemma (v: t_Array i16 (sz 16))
+  (_: squash (forall i. Rust_primitives.bounded (Seq.index v i) 10))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 10 in
+     let outputs = bit_vec_of_int_t_array (serialize_10_ ({ f_elements = v })) 8 in
+     (forall (i: nat {i < 160}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+
+#push-options "--z3rlimit 300"
+
+let serialize_10_lemma inputs =
+  serialize_10_bit_vec_lemma inputs.f_elements ();
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (serialize_10_ inputs) 8) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs.f_elements 10))
+
+#pop-options
+
 let serialize_11_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
   let r0_10_:(u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8) =
     serialize_11_int (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ {
@@ -401,8 +772,6 @@ let serialize_11_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVecto
   in
   FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 22);
   Rust_primitives.Hax.array_of_list 22 list
-
-#pop-options
 
 let serialize_12_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
   let r0_2_:(u8 & u8 & u8) =
@@ -495,16 +864,25 @@ let serialize_12_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVecto
   FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 24);
   Rust_primitives.Hax.array_of_list 24 list
 
-#push-options "--compat_pre_core 2"
+#push-options "--compat_pre_core 2 --z3rlimit 300"
 
-let serialize_12_bit_vec_lemma (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
-  (_: squash (forall i. Rust_primitives.bounded (Seq.index v.f_elements i) 12))
+let serialize_12_bit_vec_lemma (v: t_Array i16 (sz 16))
+  (_: squash (forall i. Rust_primitives.bounded (Seq.index v i) 12))
    : squash (
-     let inputs = bit_vec_of_int_t_array v.f_elements 12 in
-     let outputs = bit_vec_of_int_t_array (serialize_12_ v) 8 in
+     let inputs = bit_vec_of_int_t_array v 12 in
+     let outputs = bit_vec_of_int_t_array (serialize_12_ ({ f_elements = v })) 8 in
      (forall (i: nat {i < 192}). inputs i == outputs i)
    ) =
   _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+
+#push-options "--z3rlimit 300"
+
+let serialize_12_lemma inputs =
+  serialize_12_bit_vec_lemma inputs.f_elements ();
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (serialize_12_ inputs) 8) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs.f_elements 12))
 
 #pop-options
 
@@ -544,6 +922,28 @@ let serialize_4_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
   FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 8);
   Rust_primitives.Hax.array_of_list 8 list
 
+#push-options "--compat_pre_core 2 --z3rlimit 300"
+
+let serialize_4_bit_vec_lemma (v: t_Array i16 (sz 16))
+  (_: squash (forall i. Rust_primitives.bounded (Seq.index v i) 4))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 4 in
+     let outputs = bit_vec_of_int_t_array (serialize_4_ ({ f_elements = v })) 8 in
+     (forall (i: nat {i < 64}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+
+#push-options "--z3rlimit 300"
+
+let serialize_4_lemma inputs =
+  serialize_4_bit_vec_lemma inputs.f_elements ();
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (serialize_4_ inputs) 8) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs.f_elements 4))
+
+#pop-options
+
 let serialize_5_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) =
   let r0_4_:(u8 & u8 & u8 & u8 & u8) =
     serialize_5_int (v.Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements.[ {
@@ -565,1045 +965,11 @@ let serialize_5_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
         <:
         t_Slice i16)
   in
-  let result:t_Array u8 (sz 10) = Rust_primitives.Hax.repeat 0uy (sz 10) in
-  let result:t_Array u8 (sz 10) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 0) r0_4_._1
-  in
-  let result:t_Array u8 (sz 10) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 1) r0_4_._2
-  in
-  let result:t_Array u8 (sz 10) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 2) r0_4_._3
-  in
-  let result:t_Array u8 (sz 10) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 3) r0_4_._4
-  in
-  let result:t_Array u8 (sz 10) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 4) r0_4_._5
-  in
-  let result:t_Array u8 (sz 10) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 5) r5_9_._1
-  in
-  let result:t_Array u8 (sz 10) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 6) r5_9_._2
-  in
-  let result:t_Array u8 (sz 10) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 7) r5_9_._3
-  in
-  let result:t_Array u8 (sz 10) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 8) r5_9_._4
-  in
-  let result:t_Array u8 (sz 10) =
-    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result (sz 9) r5_9_._5
-  in
-  result
-
-let deserialize_1_ (v: t_Slice u8) =
-  let result:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    Libcrux_ml_kem.Vector.Portable.Vector_type.zero ()
-  in
-  let result:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    Rust_primitives.Hax.Folds.fold_range (sz 0)
-      (sz 8)
-      (fun result temp_1_ ->
-          let result:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector = result in
-          let _:usize = temp_1_ in
-          true)
-      result
-      (fun result i ->
-          let result:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector = result in
-          let i:usize = i in
-          {
-            result with
-            Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-            =
-            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
-                .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-              i
-              (cast (((v.[ sz 0 ] <: u8) >>! i <: u8) &. 1uy <: u8) <: i16)
-            <:
-            t_Array i16 (sz 16)
-          }
-          <:
-          Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
-  in
-  let result:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    Rust_primitives.Hax.Folds.fold_range (sz 8)
-      Libcrux_ml_kem.Vector.Traits.v_FIELD_ELEMENTS_IN_VECTOR
-      (fun result temp_1_ ->
-          let result:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector = result in
-          let _:usize = temp_1_ in
-          true)
-      result
-      (fun result i ->
-          let result:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector = result in
-          let i:usize = i in
-          {
-            result with
-            Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-            =
-            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize result
-                .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-              i
-              (cast (((v.[ sz 1 ] <: u8) >>! (i -! sz 8 <: usize) <: u8) &. 1uy <: u8) <: i16)
-            <:
-            t_Array i16 (sz 16)
-          }
-          <:
-          Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
-  in
-  result
-
-let deserialize_10_ (bytes: t_Slice u8) =
-  let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    deserialize_10_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 10 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v8_15_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    deserialize_10_int (bytes.[ { Core.Ops.Range.f_start = sz 10; Core.Ops.Range.f_end = sz 20 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    Libcrux_ml_kem.Vector.Portable.Vector_type.zero ()
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 0)
-        v0_7_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 1)
-        v0_7_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 2)
-        v0_7_._3
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 3)
-        v0_7_._4
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 4)
-        v0_7_._5
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 5)
-        v0_7_._6
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 6)
-        v0_7_._7
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 7)
-        v0_7_._8
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 8)
-        v8_15_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 9)
-        v8_15_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 10)
-        v8_15_._3
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 11)
-        v8_15_._4
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 12)
-        v8_15_._5
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 13)
-        v8_15_._6
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 14)
-        v8_15_._7
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 15)
-        v8_15_._8
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  v
-
-let deserialize_11_ (bytes: t_Slice u8) =
-  let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    deserialize_11_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 11 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v8_15_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    deserialize_11_int (bytes.[ { Core.Ops.Range.f_start = sz 11; Core.Ops.Range.f_end = sz 22 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    Libcrux_ml_kem.Vector.Portable.Vector_type.zero ()
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 0)
-        v0_7_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 1)
-        v0_7_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 2)
-        v0_7_._3
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 3)
-        v0_7_._4
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 4)
-        v0_7_._5
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 5)
-        v0_7_._6
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 6)
-        v0_7_._7
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 7)
-        v0_7_._8
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 8)
-        v8_15_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 9)
-        v8_15_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 10)
-        v8_15_._3
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 11)
-        v8_15_._4
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 12)
-        v8_15_._5
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 13)
-        v8_15_._6
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 14)
-        v8_15_._7
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 15)
-        v8_15_._8
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  v
-
-let deserialize_12_ (bytes: t_Slice u8) =
-  let v0_1_:(i16 & i16) =
-    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 3 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v2_3_:(i16 & i16) =
-    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 3; Core.Ops.Range.f_end = sz 6 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v4_5_:(i16 & i16) =
-    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 6; Core.Ops.Range.f_end = sz 9 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v6_7_:(i16 & i16) =
-    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 9; Core.Ops.Range.f_end = sz 12 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v8_9_:(i16 & i16) =
-    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 12; Core.Ops.Range.f_end = sz 15 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v10_11_:(i16 & i16) =
-    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 15; Core.Ops.Range.f_end = sz 18 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v12_13_:(i16 & i16) =
-    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 18; Core.Ops.Range.f_end = sz 21 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v14_15_:(i16 & i16) =
-    deserialize_12_int (bytes.[ { Core.Ops.Range.f_start = sz 21; Core.Ops.Range.f_end = sz 24 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    Libcrux_ml_kem.Vector.Portable.Vector_type.zero ()
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 0)
-        v0_1_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 1)
-        v0_1_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 2)
-        v2_3_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 3)
-        v2_3_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 4)
-        v4_5_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 5)
-        v4_5_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 6)
-        v6_7_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 7)
-        v6_7_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 8)
-        v8_9_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 9)
-        v8_9_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 10)
-        v10_11_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 11)
-        v10_11_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 12)
-        v12_13_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 13)
-        v12_13_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 14)
-        v14_15_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let re:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      re with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize re
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 15)
-        v14_15_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  re
-
-let deserialize_5_ (bytes: t_Slice u8) =
-  let v0_7_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    deserialize_5_int (bytes.[ { Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 5 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v8_15_:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) =
-    deserialize_5_int (bytes.[ { Core.Ops.Range.f_start = sz 5; Core.Ops.Range.f_end = sz 10 }
-          <:
-          Core.Ops.Range.t_Range usize ]
-        <:
-        t_Slice u8)
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    Libcrux_ml_kem.Vector.Portable.Vector_type.zero ()
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 0)
-        v0_7_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 1)
-        v0_7_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 2)
-        v0_7_._3
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 3)
-        v0_7_._4
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 4)
-        v0_7_._5
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 5)
-        v0_7_._6
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 6)
-        v0_7_._7
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 7)
-        v0_7_._8
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 8)
-        v8_15_._1
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 9)
-        v8_15_._2
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 10)
-        v8_15_._3
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 11)
-        v8_15_._4
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 12)
-        v8_15_._5
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 13)
-        v8_15_._6
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 14)
-        v8_15_._7
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  let v:Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector =
-    {
-      v with
-      Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-      =
-      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
-          .Libcrux_ml_kem.Vector.Portable.Vector_type.f_elements
-        (sz 15)
-        v8_15_._8
-    }
-    <:
-    Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-  in
-  v
+  let list =
+    [
+      r0_4_._1; r0_4_._2; r0_4_._3; r0_4_._4; r0_4_._5; r5_9_._1; r5_9_._2; r5_9_._3; r5_9_._4;
+      r5_9_._5
+    ]
+  in
+  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 10);
+  Rust_primitives.Hax.array_of_list 10 list

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Serialize.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Serialize.fsti
@@ -6,92 +6,57 @@ open FStar.Mul
 val deserialize_10_int (bytes: t_Slice u8)
     : Prims.Pure (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
       (requires Core.Slice.impl__len #u8 bytes =. sz 10)
-      (ensures
-        fun tuple ->
-          let tuple:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) = tuple in
-          BitVecEq.int_t_array_bitwise_eq' (bytes <: t_Array _ (sz 10)) 8 (MkSeq.create8 tuple) 10 /\
-          (forall i. Rust_primitives.bounded (Seq.index (MkSeq.create8 tuple) i) 10))
+      (fun _ -> Prims.l_True)
 
 val deserialize_11_int (bytes: t_Slice u8)
     : Prims.Pure (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
       (requires Core.Slice.impl__len #u8 bytes =. sz 11)
-      (ensures
-        fun tuple ->
-          let tuple:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) = tuple in
-          BitVecEq.int_t_array_bitwise_eq' (bytes <: t_Array _ (sz 11)) 8 (MkSeq.create8 tuple) 11 /\
-          (forall i. Rust_primitives.bounded (Seq.index (MkSeq.create8 tuple) i) 11))
+      (fun _ -> Prims.l_True)
 
 val deserialize_12_int (bytes: t_Slice u8)
     : Prims.Pure (i16 & i16)
       (requires Core.Slice.impl__len #u8 bytes =. sz 3)
-      (ensures
-        fun tuple ->
-          let tuple:(i16 & i16) = tuple in
-          BitVecEq.int_t_array_bitwise_eq' (bytes <: t_Array _ (sz 3)) 8 (MkSeq.create2 tuple) 12 /\
-          (forall i. Rust_primitives.bounded (Seq.index (MkSeq.create2 tuple) i) 12))
+      (fun _ -> Prims.l_True)
 
 val deserialize_4_int (bytes: t_Slice u8)
     : Prims.Pure (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
       (requires Core.Slice.impl__len #u8 bytes =. sz 4)
-      (ensures
-        fun tuple ->
-          let tuple:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) = tuple in
-          BitVecEq.int_t_array_bitwise_eq' (bytes <: t_Array _ (sz 4)) 8 (MkSeq.create8 tuple) 4 /\
-          (forall i. Rust_primitives.bounded (Seq.index (MkSeq.create8 tuple) i) 4))
+      (fun _ -> Prims.l_True)
 
 val deserialize_5_int (bytes: t_Slice u8)
     : Prims.Pure (i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16)
       (requires Core.Slice.impl__len #u8 bytes =. sz 5)
-      (ensures
-        fun tuple ->
-          let tuple:(i16 & i16 & i16 & i16 & i16 & i16 & i16 & i16) = tuple in
-          BitVecEq.int_t_array_bitwise_eq' (bytes <: t_Array _ (sz 5)) 8 (MkSeq.create8 tuple) 5 /\
-          (forall i. Rust_primitives.bounded (Seq.index (MkSeq.create8 tuple) i) 4))
+      (fun _ -> Prims.l_True)
 
 val serialize_10_int (v: t_Slice i16)
     : Prims.Pure (u8 & u8 & u8 & u8 & u8)
-      (requires (Core.Slice.impl__len #i16 v <: usize) =. sz 4)
-      (ensures
-        fun tuple ->
-          let tuple:(u8 & u8 & u8 & u8 & u8) = tuple in
-          BitVecEq.int_t_array_bitwise_eq' (v <: t_Array _ (sz 4)) 10 (MkSeq.create5 tuple) 8)
+      (requires Core.Slice.impl__len #i16 v =. sz 4)
+      (fun _ -> Prims.l_True)
 
 val serialize_11_int (v: t_Slice i16)
     : Prims.Pure (u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8)
-      (requires
-        Core.Slice.impl__len #i16 v =. sz 8 /\
-        (forall i. Rust_primitives.bounded (Seq.index v i) 11))
-      (ensures
-        fun tuple ->
-          let tuple:(u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8 & u8) = tuple in
-          BitVecEq.int_t_array_bitwise_eq' (v <: t_Array _ (sz 8)) 11 (MkSeq.create11 tuple) 8)
+      (requires Core.Slice.impl__len #i16 v =. sz 8)
+      (fun _ -> Prims.l_True)
 
 val serialize_12_int (v: t_Slice i16)
     : Prims.Pure (u8 & u8 & u8)
-      (requires
-        Core.Slice.impl__len #i16 v =. sz 2 /\
-        (forall i. Rust_primitives.bounded (Seq.index v i) 12))
-      (ensures
-        fun tuple ->
-          let tuple:(u8 & u8 & u8) = tuple in
-          BitVecEq.int_t_array_bitwise_eq' (v <: t_Array _ (sz 2)) 12 (MkSeq.create3 tuple) 8)
+      (requires Core.Slice.impl__len #i16 v =. sz 2)
+      (fun _ -> Prims.l_True)
 
 val serialize_4_int (v: t_Slice i16)
     : Prims.Pure (u8 & u8 & u8 & u8)
-      (requires
-        Core.Slice.impl__len #i16 v =. sz 8 /\ (forall i. Rust_primitives.bounded (Seq.index v i) 4)
-      )
+      (requires Core.Slice.impl__len #i16 v =. sz 8)
       (fun _ -> Prims.l_True)
 
 val serialize_5_int (v: t_Slice i16)
     : Prims.Pure (u8 & u8 & u8 & u8 & u8)
-      (requires
-        Core.Slice.impl__len #i16 v =. sz 8 /\ (forall i. Rust_primitives.bounded (Seq.index v i) 5)
-      )
-      (ensures
-        fun tuple ->
-          let tuple:(u8 & u8 & u8 & u8 & u8) = tuple in
-          BitVecEq.int_t_array_bitwise_eq' (v <: t_Array _ (sz 8)) 5 (MkSeq.create5 tuple) 8)
+      (requires Core.Slice.impl__len #i16 v =. sz 8)
+      (fun _ -> Prims.l_True)
+
+val deserialize_4_ (bytes: t_Slice u8)
+    : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+      (requires Core.Slice.impl__len #u8 bytes =. sz 8)
+      (fun _ -> Prims.l_True)
 
 val serialize_1_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
     : Prims.Pure (t_Array u8 (sz 2)) Prims.l_True (fun _ -> Prims.l_True)
@@ -113,30 +78,25 @@ val serialize_5_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
 
 val deserialize_1_ (v: t_Slice u8)
     : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-      Prims.l_True
+      (requires Core.Slice.impl__len #u8 v =. sz 2)
       (fun _ -> Prims.l_True)
 
 val deserialize_10_ (bytes: t_Slice u8)
     : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-      Prims.l_True
+      (requires Core.Slice.impl__len #u8 bytes =. sz 20)
       (fun _ -> Prims.l_True)
 
 val deserialize_11_ (bytes: t_Slice u8)
     : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-      Prims.l_True
+      (requires Core.Slice.impl__len #u8 bytes =. sz 22)
       (fun _ -> Prims.l_True)
 
 val deserialize_12_ (bytes: t_Slice u8)
     : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-val deserialize_4_ (bytes: t_Slice u8)
-    : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-      Prims.l_True
+      (requires Core.Slice.impl__len #u8 bytes =. sz 24)
       (fun _ -> Prims.l_True)
 
 val deserialize_5_ (bytes: t_Slice u8)
     : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-      Prims.l_True
+      (requires Core.Slice.impl__len #u8 bytes =. sz 10)
       (fun _ -> Prims.l_True)

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Serialize.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.Serialize.fsti
@@ -53,38 +53,21 @@ val serialize_5_int (v: t_Slice i16)
       (requires Core.Slice.impl__len #i16 v =. sz 8)
       (fun _ -> Prims.l_True)
 
-val deserialize_4_ (bytes: t_Slice u8)
-    : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
-      (requires Core.Slice.impl__len #u8 bytes =. sz 8)
-      (fun _ -> Prims.l_True)
-
-val serialize_1_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
-    : Prims.Pure (t_Array u8 (sz 2)) Prims.l_True (fun _ -> Prims.l_True)
-
-val serialize_10_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
-    : Prims.Pure (t_Array u8 (sz 20)) Prims.l_True (fun _ -> Prims.l_True)
-
-val serialize_11_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
-    : Prims.Pure (t_Array u8 (sz 22)) Prims.l_True (fun _ -> Prims.l_True)
-
-val serialize_12_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
-    : Prims.Pure (t_Array u8 (sz 24)) Prims.l_True (fun _ -> Prims.l_True)
-
-val serialize_4_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
-    : Prims.Pure (t_Array u8 (sz 8)) Prims.l_True (fun _ -> Prims.l_True)
-
-val serialize_5_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
-    : Prims.Pure (t_Array u8 (sz 10)) Prims.l_True (fun _ -> Prims.l_True)
-
 val deserialize_1_ (v: t_Slice u8)
     : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
       (requires Core.Slice.impl__len #u8 v =. sz 2)
       (fun _ -> Prims.l_True)
 
+val deserialize_1_lemma (inputs: t_Array u8 (sz 2)) : Lemma
+  (ensures bit_vec_of_int_t_array (deserialize_1_ inputs).f_elements 1 == bit_vec_of_int_t_array inputs 8)
+
 val deserialize_10_ (bytes: t_Slice u8)
     : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
       (requires Core.Slice.impl__len #u8 bytes =. sz 20)
       (fun _ -> Prims.l_True)
+
+val deserialize_10_lemma (inputs: t_Array u8 (sz 20)) : Lemma
+  (ensures bit_vec_of_int_t_array (deserialize_10_ inputs).f_elements 10 == bit_vec_of_int_t_array inputs 8)
 
 val deserialize_11_ (bytes: t_Slice u8)
     : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
@@ -96,7 +79,52 @@ val deserialize_12_ (bytes: t_Slice u8)
       (requires Core.Slice.impl__len #u8 bytes =. sz 24)
       (fun _ -> Prims.l_True)
 
+val deserialize_12_lemma (inputs: t_Array u8 (sz 24)) : Lemma
+  (ensures bit_vec_of_int_t_array (deserialize_12_ inputs).f_elements 12 == bit_vec_of_int_t_array inputs 8)
+
+val deserialize_4_ (bytes: t_Slice u8)
+    : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
+      (requires Core.Slice.impl__len #u8 bytes =. sz 8)
+      (fun _ -> Prims.l_True)
+
+val deserialize_4_lemma (inputs: t_Array u8 (sz 8)) : Lemma
+  (ensures bit_vec_of_int_t_array (deserialize_4_ inputs).f_elements 4 == bit_vec_of_int_t_array inputs 8)
+
 val deserialize_5_ (bytes: t_Slice u8)
     : Prims.Pure Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector
       (requires Core.Slice.impl__len #u8 bytes =. sz 10)
       (fun _ -> Prims.l_True)
+
+val serialize_1_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+    : Prims.Pure (t_Array u8 (sz 2)) Prims.l_True (fun _ -> Prims.l_True)
+
+val serialize_1_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) : Lemma
+  (requires (forall i. Rust_primitives.bounded (Seq.index inputs.f_elements i) 1)) 
+  (ensures bit_vec_of_int_t_array (serialize_1_ inputs) 8 == bit_vec_of_int_t_array inputs.f_elements 1)
+
+val serialize_10_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+    : Prims.Pure (t_Array u8 (sz 20)) Prims.l_True (fun _ -> Prims.l_True)
+
+val serialize_10_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) : Lemma
+  (requires (forall i. Rust_primitives.bounded (Seq.index inputs.f_elements i) 10)) 
+  (ensures bit_vec_of_int_t_array (serialize_10_ inputs) 8 == bit_vec_of_int_t_array inputs.f_elements 10)
+
+val serialize_11_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+    : Prims.Pure (t_Array u8 (sz 22)) Prims.l_True (fun _ -> Prims.l_True)
+
+val serialize_12_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+    : Prims.Pure (t_Array u8 (sz 24)) Prims.l_True (fun _ -> Prims.l_True)
+
+val serialize_12_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) : Lemma
+  (requires (forall i. Rust_primitives.bounded (Seq.index inputs.f_elements i) 12)) 
+  (ensures bit_vec_of_int_t_array (serialize_12_ inputs) 8 == bit_vec_of_int_t_array inputs.f_elements 12)
+
+val serialize_4_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+    : Prims.Pure (t_Array u8 (sz 8)) Prims.l_True (fun _ -> Prims.l_True)
+
+val serialize_4_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) : Lemma
+  (requires (forall i. Rust_primitives.bounded (Seq.index inputs.f_elements i) 4)) 
+  (ensures bit_vec_of_int_t_array (serialize_4_ inputs) 8 == bit_vec_of_int_t_array inputs.f_elements 4)
+
+val serialize_5_ (v: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
+    : Prims.Pure (t_Array u8 (sz 10)) Prims.l_True (fun _ -> Prims.l_True)


### PR DESCRIPTION
This PR adds lemmas for portable serialize/deserialize functions. The proofs for lemmas are based on the tactic of the following PR https://github.com/cryspen/libcrux/pull/549 and it takes long to verify (specifically for those lemmas with big ranges). It comments out the lemmas for serialize_5/deserialize_5 and serialize_11/deserialize_11 get rid of workloads of lower priority.

For now, the lemmas serialize_1/deserialize_1 and serialize_4/deserialize_4 are tested. Currently, I am verifying the lemmas all together in a one run..