### PR TITLE
Add proofs for Ind_cpa functions

### DIFF
--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Hash_functions.Avx2.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Hash_functions.Avx2.fsti
@@ -28,7 +28,12 @@ val v_PRF (v_LEN: usize) (input: t_Slice u8)
           result == Spec.Utils.v_PRF v_LEN input)
 
 val v_PRFxN (v_K v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K)
-    : Prims.Pure (t_Array (t_Array u8 v_LEN) v_K) Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Array (t_Array u8 v_LEN) v_K)
+      (requires v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4))
+      (ensures
+        fun result ->
+          let result:t_Array (t_Array u8 v_LEN) v_K = result in
+          result == Spec.Utils.v_PRFxN v_K v_LEN input)
 
 /// The state.
 /// It\'s only used for SHAKE128.
@@ -73,7 +78,8 @@ let impl (v_K: usize) : Libcrux_ml_kem.Hash_functions.t_Hash t_Simd256Hash v_K =
     f_PRF = (fun (v_LEN: usize) (input: t_Slice u8) -> v_PRF v_LEN input);
     f_PRFxN_pre
     =
-    (fun (v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) -> true);
+    (fun (v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) ->
+        v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4));
     f_PRFxN_post
     =
     (fun
@@ -81,7 +87,8 @@ let impl (v_K: usize) : Libcrux_ml_kem.Hash_functions.t_Hash t_Simd256Hash v_K =
         (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K)
         (out: t_Array (t_Array u8 v_LEN) v_K)
         ->
-        true);
+        (v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4)) ==>
+        out == Spec.Utils.v_PRFxN v_K v_LEN input);
     f_PRFxN
     =
     (fun (v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) ->

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Hash_functions.Neon.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Hash_functions.Neon.fsti
@@ -28,7 +28,12 @@ val v_PRF (v_LEN: usize) (input: t_Slice u8)
           result == Spec.Utils.v_PRF v_LEN input)
 
 val v_PRFxN (v_K v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K)
-    : Prims.Pure (t_Array (t_Array u8 v_LEN) v_K) Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Array (t_Array u8 v_LEN) v_K)
+      (requires v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4))
+      (ensures
+        fun result ->
+          let result:t_Array (t_Array u8 v_LEN) v_K = result in
+          result == Spec.Utils.v_PRFxN v_K v_LEN input)
 
 /// The state.
 /// It\'s only used for SHAKE128.
@@ -73,7 +78,8 @@ let impl (v_K: usize) : Libcrux_ml_kem.Hash_functions.t_Hash t_Simd128Hash v_K =
     f_PRF = (fun (v_LEN: usize) (input: t_Slice u8) -> v_PRF v_LEN input);
     f_PRFxN_pre
     =
-    (fun (v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) -> true);
+    (fun (v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) ->
+        v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4));
     f_PRFxN_post
     =
     (fun
@@ -81,7 +87,8 @@ let impl (v_K: usize) : Libcrux_ml_kem.Hash_functions.t_Hash t_Simd128Hash v_K =
         (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K)
         (out: t_Array (t_Array u8 v_LEN) v_K)
         ->
-        true);
+        (v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4)) ==>
+        out == Spec.Utils.v_PRFxN v_K v_LEN input);
     f_PRFxN
     =
     (fun (v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) ->

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Hash_functions.Portable.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Hash_functions.Portable.fsti
@@ -28,7 +28,12 @@ val v_PRF (v_LEN: usize) (input: t_Slice u8)
           result == Spec.Utils.v_PRF v_LEN input)
 
 val v_PRFxN (v_K v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K)
-    : Prims.Pure (t_Array (t_Array u8 v_LEN) v_K) Prims.l_True (fun _ -> Prims.l_True)
+    : Prims.Pure (t_Array (t_Array u8 v_LEN) v_K)
+      (requires v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4))
+      (ensures
+        fun result ->
+          let result:t_Array (t_Array u8 v_LEN) v_K = result in
+          result == Spec.Utils.v_PRFxN v_K v_LEN input)
 
 /// The state.
 /// It\'s only used for SHAKE128.
@@ -73,7 +78,8 @@ let impl (v_K: usize) : Libcrux_ml_kem.Hash_functions.t_Hash (t_PortableHash v_K
     f_PRF = (fun (v_LEN: usize) (input: t_Slice u8) -> v_PRF v_LEN input);
     f_PRFxN_pre
     =
-    (fun (v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) -> true);
+    (fun (v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) ->
+        v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4));
     f_PRFxN_post
     =
     (fun
@@ -81,7 +87,8 @@ let impl (v_K: usize) : Libcrux_ml_kem.Hash_functions.t_Hash (t_PortableHash v_K
         (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K)
         (out: t_Array (t_Array u8 v_LEN) v_K)
         ->
-        true);
+        (v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4)) ==>
+        out == Spec.Utils.v_PRFxN v_K v_LEN input);
     f_PRFxN
     =
     (fun (v_LEN: usize) (input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) ->

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Hash_functions.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Hash_functions.fsti
@@ -30,12 +30,16 @@ class t_Hash (v_Self: Type0) (v_K: usize) = {
   f_PRF:v_LEN: usize -> x0: t_Slice u8
     -> Prims.Pure (t_Array u8 v_LEN) (f_PRF_pre v_LEN x0) (fun result -> f_PRF_post v_LEN x0 result);
   f_PRFxN_pre:v_LEN: usize -> input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K
-    -> pred: Type0{true ==> pred};
+    -> pred: Type0{v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4) ==> pred};
   f_PRFxN_post:
       v_LEN: usize ->
-      t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K ->
-      t_Array (t_Array u8 v_LEN) v_K
-    -> Type0;
+      input: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K ->
+      result: t_Array (t_Array u8 v_LEN) v_K
+    -> pred:
+      Type0
+        { pred ==>
+          (v v_LEN < pow2 32 /\ (v v_K == 2 \/ v v_K == 3 \/ v v_K == 4)) ==>
+          result == Spec.Utils.v_PRFxN v_K v_LEN input };
   f_PRFxN:v_LEN: usize -> x0: t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K
     -> Prims.Pure (t_Array (t_Array u8 v_LEN) v_K)
         (f_PRFxN_pre v_LEN x0)

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Ind_cpa.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Ind_cpa.fst
@@ -12,6 +12,8 @@ let _ =
   let open Libcrux_ml_kem.Vector.Traits in
   ()
 
+#push-options "--max_fuel 10 --z3rlimit 1000 --ext context_pruning --z3refresh --split_queries always"
+
 let sample_ring_element_cbd
       (v_K v_ETA2_RANDOMNESS_SIZE v_ETA2: usize)
       (#v_Vector #v_Hasher: Type0)
@@ -37,6 +39,7 @@ let sample_ring_element_cbd
     Rust_primitives.Hax.repeat prf_input v_K
   in
   let v__domain_separator_init:u8 = domain_separator in
+  let v__prf_inputs_init:t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K = prf_inputs in
   let domain_separator, prf_inputs:(u8 & t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) =
     Rust_primitives.Hax.Folds.fold_range (Rust_primitives.mk_usize 0)
       v_K
@@ -46,7 +49,15 @@ let sample_ring_element_cbd
             temp_0_
           in
           let i:usize = i in
-          v domain_separator == v v__domain_separator_init + v i)
+          v domain_separator == v v__domain_separator_init + v i /\
+          (v i < v v_K ==>
+            (forall (j: nat).
+                (j >= v i /\ j < v v_K) ==> prf_inputs.[ sz j ] == v__prf_inputs_init.[ sz j ])) /\
+          (forall (j: nat).
+              j < v i ==>
+              v (Seq.index (Seq.index prf_inputs j) 32) == v v__domain_separator_init + j /\
+              Seq.slice (Seq.index prf_inputs j) 0 32 ==
+              Seq.slice (Seq.index v__prf_inputs_init j) 0 32))
       (domain_separator, prf_inputs <: (u8 & t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K)
       )
       (fun temp_0_ i ->
@@ -71,6 +82,28 @@ let sample_ring_element_cbd
           <:
           (u8 & t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K))
   in
