### PR TITLE
Fix ML-DSA benchmarks

### DIFF
--- a/.github/workflows/mldsa.yml
+++ b/.github/workflows/mldsa.yml
@@ -98,3 +98,9 @@ jobs:
         run: |
           cargo clean
           cargo test --verbose --release $RUST_TARGET_FLAG
+
+      # Benchmarks
+      - name: 🔨 Build Benchmarks
+        run: |
+          cargo clean
+          cargo bench --no-run

--- a/libcrux-ml-dsa/benches/bench_utils.rs
+++ b/libcrux-ml-dsa/benches/bench_utils.rs
@@ -116,7 +116,8 @@ macro_rules! bench_group_libcrux {
                 let signing_randomness: [u8; SIGNING_RANDOMNESS_SIZE] = bench_utils::random_array();
                 let message = bench_utils::random_array::<1023>();
                 let keypair = p::generate_key_pair(key_generation_seed);
-                let signature = p::sign(&keypair.signing_key, &message, signing_randomness).unwrap();
+                let signature =
+                    p::sign(&keypair.signing_key, &message, signing_randomness).unwrap();
                 (keypair, message, signature)
             },
             |(keypair, message, signature): ($keypair_t, [u8; 1023], $signature_t)| {

--- a/libcrux-ml-dsa/benches/bench_utils.rs
+++ b/libcrux-ml-dsa/benches/bench_utils.rs
@@ -51,7 +51,7 @@ macro_rules! bench {
         // Warmup
         for _ in 0..bench_utils::WARMUP_ITERATIONS {
             let input = $setup($input);
-            $routine(input);
+            let _ = $routine(input);
         }
 
         // Benchmark
@@ -59,7 +59,7 @@ macro_rules! bench {
             let input = $setup($input);
 
             let start = std::time::Instant::now();
-            core::hint::black_box($routine(input));
+            let _ = core::hint::black_box($routine(input));
             let end = std::time::Instant::now();
 
             time += end.duration_since(start);
@@ -116,7 +116,7 @@ macro_rules! bench_group_libcrux {
                 let signing_randomness: [u8; SIGNING_RANDOMNESS_SIZE] = bench_utils::random_array();
                 let message = bench_utils::random_array::<1023>();
                 let keypair = p::generate_key_pair(key_generation_seed);
-                let signature = p::sign(&keypair.signing_key, &message, signing_randomness);
+                let signature = p::sign(&keypair.signing_key, &message, signing_randomness).unwrap();
                 (keypair, message, signature)
             },
             |(keypair, message, signature): ($keypair_t, [u8; 1023], $signature_t)| {

--- a/libcrux-ml-dsa/benches/ml-dsa.rs
+++ b/libcrux-ml-dsa/benches/ml-dsa.rs
@@ -67,7 +67,7 @@ pub fn comparisons_verification(c: &mut Criterion) {
     let keypair = ml_dsa_65::generate_key_pair(randomness);
 
     rng.fill_bytes(&mut randomness);
-    let signature = ml_dsa_65::sign(&keypair.signing_key, &message, randomness);
+    let signature = ml_dsa_65::sign(&keypair.signing_key, &message, randomness).unwrap();
 
     group.bench_function("libcrux", move |b| {
         b.iter(|| {


### PR DESCRIPTION
As a first step in addressing #571, it would be nice to be able to run some benchmarks. Unfortunately, with #558, I broke benchmarks on `main` and didn't notice. This fixes the benchmarks and includes a `--no-run` build of the benchmarks on CI for the future.