### PR TITLE
Include hidden files in extraction upload

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           name: c-extraction
           path: libcrux-ml-kem/c
+          include-hidden-files: true
           if-no-files-found: error
 
   extract-header-only:
@@ -53,6 +54,7 @@ jobs:
         with:
           name: header-only-c-extraction
           path: libcrux-ml-kem/cg/
+          include-hidden-files: true
           if-no-files-found: error
 
   diff:


### PR DESCRIPTION
The `upload-artifact` action in `v3` and `v4` no longer uploads hidden files by default, as announced [here](https://github.com/actions/upload-artifact/issues/602), thus breaking our extraction CI, because the C extraction includes a `.gitignore` file that is no longer uploaded.

This fixes the issue by making the action upload hidden files as well, restoring the previous behaviour.