+  let _:Prims.unit =
+    let lemma_aux (i: nat{i < v v_K})
+        : Lemma
+        (prf_inputs.[ sz i ] ==
+          (Seq.append (Seq.slice prf_input 0 32)
+              (Seq.create 1
+                  (mk_int #u8_inttype (v (v__domain_separator_init +! (mk_int #u8_inttype i))))))) =
+      Lib.Sequence.eq_intro #u8
+        #33
+        prf_inputs.[ sz i ]
+        (Seq.append (Seq.slice prf_input 0 32)
+            (Seq.create 1 (mk_int #u8_inttype (v v__domain_separator_init + i))))
+    in
+    Classical.forall_intro lemma_aux;
+    Lib.Sequence.eq_intro #(t_Array u8 (sz 33))
+      #(v v_K)
+      prf_inputs
+      (createi v_K
+          (Spec.MLKEM.sample_vector_cbd2_prf_input #v_K
+              (Seq.slice prf_input 0 32)
+              (sz (v v__domain_separator_init))))
+  in
   let (prf_outputs: t_Array (t_Array u8 v_ETA2_RANDOMNESS_SIZE) v_K):t_Array
     (t_Array u8 v_ETA2_RANDOMNESS_SIZE) v_K =
     Libcrux_ml_kem.Hash_functions.f_PRFxN #v_Hasher
@@ -82,37 +115,47 @@ let sample_ring_element_cbd
   let error_1_:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
     Rust_primitives.Hax.Folds.fold_range (Rust_primitives.mk_usize 0)
       v_K
-      (fun error_1_ temp_1_ ->
+      (fun error_1_ i ->
           let error_1_:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
             error_1_
           in
-          let _:usize = temp_1_ in
-          true)
+          let i:usize = i in
+          forall (j: nat).
+            j < v i ==>
+            Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector error_1_.[ sz j ] ==
+            Spec.MLKEM.sample_poly_cbd v_ETA2 prf_outputs.[ sz j ])
       error_1_
       (fun error_1_ i ->
           let error_1_:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
             error_1_
           in
           let i:usize = i in
-          Rust_primitives.Hax.Monomorphized_update_at.update_at_usize error_1_
-            i
-            (Libcrux_ml_kem.Sampling.sample_from_binomial_distribution v_ETA2
-                #v_Vector
-                (prf_outputs.[ i ] <: t_Slice u8)
-              <:
-              Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-          <:
-          t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K)
+          let error_1_:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize error_1_
+              i
+              (Libcrux_ml_kem.Sampling.sample_from_binomial_distribution v_ETA2
+                  #v_Vector
+                  (prf_outputs.[ i ] <: t_Slice u8)
+                <:
+                Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
+          in
+          error_1_)
   in
-  let result:(t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K & u8) =
-    error_1_, domain_separator
-    <:
-    (t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K & u8)
+  let _:Prims.unit =
+    Lib.Sequence.eq_intro #(Spec.MLKEM.polynomial)
+      #(v v_K)
+      (Libcrux_ml_kem.Polynomial.to_spec_vector_t #v_K #v_Vector error_1_)
+      (Spec.MLKEM.sample_vector_cbd2 #v_K
+          (Seq.slice prf_input 0 32)
+          (sz (v v__domain_separator_init)))
   in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  error_1_, domain_separator
+  <:
+  (t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K & u8)
 
-#push-options "--admit_smt_queries true"
+#pop-options
+
+#push-options "--max_fuel 10 --z3rlimit 1000 --ext context_pruning --z3refresh --split_queries always"
 
 let sample_vector_cbd_then_ntt
       (v_K v_ETA v_ETA_RANDOMNESS_SIZE: usize)
@@ -131,6 +174,7 @@ let sample_vector_cbd_then_ntt
     Rust_primitives.Hax.repeat prf_input v_K
   in
   let v__domain_separator_init:u8 = domain_separator in
+  let v__prf_inputs_init:t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K = prf_inputs in
   let domain_separator, prf_inputs:(u8 & t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K) =
     Rust_primitives.Hax.Folds.fold_range (Rust_primitives.mk_usize 0)
       v_K
@@ -140,7 +184,15 @@ let sample_vector_cbd_then_ntt
             temp_0_
           in
           let i:usize = i in
-          v domain_separator == v v__domain_separator_init + v i)
+          v domain_separator == v v__domain_separator_init + v i /\
+          (v i < v v_K ==>
+            (forall (j: nat).
+                (j >= v i /\ j < v v_K) ==> prf_inputs.[ sz j ] == v__prf_inputs_init.[ sz j ])) /\
+          (forall (j: nat).
+              j < v i ==>
+              v (Seq.index (Seq.index prf_inputs j) 32) == v v__domain_separator_init + j /\
+              Seq.slice (Seq.index prf_inputs j) 0 32 ==
+              Seq.slice (Seq.index v__prf_inputs_init j) 0 32))
       (domain_separator, prf_inputs <: (u8 & t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K)
       )
       (fun temp_0_ i ->
@@ -165,6 +217,28 @@ let sample_vector_cbd_then_ntt
           <:
           (u8 & t_Array (t_Array u8 (Rust_primitives.mk_usize 33)) v_K))
   in
+  let _:Prims.unit =
+    let lemma_aux (i: nat{i < v v_K})
+        : Lemma
+        (prf_inputs.[ sz i ] ==
+          (Seq.append (Seq.slice prf_input 0 32)
+              (Seq.create 1
+                  (mk_int #u8_inttype (v (v__domain_separator_init +! (mk_int #u8_inttype i))))))) =
+      Lib.Sequence.eq_intro #u8
+        #33
+        prf_inputs.[ sz i ]
+        (Seq.append (Seq.slice prf_input 0 32)
+            (Seq.create 1 (mk_int #u8_inttype (v v__domain_separator_init + i))))
+    in
+    Classical.forall_intro lemma_aux;
+    Lib.Sequence.eq_intro #(t_Array u8 (sz 33))
+      #(v v_K)
+      prf_inputs
+      (createi v_K
+          (Spec.MLKEM.sample_vector_cbd1_prf_input #v_K
+              (Seq.slice prf_input 0 32)
+              (sz (v v__domain_separator_init))))
+  in
   let (prf_outputs: t_Array (t_Array u8 v_ETA_RANDOMNESS_SIZE) v_K):t_Array
     (t_Array u8 v_ETA_RANDOMNESS_SIZE) v_K =
     Libcrux_ml_kem.Hash_functions.f_PRFxN #v_Hasher
@@ -176,12 +250,15 @@ let sample_vector_cbd_then_ntt
   let re_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
     Rust_primitives.Hax.Folds.fold_range (Rust_primitives.mk_usize 0)
       v_K
-      (fun re_as_ntt temp_1_ ->
+      (fun re_as_ntt i ->
           let re_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
             re_as_ntt
           in
-          let _:usize = temp_1_ in
-          true)
+          let i:usize = i in
+          forall (j: nat).
+            j < v i ==>
+            Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector re_as_ntt.[ sz j ] ==
+            Spec.MLKEM.poly_ntt (Spec.MLKEM.sample_poly_cbd v_ETA prf_outputs.[ sz j ]))
       re_as_ntt
       (fun re_as_ntt i ->
           let re_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
@@ -206,6 +283,14 @@ let sample_vector_cbd_then_ntt
                 Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
           in
           re_as_ntt)
+  in
+  let _:Prims.unit =
+    Lib.Sequence.eq_intro #(Spec.MLKEM.polynomial)
+      #(v v_K)
+      (Libcrux_ml_kem.Polynomial.to_spec_vector_t #v_K #v_Vector re_as_ntt)
+      (Spec.MLKEM.sample_vector_cbd_then_ntt #v_K
+          (Seq.slice prf_input 0 32)
+          (sz (v v__domain_separator_init)))
   in
   let hax_temp_output:u8 = domain_separator in
   re_as_ntt, hax_temp_output
@@ -247,13 +332,11 @@ let sample_vector_cbd_then_ntt_out
   in
   let re_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K = tmp0 in
   let domain_separator:u8 = out in
-  let result:(t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K & u8) =
-    re_as_ntt, domain_separator
-    <:
-    (t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K & u8)
-  in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  re_as_ntt, domain_separator
+  <:
+  (t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K & u8)
+
+#push-options "--z3rlimit 200 --ext context_pruning --z3refresh"
 
 let compress_then_serialize_u
       (v_K v_OUT_LEN v_COMPRESSION_FACTOR v_BLOCK_LEN: usize)
@@ -265,24 +348,36 @@ let compress_then_serialize_u
       (out: t_Slice u8)
      =
   let _:Prims.unit =
-    assert ((v Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT * v v_COMPRESSION_FACTOR) / 8 ==
-        320 \/
-        (v Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT * v v_COMPRESSION_FACTOR) / 8 ==
-        352)
+    assert (v (sz 32 *! v_COMPRESSION_FACTOR) == 32 * v v_COMPRESSION_FACTOR);
+    assert (v (v_OUT_LEN /! v_K) == v v_OUT_LEN / v v_K);
+    assert (v v_OUT_LEN / v v_K == 32 * v v_COMPRESSION_FACTOR)
   in
   let out:t_Slice u8 =
     Rust_primitives.Hax.Folds.fold_enumerated_slice input
       (fun out i ->
           let out:t_Slice u8 = out in
           let i:usize = i in
-          v i < v v_K ==>
-          (Seq.length out == v v_OUT_LEN /\
-            Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index input (v i))))
+          (v i < v v_K ==>
+            Seq.length out == v v_OUT_LEN /\
+            Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index input (v i))) /\
+          (forall (j: nat).
+              j < v i ==>
+              Seq.length out == v v_OUT_LEN /\ (j + 1) * (v v_OUT_LEN / v v_K) <= Seq.length out /\
+              (Seq.slice out (j * (v v_OUT_LEN / v v_K)) (((j + 1)) * (v v_OUT_LEN / v v_K)) ==
+                Spec.MLKEM.compress_then_byte_encode (v v_COMPRESSION_FACTOR)
+                  (Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector (Seq.index input j)))))
       out
       (fun out temp_1_ ->
           let out:t_Slice u8 = out in
           let i, re:(usize & Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) =
             temp_1_
+          in
+          let _:Prims.unit =
+            assert (forall (j: nat).
+                  j < v i ==>
+                  ((Seq.slice out (j * (v v_OUT_LEN / v v_K)) (((j + 1)) * (v v_OUT_LEN / v v_K)) ==
+                      Spec.MLKEM.compress_then_byte_encode (v v_COMPRESSION_FACTOR)
+                        (Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector (Seq.index input j)))))
           in
           let out:t_Slice u8 =
             Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
@@ -316,12 +411,35 @@ let compress_then_serialize_u
                 <:
                 t_Slice u8)
           in
+          let _:Prims.unit =
+            let lemma_aux (j: nat{j < v i})
+                : Lemma
+                (Seq.slice out (j * (v v_OUT_LEN / v v_K)) (((j + 1)) * (v v_OUT_LEN / v v_K)) ==
+                  Spec.MLKEM.compress_then_byte_encode (v v_COMPRESSION_FACTOR)
+                    (Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector (Seq.index input j))) =
+              Lib.Sequence.eq_intro #u8
+                #(v v_OUT_LEN / v v_K)
+                (Seq.slice out (j * (v v_OUT_LEN / v v_K)) (((j + 1)) * (v v_OUT_LEN / v v_K)))
+                (Spec.MLKEM.compress_then_byte_encode (v v_COMPRESSION_FACTOR)
+                    (Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector (Seq.index input j)))
+            in
+            Classical.forall_intro lemma_aux
+          in
           out)
   in
-  let result:Prims.unit = () <: Prims.unit in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  let hax_temp_output:Prims.unit = result in
+  let _:Prims.unit =
+    Lib.Sequence.eq_intro #u8
+      #(v v_OUT_LEN)
+      out
+      (Spec.MLKEM.compress_then_encode_u #v_K
+          (Libcrux_ml_kem.Polynomial.to_spec_vector_t #v_K #v_Vector input))
+  in
+  let hax_temp_output:Prims.unit = () <: Prims.unit in
   out
+
+#pop-options
+
+#push-options "--ext context_pruning"
 
 let deserialize_then_decompress_u
       (v_K v_CIPHERTEXT_SIZE v_U_COMPRESSION_FACTOR: usize)
@@ -331,6 +449,11 @@ let deserialize_then_decompress_u
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
      =
+  let _:Prims.unit =
+    assert (v ((Libcrux_ml_kem.Constants.v_COEFFICIENTS_IN_RING_ELEMENT *! v_U_COMPRESSION_FACTOR) /!
+            Rust_primitives.mk_usize 8) ==
+        v (Spec.MLKEM.v_C1_BLOCK_SIZE v_K))
+  in
   let u_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
     Core.Array.from_fn #(Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
       v_K
@@ -349,12 +472,21 @@ let deserialize_then_decompress_u
         <:
         usize)
       (ciphertext <: t_Slice u8)
-      (fun u_as_ntt temp_1_ ->
+      (fun u_as_ntt i ->
           let u_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
             u_as_ntt
           in
-          let _:usize = temp_1_ in
-          true)
+          let i:usize = i in
+          forall (j: nat).
+            j < v i ==>
+            j * v (Spec.MLKEM.v_C1_BLOCK_SIZE v_K) + v (Spec.MLKEM.v_C1_BLOCK_SIZE v_K) <=
+            v v_CIPHERTEXT_SIZE /\
+            Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector (Seq.index u_as_ntt j) ==
+            Spec.MLKEM.poly_ntt (Spec.MLKEM.byte_decode_then_decompress (v v_U_COMPRESSION_FACTOR)
+                  (Seq.slice ciphertext
+                      (j * v (Spec.MLKEM.v_C1_BLOCK_SIZE v_K))
+                      (j * v (Spec.MLKEM.v_C1_BLOCK_SIZE v_K) + v (Spec.MLKEM.v_C1_BLOCK_SIZE v_K)))
+              ))
       u_as_ntt
       (fun u_as_ntt temp_1_ ->
           let u_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
@@ -381,9 +513,19 @@ let deserialize_then_decompress_u
           in
           u_as_ntt)
   in
-  let result:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K = u_as_ntt in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  let _:Prims.unit =
+    Lib.Sequence.eq_intro #Spec.MLKEM.polynomial
+      #(v v_K)
+      (Libcrux_ml_kem.Polynomial.to_spec_vector_t #v_K #v_Vector u_as_ntt)
+      (let open Spec.MLKEM in
+        vector_ntt (decode_then_decompress_u #v_K
+              (Seq.slice ciphertext 0 (v (Spec.MLKEM.v_C1_SIZE v_K)))))
+  in
+  u_as_ntt
+
+#pop-options
+
+#push-options "--ext context_pruning"
 
 let deserialize_secret_key
       (v_K: usize)
@@ -393,6 +535,7 @@ let deserialize_secret_key
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (secret_key: t_Slice u8)
      =
+  let _:Prims.unit = assert_norm (Spec.MLKEM.polynomial_d 12 == Spec.MLKEM.polynomial) in
   let secret_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
     Core.Array.from_fn #(Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
       v_K
@@ -405,13 +548,23 @@ let deserialize_secret_key
   let secret_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
     Rust_primitives.Hax.Folds.fold_enumerated_chunked_slice Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT
       secret_key
-      (fun secret_as_ntt temp_1_ ->
+      (fun secret_as_ntt i ->
           let secret_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K
           =
             secret_as_ntt
           in
-          let _:usize = temp_1_ in
-          true)
+          let i:usize = i in
+          forall (j: nat).
+            j < v i ==>
+            j * v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT +
+            v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT <=
+            v (Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE v_K) /\
+            Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector (Seq.index secret_as_ntt j) ==
+            Spec.MLKEM.byte_decode 12
+              (Seq.slice secret_key
+                  (j * v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT)
+                  (j * v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT +
+                    v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT)))
       secret_as_ntt
       (fun secret_as_ntt temp_1_ ->
           let secret_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K
@@ -419,22 +572,28 @@ let deserialize_secret_key
             secret_as_ntt
           in
           let i, secret_bytes:(usize & t_Slice u8) = temp_1_ in
-          Rust_primitives.Hax.Monomorphized_update_at.update_at_usize secret_as_ntt
-            i
-            (Libcrux_ml_kem.Serialize.deserialize_to_uncompressed_ring_element #v_Vector
-                secret_bytes
-              <:
-              Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-          <:
-          t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K)
+          let secret_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K
+          =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize secret_as_ntt
+              i
+              (Libcrux_ml_kem.Serialize.deserialize_to_uncompressed_ring_element #v_Vector
+                  secret_bytes
+                <:
+                Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
+          in
+          secret_as_ntt)
   in
-  let result:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
-    secret_as_ntt
+  let _:Prims.unit =
+    Lib.Sequence.eq_intro #Spec.MLKEM.polynomial
+      #(v v_K)
+      (Libcrux_ml_kem.Polynomial.to_spec_vector_t #v_K #v_Vector secret_as_ntt)
+      (Spec.MLKEM.vector_decode_12 #v_K secret_key)
   in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  secret_as_ntt
 
-#push-options "--z3rlimit 200"
+#pop-options
+
+#push-options "--z3rlimit 200 --ext context_pruning --z3refresh"
 
 let serialize_secret_key
       (v_K v_OUT_LEN: usize)
@@ -444,14 +603,23 @@ let serialize_secret_key
           Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector)
       (key: t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K)
      =
+  let _:Prims.unit = assert_norm (Spec.MLKEM.polynomial_d 12 == Spec.MLKEM.polynomial) in
   let out:t_Array u8 v_OUT_LEN = Rust_primitives.Hax.repeat (Rust_primitives.mk_u8 0) v_OUT_LEN in
   let out:t_Array u8 v_OUT_LEN =
     Rust_primitives.Hax.Folds.fold_enumerated_slice key
       (fun out i ->
           let out:t_Array u8 v_OUT_LEN = out in
           let i:usize = i in
-          v i < v v_K ==>
-          Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index key (v i)))
+          (v i < v v_K ==>
+            Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index key (v i))) /\
+          (forall (j: nat).
+              j < v i ==>
+              (j + 1) * v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT <= Seq.length out /\
+              (Seq.slice out
+                  (j * v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT)
+                  ((j + 1) * v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT) ==
+                Spec.MLKEM.byte_encode 12
+                  (Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector (Seq.index key j)))))
       out
       (fun out temp_1_ ->
           let out:t_Array u8 v_OUT_LEN = out in
@@ -495,11 +663,38 @@ let serialize_secret_key
                 <:
                 t_Slice u8)
           in
+          let _:Prims.unit =
+            let lemma_aux (j: nat{j < v i})
+                : Lemma
+                (Seq.slice out
+                    (j * v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT)
+                    ((j + 1) * v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT) ==
+                  Spec.MLKEM.byte_encode 12
+                    (Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector (Seq.index key j))) =
+              Lib.Sequence.eq_intro #u8
+                #(v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT)
+                (Seq.slice out
+                    (j * v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT)
+                    ((j + 1) * v Libcrux_ml_kem.Constants.v_BYTES_PER_RING_ELEMENT))
+                (Spec.MLKEM.byte_encode 12
+                    (Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector (Seq.index key j)))
+            in
+            Classical.forall_intro lemma_aux
+          in
           out)
   in
-  let result:t_Array u8 v_OUT_LEN = out in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  let _:Prims.unit =
+    assert (Spec.MLKEM.coerce_vector_12 (Libcrux_ml_kem.Polynomial.to_spec_vector_t #v_K
+              #v_Vector
+              key) ==
+        Libcrux_ml_kem.Polynomial.to_spec_vector_t #v_K #v_Vector key);
+    Lib.Sequence.eq_intro #u8
+      #(v v_OUT_LEN)
+      out
+      (Spec.MLKEM.vector_encode_12 #v_K
+          (Libcrux_ml_kem.Polynomial.to_spec_vector_t #v_K #v_Vector key))
+  in
+  out
 
 #pop-options
 
@@ -551,7 +746,14 @@ let serialize_public_key_mut
         <:
         t_Slice u8)
   in
-  let hax_temp_output:Prims.unit = admit () (* Panic freedom *) in
+  let _:Prims.unit =
+    Lib.Sequence.eq_intro #u8
+      #(v v_PUBLIC_KEY_SIZE)
+      serialized
+      (Seq.append (Spec.MLKEM.vector_encode_12 #v_K
+              (Libcrux_ml_kem.Polynomial.to_spec_vector_t #v_K #v_Vector tt_as_ntt))
+          seed_for_a)
+  in
   serialized
 
 let serialize_public_key
@@ -575,9 +777,7 @@ let serialize_public_key
       seed_for_a
       public_key_serialized
   in
-  let result:t_Array u8 v_PUBLIC_KEY_SIZE = public_key_serialized in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  public_key_serialized
 
 let decrypt_unpacked
       (v_K v_CIPHERTEXT_SIZE v_VECTOR_U_ENCODED_SIZE v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR:
@@ -620,6 +820,7 @@ let decrypt
       (secret_key: t_Slice u8)
       (ciphertext: t_Array u8 v_CIPHERTEXT_SIZE)
      =
+  let _:Prims.unit = reveal_opaque (`%Spec.MLKEM.ind_cpa_decrypt) Spec.MLKEM.ind_cpa_decrypt in
   let secret_as_ntt:t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K =
     deserialize_secret_key v_K #v_Vector secret_key
   in
@@ -628,18 +829,14 @@ let decrypt
     <:
     Libcrux_ml_kem.Ind_cpa.Unpacked.t_IndCpaPrivateKeyUnpacked v_K v_Vector
   in
-  let result:t_Array u8 (Rust_primitives.mk_usize 32) =
-    decrypt_unpacked v_K
-      v_CIPHERTEXT_SIZE
-      v_VECTOR_U_ENCODED_SIZE
-      v_U_COMPRESSION_FACTOR
-      v_V_COMPRESSION_FACTOR
-      #v_Vector
-      secret_key_unpacked
-      ciphertext
-  in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  decrypt_unpacked v_K
+    v_CIPHERTEXT_SIZE
+    v_VECTOR_U_ENCODED_SIZE
+    v_U_COMPRESSION_FACTOR
+    v_V_COMPRESSION_FACTOR
+    #v_Vector
+    secret_key_unpacked
+    ciphertext
 
 #push-options "--z3rlimit 200"
 
@@ -672,6 +869,10 @@ let encrypt_unpacked
       prf_input
       (Rust_primitives.mk_u8 0)
   in
+  let _:Prims.unit =
+    Lib.Sequence.eq_intro #u8 #32 randomness (Seq.slice prf_input 0 32);
+    assert (v domain_separator == v v_K)
+  in
   let error_1_, domain_separator:(t_Array
       (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K &
     u8) =
@@ -687,6 +888,10 @@ let encrypt_unpacked
     Rust_primitives.Hax.Monomorphized_update_at.update_at_usize prf_input
       (Rust_primitives.mk_usize 32)
       domain_separator
+  in
+  let _:Prims.unit =
+    assert (Seq.equal prf_input (Seq.append randomness (Seq.create 1 domain_separator)));
+    assert (prf_input == Seq.append randomness (Seq.create 1 domain_separator))
   in
   let (prf_output: t_Array u8 v_ETA2_RANDOMNESS_SIZE):t_Array u8 v_ETA2_RANDOMNESS_SIZE =
     Libcrux_ml_kem.Hash_functions.f_PRF #v_Hasher
@@ -717,6 +922,12 @@ let encrypt_unpacked
       r_as_ntt
       error_2_
       message_as_ring_element
+  in
+  let _:Prims.unit =
+    assert (v_C1_LEN = Spec.MLKEM.v_C1_SIZE v_K);
+    assert (v_C2_LEN = Spec.MLKEM.v_C2_SIZE v_K);
+    assert (v_CIPHERTEXT_SIZE == v_C1_LEN +! v_C2_LEN);
+    assert (v_C1_LEN <=. v_CIPHERTEXT_SIZE)
   in
   let ciphertext:t_Array u8 v_CIPHERTEXT_SIZE =
     Rust_primitives.Hax.repeat (Rust_primitives.mk_u8 0) v_CIPHERTEXT_SIZE
@@ -756,6 +967,11 @@ let encrypt_unpacked
         <:
         t_Slice u8)
   in
+  let _:Prims.unit =
+    lemma_slice_append ciphertext
+      (Seq.slice ciphertext 0 (Rust_primitives.v v_C1_LEN))
+      (Seq.slice ciphertext (Rust_primitives.v v_C1_LEN) (Seq.length ciphertext))
+  in
   ciphertext
 
 #pop-options
@@ -774,6 +990,7 @@ let encrypt
       (message: t_Array u8 (Rust_primitives.mk_usize 32))
       (randomness: t_Slice u8)
      =
+  let _:Prims.unit = reveal_opaque (`%Spec.MLKEM.ind_cpa_encrypt) Spec.MLKEM.ind_cpa_encrypt in
   let unpacked_public_key:Libcrux_ml_kem.Ind_cpa.Unpacked.t_IndCpaPublicKeyUnpacked v_K v_Vector =
     Core.Default.f_default #(Libcrux_ml_kem.Ind_cpa.Unpacked.t_IndCpaPublicKeyUnpacked v_K v_Vector)
       #FStar.Tactics.Typeclasses.solve
@@ -801,6 +1018,12 @@ let encrypt
       <:
       Core.Ops.Range.t_RangeFrom usize ]
   in
+  let _:Prims.unit =
+    Lib.Sequence.eq_intro #u8
+      #32
+      seed
+      (Seq.slice (Libcrux_ml_kem.Utils.into_padded_array (Rust_primitives.mk_usize 34) seed) 0 32)
+  in
   let unpacked_public_key:Libcrux_ml_kem.Ind_cpa.Unpacked.t_IndCpaPublicKeyUnpacked v_K v_Vector =
     {
       unpacked_public_key with
@@ -818,13 +1041,9 @@ let encrypt
     <:
     Libcrux_ml_kem.Ind_cpa.Unpacked.t_IndCpaPublicKeyUnpacked v_K v_Vector
   in
-  let result:t_Array u8 v_CIPHERTEXT_SIZE =
-    encrypt_unpacked v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN
-      v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2
-      v_ETA2_RANDOMNESS_SIZE #v_Vector #v_Hasher unpacked_public_key message randomness
-  in
-  let _:Prims.unit = admit () (* Panic freedom *) in
-  result
+  encrypt_unpacked v_K v_CIPHERTEXT_SIZE v_T_AS_NTT_ENCODED_SIZE v_C1_LEN v_C2_LEN
+    v_U_COMPRESSION_FACTOR v_V_COMPRESSION_FACTOR v_BLOCK_LEN v_ETA1 v_ETA1_RANDOMNESS_SIZE v_ETA2
+    v_ETA2_RANDOMNESS_SIZE #v_Vector #v_Hasher unpacked_public_key message randomness
 
 let generate_keypair_unpacked
       (v_K v_ETA1 v_ETA1_RANDOMNESS_SIZE: usize)

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Ntt.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Ntt.fst
@@ -518,12 +518,13 @@ let ntt_binomially_sampled_ring_element
   let zeta_i:usize = tmp0 in
   let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = tmp1 in
   let _:Prims.unit = () in
-  let hax_temp_output, re:(Prims.unit & Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-  =
+  let result, re:(Prims.unit & Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) =
     (), Libcrux_ml_kem.Polynomial.impl_2__poly_barrett_reduce #v_Vector re
     <:
     (Prims.unit & Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
   in
+  let _:Prims.unit = admit () (* Panic freedom *) in
+  let hax_temp_output:Prims.unit = result in
   re
 
 #pop-options
@@ -609,12 +610,13 @@ let ntt_vector_u
   let zeta_i:usize = tmp0 in
   let re:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = tmp1 in
   let _:Prims.unit = () in
-  let hax_temp_output, re:(Prims.unit & Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
-  =
+  let result, re:(Prims.unit & Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) =
     (), Libcrux_ml_kem.Polynomial.impl_2__poly_barrett_reduce #v_Vector re
     <:
     (Prims.unit & Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
   in
+  let _:Prims.unit = admit () (* Panic freedom *) in
+  let hax_temp_output:Prims.unit = result in
   re
 
 #pop-options

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Ntt.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Ntt.fsti
@@ -164,7 +164,11 @@ val ntt_binomially_sampled_ring_element
         forall i.
           i < 8 ==>
           ntt_layer_7_pre (re.f_coefficients.[ sz i ]) (re.f_coefficients.[ sz i +! sz 8 ]))
-      (fun _ -> Prims.l_True)
+      (ensures
+        fun re_future ->
+          let re_future:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = re_future in
+          Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector re_future ==
+          Spec.MLKEM.poly_ntt (Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector re))
 
 val ntt_vector_u
       (v_VECTOR_U_COMPRESSION_FACTOR: usize)
@@ -173,4 +177,8 @@ val ntt_vector_u
       (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
     : Prims.Pure (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
       Prims.l_True
-      (fun _ -> Prims.l_True)
+      (ensures
+        fun re_future ->
+          let re_future:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = re_future in
+          Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector re_future ==
+          Spec.MLKEM.poly_ntt (Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector re))

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Sampling.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Sampling.fst
@@ -214,8 +214,8 @@ let sample_from_binomial_distribution_2_
             Rust_primitives.mk_u32 1431655765
           in
           let _:Prims.unit =
-            logand_lemma random_bits_as_u32 (mk_u32 1431655765);
-            logand_lemma (random_bits_as_u32 >>! (mk_i32 1)) (mk_u32 1431655765)
+            logand_lemma random_bits_as_u32 1431655765ul;
+            logand_lemma (random_bits_as_u32 >>! 1l) 1431655765ul
           in
           let coin_toss_outcomes:u32 = even_bits +! odd_bits in
           Rust_primitives.Hax.Folds.fold_range_step_by (Rust_primitives.mk_u32 0)
@@ -247,14 +247,13 @@ let sample_from_binomial_distribution_2_
                   i16
                 in
                 let _:Prims.unit =
-                  logand_lemma (coin_toss_outcomes >>! outcome_set <: u32) (mk_u32 3);
-                  logand_lemma (coin_toss_outcomes >>! (outcome_set +! (mk_u32 2) <: u32) <: u32)
-                    (mk_u32 3);
+                  logand_lemma (coin_toss_outcomes >>! outcome_set <: u32) 3ul;
+                  logand_lemma (coin_toss_outcomes >>! (outcome_set +! 2ul <: u32) <: u32) 3ul;
                   assert (v outcome_1_ >= 0 /\ v outcome_1_ <= 3);
                   assert (v outcome_2_ >= 0 /\ v outcome_2_ <= 3);
                   assert (v chunk_number <= 31);
                   assert (v (sz 8 *! chunk_number <: usize) <= 248);
-                  assert (v (cast (outcome_set >>! (mk_i32 2) <: u32) <: usize) <= 7)
+                  assert (v (cast (outcome_set >>! 2l <: u32) <: usize) <= 7)
                 in
                 let offset:usize =
                   cast (outcome_set >>! Rust_primitives.mk_i32 2 <: u32) <: usize
@@ -320,9 +319,9 @@ let sample_from_binomial_distribution_3_
             Rust_primitives.mk_u32 2396745
           in
           let _:Prims.unit =
-            logand_lemma random_bits_as_u24 (mk_u32 2396745);
-            logand_lemma (random_bits_as_u24 >>! (mk_i32 1) <: u32) (mk_u32 2396745);
-            logand_lemma (random_bits_as_u24 >>! (mk_i32 2) <: u32) (mk_u32 2396745)
+            logand_lemma random_bits_as_u24 2396745ul;
+            logand_lemma (random_bits_as_u24 >>! 1l <: u32) 2396745ul;
+            logand_lemma (random_bits_as_u24 >>! 2l <: u32) 2396745ul
           in
           let coin_toss_outcomes:u32 = (first_bits +! second_bits <: u32) +! third_bits in
           Rust_primitives.Hax.Folds.fold_range_step_by (Rust_primitives.mk_i32 0)
@@ -354,14 +353,13 @@ let sample_from_binomial_distribution_3_
                   i16
                 in
                 let _:Prims.unit =
-                  logand_lemma (coin_toss_outcomes >>! outcome_set <: u32) (mk_u32 7);
-                  logand_lemma (coin_toss_outcomes >>! (outcome_set +! (mk_i32 3) <: i32) <: u32)
-                    (mk_u32 7);
+                  logand_lemma (coin_toss_outcomes >>! outcome_set <: u32) 7ul;
+                  logand_lemma (coin_toss_outcomes >>! (outcome_set +! 3l <: i32) <: u32) 7ul;
                   assert (v outcome_1_ >= 0 /\ v outcome_1_ <= 7);
                   assert (v outcome_2_ >= 0 /\ v outcome_2_ <= 7);
                   assert (v chunk_number <= 63);
                   assert (v (sz 4 *! chunk_number <: usize) <= 252);
-                  assert (v (cast (outcome_set /! (mk_i32 6) <: i32) <: usize) <= 3)
+                  assert (v (cast (outcome_set /! 6l <: i32) <: usize) <= 3)
                 in
                 let offset:usize = cast (outcome_set /! Rust_primitives.mk_i32 6 <: i32) <: usize in
                 let sampled_i16s:t_Array i16 (Rust_primitives.mk_usize 256) =
@@ -384,14 +382,18 @@ let sample_from_binomial_distribution
       (randomness: t_Slice u8)
      =
   let _:Prims.unit = assert ((v (cast v_ETA <: u32) == 2) \/ (v (cast v_ETA <: u32) == 3)) in
-  match cast (v_ETA <: usize) <: u32 with
-  | 2 -> sample_from_binomial_distribution_2_ #v_Vector randomness
-  | 3 -> sample_from_binomial_distribution_3_ #v_Vector randomness
-  | _ ->
-    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+  let result:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector =
+    match cast (v_ETA <: usize) <: u32 with
+    | 2 -> sample_from_binomial_distribution_2_ #v_Vector randomness
+    | 3 -> sample_from_binomial_distribution_3_ #v_Vector randomness
+    | _ ->
+      Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
 
-        <:
-        Rust_primitives.Hax.t_Never)
+          <:
+          Rust_primitives.Hax.t_Never)
+  in
+  let _:Prims.unit = admit () (* Panic freedom *) in
+  result
 
 #push-options "--admit_smt_queries true"
 

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Sampling.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Sampling.fsti
@@ -123,7 +123,15 @@ val sample_from_binomial_distribution
         (v_ETA =. Rust_primitives.mk_usize 2 || v_ETA =. Rust_primitives.mk_usize 3) &&
         (Core.Slice.impl__len #u8 randomness <: usize) =.
         (v_ETA *! Rust_primitives.mk_usize 64 <: usize))
-      (fun _ -> Prims.l_True)
+      (ensures
+        fun result ->
+          let result:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = result in
+          (forall (i: nat).
+              i < 8 ==>
+              Libcrux_ml_kem.Ntt.ntt_layer_7_pre (result.f_coefficients.[ sz i ])
+                (result.f_coefficients.[ sz i +! sz 8 ])) /\
+          Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector result ==
+          Spec.MLKEM.sample_poly_cbd v_ETA randomness)
 
 val sample_from_xof
       (v_K: usize)

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fst
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Serialize.fst
@@ -401,14 +401,18 @@ let compress_then_serialize_ring_element_u
     assert ((v (cast v_COMPRESSION_FACTOR <: u32) == 10) \/
         (v (cast v_COMPRESSION_FACTOR <: u32) == 11))
   in
-  match v_COMPRESSION_FACTOR with
-  | 10 -> compress_then_serialize_10_ v_OUT_LEN #v_Vector re
-  | 11 -> compress_then_serialize_11_ v_OUT_LEN #v_Vector re
-  | _ ->
-    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+  let result:t_Array u8 v_OUT_LEN =
+    match v_COMPRESSION_FACTOR with
+    | 10 -> compress_then_serialize_10_ v_OUT_LEN #v_Vector re
+    | 11 -> compress_then_serialize_11_ v_OUT_LEN #v_Vector re
+    | _ ->
+      Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
 
-        <:
-        Rust_primitives.Hax.t_Never)
+          <:
+          Rust_primitives.Hax.t_Never)
+  in
+  let _:Prims.unit = admit () (* Panic freedom *) in
+  result
 
 let compress_then_serialize_ring_element_v
       (v_COMPRESSION_FACTOR v_OUT_LEN: usize)
@@ -423,7 +427,7 @@ let compress_then_serialize_ring_element_v
     assert ((v (cast v_COMPRESSION_FACTOR <: u32) == 4) \/
         (v (cast v_COMPRESSION_FACTOR <: u32) == 5))
   in
-  let out, hax_temp_output:(t_Slice u8 & Prims.unit) =
+  let out, result:(t_Slice u8 & Prims.unit) =
     match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
     | 4 -> compress_then_serialize_4_ #v_Vector re out, () <: (t_Slice u8 & Prims.unit)
     | 5 -> compress_then_serialize_5_ #v_Vector re out, () <: (t_Slice u8 & Prims.unit)
@@ -436,6 +440,8 @@ let compress_then_serialize_ring_element_v
       <:
       (t_Slice u8 & Prims.unit)
   in
+  let _:Prims.unit = admit () (* Panic freedom *) in
+  let hax_temp_output:Prims.unit = result in
   out
 
 let deserialize_then_decompress_10_
@@ -727,14 +733,18 @@ let deserialize_then_decompress_ring_element_u
     assert ((v (cast v_COMPRESSION_FACTOR <: u32) == 10) \/
         (v (cast v_COMPRESSION_FACTOR <: u32) == 11))
   in
-  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
-  | 10 -> deserialize_then_decompress_10_ #v_Vector serialized
-  | 11 -> deserialize_then_decompress_11_ #v_Vector serialized
-  | _ ->
-    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+  let result:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector =
+    match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+    | 10 -> deserialize_then_decompress_10_ #v_Vector serialized
+    | 11 -> deserialize_then_decompress_11_ #v_Vector serialized
+    | _ ->
+      Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
 
-        <:
-        Rust_primitives.Hax.t_Never)
+          <:
+          Rust_primitives.Hax.t_Never)
+  in
+  let _:Prims.unit = admit () (* Panic freedom *) in
+  result
 
 let deserialize_then_decompress_ring_element_v
       (v_COMPRESSION_FACTOR: usize)
@@ -748,14 +758,18 @@ let deserialize_then_decompress_ring_element_v
     assert ((v (cast v_COMPRESSION_FACTOR <: u32) == 4) \/
         (v (cast v_COMPRESSION_FACTOR <: u32) == 5))
   in
-  match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
-  | 4 -> deserialize_then_decompress_4_ #v_Vector serialized
-  | 5 -> deserialize_then_decompress_5_ #v_Vector serialized
-  | _ ->
-    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+  let result:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector =
+    match cast (v_COMPRESSION_FACTOR <: usize) <: u32 with
+    | 4 -> deserialize_then_decompress_4_ #v_Vector serialized
+    | 5 -> deserialize_then_decompress_5_ #v_Vector serialized
+    | _ ->
+      Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
 
-        <:
-        Rust_primitives.Hax.t_Never)
+          <:
+          Rust_primitives.Hax.t_Never)
+  in
+  let _:Prims.unit = admit () (* Panic freedom *) in
+  result
 
 let deserialize_to_reduced_ring_element
       (#v_Vector: Type0)
@@ -841,7 +855,9 @@ let deserialize_ring_elements_reduced
           <:
           t_Array (Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) v_K)
   in
-  let hax_temp_output:Prims.unit = () <: Prims.unit in
+  let result:Prims.unit = () <: Prims.unit in
+  let _:Prims.unit = admit () (* Panic freedom *) in
+  let hax_temp_output:Prims.unit = result in
   deserialized_pk
 
 let deserialize_ring_elements_reduced_out
@@ -910,7 +926,9 @@ let deserialize_to_uncompressed_ring_element
           <:
           Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector)
   in
-  re
+  let result:Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector = re in
+  let _:Prims.unit = admit () (* Panic freedom *) in
+  result
 
 let serialize_uncompressed_ring_element
       (#v_Vector: Type0)

--- a/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Variant.fsti
+++ b/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Variant.fsti
@@ -83,9 +83,13 @@ class t_Variant (v_Self: Type0) = {
       v_K: usize ->
       #v_Hasher: Type0 ->
       {| i4: Libcrux_ml_kem.Hash_functions.t_Hash v_Hasher v_K |} ->
-      t_Slice u8 ->
-      t_Array u8 (Rust_primitives.mk_usize 64)
-    -> Type0;
+      seed: t_Slice u8 ->
+      res: t_Array u8 (Rust_primitives.mk_usize 64)
+    -> pred:
+      Type0
+        { pred ==>
+          Seq.length seed == 32 ==>
+          res == Spec.Utils.v_G (Seq.append seed (Seq.create 1 (cast v_K <: u8))) };
   f_cpa_keygen_seed:
       v_K: usize ->
       #v_Hasher: Type0 ->
@@ -205,9 +209,10 @@ let impl: t_Variant t_MlKem =
           i4:
           Libcrux_ml_kem.Hash_functions.t_Hash v_Hasher v_K)
         (key_generation_seed: t_Slice u8)
-        (out: t_Array u8 (Rust_primitives.mk_usize 64))
+        (res: t_Array u8 (Rust_primitives.mk_usize 64))
         ->
-        true);
+        Seq.length key_generation_seed == 32 ==>
+        res == Spec.Utils.v_G (Seq.append key_generation_seed (Seq.create 1 (cast v_K <: u8))));
     f_cpa_keygen_seed
     =
     fun
@@ -248,6 +253,12 @@ let impl: t_Variant t_MlKem =
         Rust_primitives.Hax.Monomorphized_update_at.update_at_usize seed
           Libcrux_ml_kem.Constants.v_CPA_PKE_KEY_GENERATION_SEED_SIZE
           (cast (v_K <: usize) <: u8)
+      in
+      let _:Prims.unit =
+        Lib.Sequence.eq_intro #u8
+          #33
+          seed
+          (Seq.append key_generation_seed (Seq.create 1 (cast v_K <: u8)))
       in
       Libcrux_ml_kem.Hash_functions.f_G #v_Hasher
         #v_K

--- a/libcrux-ml-kem/proofs/fstar/spec/Spec.MLKEM.Math.fst
+++ b/libcrux-ml-kem/proofs/fstar/spec/Spec.MLKEM.Math.fst
@@ -107,6 +107,7 @@ let poly_ntt_layer (p:polynomial) (l:nat{l > 0 /\ l < 8}) : polynomial =
 #pop-options
 
 val poly_ntt: polynomial -> polynomial
+[@ "opaque_to_smt"]
 let poly_ntt p =
   let p = poly_ntt_layer p 7 in
   let p = poly_ntt_layer p 6 in
@@ -235,12 +236,13 @@ let decompress_d (d: dT {d <> 12}) (x: field_element_d d): field_element
   = let r = (x * v v_FIELD_MODULUS + 1664) / pow2 d in
     r
     
-
+[@ "opaque_to_smt"]
 let byte_encode (d: dT) (coefficients: polynomial_d d): t_Array u8 (sz (32 * d))
   =  let coefficients' : t_Array nat (sz 256) = map_array #(field_element_d d) (fun x -> x <: nat) coefficients in
      bits_to_bytes #(sz (32 * d))
        (retype_bit_vector (bit_vec_of_nat_array coefficients' d))
 
+[@ "opaque_to_smt"]
 let byte_decode (d: dT) (coefficients: t_Array u8 (sz (32 * d))): polynomial_d d
   = let bv = bytes_to_bits coefficients in
     let arr: t_Array nat (sz 256) = bit_vec_to_nat_array d (retype_bit_vector bv) in
@@ -256,11 +258,13 @@ let byte_decode (d: dT) (coefficients: t_Array u8 (sz (32 * d))): polynomial_d d
 let coerce_polynomial_12 (p:polynomial): polynomial_d 12 = p
 let coerce_vector_12 (#r:rank) (v:vector r): vector_d r 12 = v
 
+[@ "opaque_to_smt"]
 let compress_then_byte_encode (d: dT {d <> 12}) (coefficients: polynomial): t_Array u8 (sz (32 * d))
   = let coefs: t_Array (field_element_d d) (sz 256) = map_array (compress_d d) coefficients
     in
     byte_encode d coefs
 
+[@ "opaque_to_smt"]
 let byte_decode_then_decompress (d: dT {d <> 12}) (b:t_Array u8 (sz (32 * d))): polynomial
   = map_array (decompress_d d) (byte_decode d b)
 

--- a/libcrux-ml-kem/proofs/fstar/spec/Spec.MLKEM.fst
+++ b/libcrux-ml-kem/proofs/fstar/spec/Spec.MLKEM.fst
@@ -168,17 +168,27 @@ let sample_poly_cbd2 #r seed domain_sep =
   let prf_output = v_PRF (v_ETA2_RANDOMNESS_SIZE r) prf_input in
   sample_poly_cbd (v_ETA2 r) prf_output
 
-val sample_poly_cbd1: #r:rank -> seed:t_Array u8 (sz 32) -> domain_sep:usize{v domain_sep < 256} -> polynomial
-let sample_poly_cbd1 #r seed domain_sep =
-  let prf_input = Seq.append seed (Seq.create 1 (mk_int #u8_inttype (v domain_sep))) in
-  let prf_output = v_PRF (v_ETA1_RANDOMNESS_SIZE r) prf_input in
-  sample_poly_cbd (v_ETA1 r) prf_output
+let sample_vector_cbd1_prf_input (#r:rank) (seed:t_Array u8 (sz 32)) (domain_sep:usize{v domain_sep < 2 * v r}) (i:usize{i <. r}) : t_Array u8 (sz 33) =
+  Seq.append seed (Seq.create 1 (mk_int #u8_inttype (v domain_sep + v i)))
+
+let sample_vector_cbd1_prf_output (#r:rank) (prf_output:t_Array (t_Array u8 (v_ETA1_RANDOMNESS_SIZE r)) r) (i:usize{i <. r}) : polynomial =
+  sample_poly_cbd (v_ETA1 r) prf_output.[i]
 
 let sample_vector_cbd1 (#r:rank) (seed:t_Array u8 (sz 32)) (domain_sep:usize{v domain_sep < 2 * v r}) : vector r =
-    createi r (fun i ->  sample_poly_cbd1 #r seed (domain_sep +! i))
+    let prf_input = createi r (sample_vector_cbd1_prf_input #r seed domain_sep) in
+    let prf_output = v_PRFxN r (v_ETA1_RANDOMNESS_SIZE r) prf_input in
+    createi r (sample_vector_cbd1_prf_output #r prf_output)
+
+let sample_vector_cbd2_prf_input (#r:rank) (seed:t_Array u8 (sz 32)) (domain_sep:usize{v domain_sep < 2 * v r}) (i:usize{i <. r}) : t_Array u8 (sz 33) =
+  Seq.append seed (Seq.create 1 (mk_int #u8_inttype (v domain_sep + v i)))
+
+let sample_vector_cbd2_prf_output (#r:rank) (prf_output:t_Array (t_Array u8 (v_ETA2_RANDOMNESS_SIZE r)) r) (i:usize{i <. r}) : polynomial =
+  sample_poly_cbd (v_ETA2 r) prf_output.[i]
 
 let sample_vector_cbd2 (#r:rank) (seed:t_Array u8 (sz 32)) (domain_sep:usize{v domain_sep < 2 * v r}) : vector r =
-    createi r (fun i ->  sample_poly_cbd2 #r seed (domain_sep +! i))
+    let prf_input = createi r (sample_vector_cbd2_prf_input #r seed domain_sep) in
+    let prf_output = v_PRFxN r (v_ETA2_RANDOMNESS_SIZE r) prf_input in
+    createi r (sample_vector_cbd2_prf_output #r prf_output)
 
 let sample_vector_cbd_then_ntt (#r:rank) (seed:t_Array u8 (sz 32)) (domain_sep:usize{v domain_sep < 2 * v r}) : vector r =
     vector_ntt (sample_vector_cbd1 #r seed domain_sep)
@@ -214,13 +224,24 @@ let decode_then_decompress_u (#r:rank) (arr: t_Array u8 (v_C1_SIZE r)): vector r
       byte_decode_then_decompress (v d) slice
     )
 
-let compress_then_encode_v (#r:rank): polynomial -> t_Array u8 (v_C2_SIZE r)
-  = compress_then_byte_encode (v (v_VECTOR_V_COMPRESSION_FACTOR r))
+let compress_then_encode_v (u:usize{u == sz 4 \/ u == sz 5}): polynomial -> t_Array u8 (sz 32 *! u)
+  = compress_then_byte_encode (v u)
 
-let decode_then_decompress_v (#r:rank): t_Array u8 (v_C2_SIZE r) -> polynomial
-  = byte_decode_then_decompress (v (v_VECTOR_V_COMPRESSION_FACTOR r)) 
+let decode_then_decompress_v (u:usize{u == sz 4 \/ u == sz 5}): t_Array u8 (sz 32 *! u) -> polynomial
+  = byte_decode_then_decompress (v u)
 
 (** IND-CPA Functions *)
+
+val ind_cpa_generate_keypair_unpacked (r:rank) (randomness:t_Array u8 v_CPA_KEY_GENERATION_SEED_SIZE) :
+                             ((((vector r) & (t_Array u8 (sz 32))) & (vector r)) & bool)
+let ind_cpa_generate_keypair_unpacked r randomness =
+    let hashed = v_G (Seq.append randomness (Seq.create 1 (cast r <: u8))) in
+    let (seed_for_A, seed_for_secret_and_error) = split hashed (sz 32) in
+    let (matrix_A_as_ntt, sufficient_randomness) = sample_matrix_A_ntt #r seed_for_A in
+    let secret_as_ntt = sample_vector_cbd_then_ntt #r seed_for_secret_and_error (sz 0) in
+    let error_as_ntt = sample_vector_cbd_then_ntt #r seed_for_secret_and_error r in
+    let t_as_ntt = compute_As_plus_e_ntt #r matrix_A_as_ntt secret_as_ntt error_as_ntt in
+    (((t_as_ntt,seed_for_A), secret_as_ntt), sufficient_randomness)
 
 /// This function implements most of <strong>Algorithm 12</strong> of the
 /// NIST FIPS 203 specification; this is the MLKEM CPA-PKE key generation algorithm.
@@ -232,15 +253,29 @@ let decode_then_decompress_v (#r:rank): t_Array u8 (v_C2_SIZE r) -> polynomial
 val ind_cpa_generate_keypair (r:rank) (randomness:t_Array u8 v_CPA_KEY_GENERATION_SEED_SIZE) :
                              (t_MLKEMCPAKeyPair r & bool)
 let ind_cpa_generate_keypair r randomness =
-    let hashed = v_G randomness in
-    let (seed_for_A, seed_for_secret_and_error) = split hashed (sz 32) in
-    let (matrix_A_as_ntt, sufficient_randomness) = sample_matrix_A_ntt #r seed_for_A in
-    let secret_as_ntt = sample_vector_cbd_then_ntt #r seed_for_secret_and_error (sz 0) in
-    let error_as_ntt = sample_vector_cbd_then_ntt #r seed_for_secret_and_error r in
-    let t_as_ntt = compute_As_plus_e_ntt #r matrix_A_as_ntt secret_as_ntt error_as_ntt in
+    let (((t_as_ntt,seed_for_A), secret_as_ntt), sufficient_randomness) =
+      ind_cpa_generate_keypair_unpacked r randomness in
     let public_key_serialized = Seq.append (vector_encode_12 #r t_as_ntt) seed_for_A in
     let secret_key_serialized = vector_encode_12 #r secret_as_ntt in
     ((secret_key_serialized,public_key_serialized), sufficient_randomness)
+
+val ind_cpa_encrypt_unpacked (r:rank)
+                    (message: t_Array u8 v_SHARED_SECRET_SIZE)
+                    (randomness:t_Array u8 v_SHARED_SECRET_SIZE)
+                    (t_as_ntt:vector r)
+                    (matrix_A_as_ntt:matrix r) :
+                    t_MLKEMCiphertext r
+
+let ind_cpa_encrypt_unpacked r message randomness t_as_ntt matrix_A_as_ntt =
+    let r_as_ntt = sample_vector_cbd_then_ntt #r randomness (sz 0) in
+    let error_1 = sample_vector_cbd2 #r randomness r in
+    let error_2 = sample_poly_cbd2 #r randomness (r +! r) in
+    let u = vector_add (vector_inv_ntt (matrix_vector_mul_ntt matrix_A_as_ntt r_as_ntt)) error_1 in
+    let mu = decode_then_decompress_message message in
+    let v = poly_add (poly_add (vector_dot_product_ntt t_as_ntt r_as_ntt) error_2) mu in  
+    let c1 = compress_then_encode_u #r u in
+    let c2 = compress_then_encode_v (v_VECTOR_V_COMPRESSION_FACTOR r) v in
+    concat c1 c2
 
 /// This function implements <strong>Algorithm 13</strong> of the
 /// NIST FIPS 203 specification; this is the MLKEM CPA-PKE encryption algorithm.
@@ -255,15 +290,19 @@ let ind_cpa_encrypt r public_key message randomness =
     let (t_as_ntt_bytes, seed_for_A) = split public_key (v_T_AS_NTT_ENCODED_SIZE r) in
     let t_as_ntt = vector_decode_12 #r t_as_ntt_bytes in 
     let matrix_A_as_ntt, sufficient_randomness = sample_matrix_A_ntt #r seed_for_A in
-    let r_as_ntt = sample_vector_cbd_then_ntt #r randomness (sz 0) in
-    let error_1 = sample_vector_cbd2 #r randomness r in
-    let error_2 = sample_poly_cbd2 #r randomness (r +! r) in
-    let u = vector_add (vector_inv_ntt (matrix_vector_mul_ntt (matrix_transpose matrix_A_as_ntt) r_as_ntt)) error_1 in
-    let mu = decode_then_decompress_message message in
-    let v = poly_add (poly_add (vector_dot_product_ntt t_as_ntt r_as_ntt) error_2) mu in  
-    let c1 = compress_then_encode_u #r u in
-    let c2 = compress_then_encode_v #r v in
-    (concat c1 c2, sufficient_randomness)
+    let c = ind_cpa_encrypt_unpacked r message randomness t_as_ntt (matrix_transpose matrix_A_as_ntt) in
+    (c, sufficient_randomness)
+
+val ind_cpa_decrypt_unpacked (r:rank)
+                    (ciphertext: t_MLKEMCiphertext r) (secret_as_ntt:vector r): 
+                    t_MLKEMSharedSecret
+
+let ind_cpa_decrypt_unpacked r ciphertext secret_as_ntt =
+    let (c1,c2) = split ciphertext (v_C1_SIZE r) in
+    let u = decode_then_decompress_u #r c1 in
+    let v = decode_then_decompress_v (v_VECTOR_V_COMPRESSION_FACTOR r) c2 in
+    let w = poly_sub v (poly_inv_ntt (vector_dot_product_ntt secret_as_ntt (vector_ntt u))) in
+    compress_then_encode_message w
 
 /// This function implements <strong>Algorithm 14</strong> of the
 /// NIST FIPS 203 specification; this is the MLKEM CPA-PKE decryption algorithm.
@@ -274,12 +313,8 @@ val ind_cpa_decrypt (r:rank) (secret_key: t_MLKEMCPAPrivateKey r)
 
 [@ "opaque_to_smt"]
 let ind_cpa_decrypt r secret_key ciphertext =
-    let (c1,c2) = split ciphertext (v_C1_SIZE r) in
-    let u = decode_then_decompress_u #r c1 in
-    let v = decode_then_decompress_v #r c2 in
     let secret_as_ntt = vector_decode_12 #r secret_key in
-    let w = poly_sub v (poly_inv_ntt (vector_dot_product_ntt secret_as_ntt (vector_ntt u))) in
-    compress_then_encode_message w
+    ind_cpa_decrypt_unpacked r ciphertext secret_as_ntt
 
 (** IND-CCA Functions *)
 

--- a/libcrux-ml-kem/proofs/fstar/spec/Spec.Utils.fst
+++ b/libcrux-ml-kem/proofs/fstar/spec/Spec.Utils.fst
@@ -129,6 +129,9 @@ let v_PRF v_LEN input = map_slice
             (map_slice (fun x -> Lib.IntTypes.secret #Lib.IntTypes.U8 (to_uint8 x)) input) 
             (v v_LEN))
 
+assume val v_PRFxN (r:usize{v r == 2 \/ v r == 3 \/ v r == 4}) (v_LEN: usize{v v_LEN < pow2 32})
+  (input: t_Array (t_Array u8 (sz 33)) r) : t_Array (t_Array u8 v_LEN) r
+
 let v_J (input: t_Slice u8) : t_Array u8 (sz 32) = v_PRF (sz 32) input
 
 val v_XOF (v_LEN: usize{v v_LEN < pow2 32}) (input: t_Slice u8) : t_Array u8 v_LEN

--- a/libcrux-ml-kem/src/hash_functions.rs
+++ b/libcrux-ml-kem/src/hash_functions.rs
@@ -48,7 +48,12 @@ pub(crate) trait Hash<const K: usize> {
     fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN];
 
     /// PRFxN aka N SHAKE256
-    #[requires(true)]
+    #[requires(fstar!("v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)"))]
+    #[ensures(|result|
+        // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
+        fstar!("(v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)) ==>
+            $result == Spec.Utils.v_PRFxN $K $LEN $input"))
+    ]
     fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K];
 
     /// Create a SHAKE128 state and absorb the input.
@@ -113,6 +118,10 @@ pub(crate) mod portable {
         digest
     }
 
+    #[hax_lib::requires(fstar!("v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)"))]
+    #[hax_lib::ensures(|result|
+        fstar!("$result == Spec.Utils.v_PRFxN $K $LEN $input"))
+    ]
     #[inline(always)]
     fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
         debug_assert!(K == 2 || K == 3 || K == 4);
@@ -190,6 +199,12 @@ pub(crate) mod portable {
             PRF::<LEN>(input)
         }
 
+        #[requires(fstar!("v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)"))]
+        // Output name has be `out` https://github.com/hacspec/hax/issues/832
+        #[ensures(|out|
+            fstar!("(v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)) ==>
+                $out == Spec.Utils.v_PRFxN $K $LEN $input"))
+        ]
         #[inline(always)]
         fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
             PRFxN::<K, LEN>(input)
@@ -261,6 +276,10 @@ pub(crate) mod avx2 {
         digest
     }
 
+    #[hax_lib::requires(fstar!("v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)"))]
+    #[hax_lib::ensures(|result|
+        fstar!("$result == Spec.Utils.v_PRFxN $K $LEN $input"))
+    ]
     #[inline(always)]
     fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
         debug_assert!(K == 2 || K == 3 || K == 4);
@@ -437,6 +456,12 @@ pub(crate) mod avx2 {
             PRF::<LEN>(input)
         }
 
+        #[requires(fstar!("v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)"))]
+        // Output name has be `out` https://github.com/hacspec/hax/issues/832
+        #[ensures(|out|
+            fstar!("(v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)) ==>
+                $out == Spec.Utils.v_PRFxN $K $LEN $input"))
+        ]
         #[inline(always)]
         fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
             PRFxN::<K, LEN>(input)
@@ -506,6 +531,10 @@ pub(crate) mod neon {
         digest
     }
 
+    #[hax_lib::requires(fstar!("v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)"))]
+    #[hax_lib::ensures(|result|
+        fstar!("$result == Spec.Utils.v_PRFxN $K $LEN $input"))
+    ]
     #[inline(always)]
     fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
         debug_assert!(K == 2 || K == 3 || K == 4);
@@ -712,6 +741,13 @@ pub(crate) mod neon {
             PRF::<LEN>(input)
         }
 
+        #[requires(fstar!("v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)"))]
+        // Output name has be `out` https://github.com/hacspec/hax/issues/832
+        #[ensures(|out|
+            // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
+            fstar!("(v $LEN < pow2 32 /\\ (v $K == 2 \\/ v $K == 3 \\/ v $K == 4)) ==>
+                $out == Spec.Utils.v_PRFxN $K $LEN $input"))
+        ]
         #[inline(always)]
         fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
             PRFxN::<K, LEN>(input)

--- a/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux-ml-kem/src/ind_cpa.rs
@@ -60,7 +60,6 @@ use unpacked::*;
 
 /// Concatenate `t` and `ρ` into the public key.
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     $RANKED_BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\\
@@ -92,7 +91,6 @@ pub(crate) fn serialize_public_key<
 
 /// Concatenate `t` and `ρ` into the public key.
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     $RANKED_BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\\
@@ -121,12 +119,14 @@ pub(crate) fn serialize_public_key_mut<
         Vector,
     >(t_as_ntt));
     serialized[RANKED_BYTES_PER_RING_ELEMENT..].copy_from_slice(seed_for_a);
+    hax_lib::fstar!("Lib.Sequence.eq_intro #u8 #(v $PUBLIC_KEY_SIZE) serialized
+        (Seq.append (Spec.MLKEM.vector_encode_12 #$K (Libcrux_ml_kem.Polynomial.to_spec_vector_t
+            #$K #$:Vector $t_as_ntt)) $seed_for_a)");
 }
 
 /// Call [`serialize_uncompressed_ring_element`] for each ring element.
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200")]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning --z3refresh")]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     $OUT_LEN == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\\
     (forall (i:nat). i < v $K ==>
@@ -138,27 +138,51 @@ pub(crate) fn serialize_public_key_mut<
 pub(crate) fn serialize_secret_key<const K: usize, const OUT_LEN: usize, Vector: Operations>(
     key: &[PolynomialRingElement<Vector>; K],
 ) -> [u8; OUT_LEN] {
+    hax_lib::fstar!("assert_norm (Spec.MLKEM.polynomial_d 12 == Spec.MLKEM.polynomial)");
     let mut out = [0u8; OUT_LEN];
 
     cloop! {
         for (i, re) in key.into_iter().enumerate() {
-            hax_lib::loop_invariant!(|i: usize| { fstar!("v $i < v $K ==>
-                Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index $key (v $i))") });
+            hax_lib::loop_invariant!(|i: usize| { fstar!("(v $i < v $K ==>
+                Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index $key (v $i))) /\\
+                (forall (j: nat). j < v $i ==>
+                (j + 1) * v $BYTES_PER_RING_ELEMENT <= Seq.length $out /\\
+                (Seq.slice $out (j * v $BYTES_PER_RING_ELEMENT) ((j + 1) * v $BYTES_PER_RING_ELEMENT) ==
+                    Spec.MLKEM.byte_encode 12 (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector (Seq.index $key j))))") });
             out[i * BYTES_PER_RING_ELEMENT..(i + 1) * BYTES_PER_RING_ELEMENT]
             .copy_from_slice(&serialize_uncompressed_ring_element(&re));
+            hax_lib::fstar!("let lemma_aux (j: nat{ j < v $i }) : Lemma
+                (Seq.slice out (j * v $BYTES_PER_RING_ELEMENT) ((j + 1) * v $BYTES_PER_RING_ELEMENT) ==
+                    Spec.MLKEM.byte_encode 12 (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector (Seq.index $key j))) =
+                Lib.Sequence.eq_intro #u8 #(v $BYTES_PER_RING_ELEMENT)
+                (Seq.slice out (j * v $BYTES_PER_RING_ELEMENT) ((j + 1) * v $BYTES_PER_RING_ELEMENT))
+                (Spec.MLKEM.byte_encode 12 (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector (Seq.index $key j)))
+            in
+            Classical.forall_intro lemma_aux");
         }
     }
 
+    hax_lib::fstar!("assert (Spec.MLKEM.coerce_vector_12 (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $key) ==
+        Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $key);
+    Lib.Sequence.eq_intro #u8 #(v $OUT_LEN) $out
+        (Spec.MLKEM.vector_encode_12 #$K
+            (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $key))");
     out
 }
 
 /// Sample a vector of ring elements from a centered binomial distribution.
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::fstar::options("--max_fuel 10 --z3rlimit 1000 --ext context_pruning --z3refresh --split_queries always")]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K /\\
     $ETA2 == Spec.MLKEM.v_ETA2 $K /\\
+    v $domain_separator < 2 * v $K /\\
     range (v $domain_separator + v $K) u8_inttype"))]
+#[hax_lib::ensures(|(err1,ds)|
+    fstar!("v $ds == v $domain_separator + v $K /\\
+                Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $err1 ==
+                Spec.MLKEM.sample_vector_cbd2 #$K (Seq.slice $prf_input 0 32) (sz (v $domain_separator))")
+)]
 fn sample_ring_element_cbd<
     const K: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
@@ -172,22 +196,41 @@ fn sample_ring_element_cbd<
     let mut error_1 = from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
     let mut prf_inputs = [prf_input; K];
     let _domain_separator_init = domain_separator;
+    let _prf_inputs_init = prf_inputs;
     for i in 0..K {
-        hax_lib::loop_invariant!(|i: usize| { fstar!("v $domain_separator == v $_domain_separator_init + v $i") });
+        hax_lib::loop_invariant!(|i: usize| { fstar!("v $domain_separator == v $_domain_separator_init + v $i /\\
+          (v $i < v $K ==> (forall (j:nat). (j >= v $i /\\ j < v $K) ==>
+            ${prf_inputs}.[ sz j ] == ${_prf_inputs_init}.[ sz j ])) /\\
+          (forall (j:nat). j < v $i ==> v (Seq.index (Seq.index $prf_inputs j) 32) == v $_domain_separator_init + j /\\
+            Seq.slice (Seq.index $prf_inputs j) 0 32 == Seq.slice (Seq.index $_prf_inputs_init j) 0 32)") });
         prf_inputs[i][32] = domain_separator;
         domain_separator += 1;
     }
+    hax_lib::fstar!("let lemma_aux (i:nat{ i < v $K }) : Lemma (${prf_inputs}.[sz i] == (Seq.append (Seq.slice $prf_input 0 32) 
+        (Seq.create 1 (mk_int #u8_inttype (v ($_domain_separator_init +! (mk_int #u8_inttype i))))))) =
+        Lib.Sequence.eq_intro #u8 #33 ${prf_inputs}.[sz i] (Seq.append (Seq.slice $prf_input 0 32) 
+        (Seq.create 1 (mk_int #u8_inttype (v $_domain_separator_init + i)))) in
+
+    Classical.forall_intro lemma_aux;
+    Lib.Sequence.eq_intro #(t_Array u8 (sz 33)) #(v $K) $prf_inputs 
+        (createi $K (Spec.MLKEM.sample_vector_cbd2_prf_input #$K (Seq.slice $prf_input 0 32) (sz (v $_domain_separator_init))))");
     let prf_outputs: [[u8; ETA2_RANDOMNESS_SIZE]; K] = Hasher::PRFxN(&prf_inputs);
     for i in 0..K {
+        hax_lib::loop_invariant!(|i: usize| { fstar!("forall (j:nat). j < v $i ==>
+            Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector ${error_1}.[ sz j ] ==
+              Spec.MLKEM.sample_poly_cbd $ETA2 ${prf_outputs}.[ sz j ]") });
         error_1[i] = sample_from_binomial_distribution::<ETA2, Vector>(&prf_outputs[i]);
     }
+    hax_lib::fstar!("Lib.Sequence.eq_intro #(Spec.MLKEM.polynomial) #(v $K)
+    (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $error_1) 
+    (Spec.MLKEM.sample_vector_cbd2 #$K (Seq.slice $prf_input 0 32) (sz (v $_domain_separator_init)))");
     (error_1, domain_separator)
 }
 
 /// Sample a vector of ring elements from a centered binomial distribution and
 /// convert them into their NTT representations.
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
+#[hax_lib::fstar::options("--max_fuel 10 --z3rlimit 1000 --ext context_pruning --z3refresh --split_queries always")]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     $ETA_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\\
     $ETA == Spec.MLKEM.v_ETA1 $K /\\
@@ -211,21 +254,39 @@ fn sample_vector_cbd_then_ntt<
 ) -> u8 {
     let mut prf_inputs = [prf_input; K];
     let _domain_separator_init = domain_separator;
+    let _prf_inputs_init = prf_inputs;
     for i in 0..K {
-        hax_lib::loop_invariant!(|i: usize| { fstar!("v $domain_separator == v $_domain_separator_init + v $i") });
+        hax_lib::loop_invariant!(|i: usize| { fstar!("v $domain_separator == v $_domain_separator_init + v $i /\\
+          (v $i < v $K ==> (forall (j:nat). (j >= v $i /\\ j < v $K) ==>
+            ${prf_inputs}.[ sz j ] == ${_prf_inputs_init}.[ sz j ])) /\\
+          (forall (j:nat). j < v $i ==> v (Seq.index (Seq.index $prf_inputs j) 32) == v $_domain_separator_init + j /\\
+            Seq.slice (Seq.index $prf_inputs j) 0 32 == Seq.slice (Seq.index $_prf_inputs_init j) 0 32)") });
         prf_inputs[i][32] = domain_separator;
         domain_separator += 1;
     }
+    hax_lib::fstar!("let lemma_aux (i:nat{ i < v $K }) : Lemma (${prf_inputs}.[sz i] == (Seq.append (Seq.slice $prf_input 0 32) 
+        (Seq.create 1 (mk_int #u8_inttype (v ($_domain_separator_init +! (mk_int #u8_inttype i))))))) =
+        Lib.Sequence.eq_intro #u8 #33 ${prf_inputs}.[sz i] (Seq.append (Seq.slice $prf_input 0 32) 
+        (Seq.create 1 (mk_int #u8_inttype (v $_domain_separator_init + i)))) in
+
+    Classical.forall_intro lemma_aux;
+    Lib.Sequence.eq_intro #(t_Array u8 (sz 33)) #(v $K) $prf_inputs 
+        (createi $K (Spec.MLKEM.sample_vector_cbd1_prf_input #$K (Seq.slice $prf_input 0 32) (sz (v $_domain_separator_init))))");
     let prf_outputs: [[u8; ETA_RANDOMNESS_SIZE]; K] = Hasher::PRFxN(&prf_inputs);
     for i in 0..K {
+        hax_lib::loop_invariant!(|i: usize| { fstar!("forall (j:nat). j < v $i ==>
+            Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector re_as_ntt.[ sz j ] ==
+              Spec.MLKEM.poly_ntt (Spec.MLKEM.sample_poly_cbd $ETA ${prf_outputs}.[ sz j ])") });
         re_as_ntt[i] = sample_from_binomial_distribution::<ETA, Vector>(&prf_outputs[i]);
         ntt_binomially_sampled_ring_element(&mut re_as_ntt[i]);
     }
+    hax_lib::fstar!("Lib.Sequence.eq_intro #(Spec.MLKEM.polynomial) #(v $K)
+    (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector re_as_ntt) 
+    (Spec.MLKEM.sample_vector_cbd_then_ntt #$K (Seq.slice $prf_input 0 32) (sz (v $_domain_separator_init)))");
     domain_separator
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     $ETA_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\\
     $ETA == Spec.MLKEM.v_ETA1 $K /\\
@@ -299,7 +360,10 @@ fn sample_vector_cbd_then_ntt_out<
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\\
     length $key_generation_seed == Spec.MLKEM.v_CPA_KEY_GENERATION_SEED_SIZE"))]
-#[hax_lib::ensures(|_| fstar!("
+#[hax_lib::ensures(|_| fstar!("let (((t_as_ntt,seed_for_A), secret_as_ntt), valid) = Spec.MLKEM.ind_cpa_generate_keypair_unpacked $K $key_generation_seed in 
+    (valid ==> ((Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${public_key}.f_t_as_ntt) == t_as_ntt) /\\
+        (${public_key}.f_seed_for_A == seed_for_A) /\\
+        ((Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${private_key}.f_secret_as_ntt) == secret_as_ntt)) /\\
     (forall (i:nat). i < v $K ==>
         Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index ${private_key}_future.f_secret_as_ntt i)) /\\
     (forall (i:nat). i < v $K ==>
@@ -398,7 +462,7 @@ pub(crate) fn generate_keypair<
 }
 
 /// Call [`compress_then_serialize_ring_element_u`] on each ring element.
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning --z3refresh")]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     $OUT_LEN == Spec.MLKEM.v_C1_SIZE $K /\\
     $COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K /\\
@@ -420,19 +484,43 @@ fn compress_then_serialize_u<
     input: [PolynomialRingElement<Vector>; K],
     out: &mut [u8],
 ) {
-    hax_lib::fstar!("assert ((v $COEFFICIENTS_IN_RING_ELEMENT * v $COMPRESSION_FACTOR) / 8 == 320 \\/
-        (v $COEFFICIENTS_IN_RING_ELEMENT * v $COMPRESSION_FACTOR) / 8 == 352)");
+    hax_lib::fstar!("assert (v (sz 32 *! $COMPRESSION_FACTOR) == 32 * v $COMPRESSION_FACTOR);
+        assert (v ($OUT_LEN /! $K) == v $OUT_LEN / v $K);
+        assert (v $OUT_LEN / v $K == 32 * v $COMPRESSION_FACTOR)");
     // The semicolon and parentheses at the end of loop are a workaround
     // for the following bug https://github.com/hacspec/hax/issues/720
     cloop! {
         for (i, re) in input.into_iter().enumerate() {
-            hax_lib::loop_invariant!(|i: usize| { fstar!("v $i < v $K ==> (Seq.length out == v $OUT_LEN /\\
-                Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index $input (v $i)))") });
+            hax_lib::loop_invariant!(|i: usize| { fstar!("(v $i < v $K ==> Seq.length out == v $OUT_LEN /\\
+                Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index $input (v $i))) /\\
+            (forall (j: nat). j < v $i ==>
+                Seq.length out == v $OUT_LEN /\\
+                (j + 1) * (v $OUT_LEN / v $K) <= Seq.length out /\\
+                (Seq.slice out (j * (v $OUT_LEN / v $K)) (((j + 1)) * (v $OUT_LEN / v $K)) == 
+                    Spec.MLKEM.compress_then_byte_encode (v $COMPRESSION_FACTOR)
+                        (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector (Seq.index $input j))))") });
+            hax_lib::fstar!("assert (forall (j: nat). j < v $i ==>
+                ((Seq.slice out (j * (v $OUT_LEN / v $K)) (((j + 1)) * (v $OUT_LEN / v $K)) == 
+                Spec.MLKEM.compress_then_byte_encode (v $COMPRESSION_FACTOR)
+                    (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector (Seq.index $input j)))))");
             out[i * (OUT_LEN / K)..(i + 1) * (OUT_LEN / K)].copy_from_slice(
                 &compress_then_serialize_ring_element_u::<COMPRESSION_FACTOR, BLOCK_LEN, Vector>(&re),
             );
+            hax_lib::fstar!("let lemma_aux (j: nat{ j < v $i }) : Lemma
+                (Seq.slice out (j * (v $OUT_LEN / v $K)) (((j + 1)) * (v $OUT_LEN / v $K)) ==
+                Spec.MLKEM.compress_then_byte_encode (v $COMPRESSION_FACTOR)
+                    (Libcrux_ml_kem.Polynomial.to_spec_poly_t #v_Vector (Seq.index $input j))) =
+                Lib.Sequence.eq_intro #u8 #(v $OUT_LEN / v $K) 
+                (Seq.slice out (j * (v $OUT_LEN / v $K)) (((j + 1)) * (v $OUT_LEN / v $K)))
+                (Spec.MLKEM.compress_then_byte_encode (v $COMPRESSION_FACTOR)
+                    (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector (Seq.index $input j)))
+            in
+            Classical.forall_intro lemma_aux");
         }
     };
+    hax_lib::fstar!("Lib.Sequence.eq_intro #u8 #(v $OUT_LEN) out
+        (Spec.MLKEM.compress_then_encode_u #$K
+            (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $input))");
     ()
 }
 
@@ -489,6 +577,11 @@ fn compress_then_serialize_u<
       $BLOCK_LEN == Spec.MLKEM.v_C1_BLOCK_SIZE $K /\\
       $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\\
       length $randomness == Spec.MLKEM.v_SHARED_SECRET_SIZE"))]
+#[hax_lib::ensures(|result|
+    fstar!("$result == Spec.MLKEM.ind_cpa_encrypt_unpacked $K $message $randomness
+        (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${public_key}.f_t_as_ntt)
+        (Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector ${public_key}.f_A)")
+)]
 pub(crate) fn encrypt_unpacked<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
@@ -519,6 +612,8 @@ pub(crate) fn encrypt_unpacked<
         sample_vector_cbd_then_ntt_out::<K, ETA1, ETA1_RANDOMNESS_SIZE, Vector, Hasher>(
             prf_input, 0,
         );
+    hax_lib::fstar!("Lib.Sequence.eq_intro #u8 #32 $randomness (Seq.slice $prf_input 0 32);
+        assert (v $domain_separator == v $K)");
 
     // for i from 0 to k−1 do
     //     e1[i] := CBD_{η2}(PRF(r,N))
@@ -532,6 +627,8 @@ pub(crate) fn encrypt_unpacked<
 
     // e_2 := CBD{η2}(PRF(r, N))
     prf_input[32] = domain_separator;
+    hax_lib::fstar!("assert (Seq.equal $prf_input (Seq.append $randomness (Seq.create 1 $domain_separator)));
+        assert ($prf_input == Seq.append $randomness (Seq.create 1 $domain_separator))");
     let prf_output: [u8; ETA2_RANDOMNESS_SIZE] = Hasher::PRF(&prf_input);
     let error_2 = sample_from_binomial_distribution::<ETA2, Vector>(&prf_output);
 
@@ -546,6 +643,10 @@ pub(crate) fn encrypt_unpacked<
         &error_2,
         &message_as_ring_element,
     );
+    hax_lib::fstar!("assert ($C1_LEN = Spec.MLKEM.v_C1_SIZE v_K);
+        assert ($C2_LEN = Spec.MLKEM.v_C2_SIZE v_K);
+        assert ($CIPHERTEXT_SIZE == $C1_LEN +! $C2_LEN);
+        assert ($C1_LEN <=. $CIPHERTEXT_SIZE)");
 
     let mut ciphertext = [0u8; CIPHERTEXT_SIZE];
 
@@ -560,12 +661,13 @@ pub(crate) fn encrypt_unpacked<
         v,
         &mut ciphertext[C1_LEN..],
     );
+    hax_lib::fstar!("lemma_slice_append $ciphertext (Seq.slice $ciphertext 0 (Rust_primitives.v $C1_LEN))
+        (Seq.slice $ciphertext (Rust_primitives.v $C1_LEN) (Seq.length $ciphertext))");
 
     ciphertext
 }
 
 #[allow(non_snake_case)]
-#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     $ETA1 = Spec.MLKEM.v_ETA1 $K /\\
     $ETA1_RANDOMNESS_SIZE = Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\\
@@ -604,6 +706,7 @@ pub(crate) fn encrypt<
     message: [u8; SHARED_SECRET_SIZE],
     randomness: &[u8],
 ) -> [u8; CIPHERTEXT_SIZE] {
+    hax_lib::fstar!("reveal_opaque (`%Spec.MLKEM.ind_cpa_encrypt) Spec.MLKEM.ind_cpa_encrypt");
     let mut unpacked_public_key = IndCpaPublicKeyUnpacked::<K, Vector>::default();
 
     // tˆ := Decode_12(pk)
@@ -619,6 +722,8 @@ pub(crate) fn encrypt<
     //     end for
     // end for
     let seed = &public_key[T_AS_NTT_ENCODED_SIZE..];
+    hax_lib::fstar!("Lib.Sequence.eq_intro #u8 #32 $seed (Seq.slice
+        (Libcrux_ml_kem.Utils.into_padded_array (Rust_primitives.mk_usize 34) $seed) 0 32)");
     sample_matrix_A::<K, Vector, Hasher>(
         &mut unpacked_public_key.A,
         into_padded_array(seed),
@@ -647,7 +752,7 @@ pub(crate) fn encrypt<
 /// Call [`deserialize_then_decompress_ring_element_u`] on each ring element
 /// in the `ciphertext`.
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::fstar::options("--ext context_pruning")]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\\
     $U_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K"))]
@@ -663,22 +768,34 @@ fn deserialize_then_decompress_u<
 >(
     ciphertext: &[u8; CIPHERTEXT_SIZE],
 ) -> [PolynomialRingElement<Vector>; K] {
+    hax_lib::fstar!("assert (v (($COEFFICIENTS_IN_RING_ELEMENT *! $U_COMPRESSION_FACTOR ) /!
+        Rust_primitives.mk_usize 8) == v (Spec.MLKEM.v_C1_BLOCK_SIZE $K))");
     let mut u_as_ntt = from_fn(|_| PolynomialRingElement::<Vector>::ZERO());
     cloop! {
         for (i, u_bytes) in ciphertext
             .chunks_exact((COEFFICIENTS_IN_RING_ELEMENT * U_COMPRESSION_FACTOR) / 8)
             .enumerate()
         {
+            hax_lib::loop_invariant!(|i: usize| { fstar!("forall (j: nat). j < v $i ==>
+              j * v (Spec.MLKEM.v_C1_BLOCK_SIZE $K) + v (Spec.MLKEM.v_C1_BLOCK_SIZE $K) <= v $CIPHERTEXT_SIZE /\\
+              Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector (Seq.index $u_as_ntt j) ==
+                Spec.MLKEM.poly_ntt (Spec.MLKEM.byte_decode_then_decompress (v $U_COMPRESSION_FACTOR)
+                  (Seq.slice $ciphertext (j * v (Spec.MLKEM.v_C1_BLOCK_SIZE $K))
+                    (j * v (Spec.MLKEM.v_C1_BLOCK_SIZE $K) + v (Spec.MLKEM.v_C1_BLOCK_SIZE $K))))") });
             u_as_ntt[i]  = deserialize_then_decompress_ring_element_u::<U_COMPRESSION_FACTOR, Vector>(u_bytes);
             ntt_vector_u::<U_COMPRESSION_FACTOR, Vector>(&mut u_as_ntt[i]);
         }
     }
+    hax_lib::fstar!("Lib.Sequence.eq_intro #Spec.MLKEM.polynomial #(v $K)
+        (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $u_as_ntt)
+        (Spec.MLKEM.(vector_ntt (decode_then_decompress_u #$K
+        (Seq.slice $ciphertext 0 (v (Spec.MLKEM.v_C1_SIZE $K))))))");
     u_as_ntt
 }
 
 /// Call [`deserialize_to_uncompressed_ring_element`] for each ring element.
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::fstar::options("--ext context_pruning")]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     length $secret_key == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\\
     v (${secret_key.len()}) / v $BYTES_PER_RING_ELEMENT <= v $K"))]
@@ -689,12 +806,23 @@ fn deserialize_then_decompress_u<
 fn deserialize_secret_key<const K: usize, Vector: Operations>(
     secret_key: &[u8],
 ) -> [PolynomialRingElement<Vector>; K] {
+    hax_lib::fstar!("assert_norm (Spec.MLKEM.polynomial_d 12 == Spec.MLKEM.polynomial)");
     let mut secret_as_ntt = from_fn(|_| PolynomialRingElement::<Vector>::ZERO());
     cloop! {
         for (i, secret_bytes) in secret_key.chunks_exact(BYTES_PER_RING_ELEMENT).enumerate() {
+            hax_lib::loop_invariant!(|i: usize| { fstar!("forall (j: nat). j < v $i ==>
+                j * v $BYTES_PER_RING_ELEMENT + v $BYTES_PER_RING_ELEMENT <=
+                    v (Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K) /\\
+                Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector (Seq.index $secret_as_ntt j) ==
+                    Spec.MLKEM.byte_decode 12 (Seq.slice $secret_key
+                        (j * v $BYTES_PER_RING_ELEMENT)
+                        (j * v $BYTES_PER_RING_ELEMENT + v $BYTES_PER_RING_ELEMENT))") });
             secret_as_ntt[i] = deserialize_to_uncompressed_ring_element(secret_bytes);
         }
     }
+    hax_lib::fstar!("Lib.Sequence.eq_intro #Spec.MLKEM.polynomial #(v $K)
+        (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $secret_as_ntt)
+        (Spec.MLKEM.vector_decode_12 #$K $secret_key)");
     secret_as_ntt
 }
 
@@ -726,6 +854,10 @@ fn deserialize_secret_key<const K: usize, Vector: Operations>(
     $U_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K /\\
     $V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K /\\
     $VECTOR_U_ENCODED_SIZE == Spec.MLKEM.v_C1_SIZE $K"))]
+#[hax_lib::ensures(|result|
+    fstar!("$result == Spec.MLKEM.ind_cpa_decrypt_unpacked $K $ciphertext
+        (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${secret_key}.f_secret_as_ntt)")
+)]
 pub(crate) fn decrypt_unpacked<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
@@ -753,7 +885,6 @@ pub(crate) fn decrypt_unpacked<
 }
 
 #[allow(non_snake_case)]
-#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(fstar!("Spec.MLKEM.is_rank $K /\\
     length $secret_key == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\\ 
     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\\
@@ -774,6 +905,7 @@ pub(crate) fn decrypt<
     secret_key: &[u8],
     ciphertext: &[u8; CIPHERTEXT_SIZE],
 ) -> [u8; SHARED_SECRET_SIZE] {
+    hax_lib::fstar!("reveal_opaque (`%Spec.MLKEM.ind_cpa_decrypt) Spec.MLKEM.ind_cpa_decrypt");
     // sˆ := Decode_12(sk)
     let secret_as_ntt = deserialize_secret_key::<K, Vector>(secret_key);
     let secret_key_unpacked = IndCpaPrivateKeyUnpacked { secret_as_ntt };

--- a/libcrux-ml-kem/src/ntt.rs
+++ b/libcrux-ml-kem/src/ntt.rs
@@ -256,9 +256,12 @@ pub(crate) fn ntt_at_layer_7<Vector: Operations>(re: &mut PolynomialRingElement<
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::fstar::options("--z3rlimit 200")]
 #[hax_lib::requires(fstar!("forall i. i < 8 ==> ntt_layer_7_pre (${re}.f_coefficients.[ sz i ])
     (${re}.f_coefficients.[ sz i +! sz 8 ])"))]
+#[hax_lib::ensures(|_| fstar!("Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector ${re}_future ==
+    Spec.MLKEM.poly_ntt (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)"))]
 pub(crate) fn ntt_binomially_sampled_ring_element<Vector: Operations>(
     re: &mut PolynomialRingElement<Vector>,
 ) {
@@ -278,7 +281,10 @@ pub(crate) fn ntt_binomially_sampled_ring_element<Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::fstar::options("--z3rlimit 200")]
+#[hax_lib::ensures(|_| fstar!("Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector ${re}_future ==
+    Spec.MLKEM.poly_ntt (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)"))]
 pub(crate) fn ntt_vector_u<const VECTOR_U_COMPRESSION_FACTOR: usize, Vector: Operations>(
     re: &mut PolynomialRingElement<Vector>,
 ) {

--- a/libcrux-ml-kem/src/sampling.rs
+++ b/libcrux-ml-kem/src/sampling.rs
@@ -176,21 +176,21 @@ fn sample_from_binomial_distribution_2<Vector: Operations>(
 
             let even_bits = random_bits_as_u32 & 0x55555555;
             let odd_bits = (random_bits_as_u32 >> 1) & 0x55555555;
-            hax_lib::fstar!("logand_lemma $random_bits_as_u32 (mk_u32 1431655765);
-                logand_lemma ($random_bits_as_u32 >>! (mk_i32 1)) (mk_u32 1431655765)");
+            hax_lib::fstar!("logand_lemma $random_bits_as_u32 1431655765ul;
+                logand_lemma ($random_bits_as_u32 >>! 1l) 1431655765ul");
             let coin_toss_outcomes = even_bits + odd_bits;
 
             cloop! {
                 for outcome_set in (0..u32::BITS).step_by(4) {
                     let outcome_1 = ((coin_toss_outcomes >> outcome_set) & 0x3) as i16;
                     let outcome_2 = ((coin_toss_outcomes >> (outcome_set + 2)) & 0x3) as i16;
-                    hax_lib::fstar!("logand_lemma ($coin_toss_outcomes >>! $outcome_set <: u32) (mk_u32 3);
-                        logand_lemma ($coin_toss_outcomes >>! ($outcome_set +! (mk_u32 2) <: u32) <: u32) (mk_u32 3);
+                    hax_lib::fstar!("logand_lemma ($coin_toss_outcomes >>! $outcome_set <: u32) 3ul;
+                        logand_lemma ($coin_toss_outcomes >>! ($outcome_set +! 2ul <: u32) <: u32) 3ul;
                         assert (v $outcome_1 >= 0 /\\ v $outcome_1 <= 3);
                         assert (v $outcome_2 >= 0 /\\ v $outcome_2 <= 3);
                         assert (v $chunk_number <= 31);
                         assert (v (sz 8 *! $chunk_number <: usize) <= 248);
-                        assert (v (cast ($outcome_set >>! (mk_i32 2) <: u32) <: usize) <= 7)");
+                        assert (v (cast ($outcome_set >>! 2l <: u32) <: usize) <= 7)");
 
                     let offset = (outcome_set >> 2) as usize;
                     sampled_i16s[8 * chunk_number + offset] = outcome_1 - outcome_2;
@@ -224,9 +224,9 @@ fn sample_from_binomial_distribution_3<Vector: Operations>(
             let first_bits = random_bits_as_u24 & 0x00249249;
             let second_bits = (random_bits_as_u24 >> 1) & 0x00249249;
             let third_bits = (random_bits_as_u24 >> 2) & 0x00249249;
-            hax_lib::fstar!("logand_lemma $random_bits_as_u24 (mk_u32 2396745);
-                logand_lemma ($random_bits_as_u24 >>! (mk_i32 1) <: u32) (mk_u32 2396745);
-                logand_lemma ($random_bits_as_u24 >>! (mk_i32 2) <: u32) (mk_u32 2396745)");
+            hax_lib::fstar!("logand_lemma $random_bits_as_u24 2396745ul;
+                logand_lemma ($random_bits_as_u24 >>! 1l <: u32) 2396745ul;
+                logand_lemma ($random_bits_as_u24 >>! 2l <: u32) 2396745ul");
 
             let coin_toss_outcomes = first_bits + second_bits + third_bits;
 
@@ -234,13 +234,13 @@ fn sample_from_binomial_distribution_3<Vector: Operations>(
                 for outcome_set in (0..24).step_by(6) {
                     let outcome_1 = ((coin_toss_outcomes >> outcome_set) & 0x7) as i16;
                     let outcome_2 = ((coin_toss_outcomes >> (outcome_set + 3)) & 0x7) as i16;
-                    hax_lib::fstar!("logand_lemma ($coin_toss_outcomes >>! $outcome_set <: u32) (mk_u32 7);
-                        logand_lemma ($coin_toss_outcomes >>! ($outcome_set +! (mk_i32 3) <: i32) <: u32) (mk_u32 7);
+                    hax_lib::fstar!("logand_lemma ($coin_toss_outcomes >>! $outcome_set <: u32) 7ul;
+                        logand_lemma ($coin_toss_outcomes >>! ($outcome_set +! 3l <: i32) <: u32) 7ul;
                         assert (v $outcome_1 >= 0 /\\ v $outcome_1 <= 7);
                         assert (v $outcome_2 >= 0 /\\ v $outcome_2 <= 7);
                         assert (v $chunk_number <= 63);
                         assert (v (sz 4 *! $chunk_number <: usize) <= 252);
-                        assert (v (cast ($outcome_set /! (mk_i32 6) <: i32) <: usize) <= 3)");
+                        assert (v (cast ($outcome_set /! 6l <: i32) <: usize) <= 3)");
 
                     let offset = (outcome_set / 6) as usize;
                     sampled_i16s[4 * chunk_number + offset] = outcome_1 - outcome_2;
@@ -252,7 +252,12 @@ fn sample_from_binomial_distribution_3<Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires((ETA == 2 || ETA == 3) && randomness.len() == ETA * 64)]
+#[hax_lib::ensures(|result| fstar!("(forall (i:nat). i < 8 ==> Libcrux_ml_kem.Ntt.ntt_layer_7_pre
+    (${result}.f_coefficients.[ sz i ]) (${result}.f_coefficients.[ sz i +! sz 8 ])) /\\
+    Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $result ==
+        Spec.MLKEM.sample_poly_cbd $ETA $randomness"))]
 pub(super) fn sample_from_binomial_distribution<const ETA: usize, Vector: Operations>(
     randomness: &[u8],
 ) -> PolynomialRingElement<Vector> {

--- a/libcrux-ml-kem/src/serialize.rs
+++ b/libcrux-ml-kem/src/serialize.rs
@@ -33,6 +33,10 @@ pub(super) fn to_unsigned_field_modulus<Vector: Operations>(
 #[inline(always)]
 #[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(fstar!("coefficients_field_modulus_range $re"))]
+#[hax_lib::ensures(|result|
+    fstar!("$result ==
+        Spec.MLKEM.compress_then_encode_message (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)")
+)]
 pub(super) fn compress_then_serialize_message<Vector: Operations>(
     re: PolynomialRingElement<Vector>,
 ) -> [u8; SHARED_SECRET_SIZE] {
@@ -55,6 +59,10 @@ pub(super) fn compress_then_serialize_message<Vector: Operations>(
 
 #[inline(always)]
 #[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::ensures(|result|
+    fstar!("Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $result ==
+        Spec.MLKEM.decode_then_decompress_message $serialized")
+)]
 pub(super) fn deserialize_then_decompress_message<Vector: Operations>(
     serialized: [u8; SHARED_SECRET_SIZE],
 ) -> PolynomialRingElement<Vector> {
@@ -69,6 +77,10 @@ pub(super) fn deserialize_then_decompress_message<Vector: Operations>(
 #[inline(always)]
 #[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(fstar!("coefficients_field_modulus_range $re"))]
+#[hax_lib::ensures(|result|
+    fstar!("$result ==
+        Spec.MLKEM.byte_encode 12 (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)")
+)]
 pub(super) fn serialize_uncompressed_ring_element<Vector: Operations>(
     re: &PolynomialRingElement<Vector>,
 ) -> [u8; BYTES_PER_RING_ELEMENT] {
@@ -89,8 +101,13 @@ pub(super) fn serialize_uncompressed_ring_element<Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(
     serialized.len() == BYTES_PER_RING_ELEMENT
+)]
+#[hax_lib::ensures(|result|
+    fstar!("Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $result == 
+        Spec.MLKEM.byte_decode 12 $serialized")
 )]
 pub(super) fn deserialize_to_uncompressed_ring_element<Vector: Operations>(
     serialized: &[u8],
@@ -160,9 +177,14 @@ pub(super) fn deserialize_ring_elements_reduced_out<
 
 /// See [deserialize_ring_elements_reduced_out].
 #[inline(always)]
+#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(
     fstar!("Spec.MLKEM.is_rank v_K /\\ 
             Seq.length public_key == v (Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K)")
+)]
+#[hax_lib::ensures(|_|
+    fstar!("Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${deserialized_pk}_future == 
+        Spec.MLKEM.vector_decode_12 #$K $public_key")
 )]
 pub(super) fn deserialize_ring_elements_reduced<
     const K: usize,
@@ -222,8 +244,13 @@ fn compress_then_serialize_11<const OUT_LEN: usize, Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(fstar!("(v $COMPRESSION_FACTOR == 10 \\/ v $COMPRESSION_FACTOR == 11) /\\
     v $OUT_LEN == 32 * v $COMPRESSION_FACTOR /\\ coefficients_field_modulus_range $re"))]
+#[hax_lib::ensures(|result|
+    fstar!("$result == Spec.MLKEM.compress_then_byte_encode (v $COMPRESSION_FACTOR)
+        (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)")
+)]
 pub(super) fn compress_then_serialize_ring_element_u<
     const COMPRESSION_FACTOR: usize,
     const OUT_LEN: usize,
@@ -296,10 +323,13 @@ fn compress_then_serialize_5<Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(fstar!("(v $COMPRESSION_FACTOR == 4 \\/ v $COMPRESSION_FACTOR == 5) /\\ v $OUT_LEN == 32 * v $COMPRESSION_FACTOR /\\
     Seq.length $out == v $OUT_LEN /\\ coefficients_field_modulus_range $re"))]
 #[hax_lib::ensures(|_|
-    fstar!("${out_future.len()} == ${out.len()}")
+    fstar!("${out_future.len()} == ${out.len()} /\\
+        ${out}_future == Spec.MLKEM.compress_then_encode_v $COMPRESSION_FACTOR
+            (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)")
 )]
 pub(super) fn compress_then_serialize_ring_element_v<
     const COMPRESSION_FACTOR: usize,
@@ -360,9 +390,14 @@ fn deserialize_then_decompress_11<Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(
     (COMPRESSION_FACTOR == 10 || COMPRESSION_FACTOR == 11) &&
     serialized.len() == 32 * COMPRESSION_FACTOR
+)]
+#[hax_lib::ensures(|result|
+    fstar!("Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $result == 
+        Spec.MLKEM.byte_decode_then_decompress (v $COMPRESSION_FACTOR) $serialized")
 )]
 pub(super) fn deserialize_then_decompress_ring_element_u<
     const COMPRESSION_FACTOR: usize,
@@ -419,9 +454,14 @@ fn deserialize_then_decompress_5<Vector: Operations>(
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::requires(
     (COMPRESSION_FACTOR == 4 || COMPRESSION_FACTOR == 5) &&
     serialized.len() == 32 * COMPRESSION_FACTOR
+)]
+#[hax_lib::ensures(|result|
+    fstar!("Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $result == 
+        Spec.MLKEM.decode_then_decompress_v $COMPRESSION_FACTOR $serialized")
 )]
 pub(super) fn deserialize_then_decompress_ring_element_v<
     const COMPRESSION_FACTOR: usize,


### PR DESCRIPTION
This PR adds spec for unpacked functions and writes full proofs for Ind_cpa functions.

Note there's a mismatch between the spec and implementation for `generate_keypair` function, I will confirm the right procedure and upload the changes for this function.