### PR TITLE
Allow hax extraction for ML-DSA

### DIFF
--- a/libcrux-ml-dsa/examples/sign_65.rs
+++ b/libcrux-ml-dsa/examples/sign_65.rs
@@ -16,6 +16,7 @@ fn main() {
     let keypair = ml_dsa_65::generate_key_pair(key_generation_seed);
 
     for _i in 0..100_000 {
-        let _ = ml_dsa_65::sign(&keypair.signing_key, &message, signing_randomness);
+        let _ = ml_dsa_65::sign(&keypair.signing_key, &message, signing_randomness)
+            .expect("Rejection sampling failure probability is < 2⁻¹²⁸");
     }
 }

--- a/libcrux-ml-dsa/examples/verify_65.rs
+++ b/libcrux-ml-dsa/examples/verify_65.rs
@@ -14,7 +14,8 @@ fn main() {
     let message = random_array::<1023>();
 
     let keypair = ml_dsa_65::generate_key_pair(key_generation_seed);
-    let signature = ml_dsa_65::sign(&keypair.signing_key, &message, signing_randomness);
+    let signature = ml_dsa_65::sign(&keypair.signing_key, &message, signing_randomness)
+        .expect("Rejection sampling failure probability is < 2⁻¹²⁸");
 
     for _i in 0..100_000 {
         ml_dsa_65::verify(&keypair.verification_key, &message, &signature).unwrap();

--- a/libcrux-ml-dsa/src/encoding/commitment.rs
+++ b/libcrux-ml-dsa/src/encoding/commitment.rs
@@ -6,7 +6,7 @@ fn serialize<SIMDUnit: Operations, const OUTPUT_SIZE: usize>(
 ) -> [u8; OUTPUT_SIZE] {
     let mut serialized = [0u8; OUTPUT_SIZE];
 
-    match OUTPUT_SIZE {
+    match OUTPUT_SIZE as u8 {
         128 => {
             // The commitment has coefficients in [0,15] => each coefficient occupies
             // 4 bits. Each SIMD unit contains 8 elements, which means each

--- a/libcrux-ml-dsa/src/encoding/error.rs
+++ b/libcrux-ml-dsa/src/encoding/error.rs
@@ -8,7 +8,7 @@ pub(crate) fn serialize<SIMDUnit: Operations, const ETA: usize, const OUTPUT_SIZ
 ) -> [u8; OUTPUT_SIZE] {
     let mut serialized = [0u8; OUTPUT_SIZE];
 
-    match ETA {
+    match ETA as u8 {
         2 => {
             const OUTPUT_BYTES_PER_SIMD_UNIT: usize = 3;
 
@@ -41,7 +41,7 @@ pub(crate) fn serialize<SIMDUnit: Operations, const ETA: usize, const OUTPUT_SIZ
 fn deserialize<SIMDUnit: Operations, const ETA: usize>(
     serialized: &[u8],
 ) -> PolynomialRingElement<SIMDUnit> {
-    let mut serialized_chunks = match ETA {
+    let mut serialized_chunks = match ETA as u8 {
         2 => serialized.chunks(3),
         4 => serialized.chunks(4),
         _ => unreachable!(),

--- a/libcrux-ml-dsa/src/encoding/gamma1.rs
+++ b/libcrux-ml-dsa/src/encoding/gamma1.rs
@@ -10,7 +10,7 @@ pub(crate) fn serialize<
 ) -> [u8; OUTPUT_BYTES] {
     let mut serialized = [0u8; OUTPUT_BYTES];
 
-    match GAMMA1_EXPONENT {
+    match GAMMA1_EXPONENT as u8 {
         17 => {
             const OUTPUT_BYTES_PER_SIMD_UNIT: usize = 18;
 
@@ -43,7 +43,7 @@ pub(crate) fn serialize<
 pub(crate) fn deserialize<SIMDUnit: Operations, const GAMMA1_EXPONENT: usize>(
     serialized: &[u8],
 ) -> PolynomialRingElement<SIMDUnit> {
-    let mut serialized_chunks = match GAMMA1_EXPONENT {
+    let mut serialized_chunks = match GAMMA1_EXPONENT as u8 {
         17 => serialized.chunks(18),
         19 => serialized.chunks(20),
         _ => unreachable!(),

--- a/libcrux-ml-dsa/src/lib.rs
+++ b/libcrux-ml-dsa/src/lib.rs
@@ -17,7 +17,10 @@ mod utils;
 
 // Public interface
 
-pub use {ml_dsa_generic::VerificationError, types::*};
+pub use {
+    ml_dsa_generic::{SigningError, VerificationError},
+    types::*,
+};
 
 pub use crate::constants::KEY_GENERATION_RANDOMNESS_SIZE;
 pub use crate::constants::SIGNING_RANDOMNESS_SIZE;

--- a/libcrux-ml-dsa/src/ml_dsa_44.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_44.rs
@@ -1,4 +1,4 @@
-use crate::{constants::*, ml_dsa_generic, types::*, VerificationError};
+use crate::{constants::*, ml_dsa_generic, types::*, SigningError, VerificationError};
 
 // ML-DSA-44-specific parameters
 
@@ -112,7 +112,7 @@ pub fn sign(
     signing_key: &MLDSA44SigningKey,
     message: &[u8],
     randomness: [u8; SIGNING_RANDOMNESS_SIZE],
-) -> MLDSA44Signature {
+) -> Result<MLDSA44Signature, SigningError> {
     ml_dsa_generic::sign::<
         SIMDUnit, // TODO: Multiplex this based on platform detection.
         Shake128,

--- a/libcrux-ml-dsa/src/ml_dsa_65.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_65.rs
@@ -1,4 +1,4 @@
-use crate::{constants::*, types::*, VerificationError};
+use crate::{constants::*, types::*, SigningError, VerificationError};
 
 // ML-DSA-65-specific parameters
 
@@ -114,7 +114,7 @@ pub fn sign(
     signing_key: &MLDSA65SigningKey,
     message: &[u8],
     randomness: [u8; SIGNING_RANDOMNESS_SIZE],
-) -> MLDSA65Signature {
+) -> Result<MLDSA65Signature, SigningError> {
     crate::ml_dsa_generic::sign::<
         SIMDUnit,
         Shake128,

--- a/libcrux-ml-dsa/src/ml_dsa_87.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_87.rs
@@ -1,4 +1,4 @@
-use crate::{constants::*, types::*, VerificationError};
+use crate::{constants::*, types::*, SigningError, VerificationError};
 
 // ML-DSA-87 parameters
 
@@ -117,7 +117,7 @@ pub fn sign(
     signing_key: &MLDSA87SigningKey,
     message: &[u8],
     randomness: [u8; SIGNING_RANDOMNESS_SIZE],
-) -> MLDSA87Signature {
+) -> Result<MLDSA87Signature, SigningError> {
     crate::ml_dsa_generic::sign::<
         SIMDUnit,
         Shake128,

--- a/libcrux-ml-dsa/src/sample.rs
+++ b/libcrux-ml-dsa/src/sample.rs
@@ -210,7 +210,7 @@ pub(crate) fn rejection_sample_less_than_eta<SIMDUnit: Operations, const ETA: us
     sampled: &mut usize,
     out: &mut [i32; 263],
 ) -> bool {
-    match ETA {
+    match ETA as u8 {
         2 => rejection_sample_less_than_eta_equals_2::<SIMDUnit>(randomness, sampled, out),
         4 => rejection_sample_less_than_eta_equals_4::<SIMDUnit>(randomness, sampled, out),
         _ => unreachable!(),
@@ -337,7 +337,7 @@ fn sample_mask_ring_element<
 >(
     seed: [u8; 66],
 ) -> PolynomialRingElement<SIMDUnit> {
-    match GAMMA1_EXPONENT {
+    match GAMMA1_EXPONENT as u8 {
         17 => {
             let mut out = [0u8; 576];
             Shake256::shake256::<576>(&seed, &mut out);
@@ -374,7 +374,7 @@ pub(crate) fn sample_mask_vector<
     let seed2 = update_seed(seed, domain_separator);
     let seed3 = update_seed(seed, domain_separator);
 
-    match GAMMA1_EXPONENT {
+    match GAMMA1_EXPONENT as u8 {
         17 => {
             let mut out0 = [0; 576];
             let mut out1 = [0; 576];

--- a/libcrux-ml-dsa/src/samplex4.rs
+++ b/libcrux-ml-dsa/src/samplex4.rs
@@ -374,7 +374,7 @@ pub(crate) fn matrix_A<
 >(
     seed: [u8; 34],
 ) -> [[PolynomialRingElement<SIMDUnit>; COLUMNS_IN_A]; ROWS_IN_A] {
-    match (ROWS_IN_A, COLUMNS_IN_A) {
+    match (ROWS_IN_A as u8, COLUMNS_IN_A as u8) {
         (4, 4) => matrix_A_4_by_4::<SIMDUnit, Shake128X4, ROWS_IN_A, COLUMNS_IN_A>(seed),
         (6, 5) => matrix_A_6_by_5::<SIMDUnit, Shake128X4, ROWS_IN_A, COLUMNS_IN_A>(seed),
         (8, 7) => matrix_A_8_by_7::<SIMDUnit, Shake128X4, ROWS_IN_A, COLUMNS_IN_A>(seed),
@@ -504,7 +504,7 @@ pub(crate) fn sample_s1_and_s2<
     [PolynomialRingElement<SIMDUnit>; S1_DIMENSION],
     [PolynomialRingElement<SIMDUnit>; S2_DIMENSION],
 ) {
-    match (S1_DIMENSION, S2_DIMENSION) {
+    match (S1_DIMENSION as u8, S2_DIMENSION as u8) {
         (4, 4) => {
             sample_s1_and_s2_4_by_4::<SIMDUnit, Shake256X4, ETA, S1_DIMENSION, S2_DIMENSION>(seed)
         }

--- a/libcrux-ml-dsa/src/simd/portable/encoding/commitment.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/commitment.rs
@@ -4,7 +4,7 @@ use crate::simd::portable::PortableSIMDUnit;
 pub fn serialize<const OUTPUT_SIZE: usize>(simd_unit: PortableSIMDUnit) -> [u8; OUTPUT_SIZE] {
     let mut serialized = [0u8; OUTPUT_SIZE];
 
-    match OUTPUT_SIZE {
+    match OUTPUT_SIZE as u8 {
         4 => {
             // The commitment has coefficients in [0,15] => each coefficient occupies
             // 4 bits.

--- a/libcrux-ml-dsa/src/simd/portable/encoding/error.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/error.rs
@@ -43,7 +43,7 @@ fn serialize_when_eta_is_4<const OUTPUT_SIZE: usize>(
 pub(crate) fn serialize<const OUTPUT_SIZE: usize>(
     simd_unit: PortableSIMDUnit,
 ) -> [u8; OUTPUT_SIZE] {
-    match OUTPUT_SIZE {
+    match OUTPUT_SIZE as u8 {
         3 => serialize_when_eta_is_2::<OUTPUT_SIZE>(simd_unit),
         4 => serialize_when_eta_is_4::<OUTPUT_SIZE>(simd_unit),
         _ => unreachable!(),
@@ -88,7 +88,7 @@ fn deserialize_when_eta_is_4(serialized: &[u8]) -> PortableSIMDUnit {
 }
 #[inline(always)]
 pub(crate) fn deserialize<const ETA: usize>(serialized: &[u8]) -> PortableSIMDUnit {
-    match ETA {
+    match ETA as u8 {
         2 => deserialize_when_eta_is_2(serialized),
         4 => deserialize_when_eta_is_4(serialized),
         _ => unreachable!(),

--- a/libcrux-ml-dsa/src/simd/portable/encoding/gamma1.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/gamma1.rs
@@ -65,7 +65,7 @@ fn serialize_when_gamma1_is_2_pow_19<const OUTPUT_SIZE: usize>(
 pub(crate) fn serialize<const OUTPUT_SIZE: usize>(
     simd_unit: PortableSIMDUnit,
 ) -> [u8; OUTPUT_SIZE] {
-    match OUTPUT_SIZE {
+    match OUTPUT_SIZE as u8 {
         18 => serialize_when_gamma1_is_2_pow_17::<OUTPUT_SIZE>(simd_unit),
         20 => serialize_when_gamma1_is_2_pow_19::<OUTPUT_SIZE>(simd_unit),
         _ => unreachable!(),
@@ -141,7 +141,7 @@ fn deserialize_when_gamma1_is_2_pow_19(serialized: &[u8]) -> PortableSIMDUnit {
 }
 #[inline(always)]
 pub(crate) fn deserialize<const GAMMA1_EXPONENT: usize>(serialized: &[u8]) -> PortableSIMDUnit {
-    match GAMMA1_EXPONENT {
+    match GAMMA1_EXPONENT as u8 {
         17 => deserialize_when_gamma1_is_2_pow_17(serialized),
         19 => deserialize_when_gamma1_is_2_pow_19(serialized),
         _ => unreachable!(),

--- a/libcrux-ml-dsa/tests/nistkats.rs
+++ b/libcrux-ml-dsa/tests/nistkats.rs
@@ -57,7 +57,8 @@ macro_rules! impl_nist_known_answer_tests {
 
                 let message = hex::decode(kat.message).expect("Hex-decoding the message failed.");
 
-                let signature = $sign(&key_pair.signing_key, &message, kat.signing_randomness);
+                let signature = $sign(&key_pair.signing_key, &message, kat.signing_randomness)
+                    .expect("Rejection sampling failure probability is < 2⁻¹²⁸");
 
                 let signature_hash = libcrux_sha3::sha256(&signature.0);
                 assert_eq!(

--- a/libcrux-ml-dsa/tests/self.rs
+++ b/libcrux-ml-dsa/tests/self.rs
@@ -59,7 +59,8 @@ macro_rules! impl_consistency_test {
 
             let key_pair = $key_gen(key_generation_seed);
 
-            let signature = $sign(&key_pair.signing_key, &message, signing_randomness);
+            let signature = $sign(&key_pair.signing_key, &message, signing_randomness)
+                .expect("Rejection sampling failure probability is < 2⁻¹²⁸");
 
             $verify(&key_pair.verification_key, &message, &signature)
                 .expect("Verification should pass since the signature was honestly generated");
@@ -80,7 +81,8 @@ macro_rules! impl_modified_signing_key_test {
 
             modify_signing_key::<{ $signing_key_size }>(&mut key_pair.signing_key.0);
 
-            let signature = $sign(&key_pair.signing_key, &message, signing_randomness);
+            let signature = $sign(&key_pair.signing_key, &message, signing_randomness)
+                .expect("Rejection sampling failure probability is < 2⁻¹²⁸");
 
             assert!($verify(&key_pair.verification_key, &message, &signature).is_err());
         }

--- a/libcrux-ml-dsa/tests/wycheproof_sign.rs
+++ b/libcrux-ml-dsa/tests/wycheproof_sign.rs
@@ -48,7 +48,8 @@ macro_rules! wycheproof_sign_test {
                 for test in test_group.tests {
                     let message = hex::decode(test.msg).unwrap();
 
-                    let signature = $sign(&signing_key, &message, signing_randomness);
+                    let signature = $sign(&signing_key, &message, signing_randomness)
+                        .expect("Rejection sampling failure probability is < 2⁻¹²⁸");
 
                     if test.result == Result::Valid {
                         assert_eq!(


### PR DESCRIPTION
This PR will make it possible to extract ML-DSA to F*.

- [x] Cast `match` scrutinees to known-size types as a workaround for https://github.com/hacspec/hax/issues/464
- [x] Replace `loop/continue/break`-style rejection sampling with a bounded loop. As @xvzcf had already pointed out, the probability of the bounded rejection sampling to not succeed within 576 attempts is smaller than 2^128. Nonetheless, I've introduced a `SigningError` type to indicate this, so we don't panic, even in this most unlikely case.
- [ ] `RefMut` issues in `encoding::signature`
- [ ] `FunctionalizeLoops` issue in `encoding::signature`