### PR TITLE
Remove unsafe code from include to avoid being rejected by hax.

### DIFF
--- a/libcrux-ml-kem/hax.py
+++ b/libcrux-ml-kem/hax.py
@@ -31,7 +31,7 @@ class extractAction(argparse.Action):
 
     def __call__(self, parser, args, values, option_string=None) -> None:
         # Extract platform interfaces
-        include_str = "+:**"
+        include_str = "+:** -**::x86::init::cpuid -**::x86::init::cpuid_count"
         interface_include = "+**"
         cargo_hax_into = [
             "cargo",


### PR DESCRIPTION
Fixes build failure that happened here: https://github.com/cryspen/libcrux/actions/runs/10677857822/job/29593758713?pr=555
This comes after merging https://github.com/hacspec/hax/pull/867 that rejects any AST containing unsafe blocks.
We still extract the interfaces for these functions.