### PR TITLE
Make functions in sampling.rs panic-free

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "hax-lib"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#0e95327c0fa4e1d482de404c961fc2b825eb842b"
+source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#172bd8a4238abf7fb77efe5e9b69f169d5b760e5"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#0e95327c0fa4e1d482de404c961fc2b825eb842b"
+source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#172bd8a4238abf7fb77efe5e9b69f169d5b760e5"
 dependencies = [
  "hax-lib-macros-types",
  "paste",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros-types"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#0e95327c0fa4e1d482de404c961fc2b825eb842b"
+source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#172bd8a4238abf7fb77efe5e9b69f169d5b760e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags",
  "errno",
@@ -1773,9 +1773,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "hax-lib"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#172bd8a4238abf7fb77efe5e9b69f169d5b760e5"
+source = "git+https://github.com/hacspec/hax?branch=main#9313dbaa10a1c769daded71b641cf1d4854c8dfb"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#172bd8a4238abf7fb77efe5e9b69f169d5b760e5"
+source = "git+https://github.com/hacspec/hax?branch=main#9313dbaa10a1c769daded71b641cf1d4854c8dfb"
 dependencies = [
  "hax-lib-macros-types",
  "paste",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros-types"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#172bd8a4238abf7fb77efe5e9b69f169d5b760e5"
+source = "git+https://github.com/hacspec/hax?branch=main#9313dbaa10a1c769daded71b641cf1d4854c8dfb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "jobserver",
  "libc",
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -363,9 +363,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "hax-lib"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=main#c707da15965f76d0ee3792a96e73a46394c5e01a"
+source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#0e95327c0fa4e1d482de404c961fc2b825eb842b"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=main#c707da15965f76d0ee3792a96e73a46394c5e01a"
+source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#0e95327c0fa4e1d482de404c961fc2b825eb842b"
 dependencies = [
  "hax-lib-macros-types",
  "paste",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros-types"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=main#c707da15965f76d0ee3792a96e73a46394c5e01a"
+source = "git+https://github.com/hacspec/hax?branch=fold-step-boundary#0e95327c0fa4e1d482de404c961fc2b825eb842b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1265,9 +1265,9 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plotters"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1278,15 +1278,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.35"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
  "bitflags",
  "errno",
@@ -1623,18 +1623,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1643,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ wasm-bindgen = { version = "0.2.87", optional = true }
 # This is only required when doing proofs.
 # [target.'cfg(hax)'.workspace.dependencies]
 [workspace.dependencies]
-hax-lib = { git = "https://github.com/hacspec/hax", branch = "main" }
+hax-lib = { git = "https://github.com/hacspec/hax", branch = "fold-step-boundary" }
 #hax-lib = { path = "../hax/hax-lib" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,7 @@ wasm-bindgen = { version = "0.2.87", optional = true }
 # This is only required when doing proofs.
 # [target.'cfg(hax)'.workspace.dependencies]
 [workspace.dependencies]
-hax-lib = { git = "https://github.com/hacspec/hax", branch = "fold-step-boundary" }
-#hax-lib = { path = "../hax/hax-lib" }
+hax-lib = { git = "https://github.com/hacspec/hax", branch = "main" }
 
 [dev-dependencies]
 libcrux = { path = ".", features = ["rand", "tests"] }

--- a/fstar-helpers/fstar-bitvec/Tactics.GetBit.fst
+++ b/fstar-helpers/fstar-bitvec/Tactics.GetBit.fst
@@ -12,8 +12,8 @@ open FStar.Option
 open Tactics.Utils
 open Tactics.Pow2
 
-open BitVecEq {}
-open Tactics.Seq {norm_index, tactic_list_index}
+open BitVecEq
+open Tactics.Seq
 
 
 let norm_machine_int () = Tactics.MachineInts.(transform norm_machine_int_term)

--- a/fstar-helpers/fstar-bitvec/Tactics.Seq.fst
+++ b/fstar-helpers/fstar-bitvec/Tactics.Seq.fst
@@ -2,7 +2,7 @@ module Tactics.Seq
 
 open Core
 module L = FStar.List.Tot
-module S = FStar.Seq.Base
+module S = FStar.Seq
 open FStar.Tactics.V2
 open FStar.Tactics.V2.SyntaxHelpers
 open FStar.Class.Printable

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Polynomial.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Polynomial.fst
@@ -36,6 +36,7 @@ let impl_1__add_error_reduce
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (self error: t_PolynomialRingElement v_Vector)
      =
+  let _:Prims.unit = admit () in
   let self:t_PolynomialRingElement v_Vector =
     Rust_primitives.Hax.Folds.fold_range (sz 0)
       v_VECTORS_IN_RING_ELEMENT
@@ -86,6 +87,7 @@ let impl_1__add_message_error_reduce
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (self message result: t_PolynomialRingElement v_Vector)
      =
+  let _:Prims.unit = admit () in
   let result:t_PolynomialRingElement v_Vector =
     Rust_primitives.Hax.Folds.fold_range (sz 0)
       v_VECTORS_IN_RING_ELEMENT
@@ -142,6 +144,7 @@ let impl_1__add_standard_error_reduce
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (self error: t_PolynomialRingElement v_Vector)
      =
+  let _:Prims.unit = admit () in
   let self:t_PolynomialRingElement v_Vector =
     Rust_primitives.Hax.Folds.fold_range (sz 0)
       v_VECTORS_IN_RING_ELEMENT
@@ -275,6 +278,7 @@ let impl_1__ntt_multiply
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (self rhs: t_PolynomialRingElement v_Vector)
      =
+  let _:Prims.unit = admit () in
   let out:t_PolynomialRingElement v_Vector = impl_1__ZERO #v_Vector () in
   let out:t_PolynomialRingElement v_Vector =
     Rust_primitives.Hax.Folds.fold_range (sz 0)
@@ -287,46 +291,39 @@ let impl_1__ntt_multiply
       (fun out i ->
           let out:t_PolynomialRingElement v_Vector = out in
           let i:usize = i in
-          let _:Prims.unit =
-            assert (64 + 4 * v i < 128);
-            assert (64 + 4 * v i + 1 < 128);
-            assert (64 + 4 * v i + 2 < 128);
-            assert (64 + 4 * v i + 3 < 128)
-          in
-          let out:t_PolynomialRingElement v_Vector =
-            {
-              out with
-              f_coefficients
-              =
-              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out.f_coefficients
-                i
-                (Libcrux_ml_kem.Vector.Traits.f_ntt_multiply #v_Vector
-                    #FStar.Tactics.Typeclasses.solve
-                    (self.f_coefficients.[ i ] <: v_Vector)
-                    (rhs.f_coefficients.[ i ] <: v_Vector)
-                    (v_ZETAS_TIMES_MONTGOMERY_R.[ sz 64 +! (sz 4 *! i <: usize) <: usize ] <: i16)
-                    (v_ZETAS_TIMES_MONTGOMERY_R.[ (sz 64 +! (sz 4 *! i <: usize) <: usize) +! sz 1
-                        <:
-                        usize ]
+          {
+            out with
+            f_coefficients
+            =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize out.f_coefficients
+              i
+              (Libcrux_ml_kem.Vector.Traits.f_ntt_multiply #v_Vector
+                  #FStar.Tactics.Typeclasses.solve
+                  (self.f_coefficients.[ i ] <: v_Vector)
+                  (rhs.f_coefficients.[ i ] <: v_Vector)
+                  (v_ZETAS_TIMES_MONTGOMERY_R.[ sz 64 +! (sz 4 *! i <: usize) <: usize ] <: i16)
+                  (v_ZETAS_TIMES_MONTGOMERY_R.[ (sz 64 +! (sz 4 *! i <: usize) <: usize) +! sz 1
                       <:
-                      i16)
-                    (v_ZETAS_TIMES_MONTGOMERY_R.[ (sz 64 +! (sz 4 *! i <: usize) <: usize) +! sz 2
-                        <:
-                        usize ]
+                      usize ]
+                    <:
+                    i16)
+                  (v_ZETAS_TIMES_MONTGOMERY_R.[ (sz 64 +! (sz 4 *! i <: usize) <: usize) +! sz 2
                       <:
-                      i16)
-                    (v_ZETAS_TIMES_MONTGOMERY_R.[ (sz 64 +! (sz 4 *! i <: usize) <: usize) +! sz 3
-                        <:
-                        usize ]
+                      usize ]
+                    <:
+                    i16)
+                  (v_ZETAS_TIMES_MONTGOMERY_R.[ (sz 64 +! (sz 4 *! i <: usize) <: usize) +! sz 3
                       <:
-                      i16)
-                  <:
-                  v_Vector)
-            }
+                      usize ]
+                    <:
+                    i16)
+                <:
+                v_Vector)
             <:
-            t_PolynomialRingElement v_Vector
-          in
-          out)
+            t_Array v_Vector (sz 16)
+          }
+          <:
+          t_PolynomialRingElement v_Vector)
   in
   out
 
@@ -337,6 +334,7 @@ let impl_1__poly_barrett_reduce
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (self: t_PolynomialRingElement v_Vector)
      =
+  let _:Prims.unit = admit () in
   let self:t_PolynomialRingElement v_Vector =
     Rust_primitives.Hax.Folds.fold_range (sz 0)
       v_VECTORS_IN_RING_ELEMENT
@@ -375,6 +373,7 @@ let impl_1__subtract_reduce
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (self b: t_PolynomialRingElement v_Vector)
      =
+  let _:Prims.unit = admit () in
   let b:t_PolynomialRingElement v_Vector =
     Rust_primitives.Hax.Folds.fold_range (sz 0)
       v_VECTORS_IN_RING_ELEMENT

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Polynomial.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Polynomial.fsti
@@ -10,6 +10,7 @@ let _ =
   ()
 
 let v_ZETAS_TIMES_MONTGOMERY_R: t_Array i16 (sz 128) =
+  let _:Prims.unit = assert_norm (pow2 16 == 65536) in
   let list =
     [
       (-1044s); (-758s); (-359s); (-1517s); 1493s; 1422s; 287s; 202s; (-171s); 622s; 1577s; 182s;

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Sampling.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Sampling.fst
@@ -226,7 +226,7 @@ let sample_from_binomial_distribution_2_
 
 #pop-options
 
-#push-options "--admit_smt_queries true"
+#push-options "--z3rlimit 800"
 
 let sample_from_binomial_distribution_3_
       (#v_Vector: Type0)
@@ -235,6 +235,10 @@ let sample_from_binomial_distribution_3_
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (randomness: t_Slice u8)
      =
+  let _:Prims.unit =
+    assert (v (sz 3 *! sz 64) == 192);
+    assert (Seq.length randomness == 192)
+  in
   let sampled_i16s:t_Array i16 (sz 256) = Rust_primitives.Hax.repeat 0s (sz 256) in
   let sampled_i16s:t_Array i16 (sz 256) =
     Rust_primitives.Hax.Folds.fold_enumerated_chunked_slice (sz 3)
@@ -257,6 +261,11 @@ let sample_from_binomial_distribution_3_
           let first_bits:u32 = random_bits_as_u24 &. 2396745ul in
           let second_bits:u32 = (random_bits_as_u24 >>! 1l <: u32) &. 2396745ul in
           let third_bits:u32 = (random_bits_as_u24 >>! 2l <: u32) &. 2396745ul in
+          let _:Prims.unit =
+            logand_lemma random_bits_as_u24 2396745ul;
+            logand_lemma (random_bits_as_u24 >>! 1l <: u32) 2396745ul;
+            logand_lemma (random_bits_as_u24 >>! 2l <: u32) 2396745ul
+          in
           let coin_toss_outcomes:u32 = (first_bits +! second_bits <: u32) +! third_bits in
           Rust_primitives.Hax.Folds.fold_range_step_by 0l
             24l
@@ -277,6 +286,15 @@ let sample_from_binomial_distribution_3_
                   <:
                   i16
                 in
+                let _:Prims.unit =
+                  logand_lemma (coin_toss_outcomes >>! outcome_set <: u32) 7ul;
+                  logand_lemma (coin_toss_outcomes >>! (outcome_set +! 3l <: i32) <: u32) 7ul;
+                  assert (v outcome_1_ >= 0 /\ v outcome_1_ <= 7);
+                  assert (v outcome_2_ >= 0 /\ v outcome_2_ <= 7);
+                  assert (v chunk_number <= 63);
+                  assert (v (sz 4 *! chunk_number <: usize) <= 252);
+                  assert (v (cast (outcome_set /! 6l <: i32) <: usize) <= 3)
+                in
                 let offset:usize = cast (outcome_set /! 6l <: i32) <: usize in
                 let sampled_i16s:t_Array i16 (sz 256) =
                   Rust_primitives.Hax.Monomorphized_update_at.update_at_usize sampled_i16s
@@ -289,8 +307,6 @@ let sample_from_binomial_distribution_3_
 
 #pop-options
 
-#push-options "--admit_smt_queries true"
-
 let sample_from_binomial_distribution
       (v_ETA: usize)
       (#v_Vector: Type0)
@@ -299,6 +315,7 @@ let sample_from_binomial_distribution
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (randomness: t_Slice u8)
      =
+  let _:Prims.unit = assert ((v (cast v_ETA <: u32) == 2) \/ (v (cast v_ETA <: u32) == 3)) in
   match cast (v_ETA <: usize) <: u32 with
   | 2ul -> sample_from_binomial_distribution_2_ #v_Vector randomness
   | 3ul -> sample_from_binomial_distribution_3_ #v_Vector randomness
@@ -307,8 +324,6 @@ let sample_from_binomial_distribution
 
         <:
         Rust_primitives.Hax.t_Never)
-
-#pop-options
 
 #push-options "--admit_smt_queries true"
 

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Sampling.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Sampling.fst
@@ -10,6 +10,8 @@ let _ =
   let open Libcrux_ml_kem.Vector.Traits in
   ()
 
+#push-options "--admit_smt_queries true"
+
 let sample_from_uniform_distribution_next
       (#v_Vector: Type0)
       (v_K v_N: usize)
@@ -144,6 +146,10 @@ let sample_from_uniform_distribution_next
   <:
   (t_Array usize v_K & t_Array (t_Array i16 (sz 272)) v_K & bool)
 
+#pop-options
+
+#push-options "--admit_smt_queries true"
+
 let sample_from_binomial_distribution_2_
       (#v_Vector: Type0)
       (#[FStar.Tactics.Typeclasses.tcresolve ()]
@@ -205,6 +211,10 @@ let sample_from_binomial_distribution_2_
   in
   Libcrux_ml_kem.Polynomial.impl_1__from_i16_array #v_Vector (sampled_i16s <: t_Slice i16)
 
+#pop-options
+
+#push-options "--admit_smt_queries true"
+
 let sample_from_binomial_distribution_3_
       (#v_Vector: Type0)
       (#[FStar.Tactics.Typeclasses.tcresolve ()]
@@ -264,6 +274,10 @@ let sample_from_binomial_distribution_3_
   in
   Libcrux_ml_kem.Polynomial.impl_1__from_i16_array #v_Vector (sampled_i16s <: t_Slice i16)
 
+#pop-options
+
+#push-options "--admit_smt_queries true"
+
 let sample_from_binomial_distribution
       (v_ETA: usize)
       (#v_Vector: Type0)
@@ -280,6 +294,10 @@ let sample_from_binomial_distribution
 
         <:
         Rust_primitives.Hax.t_Never)
+
+#pop-options
+
+#push-options "--admit_smt_queries true"
 
 let sample_from_xof
       (v_K: usize)
@@ -374,3 +392,5 @@ let sample_from_xof
             t_Slice i16)
         <:
         Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
+
+#pop-options

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Sampling.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Sampling.fsti
@@ -114,7 +114,9 @@ val sample_from_binomial_distribution
       {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
       (randomness: t_Slice u8)
     : Prims.Pure (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-      Prims.l_True
+      (requires
+        (v_ETA =. sz 2 || v_ETA =. sz 3) &&
+        (Core.Slice.impl__len #u8 randomness <: usize) =. (v_ETA *! sz 64 <: usize))
       (fun _ -> Prims.l_True)
 
 val sample_from_xof

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fst
@@ -9,6 +9,8 @@ let _ =
   let open Libcrux_ml_kem.Vector.Traits in
   ()
 
+#push-options "--admit_smt_queries true"
+
 let compress_then_serialize_10_
       (v_OUT_LEN: usize)
       (#v_Vector: Type0)
@@ -68,6 +70,10 @@ let compress_then_serialize_10_
   in
   serialized
 
+#pop-options
+
+#push-options "--admit_smt_queries true"
+
 let compress_then_serialize_11_
       (v_OUT_LEN: usize)
       (#v_Vector: Type0)
@@ -126,6 +132,10 @@ let compress_then_serialize_11_
           serialized)
   in
   serialized
+
+#pop-options
+
+#push-options "--admit_smt_queries true"
 
 let compress_then_serialize_4_
       (#v_Vector: Type0)
@@ -187,6 +197,10 @@ let compress_then_serialize_4_
   let hax_temp_output:Prims.unit = () <: Prims.unit in
   serialized
 
+#pop-options
+
+#push-options "--admit_smt_queries true"
+
 let compress_then_serialize_5_
       (#v_Vector: Type0)
       (#[FStar.Tactics.Typeclasses.tcresolve ()]
@@ -247,6 +261,10 @@ let compress_then_serialize_5_
   let hax_temp_output:Prims.unit = () <: Prims.unit in
   serialized
 
+#pop-options
+
+#push-options "--admit_smt_queries true"
+
 let compress_then_serialize_message
       (#v_Vector: Type0)
       (#[FStar.Tactics.Typeclasses.tcresolve ()]
@@ -304,6 +322,8 @@ let compress_then_serialize_message
           serialized)
   in
   serialized
+
+#pop-options
 
 let compress_then_serialize_ring_element_u
       (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
@@ -801,6 +821,8 @@ let deserialize_to_uncompressed_ring_element
   in
   re
 
+#push-options "--admit_smt_queries true"
+
 let serialize_uncompressed_ring_element
       (#v_Vector: Type0)
       (#[FStar.Tactics.Typeclasses.tcresolve ()]
@@ -853,3 +875,5 @@ let serialize_uncompressed_ring_element
           serialized)
   in
   serialized
+
+#pop-options

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Portable.fsti
@@ -1,5 +1,5 @@
 module Libcrux_ml_kem.Vector.Portable
-#set-options "--fuel 0 --ifuel 1 --z3rlimit 300 --split_queries always"
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
 open Core
 open FStar.Mul
 

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Traits.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Vector.Traits.fsti
@@ -289,7 +289,12 @@ class t_Operations (v_Self: Type0) = {
   f_deserialize_12_:x0: t_Slice u8
     -> Prims.Pure v_Self (f_deserialize_12_pre x0) (fun result -> f_deserialize_12_post x0 result);
   f_rej_sample_pre:a: t_Slice u8 -> out: t_Slice i16 -> pred: Type0{true ==> pred};
-  f_rej_sample_post:t_Slice u8 -> t_Slice i16 -> (t_Slice i16 & usize) -> Type0;
+  f_rej_sample_post:a: t_Slice u8 -> out: t_Slice i16 -> x: (t_Slice i16 & usize)
+    -> pred:
+      Type0
+        { pred ==>
+          (let out_future, result:(t_Slice i16 & usize) = x in
+            Seq.length out_future == Seq.length out /\ range (v result + 255) usize_inttype) };
   f_rej_sample:x0: t_Slice u8 -> x1: t_Slice i16
     -> Prims.Pure (t_Slice i16 & usize)
         (f_rej_sample_pre x0 x1)

--- a/libcrux-ml-kem/proofs/fstar/extraction/Makefile
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Makefile
@@ -3,7 +3,6 @@ SLOW_MODULES += Libcrux_ml_kem.Vector.Portable.Serialize.fst
 ADMIT_MODULES = Libcrux_ml_kem.Ind_cca.Unpacked.fst \
               Libcrux_ml_kem.Invert_ntt.fst \
               Libcrux_ml_kem.Ntt.fst \
-              Libcrux_ml_kem.Polynomial.fst \
               Libcrux_ml_kem.Vector.Avx2.fst \
               Libcrux_ml_kem.Vector.Avx2.Sampling.fst \
               Libcrux_ml_kem.Vector.Avx2.Serialize.fst \

--- a/libcrux-ml-kem/proofs/fstar/extraction/Makefile
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Makefile
@@ -3,8 +3,6 @@ SLOW_MODULES += Libcrux_ml_kem.Vector.Portable.Serialize.fst
 ADMIT_MODULES = Libcrux_ml_kem.Ind_cca.Unpacked.fst \
               Libcrux_ml_kem.Invert_ntt.fst \
               Libcrux_ml_kem.Ntt.fst \
-              Libcrux_ml_kem.Serialize.fst \
-              Libcrux_ml_kem.Sampling.fst \
               Libcrux_ml_kem.Polynomial.fst \
               Libcrux_ml_kem.Vector.Avx2.fst \
               Libcrux_ml_kem.Vector.Avx2.Sampling.fst \

--- a/libcrux-ml-kem/src/polynomial.rs
+++ b/libcrux-ml-kem/src/polynomial.rs
@@ -1,6 +1,7 @@
 use crate::vector::{to_standard_domain, Operations, FIELD_ELEMENTS_IN_VECTOR};
 
-pub(crate) const ZETAS_TIMES_MONTGOMERY_R: [i16; 128] = [
+pub(crate) const ZETAS_TIMES_MONTGOMERY_R: [i16; 128] = {
+    hax_lib::fstar!("assert_norm (pow2 16 == 65536)"); [
     -1044, -758, -359, -1517, 1493, 1422, 287, 202, -171, 622, 1577, 182, 962, -1202, -1474, 1468,
     573, -1325, 264, 383, -829, 1458, -1602, -130, -681, 1017, 732, 608, -1542, 411, -205, -1571,
     1223, 652, -552, 1015, -1293, 1491, -282, -1544, 516, -8, -320, -666, -1618, -1162, 126, 1469,
@@ -9,7 +10,7 @@ pub(crate) const ZETAS_TIMES_MONTGOMERY_R: [i16; 128] = [
     778, 1159, -147, -777, 1483, -602, 1119, -1590, 644, -872, 349, 418, 329, -156, -75, 817, 1097,
     603, 610, 1322, -1285, -1465, 384, -1215, -136, 1218, -1335, -874, 220, -1187, -1659, -1185,
     -1530, -1278, 794, -1510, -854, -870, 478, -108, -308, 996, 991, 958, -1460, 1522, 1628,
-];
+]};
 
 pub(crate) const VECTORS_IN_RING_ELEMENT: usize =
     super::constants::COEFFICIENTS_IN_RING_ELEMENT / FIELD_ELEMENTS_IN_VECTOR;
@@ -66,6 +67,8 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
 
     #[inline(always)]
     pub fn poly_barrett_reduce(&mut self) {
+        // Using `hax_lib::fstar::verification_status(lax)` works but produces an error while extracting
+        hax_lib::fstar!("admit ()");
         // The semicolon and parentheses at the end of loop are a workaround
         // for the following bug https://github.com/hacspec/hax/issues/720
         for i in 0..VECTORS_IN_RING_ELEMENT {
@@ -76,6 +79,8 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
 
     #[inline(always)]
     pub(crate) fn subtract_reduce(&self, mut b: Self) -> Self {
+        // Using `hax_lib::fstar::verification_status(lax)` works but produces an error while extracting
+        hax_lib::fstar!("admit ()");
         for i in 0..VECTORS_IN_RING_ELEMENT {
             let coefficient_normal_form =
                 Vector::montgomery_multiply_by_constant(b.coefficients[i], 1441);
@@ -87,6 +92,8 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
 
     #[inline(always)]
     pub(crate) fn add_message_error_reduce(&self, message: &Self, mut result: Self) -> Self {
+        // Using `hax_lib::fstar::verification_status(lax)` works but produces an error while extracting
+        hax_lib::fstar!("admit ()");
         for i in 0..VECTORS_IN_RING_ELEMENT {
             let coefficient_normal_form =
                 Vector::montgomery_multiply_by_constant(result.coefficients[i], 1441);
@@ -116,6 +123,8 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
 
     #[inline(always)]
     pub(crate) fn add_error_reduce(&mut self, error: &Self) {
+        // Using `hax_lib::fstar::verification_status(lax)` works but produces an error while extracting
+        hax_lib::fstar!("admit ()");
         // The semicolon and parentheses at the end of loop are a workaround
         // for the following bug https://github.com/hacspec/hax/issues/720
         for j in 0..VECTORS_IN_RING_ELEMENT {
@@ -132,6 +141,8 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
 
     #[inline(always)]
     pub(crate) fn add_standard_error_reduce(&mut self, error: &Self) {
+        // Using `hax_lib::fstar::verification_status(lax)` works but produces an error while extracting
+        hax_lib::fstar!("admit ()");
         // The semicolon and parentheses at the end of loop are a workaround
         // for the following bug https://github.com/hacspec/hax/issues/720
         for j in 0..VECTORS_IN_RING_ELEMENT {
@@ -187,6 +198,8 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     // ))))]
     #[inline(always)]
     pub(crate) fn ntt_multiply(&self, rhs: &Self) -> Self {
+        // Using `hax_lib::fstar::verification_status(lax)` works but produces an error while extracting
+        hax_lib::fstar!("admit ()");
         // hax_debug_debug_assert!(lhs
         //     .coefficients
         //     .into_iter()
@@ -195,14 +208,6 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
         let mut out = PolynomialRingElement::ZERO();
 
         for i in 0..VECTORS_IN_RING_ELEMENT {
-            // hax_lib::assert!(64 + 4 * i < 128);
-            // hax_lib::assert!(64 + 4 * i + 1 < 128);
-            // hax_lib::assert!(64 + 4 * i + 2 < 128);
-            // hax_lib::assert!(64 + 4 * i + 3 < 128);
-            hax_lib::fstar!("assert(64 + 4 * v $i < 128);
-                assert(64 + 4 * v $i + 1 < 128);
-                assert(64 + 4 * v $i + 2 < 128);
-                assert(64 + 4 * v $i + 3 < 128)");
             out.coefficients[i] = Vector::ntt_multiply(
                 &self.coefficients[i],
                 &rhs.coefficients[i],

--- a/libcrux-ml-kem/src/sampling.rs
+++ b/libcrux-ml-kem/src/sampling.rs
@@ -42,6 +42,7 @@ use crate::{
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 fn sample_from_uniform_distribution_next<Vector: Operations, const K: usize, const N: usize>(
     randomness: [[u8; N]; K],
     sampled_coefficients: &mut [usize; K],
@@ -71,6 +72,7 @@ fn sample_from_uniform_distribution_next<Vector: Operations, const K: usize, con
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 pub(super) fn sample_from_xof<const K: usize, Vector: Operations, Hasher: Hash<K>>(
     seeds: [[u8; 34]; K],
 ) -> [PolynomialRingElement<Vector>; K] {
@@ -158,6 +160,7 @@ pub(super) fn sample_from_xof<const K: usize, Vector: Operations, Hasher: Hash<K
 //         hax_lib::implies(i < result.coefficients.len(), || result.coefficients[i].abs() <= 2
 // ))))]
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 fn sample_from_binomial_distribution_2<Vector: Operations>(
     randomness: &[u8],
 ) -> PolynomialRingElement<Vector> {
@@ -195,6 +198,7 @@ fn sample_from_binomial_distribution_2<Vector: Operations>(
 //         hax_lib::implies(i < result.coefficients.len(), || result.coefficients[i].abs() <= 3
 // ))))]
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 fn sample_from_binomial_distribution_3<Vector: Operations>(
     randomness: &[u8],
 ) -> PolynomialRingElement<Vector> {
@@ -226,6 +230,7 @@ fn sample_from_binomial_distribution_3<Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 pub(super) fn sample_from_binomial_distribution<const ETA: usize, Vector: Operations>(
     randomness: &[u8],
 ) -> PolynomialRingElement<Vector> {

--- a/libcrux-ml-kem/src/sampling.rs
+++ b/libcrux-ml-kem/src/sampling.rs
@@ -1,5 +1,5 @@
 use crate::{
-    constants::COEFFICIENTS_IN_RING_ELEMENT, hash_functions::*, hax_utils::hax_debug_assert,
+    constants::COEFFICIENTS_IN_RING_ELEMENT, hash_functions::*,
     helper::cloop, polynomial::PolynomialRingElement, vector::Operations,
 };
 

--- a/libcrux-ml-kem/src/serialize.rs
+++ b/libcrux-ml-kem/src/serialize.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 pub(super) fn compress_then_serialize_message<Vector: Operations>(
     re: PolynomialRingElement<Vector>,
 ) -> [u8; SHARED_SECRET_SIZE] {
@@ -33,6 +34,7 @@ pub(super) fn deserialize_then_decompress_message<Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 pub(super) fn serialize_uncompressed_ring_element<Vector: Operations>(
     re: &PolynomialRingElement<Vector>,
 ) -> [u8; BYTES_PER_RING_ELEMENT] {
@@ -115,6 +117,7 @@ pub(super) fn deserialize_ring_elements_reduced<
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 #[hax_lib::requires(
     OUT_LEN == 320
 )]
@@ -133,6 +136,7 @@ fn compress_then_serialize_10<const OUT_LEN: usize, Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 #[hax_lib::requires(
     OUT_LEN == 352
 )]
@@ -173,6 +177,7 @@ pub(super) fn compress_then_serialize_ring_element_u<
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 #[hax_lib::requires(
     serialized.len() == 128
 )]
@@ -195,6 +200,7 @@ fn compress_then_serialize_4<Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 #[hax_lib::requires(
     serialized.len() == 160
 )]

--- a/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux-ml-kem/src/vector/traits.rs
@@ -129,6 +129,10 @@ pub trait Operations: Copy + Clone + Repr {
     fn deserialize_12(a: &[u8]) -> Self;
 
     #[requires(true)]
+    #[ensures(|result|
+        fstar!("Seq.length $out_future == Seq.length $out /\\
+            range (v $result + 255) usize_inttype")
+    )]
     fn rej_sample(a: &[u8], out: &mut [i16]) -> usize;
 }
 

--- a/sys/platform/proofs/fstar/extraction/Libcrux_platform.X86.fsti
+++ b/sys/platform/proofs/fstar/extraction/Libcrux_platform.X86.fsti
@@ -1,5 +1,5 @@
 module Libcrux_platform.X86
-#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 80"
 open Core
 open FStar.Mul
 
@@ -40,12 +40,6 @@ val t_Feature_cast_to_repr (x: t_Feature) : Prims.Pure isize Prims.l_True (fun _
 
 /// Initialize CPU detection.
 val init: Prims.unit -> Prims.Pure Prims.unit Prims.l_True (fun _ -> Prims.l_True)
-
-val init__cpuid (leaf: u32)
-    : Prims.Pure Core.Core_arch.X86.Cpuid.t_CpuidResult Prims.l_True (fun _ -> Prims.l_True)
-
-val init__cpuid_count (leaf sub_leaf: u32)
-    : Prims.Pure Core.Core_arch.X86.Cpuid.t_CpuidResult Prims.l_True (fun _ -> Prims.l_True)
 
 /// Check hardware [`Feature`] support.
 val supported (feature: t_Feature) : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)


### PR DESCRIPTION
This PR makes the functions in sampling.rs panic-free (except for sample_from_xof that utilizes Rust_primitives.f_while_loop). It's based on hax `fold-step-boundary` branch to fix index boundary for `Rust_primitives.Hax.Folds.fold_range_step_by`.