### PR TITLE
ML-KEM: AVX2 target feature edition

### DIFF
--- a/libcrux-intrinsics/src/avx2.rs
+++ b/libcrux-intrinsics/src/avx2.rs
@@ -36,6 +36,7 @@ pub fn mm_storeu_si128(output: &mut [i16], vector: Vec128) {
         _mm_storeu_si128(output.as_mut_ptr() as *mut Vec128, vector);
     }
 }
+#[inline(always)]
 pub fn mm_storeu_si128_i32(output: &mut [i32], vector: Vec128) {
     debug_assert_eq!(output.len(), 4);
     unsafe {

--- a/libcrux-intrinsics/src/avx2.rs
+++ b/libcrux-intrinsics/src/avx2.rs
@@ -7,18 +7,21 @@ pub type Vec256 = __m256i;
 pub type Vec128 = __m128i;
 pub type Vec256Float = __m256;
 
+#[inline(always)]
 pub fn mm256_storeu_si256_u8(output: &mut [u8], vector: Vec256) {
     debug_assert_eq!(output.len(), 32);
     unsafe {
         _mm256_storeu_si256(output.as_mut_ptr() as *mut Vec256, vector);
     }
 }
+#[inline(always)]
 pub fn mm256_storeu_si256_i16(output: &mut [i16], vector: Vec256) {
     debug_assert_eq!(output.len(), 16);
     unsafe {
         _mm256_storeu_si256(output.as_mut_ptr() as *mut Vec256, vector);
     }
 }
+#[inline(always)]
 pub fn mm256_storeu_si256_i32(output: &mut [i32], vector: Vec256) {
     debug_assert_eq!(output.len(), 8);
     unsafe {
@@ -26,6 +29,7 @@ pub fn mm256_storeu_si256_i32(output: &mut [i32], vector: Vec256) {
     }
 }
 
+#[inline(always)]
 pub fn mm_storeu_si128(output: &mut [i16], vector: Vec128) {
     debug_assert!(output.len() >= 8);
     unsafe {
@@ -39,6 +43,7 @@ pub fn mm_storeu_si128_i32(output: &mut [i32], vector: Vec128) {
     }
 }
 
+#[inline(always)]
 pub fn mm_storeu_bytes_si128(output: &mut [u8], vector: Vec128) {
     debug_assert_eq!(output.len(), 16);
     unsafe {
@@ -46,31 +51,38 @@ pub fn mm_storeu_bytes_si128(output: &mut [u8], vector: Vec128) {
     }
 }
 
+#[inline(always)]
 pub fn mm_loadu_si128(input: &[u8]) -> Vec128 {
     debug_assert_eq!(input.len(), 16);
     unsafe { _mm_loadu_si128(input.as_ptr() as *const Vec128) }
 }
 
+#[inline(always)]
 pub fn mm256_loadu_si256_u8(input: &[u8]) -> Vec256 {
     debug_assert_eq!(input.len(), 32);
     unsafe { _mm256_loadu_si256(input.as_ptr() as *const Vec256) }
 }
+#[inline(always)]
 pub fn mm256_loadu_si256_i16(input: &[i16]) -> Vec256 {
     debug_assert_eq!(input.len(), 16);
     unsafe { _mm256_loadu_si256(input.as_ptr() as *const Vec256) }
 }
+#[inline(always)]
 pub fn mm256_loadu_si256_i32(input: &[i32]) -> Vec256 {
     debug_assert_eq!(input.len(), 8);
     unsafe { _mm256_loadu_si256(input.as_ptr() as *const Vec256) }
 }
 
+#[inline(always)]
 pub fn mm256_setzero_si256() -> Vec256 {
     unsafe { _mm256_setzero_si256() }
 }
+#[inline(always)]
 pub fn mm256_set_m128i(hi: Vec128, lo: Vec128) -> Vec256 {
     unsafe { _mm256_set_m128i(hi, lo) }
 }
 
+#[inline(always)]
 pub fn mm_set_epi8(
     byte15: u8,
     byte14: u8,
@@ -111,6 +123,7 @@ pub fn mm_set_epi8(
     }
 }
 
+#[inline(always)]
 pub fn mm256_set_epi8(
     byte31: i8,
     byte30: i8,
@@ -154,9 +167,11 @@ pub fn mm256_set_epi8(
     }
 }
 
+#[inline(always)]
 pub fn mm256_set1_epi16(constant: i16) -> Vec256 {
     unsafe { _mm256_set1_epi16(constant) }
 }
+#[inline(always)]
 pub fn mm256_set_epi16(
     input15: i16,
     input14: i16,
@@ -242,21 +257,26 @@ pub fn mm256_abs_epi32(a: Vec256) -> Vec256 {
     unsafe { _mm256_abs_epi32(a) }
 }
 
+#[inline(always)]
 pub fn mm256_sub_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_sub_epi16(lhs, rhs) }
 }
+#[inline(always)]
 pub fn mm256_sub_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_sub_epi32(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm_sub_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_sub_epi16(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm256_mullo_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mullo_epi16(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm_mullo_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_mullo_epi16(lhs, rhs) }
 }
@@ -289,18 +309,22 @@ pub fn mm256_movemask_ps(a: Vec256Float) -> i32 {
     unsafe { _mm256_movemask_ps(a) }
 }
 
+#[inline(always)]
 pub fn mm_mulhi_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_mulhi_epi16(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm256_mullo_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mullo_epi32(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm256_mulhi_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mulhi_epi16(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm256_mul_epu32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mul_epu32(lhs, rhs) }
 }
@@ -320,102 +344,126 @@ pub fn mm256_or_si256(a: Vec256, b: Vec256) -> Vec256 {
     unsafe { _mm256_or_si256(a, b) }
 }
 
+#[inline(always)]
 pub fn mm256_testz_si256(lhs: Vec256, rhs: Vec256) -> i32 {
     unsafe { _mm256_testz_si256(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm256_xor_si256(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_xor_si256(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm256_srai_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
     unsafe { _mm256_srai_epi16(vector, SHIFT_BY) }
 }
+#[inline(always)]
 pub fn mm256_srai_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 32);
     unsafe { _mm256_srai_epi32(vector, SHIFT_BY) }
 }
 
+#[inline(always)]
 pub fn mm256_srli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
     unsafe { _mm256_srli_epi16(vector, SHIFT_BY) }
 }
+#[inline(always)]
 pub fn mm256_srli_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 32);
     unsafe { _mm256_srli_epi32(vector, SHIFT_BY) }
 }
 
+#[inline(always)]
 pub fn mm_srli_epi64<const SHIFT_BY: i32>(vector: Vec128) -> Vec128 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 64);
     unsafe { _mm_srli_epi64(vector, SHIFT_BY) }
 }
+#[inline(always)]
 pub fn mm256_srli_epi64<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 64);
     unsafe { _mm256_srli_epi64(vector, SHIFT_BY) }
 }
 
+#[inline(always)]
 pub fn mm256_slli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
     unsafe { _mm256_slli_epi16(vector, SHIFT_BY) }
 }
 
+#[inline(always)]
 pub fn mm256_slli_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 32);
     unsafe { _mm256_slli_epi32(vector, SHIFT_BY) }
 }
 
+#[inline(always)]
 pub fn mm_shuffle_epi8(vector: Vec128, control: Vec128) -> Vec128 {
     unsafe { _mm_shuffle_epi8(vector, control) }
 }
+#[inline(always)]
 pub fn mm256_shuffle_epi8(vector: Vec256, control: Vec256) -> Vec256 {
     unsafe { _mm256_shuffle_epi8(vector, control) }
 }
+#[inline(always)]
 pub fn mm256_shuffle_epi32<const CONTROL: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
     unsafe { _mm256_shuffle_epi32(vector, CONTROL) }
 }
 
+#[inline(always)]
 pub fn mm256_permute4x64_epi64<const CONTROL: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
     unsafe { _mm256_permute4x64_epi64(vector, CONTROL) }
 }
 
+#[inline(always)]
 pub fn mm256_unpackhi_epi64(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_unpackhi_epi64(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm256_unpacklo_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_unpacklo_epi32(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm256_unpackhi_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_unpackhi_epi32(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm256_castsi256_si128(vector: Vec256) -> Vec128 {
     unsafe { _mm256_castsi256_si128(vector) }
 }
+#[inline(always)]
 pub fn mm256_castsi128_si256(vector: Vec128) -> Vec256 {
     unsafe { _mm256_castsi128_si256(vector) }
 }
 
+#[inline(always)]
 pub fn mm256_cvtepi16_epi32(vector: Vec128) -> Vec256 {
     unsafe { _mm256_cvtepi16_epi32(vector) }
 }
 
+#[inline(always)]
 pub fn mm_packs_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_packs_epi16(lhs, rhs) }
 }
+#[inline(always)]
 pub fn mm256_packs_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_packs_epi32(lhs, rhs) }
 }
 
+#[inline(always)]
 pub fn mm256_extracti128_si256<const CONTROL: i32>(vector: Vec256) -> Vec128 {
     debug_assert!(CONTROL == 0 || CONTROL == 1);
     unsafe { _mm256_extracti128_si256(vector, CONTROL) }
 }
 
+#[inline(always)]
 pub fn mm256_inserti128_si256<const CONTROL: i32>(vector: Vec256, vector_i128: Vec128) -> Vec256 {
     debug_assert!(CONTROL == 0 || CONTROL == 1);
     unsafe { _mm256_inserti128_si256(vector, vector_i128, CONTROL) }
@@ -465,9 +513,11 @@ pub fn mm256_srlv_epi64(vector: Vec256, counts: Vec256) -> Vec256 {
     unsafe { _mm256_srlv_epi64(vector, counts) }
 }
 
+#[inline(always)]
 pub fn mm_sllv_epi32(vector: Vec128, counts: Vec128) -> Vec128 {
     unsafe { _mm_sllv_epi32(vector, counts) }
 }
+#[inline(always)]
 pub fn mm256_sllv_epi32(vector: Vec256, counts: Vec256) -> Vec256 {
     unsafe { _mm256_sllv_epi32(vector, counts) }
 }

--- a/libcrux-ml-kem/benches/ml-kem.rs
+++ b/libcrux-ml-kem/benches/ml-kem.rs
@@ -107,8 +107,7 @@ pub fn pk_validation(c: &mut Criterion) {
     init!(mlkem1024, "PK Validation", c);
 }
 
-#[target_feature(enable = "avx2")]
-pub unsafe fn encapsulation(c: &mut Criterion) {
+pub fn encapsulation(c: &mut Criterion) {
     macro_rules! fun {
         ($name:expr, $p:path, $group:expr) => {
             $group.bench_function(format!("libcrux {} (external random)", $name), |b| {
@@ -161,8 +160,7 @@ pub unsafe fn encapsulation(c: &mut Criterion) {
     init!(mlkem1024, "Encapsulation", c);
 }
 
-#[target_feature(enable = "avx2")]
-pub unsafe fn decapsulation(c: &mut Criterion) {
+pub fn decapsulation(c: &mut Criterion) {
     macro_rules! fun {
         ($name:expr, $p:path, $group:expr) => {
             $group.bench_function(format!("libcrux {}", $name), |b| {
@@ -221,8 +219,8 @@ pub unsafe fn decapsulation(c: &mut Criterion) {
 pub fn comparisons(c: &mut Criterion) {
     pk_validation(c);
     key_generation(c);
-    unsafe { encapsulation(c) };
-    unsafe { decapsulation(c) };
+    encapsulation(c);
+    decapsulation(c);
 }
 
 criterion_group!(benches, comparisons);

--- a/libcrux-ml-kem/benches/ml-kem.rs
+++ b/libcrux-ml-kem/benches/ml-kem.rs
@@ -107,7 +107,8 @@ pub fn pk_validation(c: &mut Criterion) {
     init!(mlkem1024, "PK Validation", c);
 }
 
-pub fn encapsulation(c: &mut Criterion) {
+#[target_feature(enable = "avx2")]
+pub unsafe fn encapsulation(c: &mut Criterion) {
     macro_rules! fun {
         ($name:expr, $p:path, $group:expr) => {
             $group.bench_function(format!("libcrux {} (external random)", $name), |b| {
@@ -160,7 +161,8 @@ pub fn encapsulation(c: &mut Criterion) {
     init!(mlkem1024, "Encapsulation", c);
 }
 
-pub fn decapsulation(c: &mut Criterion) {
+#[target_feature(enable = "avx2")]
+pub unsafe fn decapsulation(c: &mut Criterion) {
     macro_rules! fun {
         ($name:expr, $p:path, $group:expr) => {
             $group.bench_function(format!("libcrux {}", $name), |b| {
@@ -219,8 +221,8 @@ pub fn decapsulation(c: &mut Criterion) {
 pub fn comparisons(c: &mut Criterion) {
     pk_validation(c);
     key_generation(c);
-    encapsulation(c);
-    decapsulation(c);
+    unsafe{encapsulation(c)};
+    unsafe{decapsulation(c)};
 }
 
 criterion_group!(benches, comparisons);

--- a/libcrux-ml-kem/benches/ml-kem.rs
+++ b/libcrux-ml-kem/benches/ml-kem.rs
@@ -221,8 +221,8 @@ pub unsafe fn decapsulation(c: &mut Criterion) {
 pub fn comparisons(c: &mut Criterion) {
     pk_validation(c);
     key_generation(c);
-    unsafe{encapsulation(c)};
-    unsafe{decapsulation(c)};
+    unsafe { encapsulation(c) };
+    unsafe { decapsulation(c) };
 }
 
 criterion_group!(benches, comparisons);

--- a/libcrux-ml-kem/c/code_gen.txt
+++ b/libcrux-ml-kem/c/code_gen.txt
@@ -3,4 +3,4 @@ Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
 Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
 Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
 F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
-Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664

--- a/libcrux-ml-kem/c/code_gen.txt
+++ b/libcrux-ml-kem/c/code_gen.txt
@@ -1,6 +1,6 @@
 This code was generated with the following revisions:
-Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
 Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
-Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
-F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
-Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b

--- a/libcrux-ml-kem/c/code_gen.txt
+++ b/libcrux-ml-kem/c/code_gen.txt
@@ -2,5 +2,5 @@ This code was generated with the following revisions:
 Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
 Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
 Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
-F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
-Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911

--- a/libcrux-ml-kem/c/internal/libcrux_core.h
+++ b/libcrux-ml-kem/c/internal/libcrux_core.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __internal_libcrux_core_H

--- a/libcrux-ml-kem/c/internal/libcrux_core.h
+++ b/libcrux-ml-kem/c/internal/libcrux_core.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __internal_libcrux_core_H

--- a/libcrux-ml-kem/c/internal/libcrux_core.h
+++ b/libcrux-ml-kem/c/internal/libcrux_core.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __internal_libcrux_core_H

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __internal_libcrux_mlkem_avx2_H

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __internal_libcrux_mlkem_avx2_H

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __internal_libcrux_mlkem_avx2_H

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __internal_libcrux_mlkem_portable_H

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __internal_libcrux_mlkem_portable_H

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __internal_libcrux_mlkem_portable_H

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __internal_libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __internal_libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __internal_libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __internal_libcrux_sha3_internal_H

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __internal_libcrux_sha3_internal_H

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __internal_libcrux_sha3_internal_H

--- a/libcrux-ml-kem/c/libcrux_core.c
+++ b/libcrux-ml-kem/c/libcrux_core.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "internal/libcrux_core.h"

--- a/libcrux-ml-kem/c/libcrux_core.c
+++ b/libcrux-ml-kem/c/libcrux_core.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "internal/libcrux_core.h"

--- a/libcrux-ml-kem/c/libcrux_core.c
+++ b/libcrux-ml-kem/c/libcrux_core.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "internal/libcrux_core.h"

--- a/libcrux-ml-kem/c/libcrux_core.h
+++ b/libcrux-ml-kem/c/libcrux_core.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_core_H

--- a/libcrux-ml-kem/c/libcrux_core.h
+++ b/libcrux-ml-kem/c/libcrux_core.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_core_H

--- a/libcrux-ml-kem/c/libcrux_core.h
+++ b/libcrux-ml-kem/c/libcrux_core.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_core_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem1024_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem1024_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem1024_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "libcrux_mlkem1024_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "libcrux_mlkem1024_avx2.h"
@@ -16,8 +16,31 @@
 #include "internal/libcrux_mlkem_avx2.h"
 
 /**
- Portable decapsulate
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.decapsulate_avx2 with const generics
+- K= 4
+- SECRET_KEY_SIZE= 3168
+- CPA_SECRET_KEY_SIZE= 1536
+- PUBLIC_KEY_SIZE= 1568
+- CIPHERTEXT_SIZE= 1568
+- T_AS_NTT_ENCODED_SIZE= 1536
+- C1_SIZE= 1408
+- C2_SIZE= 160
+- VECTOR_U_COMPRESSION_FACTOR= 11
+- VECTOR_V_COMPRESSION_FACTOR= 5
+- C1_BLOCK_SIZE= 352
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+- IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
+static void decapsulate_avx2_e0(
+    libcrux_ml_kem_types_MlKemPrivateKey_83 *private_key,
+    libcrux_ml_kem_types_MlKemCiphertext_64 *ciphertext, uint8_t ret[32U]) {
+  libcrux_ml_kem_ind_cca_decapsulate_a10(private_key, ciphertext, ret);
+}
+
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.instantiations.avx2.decapsulate
 with const generics
@@ -41,7 +64,7 @@ with const generics
 static void decapsulate_e0(libcrux_ml_kem_types_MlKemPrivateKey_83 *private_key,
                            libcrux_ml_kem_types_MlKemCiphertext_64 *ciphertext,
                            uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_a10(private_key, ciphertext, ret);
+  decapsulate_avx2_e0(private_key, ciphertext, ret);
 }
 
 /**
@@ -55,6 +78,33 @@ void libcrux_ml_kem_mlkem1024_avx2_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_83 *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_64 *ciphertext, uint8_t ret[32U]) {
   decapsulate_e0(private_key, ciphertext, ret);
+}
+
+/**
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.encapsulate_avx2 with const generics
+- K= 4
+- CIPHERTEXT_SIZE= 1568
+- PUBLIC_KEY_SIZE= 1568
+- T_AS_NTT_ENCODED_SIZE= 1536
+- C1_SIZE= 1408
+- C2_SIZE= 160
+- VECTOR_U_COMPRESSION_FACTOR= 11
+- VECTOR_V_COMPRESSION_FACTOR= 5
+- VECTOR_U_BLOCK_LEN= 352
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+*/
+static tuple_fa encapsulate_avx2_8f(
+    libcrux_ml_kem_types_MlKemPublicKey_64 *public_key,
+    uint8_t randomness[32U]) {
+  libcrux_ml_kem_types_MlKemPublicKey_64 *uu____0 = public_key;
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[32U];
+  memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_encapsulate_700(uu____0, copy_of_randomness);
 }
 
 /**
@@ -81,7 +131,7 @@ static tuple_fa encapsulate_8f(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_700(uu____0, copy_of_randomness);
+  return encapsulate_avx2_8f(uu____0, copy_of_randomness);
 }
 
 /**
@@ -106,6 +156,26 @@ tuple_fa libcrux_ml_kem_mlkem1024_avx2_encapsulate(
 */
 /**
 A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair_avx2 with const
+generics
+- K= 4
+- CPA_PRIVATE_KEY_SIZE= 1536
+- PRIVATE_KEY_SIZE= 3168
+- PUBLIC_KEY_SIZE= 1568
+- BYTES_PER_RING_ELEMENT= 1536
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+static libcrux_ml_kem_mlkem1024_MlKem1024KeyPair generate_keypair_avx2_c9(
+    uint8_t randomness[64U]) {
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[64U];
+  memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_generate_keypair_d60(copy_of_randomness);
+}
+
+/**
+A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair with const generics
 - K= 4
 - CPA_PRIVATE_KEY_SIZE= 1536
@@ -120,7 +190,7 @@ static libcrux_ml_kem_mlkem1024_MlKem1024KeyPair generate_keypair_c9(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_d60(copy_of_randomness);
+  return generate_keypair_avx2_c9(copy_of_randomness);
 }
 
 /**
@@ -135,8 +205,20 @@ libcrux_ml_kem_mlkem1024_avx2_generate_key_pair(uint8_t randomness[64U]) {
 }
 
 /**
- Portable private key validation
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.validate_private_key_avx2 with const
+generics
+- K= 4
+- SECRET_KEY_SIZE= 3168
+- CIPHERTEXT_SIZE= 1568
 */
+static bool validate_private_key_avx2_6b(
+    libcrux_ml_kem_types_MlKemPrivateKey_83 *private_key,
+    libcrux_ml_kem_types_MlKemCiphertext_64 *ciphertext) {
+  return libcrux_ml_kem_ind_cca_validate_private_key_b9(private_key,
+                                                        ciphertext);
+}
+
 /**
 A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.validate_private_key with const
@@ -145,11 +227,10 @@ generics
 - SECRET_KEY_SIZE= 3168
 - CIPHERTEXT_SIZE= 1568
 */
-static KRML_MUSTINLINE bool validate_private_key_6b(
+static bool validate_private_key_6b(
     libcrux_ml_kem_types_MlKemPrivateKey_83 *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_64 *ciphertext) {
-  return libcrux_ml_kem_ind_cca_validate_private_key_b9(private_key,
-                                                        ciphertext);
+  return validate_private_key_avx2_6b(private_key, ciphertext);
 }
 
 /**
@@ -164,8 +245,17 @@ bool libcrux_ml_kem_mlkem1024_avx2_validate_private_key(
 }
 
 /**
- Portable public key validation
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.validate_public_key_avx2 with const
+generics
+- K= 4
+- RANKED_BYTES_PER_RING_ELEMENT= 1536
+- PUBLIC_KEY_SIZE= 1568
 */
+static bool validate_public_key_avx2_6b(uint8_t *public_key) {
+  return libcrux_ml_kem_ind_cca_validate_public_key_1e(public_key);
+}
+
 /**
 A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.validate_public_key with const
@@ -174,8 +264,8 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1536
 - PUBLIC_KEY_SIZE= 1568
 */
-static KRML_MUSTINLINE bool validate_public_key_6b(uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_1e(public_key);
+static bool validate_public_key_6b(uint8_t *public_key) {
+  return validate_public_key_avx2_6b(public_key);
 }
 
 /**

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "libcrux_mlkem1024_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem1024_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem1024_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem1024_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "libcrux_mlkem1024_portable.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "libcrux_mlkem1024_portable.h"
@@ -38,9 +38,9 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-static KRML_MUSTINLINE void decapsulate_e0(
-    libcrux_ml_kem_types_MlKemPrivateKey_83 *private_key,
-    libcrux_ml_kem_types_MlKemCiphertext_64 *ciphertext, uint8_t ret[32U]) {
+static void decapsulate_e0(libcrux_ml_kem_types_MlKemPrivateKey_83 *private_key,
+                           libcrux_ml_kem_types_MlKemCiphertext_64 *ciphertext,
+                           uint8_t ret[32U]) {
   libcrux_ml_kem_ind_cca_decapsulate_621(private_key, ciphertext, ret);
 }
 
@@ -74,9 +74,9 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE tuple_fa
-encapsulate_8f(libcrux_ml_kem_types_MlKemPublicKey_64 *public_key,
-               uint8_t randomness[32U]) {
+static tuple_fa encapsulate_8f(
+    libcrux_ml_kem_types_MlKemPublicKey_64 *public_key,
+    uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_64 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
@@ -116,8 +116,8 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE libcrux_ml_kem_mlkem1024_MlKem1024KeyPair
-generate_keypair_c9(uint8_t randomness[64U]) {
+static libcrux_ml_kem_mlkem1024_MlKem1024KeyPair generate_keypair_c9(
+    uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
@@ -146,7 +146,7 @@ generics
 - SECRET_KEY_SIZE= 3168
 - CIPHERTEXT_SIZE= 1568
 */
-static KRML_MUSTINLINE bool validate_private_key_6b(
+static bool validate_private_key_6b(
     libcrux_ml_kem_types_MlKemPrivateKey_83 *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_64 *ciphertext) {
   return libcrux_ml_kem_ind_cca_validate_private_key_b5(private_key,
@@ -175,7 +175,7 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1536
 - PUBLIC_KEY_SIZE= 1568
 */
-static KRML_MUSTINLINE bool validate_public_key_6b(uint8_t *public_key) {
+static bool validate_public_key_6b(uint8_t *public_key) {
   return libcrux_ml_kem_ind_cca_validate_public_key_00(public_key);
 }
 

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "libcrux_mlkem1024_portable.h"
@@ -38,9 +38,9 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1600
 */
-static void decapsulate_e0(libcrux_ml_kem_types_MlKemPrivateKey_83 *private_key,
-                           libcrux_ml_kem_types_MlKemCiphertext_64 *ciphertext,
-                           uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decapsulate_e0(
+    libcrux_ml_kem_types_MlKemPrivateKey_83 *private_key,
+    libcrux_ml_kem_types_MlKemCiphertext_64 *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_ind_cca_decapsulate_621(private_key, ciphertext, ret);
 }
 
@@ -74,9 +74,9 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_fa encapsulate_8f(
-    libcrux_ml_kem_types_MlKemPublicKey_64 *public_key,
-    uint8_t randomness[32U]) {
+static KRML_MUSTINLINE tuple_fa
+encapsulate_8f(libcrux_ml_kem_types_MlKemPublicKey_64 *public_key,
+               uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_64 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
@@ -116,8 +116,8 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_mlkem1024_MlKem1024KeyPair generate_keypair_c9(
-    uint8_t randomness[64U]) {
+static KRML_MUSTINLINE libcrux_ml_kem_mlkem1024_MlKem1024KeyPair
+generate_keypair_c9(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem1024_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem1024_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem1024_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem512_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem512_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem512_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "libcrux_mlkem512_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "libcrux_mlkem512_avx2.h"
@@ -16,8 +16,31 @@
 #include "internal/libcrux_mlkem_avx2.h"
 
 /**
- Portable decapsulate
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.decapsulate_avx2 with const generics
+- K= 2
+- SECRET_KEY_SIZE= 1632
+- CPA_SECRET_KEY_SIZE= 768
+- PUBLIC_KEY_SIZE= 800
+- CIPHERTEXT_SIZE= 768
+- T_AS_NTT_ENCODED_SIZE= 768
+- C1_SIZE= 640
+- C2_SIZE= 128
+- VECTOR_U_COMPRESSION_FACTOR= 10
+- VECTOR_V_COMPRESSION_FACTOR= 4
+- C1_BLOCK_SIZE= 320
+- ETA1= 3
+- ETA1_RANDOMNESS_SIZE= 192
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+- IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
+static void decapsulate_avx2_69(
+    libcrux_ml_kem_types_MlKemPrivateKey_fa *private_key,
+    libcrux_ml_kem_types_MlKemCiphertext_1a *ciphertext, uint8_t ret[32U]) {
+  libcrux_ml_kem_ind_cca_decapsulate_a1(private_key, ciphertext, ret);
+}
+
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.instantiations.avx2.decapsulate
 with const generics
@@ -41,7 +64,7 @@ with const generics
 static void decapsulate_69(libcrux_ml_kem_types_MlKemPrivateKey_fa *private_key,
                            libcrux_ml_kem_types_MlKemCiphertext_1a *ciphertext,
                            uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_a1(private_key, ciphertext, ret);
+  decapsulate_avx2_69(private_key, ciphertext, ret);
 }
 
 /**
@@ -55,6 +78,33 @@ void libcrux_ml_kem_mlkem512_avx2_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_fa *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_1a *ciphertext, uint8_t ret[32U]) {
   decapsulate_69(private_key, ciphertext, ret);
+}
+
+/**
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.encapsulate_avx2 with const generics
+- K= 2
+- CIPHERTEXT_SIZE= 768
+- PUBLIC_KEY_SIZE= 800
+- T_AS_NTT_ENCODED_SIZE= 768
+- C1_SIZE= 640
+- C2_SIZE= 128
+- VECTOR_U_COMPRESSION_FACTOR= 10
+- VECTOR_V_COMPRESSION_FACTOR= 4
+- VECTOR_U_BLOCK_LEN= 320
+- ETA1= 3
+- ETA1_RANDOMNESS_SIZE= 192
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+*/
+static tuple_41 encapsulate_avx2_35(
+    libcrux_ml_kem_types_MlKemPublicKey_52 *public_key,
+    uint8_t randomness[32U]) {
+  libcrux_ml_kem_types_MlKemPublicKey_52 *uu____0 = public_key;
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[32U];
+  memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_encapsulate_70(uu____0, copy_of_randomness);
 }
 
 /**
@@ -81,7 +131,7 @@ static tuple_41 encapsulate_35(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_70(uu____0, copy_of_randomness);
+  return encapsulate_avx2_35(uu____0, copy_of_randomness);
 }
 
 /**
@@ -106,6 +156,26 @@ tuple_41 libcrux_ml_kem_mlkem512_avx2_encapsulate(
 */
 /**
 A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair_avx2 with const
+generics
+- K= 2
+- CPA_PRIVATE_KEY_SIZE= 768
+- PRIVATE_KEY_SIZE= 1632
+- PUBLIC_KEY_SIZE= 800
+- BYTES_PER_RING_ELEMENT= 768
+- ETA1= 3
+- ETA1_RANDOMNESS_SIZE= 192
+*/
+static libcrux_ml_kem_types_MlKemKeyPair_3e generate_keypair_avx2_a8(
+    uint8_t randomness[64U]) {
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[64U];
+  memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_generate_keypair_d6(copy_of_randomness);
+}
+
+/**
+A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair with const generics
 - K= 2
 - CPA_PRIVATE_KEY_SIZE= 768
@@ -120,7 +190,7 @@ static libcrux_ml_kem_types_MlKemKeyPair_3e generate_keypair_a8(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_d6(copy_of_randomness);
+  return generate_keypair_avx2_a8(copy_of_randomness);
 }
 
 /**
@@ -135,8 +205,20 @@ libcrux_ml_kem_mlkem512_avx2_generate_key_pair(uint8_t randomness[64U]) {
 }
 
 /**
- Portable private key validation
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.validate_private_key_avx2 with const
+generics
+- K= 2
+- SECRET_KEY_SIZE= 1632
+- CIPHERTEXT_SIZE= 768
 */
+static bool validate_private_key_avx2_1c(
+    libcrux_ml_kem_types_MlKemPrivateKey_fa *private_key,
+    libcrux_ml_kem_types_MlKemCiphertext_1a *ciphertext) {
+  return libcrux_ml_kem_ind_cca_validate_private_key_ad(private_key,
+                                                        ciphertext);
+}
+
 /**
 A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.validate_private_key with const
@@ -145,11 +227,10 @@ generics
 - SECRET_KEY_SIZE= 1632
 - CIPHERTEXT_SIZE= 768
 */
-static KRML_MUSTINLINE bool validate_private_key_1c(
+static bool validate_private_key_1c(
     libcrux_ml_kem_types_MlKemPrivateKey_fa *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_1a *ciphertext) {
-  return libcrux_ml_kem_ind_cca_validate_private_key_ad(private_key,
-                                                        ciphertext);
+  return validate_private_key_avx2_1c(private_key, ciphertext);
 }
 
 /**
@@ -164,8 +245,17 @@ bool libcrux_ml_kem_mlkem512_avx2_validate_private_key(
 }
 
 /**
- Portable public key validation
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.validate_public_key_avx2 with const
+generics
+- K= 2
+- RANKED_BYTES_PER_RING_ELEMENT= 768
+- PUBLIC_KEY_SIZE= 800
 */
+static bool validate_public_key_avx2_1c(uint8_t *public_key) {
+  return libcrux_ml_kem_ind_cca_validate_public_key_ba(public_key);
+}
+
 /**
 A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.validate_public_key with const
@@ -174,8 +264,8 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 768
 - PUBLIC_KEY_SIZE= 800
 */
-static KRML_MUSTINLINE bool validate_public_key_1c(uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_ba(public_key);
+static bool validate_public_key_1c(uint8_t *public_key) {
+  return validate_public_key_avx2_1c(public_key);
 }
 
 /**

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "libcrux_mlkem512_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem512_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem512_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem512_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "libcrux_mlkem512_portable.h"
@@ -38,9 +38,9 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-static KRML_MUSTINLINE void decapsulate_69(
-    libcrux_ml_kem_types_MlKemPrivateKey_fa *private_key,
-    libcrux_ml_kem_types_MlKemCiphertext_1a *ciphertext, uint8_t ret[32U]) {
+static void decapsulate_69(libcrux_ml_kem_types_MlKemPrivateKey_fa *private_key,
+                           libcrux_ml_kem_types_MlKemCiphertext_1a *ciphertext,
+                           uint8_t ret[32U]) {
   libcrux_ml_kem_ind_cca_decapsulate_620(private_key, ciphertext, ret);
 }
 
@@ -74,9 +74,9 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE tuple_41
-encapsulate_35(libcrux_ml_kem_types_MlKemPublicKey_52 *public_key,
-               uint8_t randomness[32U]) {
+static tuple_41 encapsulate_35(
+    libcrux_ml_kem_types_MlKemPublicKey_52 *public_key,
+    uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_52 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
@@ -116,8 +116,8 @@ generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static KRML_MUSTINLINE libcrux_ml_kem_types_MlKemKeyPair_3e
-generate_keypair_a8(uint8_t randomness[64U]) {
+static libcrux_ml_kem_types_MlKemKeyPair_3e generate_keypair_a8(
+    uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
@@ -146,7 +146,7 @@ generics
 - SECRET_KEY_SIZE= 1632
 - CIPHERTEXT_SIZE= 768
 */
-static KRML_MUSTINLINE bool validate_private_key_1c(
+static bool validate_private_key_1c(
     libcrux_ml_kem_types_MlKemPrivateKey_fa *private_key,
     libcrux_ml_kem_types_MlKemCiphertext_1a *ciphertext) {
   return libcrux_ml_kem_ind_cca_validate_private_key_fb(private_key,
@@ -175,7 +175,7 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 768
 - PUBLIC_KEY_SIZE= 800
 */
-static KRML_MUSTINLINE bool validate_public_key_1c(uint8_t *public_key) {
+static bool validate_public_key_1c(uint8_t *public_key) {
   return libcrux_ml_kem_ind_cca_validate_public_key_86(public_key);
 }
 

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "libcrux_mlkem512_portable.h"
@@ -38,9 +38,9 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 800
 */
-static void decapsulate_69(libcrux_ml_kem_types_MlKemPrivateKey_fa *private_key,
-                           libcrux_ml_kem_types_MlKemCiphertext_1a *ciphertext,
-                           uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decapsulate_69(
+    libcrux_ml_kem_types_MlKemPrivateKey_fa *private_key,
+    libcrux_ml_kem_types_MlKemCiphertext_1a *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_ind_cca_decapsulate_620(private_key, ciphertext, ret);
 }
 
@@ -74,9 +74,9 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_41 encapsulate_35(
-    libcrux_ml_kem_types_MlKemPublicKey_52 *public_key,
-    uint8_t randomness[32U]) {
+static KRML_MUSTINLINE tuple_41
+encapsulate_35(libcrux_ml_kem_types_MlKemPublicKey_52 *public_key,
+               uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_52 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
@@ -116,8 +116,8 @@ generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static libcrux_ml_kem_types_MlKemKeyPair_3e generate_keypair_a8(
-    uint8_t randomness[64U]) {
+static KRML_MUSTINLINE libcrux_ml_kem_types_MlKemKeyPair_3e
+generate_keypair_a8(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "libcrux_mlkem512_portable.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem512_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem512_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem512_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem768_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem768_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem768_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "libcrux_mlkem768_avx2.h"
@@ -16,8 +16,31 @@
 #include "internal/libcrux_mlkem_avx2.h"
 
 /**
- Portable decapsulate
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.decapsulate_avx2 with const generics
+- K= 3
+- SECRET_KEY_SIZE= 2400
+- CPA_SECRET_KEY_SIZE= 1152
+- PUBLIC_KEY_SIZE= 1184
+- CIPHERTEXT_SIZE= 1088
+- T_AS_NTT_ENCODED_SIZE= 1152
+- C1_SIZE= 960
+- C2_SIZE= 128
+- VECTOR_U_COMPRESSION_FACTOR= 10
+- VECTOR_V_COMPRESSION_FACTOR= 4
+- C1_BLOCK_SIZE= 320
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+- IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
+static void decapsulate_avx2_35(
+    libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
+    libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
+  libcrux_ml_kem_ind_cca_decapsulate_a11(private_key, ciphertext, ret);
+}
+
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.instantiations.avx2.decapsulate
 with const generics
@@ -41,7 +64,7 @@ with const generics
 static void decapsulate_35(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_a11(private_key, ciphertext, ret);
+  decapsulate_avx2_35(private_key, ciphertext, ret);
 }
 
 /**
@@ -55,6 +78,33 @@ void libcrux_ml_kem_mlkem768_avx2_decapsulate(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   decapsulate_35(private_key, ciphertext, ret);
+}
+
+/**
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.encapsulate_avx2 with const generics
+- K= 3
+- CIPHERTEXT_SIZE= 1088
+- PUBLIC_KEY_SIZE= 1184
+- T_AS_NTT_ENCODED_SIZE= 1152
+- C1_SIZE= 960
+- C2_SIZE= 128
+- VECTOR_U_COMPRESSION_FACTOR= 10
+- VECTOR_V_COMPRESSION_FACTOR= 4
+- VECTOR_U_BLOCK_LEN= 320
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+*/
+static tuple_c2 encapsulate_avx2_cd(
+    libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
+    uint8_t randomness[32U]) {
+  libcrux_ml_kem_types_MlKemPublicKey_30 *uu____0 = public_key;
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[32U];
+  memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_encapsulate_701(uu____0, copy_of_randomness);
 }
 
 /**
@@ -81,7 +131,7 @@ static tuple_c2 encapsulate_cd(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_701(uu____0, copy_of_randomness);
+  return encapsulate_avx2_cd(uu____0, copy_of_randomness);
 }
 
 /**
@@ -106,6 +156,26 @@ tuple_c2 libcrux_ml_kem_mlkem768_avx2_encapsulate(
 */
 /**
 A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair_avx2 with const
+generics
+- K= 3
+- CPA_PRIVATE_KEY_SIZE= 1152
+- PRIVATE_KEY_SIZE= 2400
+- PUBLIC_KEY_SIZE= 1184
+- BYTES_PER_RING_ELEMENT= 1152
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+static libcrux_ml_kem_mlkem768_MlKem768KeyPair generate_keypair_avx2_c6(
+    uint8_t randomness[64U]) {
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[64U];
+  memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_generate_keypair_d61(copy_of_randomness);
+}
+
+/**
+A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair with const generics
 - K= 3
 - CPA_PRIVATE_KEY_SIZE= 1152
@@ -120,7 +190,7 @@ static libcrux_ml_kem_mlkem768_MlKem768KeyPair generate_keypair_c6(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_d61(copy_of_randomness);
+  return generate_keypair_avx2_c6(copy_of_randomness);
 }
 
 /**
@@ -135,8 +205,20 @@ libcrux_ml_kem_mlkem768_avx2_generate_key_pair(uint8_t randomness[64U]) {
 }
 
 /**
- Portable private key validation
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.validate_private_key_avx2 with const
+generics
+- K= 3
+- SECRET_KEY_SIZE= 2400
+- CIPHERTEXT_SIZE= 1088
 */
+static bool validate_private_key_avx2_31(
+    libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
+    libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext) {
+  return libcrux_ml_kem_ind_cca_validate_private_key_12(private_key,
+                                                        ciphertext);
+}
+
 /**
 A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.validate_private_key with const
@@ -145,11 +227,10 @@ generics
 - SECRET_KEY_SIZE= 2400
 - CIPHERTEXT_SIZE= 1088
 */
-static KRML_MUSTINLINE bool validate_private_key_31(
+static bool validate_private_key_31(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext) {
-  return libcrux_ml_kem_ind_cca_validate_private_key_12(private_key,
-                                                        ciphertext);
+  return validate_private_key_avx2_31(private_key, ciphertext);
 }
 
 /**
@@ -164,8 +245,17 @@ bool libcrux_ml_kem_mlkem768_avx2_validate_private_key(
 }
 
 /**
- Portable public key validation
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.validate_public_key_avx2 with const
+generics
+- K= 3
+- RANKED_BYTES_PER_RING_ELEMENT= 1152
+- PUBLIC_KEY_SIZE= 1184
 */
+static bool validate_public_key_avx2_31(uint8_t *public_key) {
+  return libcrux_ml_kem_ind_cca_validate_public_key_ed(public_key);
+}
+
 /**
 A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.validate_public_key with const
@@ -174,8 +264,8 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-static KRML_MUSTINLINE bool validate_public_key_31(uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_ed(public_key);
+static bool validate_public_key_31(uint8_t *public_key) {
+  return validate_public_key_avx2_31(public_key);
 }
 
 /**

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "libcrux_mlkem768_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "libcrux_mlkem768_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem768_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem768_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem768_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "libcrux_mlkem768_portable.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "libcrux_mlkem768_portable.h"
@@ -38,7 +38,7 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static KRML_MUSTINLINE void decapsulate_35(
+static void decapsulate_35(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_ind_cca_decapsulate_62(private_key, ciphertext, ret);
@@ -74,9 +74,9 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE tuple_c2
-encapsulate_cd(libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
-               uint8_t randomness[32U]) {
+static tuple_c2 encapsulate_cd(
+    libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
+    uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_30 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
@@ -116,8 +116,8 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE libcrux_ml_kem_mlkem768_MlKem768KeyPair
-generate_keypair_c6(uint8_t randomness[64U]) {
+static libcrux_ml_kem_mlkem768_MlKem768KeyPair generate_keypair_c6(
+    uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
@@ -146,7 +146,7 @@ generics
 - SECRET_KEY_SIZE= 2400
 - CIPHERTEXT_SIZE= 1088
 */
-static KRML_MUSTINLINE bool validate_private_key_31(
+static bool validate_private_key_31(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext) {
   return libcrux_ml_kem_ind_cca_validate_private_key_37(private_key,
@@ -175,7 +175,7 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-static KRML_MUSTINLINE bool validate_public_key_31(uint8_t *public_key) {
+static bool validate_public_key_31(uint8_t *public_key) {
   return libcrux_ml_kem_ind_cca_validate_public_key_6c(public_key);
 }
 

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "libcrux_mlkem768_portable.h"
@@ -38,7 +38,7 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static void decapsulate_35(
+static KRML_MUSTINLINE void decapsulate_35(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_ind_cca_decapsulate_62(private_key, ciphertext, ret);
@@ -74,9 +74,9 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static tuple_c2 encapsulate_cd(
-    libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
-    uint8_t randomness[32U]) {
+static KRML_MUSTINLINE tuple_c2
+encapsulate_cd(libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
+               uint8_t randomness[32U]) {
   libcrux_ml_kem_types_MlKemPublicKey_30 *uu____0 = public_key;
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
@@ -116,8 +116,8 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_mlkem768_MlKem768KeyPair generate_keypair_c6(
-    uint8_t randomness[64U]) {
+static KRML_MUSTINLINE libcrux_ml_kem_mlkem768_MlKem768KeyPair
+generate_keypair_c6(uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem768_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem768_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem768_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "internal/libcrux_mlkem_avx2.h"
@@ -41,7 +41,7 @@ KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_zero(void) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_ZERO_ea(void) {
+KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ZERO_ea(void) {
   return libcrux_ml_kem_vector_avx2_zero();
 }
 
@@ -54,7 +54,8 @@ libcrux_ml_kem_vector_avx2_from_i16_array(Eurydice_slice array) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_from_i16_array_ea(Eurydice_slice array) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_from_i16_array_ea(Eurydice_slice array) {
   return libcrux_ml_kem_vector_avx2_from_i16_array(array);
 }
 
@@ -70,7 +71,8 @@ KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_to_i16_array(__m256i v,
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-void libcrux_ml_kem_vector_avx2_to_i16_array_ea(__m256i x, int16_t ret[16U]) {
+KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_to_i16_array_ea(
+    __m256i x, int16_t ret[16U]) {
   libcrux_ml_kem_vector_avx2_to_i16_array(x, ret);
 }
 
@@ -83,7 +85,8 @@ KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_arithmetic_add(__m256i lhs,
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_add_ea(__m256i lhs, __m256i *rhs) {
+KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_add_ea(__m256i lhs,
+                                                          __m256i *rhs) {
   return libcrux_ml_kem_vector_avx2_arithmetic_add(lhs, rhs[0U]);
 }
 
@@ -96,7 +99,8 @@ KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_arithmetic_sub(__m256i lhs,
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_sub_ea(__m256i lhs, __m256i *rhs) {
+KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_sub_ea(__m256i lhs,
+                                                          __m256i *rhs) {
   return libcrux_ml_kem_vector_avx2_arithmetic_sub(lhs, rhs[0U]);
 }
 
@@ -110,8 +114,8 @@ libcrux_ml_kem_vector_avx2_arithmetic_multiply_by_constant(__m256i vector,
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_multiply_by_constant_ea(__m256i v,
-                                                           int16_t c) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_multiply_by_constant_ea(__m256i v, int16_t c) {
   return libcrux_ml_kem_vector_avx2_arithmetic_multiply_by_constant(v, c);
 }
 
@@ -125,7 +129,7 @@ libcrux_ml_kem_vector_avx2_arithmetic_bitwise_and_with_constant(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
+KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
     __m256i vector, int16_t constant) {
   return libcrux_ml_kem_vector_avx2_arithmetic_bitwise_and_with_constant(
       vector, constant);
@@ -152,7 +156,8 @@ libcrux_ml_kem_vector_avx2_arithmetic_cond_subtract_3329(__m256i vector) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_cond_subtract_3329_ea(__m256i vector) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_cond_subtract_3329_ea(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_arithmetic_cond_subtract_3329(vector);
 }
 
@@ -176,7 +181,8 @@ libcrux_ml_kem_vector_avx2_arithmetic_barrett_reduce(__m256i vector) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_barrett_reduce_ea(__m256i vector) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_barrett_reduce_ea(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_arithmetic_barrett_reduce(vector);
 }
 
@@ -200,7 +206,8 @@ libcrux_ml_kem_vector_avx2_arithmetic_montgomery_multiply_by_constant(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_montgomery_multiply_by_constant_ea(
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_montgomery_multiply_by_constant_ea(
     __m256i vector, int16_t constant) {
   return libcrux_ml_kem_vector_avx2_arithmetic_montgomery_multiply_by_constant(
       vector, constant);
@@ -225,7 +232,8 @@ libcrux_ml_kem_vector_avx2_compress_compress_message_coefficient(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_compress_1_ea(__m256i vector) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_compress_1_ea(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_compress_compress_message_coefficient(
       vector);
 }
@@ -273,11 +281,9 @@ KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_ntt_layer_1_step(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_ntt_layer_1_step_ea(__m256i vector,
-                                                       int16_t zeta0,
-                                                       int16_t zeta1,
-                                                       int16_t zeta2,
-                                                       int16_t zeta3) {
+KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_layer_1_step_ea(
+    __m256i vector, int16_t zeta0, int16_t zeta1, int16_t zeta2,
+    int16_t zeta3) {
   return libcrux_ml_kem_vector_avx2_ntt_ntt_layer_1_step(vector, zeta0, zeta1,
                                                          zeta2, zeta3);
 }
@@ -299,9 +305,8 @@ KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_ntt_layer_2_step(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_ntt_layer_2_step_ea(__m256i vector,
-                                                       int16_t zeta0,
-                                                       int16_t zeta1) {
+KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_layer_2_step_ea(
+    __m256i vector, int16_t zeta0, int16_t zeta1) {
   return libcrux_ml_kem_vector_avx2_ntt_ntt_layer_2_step(vector, zeta0, zeta1);
 }
 
@@ -338,8 +343,8 @@ libcrux_ml_kem_vector_avx2_ntt_ntt_layer_3_step(__m256i vector, int16_t zeta) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_ntt_layer_3_step_ea(__m256i vector,
-                                                       int16_t zeta) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_ntt_layer_3_step_ea(__m256i vector, int16_t zeta) {
   return libcrux_ml_kem_vector_avx2_ntt_ntt_layer_3_step(vector, zeta);
 }
 
@@ -368,11 +373,9 @@ KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_inv_ntt_layer_1_step(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_inv_ntt_layer_1_step_ea(__m256i vector,
-                                                           int16_t zeta0,
-                                                           int16_t zeta1,
-                                                           int16_t zeta2,
-                                                           int16_t zeta3) {
+KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_inv_ntt_layer_1_step_ea(
+    __m256i vector, int16_t zeta0, int16_t zeta1, int16_t zeta2,
+    int16_t zeta3) {
   return libcrux_ml_kem_vector_avx2_ntt_inv_ntt_layer_1_step(
       vector, zeta0, zeta1, zeta2, zeta3);
 }
@@ -400,9 +403,8 @@ KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_inv_ntt_layer_2_step(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_inv_ntt_layer_2_step_ea(__m256i vector,
-                                                           int16_t zeta0,
-                                                           int16_t zeta1) {
+KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_inv_ntt_layer_2_step_ea(
+    __m256i vector, int16_t zeta0, int16_t zeta1) {
   return libcrux_ml_kem_vector_avx2_ntt_inv_ntt_layer_2_step(vector, zeta0,
                                                              zeta1);
 }
@@ -425,8 +427,8 @@ KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_inv_ntt_layer_3_step(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_inv_ntt_layer_3_step_ea(__m256i vector,
-                                                           int16_t zeta) {
+KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_inv_ntt_layer_3_step_ea(
+    __m256i vector, int16_t zeta) {
   return libcrux_ml_kem_vector_avx2_ntt_inv_ntt_layer_3_step(vector, zeta);
 }
 
@@ -511,10 +513,9 @@ KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_ntt_multiply(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_ntt_multiply_ea(__m256i *lhs, __m256i *rhs,
-                                                   int16_t zeta0, int16_t zeta1,
-                                                   int16_t zeta2,
-                                                   int16_t zeta3) {
+KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_multiply_ea(
+    __m256i *lhs, __m256i *rhs, int16_t zeta0, int16_t zeta1, int16_t zeta2,
+    int16_t zeta3) {
   return libcrux_ml_kem_vector_avx2_ntt_ntt_multiply(lhs[0U], rhs[0U], zeta0,
                                                      zeta1, zeta2, zeta3);
 }
@@ -569,8 +570,8 @@ KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_serialize_1(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-void libcrux_ml_kem_vector_avx2_serialize_1_ea(__m256i vector,
-                                               uint8_t ret[2U]) {
+KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_1_ea(
+    __m256i vector, uint8_t ret[2U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_1(vector, ret);
 }
 
@@ -623,7 +624,8 @@ libcrux_ml_kem_vector_avx2_serialize_deserialize_1(Eurydice_slice bytes) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_deserialize_1_ea(Eurydice_slice bytes) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_1_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_1(bytes);
 }
 
@@ -692,8 +694,8 @@ KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_serialize_4(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-void libcrux_ml_kem_vector_avx2_serialize_4_ea(__m256i vector,
-                                               uint8_t ret[8U]) {
+KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_4_ea(
+    __m256i vector, uint8_t ret[8U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_4(vector, ret);
 }
 
@@ -751,7 +753,8 @@ libcrux_ml_kem_vector_avx2_serialize_deserialize_4(Eurydice_slice bytes) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_deserialize_4_ea(Eurydice_slice bytes) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_4_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_4(bytes);
 }
 
@@ -847,8 +850,8 @@ KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_serialize_5(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-void libcrux_ml_kem_vector_avx2_serialize_5_ea(__m256i vector,
-                                               uint8_t ret[10U]) {
+KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_5_ea(
+    __m256i vector, uint8_t ret[10U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_5(vector, ret);
 }
 
@@ -898,7 +901,8 @@ libcrux_ml_kem_vector_avx2_serialize_deserialize_5(Eurydice_slice bytes) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_deserialize_5_ea(Eurydice_slice bytes) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_5_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_5(bytes);
 }
 
@@ -994,8 +998,8 @@ KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_serialize_10(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-void libcrux_ml_kem_vector_avx2_serialize_10_ea(__m256i vector,
-                                                uint8_t ret[20U]) {
+KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_10_ea(
+    __m256i vector, uint8_t ret[20U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_10(vector, ret);
 }
 
@@ -1029,7 +1033,8 @@ libcrux_ml_kem_vector_avx2_serialize_deserialize_10(Eurydice_slice bytes) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_deserialize_10_ea(Eurydice_slice bytes) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_10_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_10(bytes);
 }
 
@@ -1050,8 +1055,8 @@ KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_serialize_11(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-void libcrux_ml_kem_vector_avx2_serialize_11_ea(__m256i vector,
-                                                uint8_t ret[22U]) {
+KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_11_ea(
+    __m256i vector, uint8_t ret[22U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_11(vector, ret);
 }
 
@@ -1069,7 +1074,8 @@ libcrux_ml_kem_vector_avx2_serialize_deserialize_11(Eurydice_slice bytes) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_deserialize_11_ea(Eurydice_slice bytes) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_11_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_11(bytes);
 }
 
@@ -1121,8 +1127,8 @@ KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_serialize_12(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-void libcrux_ml_kem_vector_avx2_serialize_12_ea(__m256i vector,
-                                                uint8_t ret[24U]) {
+KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_12_ea(
+    __m256i vector, uint8_t ret[24U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_12(vector, ret);
 }
 
@@ -1156,7 +1162,8 @@ libcrux_ml_kem_vector_avx2_serialize_deserialize_12(Eurydice_slice bytes) {
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-__m256i libcrux_ml_kem_vector_avx2_deserialize_12_ea(Eurydice_slice bytes) {
+KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_12_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_12(bytes);
 }
 
@@ -1243,8 +1250,8 @@ KRML_MUSTINLINE size_t libcrux_ml_kem_vector_avx2_sampling_rejection_sample(
 This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
-size_t libcrux_ml_kem_vector_avx2_rej_sample_ea(Eurydice_slice input,
-                                                Eurydice_slice output) {
+KRML_MUSTINLINE size_t libcrux_ml_kem_vector_avx2_rej_sample_ea(
+    Eurydice_slice input, Eurydice_slice output) {
   return libcrux_ml_kem_vector_avx2_sampling_rejection_sample(input, output);
 }
 
@@ -1387,7 +1394,7 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.shift_right_ea
 with const generics
 - SHIFT_BY= 15
 */
-static __m256i shift_right_ea_ef(__m256i vector) {
+static KRML_MUSTINLINE __m256i shift_right_ea_ef(__m256i vector) {
   return shift_right_ef(vector);
 }
 
@@ -1397,7 +1404,7 @@ libcrux_ml_kem.vector.traits.to_unsigned_representative with types
 libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 
 */
-static __m256i to_unsigned_representative_79(__m256i a) {
+static KRML_MUSTINLINE __m256i to_unsigned_representative_79(__m256i a) {
   __m256i t = shift_right_ea_ef(a);
   __m256i fm = libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
       t, LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS);
@@ -2344,7 +2351,8 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static __m256i montgomery_multiply_fe_79(__m256i v, int16_t fer) {
+static KRML_MUSTINLINE __m256i montgomery_multiply_fe_79(__m256i v,
+                                                         int16_t fer) {
   return libcrux_ml_kem_vector_avx2_montgomery_multiply_by_constant_ea(v, fer);
 }
 
@@ -2678,7 +2686,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static __m256i to_standard_domain_79(__m256i v) {
+static KRML_MUSTINLINE __m256i to_standard_domain_79(__m256i v) {
   return libcrux_ml_kem_vector_avx2_montgomery_multiply_by_constant_ea(
       v, LIBCRUX_ML_KEM_VECTOR_TRAITS_MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS);
 }
@@ -2810,7 +2818,7 @@ with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static void generate_keypair_unpacked_221(
+static KRML_MUSTINLINE void generate_keypair_unpacked_221(
     Eurydice_slice key_generation_seed,
     IndCpaPrivateKeyUnpacked_63 *private_key,
     IndCpaPublicKeyUnpacked_63 *public_key) {
@@ -2869,8 +2877,8 @@ with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair768 generate_keypair_bb1(
-    Eurydice_slice key_generation_seed) {
+static KRML_MUSTINLINE libcrux_ml_kem_utils_extraction_helper_Keypair768
+generate_keypair_bb1(Eurydice_slice key_generation_seed) {
   IndCpaPrivateKeyUnpacked_63 private_key = default_1a_ab();
   IndCpaPublicKeyUnpacked_63 public_key = default_8d_ab();
   generate_keypair_unpacked_221(key_generation_seed, &private_key, &public_key);
@@ -3348,7 +3356,7 @@ with types libcrux_ml_kem_vector_avx2_SIMD256Vector
 with const generics
 
 */
-static __m256i decompress_1_79(__m256i v) {
+static KRML_MUSTINLINE __m256i decompress_1_79(__m256i v) {
   return libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
       libcrux_ml_kem_vector_avx2_sub_ea(libcrux_ml_kem_vector_avx2_ZERO_ea(),
                                         &v),
@@ -3532,7 +3540,7 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.compress_ea
 with const generics
 - COEFFICIENT_BITS= 10
 */
-static __m256i compress_ea_ef(__m256i vector) {
+static KRML_MUSTINLINE __m256i compress_ea_ef(__m256i vector) {
   return compress_ciphertext_coefficient_ef(vector);
 }
 
@@ -3642,7 +3650,7 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.compress_ea
 with const generics
 - COEFFICIENT_BITS= 11
 */
-static __m256i compress_ea_c4(__m256i vector) {
+static KRML_MUSTINLINE __m256i compress_ea_c4(__m256i vector) {
   return compress_ciphertext_coefficient_c4(vector);
 }
 
@@ -3672,7 +3680,7 @@ with const generics
 - COMPRESSION_FACTOR= 10
 - BLOCK_LEN= 320
 */
-static void compress_then_serialize_u_8c(
+static KRML_MUSTINLINE void compress_then_serialize_u_8c(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f6 input[3U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -3782,7 +3790,7 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.compress_ea
 with const generics
 - COEFFICIENT_BITS= 4
 */
-static __m256i compress_ea_d1(__m256i vector) {
+static KRML_MUSTINLINE __m256i compress_ea_d1(__m256i vector) {
   return compress_ciphertext_coefficient_d1(vector);
 }
 
@@ -3895,7 +3903,7 @@ A monomorphic instance of libcrux_ml_kem.vector.avx2.compress_ea
 with const generics
 - COEFFICIENT_BITS= 5
 */
-static __m256i compress_ea_f4(__m256i vector) {
+static KRML_MUSTINLINE __m256i compress_ea_f4(__m256i vector) {
   return compress_ciphertext_coefficient_f4(vector);
 }
 
@@ -3996,10 +4004,9 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_741(IndCpaPublicKeyUnpacked_63 *public_key,
-                                 uint8_t message[32U],
-                                 Eurydice_slice randomness,
-                                 uint8_t ret[1088U]) {
+static KRML_MUSTINLINE void encrypt_unpacked_741(
+    IndCpaPublicKeyUnpacked_63 *public_key, uint8_t message[32U],
+    Eurydice_slice randomness, uint8_t ret[1088U]) {
   uint8_t prf_input[33U];
   libcrux_ml_kem_utils_into_padded_array_c8(/* for i from 0 to k−1 do r[i] :=
                                                CBD{η1}(PRF(r, N)) N := N + 1 end
@@ -4079,8 +4086,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_741(Eurydice_slice public_key, uint8_t message[32U],
-                        Eurydice_slice randomness, uint8_t ret[1088U]) {
+static KRML_MUSTINLINE void encrypt_741(Eurydice_slice public_key,
+                                        uint8_t message[32U],
+                                        Eurydice_slice randomness,
+                                        uint8_t ret[1088U]) {
   IndCpaPublicKeyUnpacked_63 unpacked_public_key = default_8d_ab();
   deserialize_ring_elements_reduced_98(
       Eurydice_slice_subslice_to(/* tˆ := Decode_12(pk) */
@@ -4320,7 +4329,8 @@ libcrux_ml_kem.vector.avx2.decompress_ciphertext_coefficient_ea with const
 generics
 - COEFFICIENT_BITS= 10
 */
-static __m256i decompress_ciphertext_coefficient_ea_ef(__m256i vector) {
+static KRML_MUSTINLINE __m256i
+decompress_ciphertext_coefficient_ea_ef(__m256i vector) {
   return decompress_ciphertext_coefficient_ef(vector);
 }
 
@@ -4415,7 +4425,8 @@ libcrux_ml_kem.vector.avx2.decompress_ciphertext_coefficient_ea with const
 generics
 - COEFFICIENT_BITS= 11
 */
-static __m256i decompress_ciphertext_coefficient_ea_c4(__m256i vector) {
+static KRML_MUSTINLINE __m256i
+decompress_ciphertext_coefficient_ea_c4(__m256i vector) {
   return decompress_ciphertext_coefficient_c4(vector);
 }
 
@@ -4583,7 +4594,8 @@ libcrux_ml_kem.vector.avx2.decompress_ciphertext_coefficient_ea with const
 generics
 - COEFFICIENT_BITS= 4
 */
-static __m256i decompress_ciphertext_coefficient_ea_d1(__m256i vector) {
+static KRML_MUSTINLINE __m256i
+decompress_ciphertext_coefficient_ea_d1(__m256i vector) {
   return decompress_ciphertext_coefficient_d1(vector);
 }
 
@@ -4678,7 +4690,8 @@ libcrux_ml_kem.vector.avx2.decompress_ciphertext_coefficient_ea with const
 generics
 - COEFFICIENT_BITS= 5
 */
-static __m256i decompress_ciphertext_coefficient_ea_f4(__m256i vector) {
+static KRML_MUSTINLINE __m256i
+decompress_ciphertext_coefficient_ea_f4(__m256i vector) {
   return decompress_ciphertext_coefficient_f4(vector);
 }
 
@@ -4826,8 +4839,9 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_unpacked_2f(IndCpaPrivateKeyUnpacked_63 *secret_key,
-                                uint8_t *ciphertext, uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_unpacked_2f(
+    IndCpaPrivateKeyUnpacked_63 *secret_key, uint8_t *ciphertext,
+    uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f6 u_as_ntt[3U];
   deserialize_then_decompress_u_ed(
       /* u := Decompress_q(Decode_{d_u}(c), d_u) */ ciphertext, u_as_ntt);
@@ -4854,8 +4868,8 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_2f(Eurydice_slice secret_key, uint8_t *ciphertext,
-                       uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_2f(Eurydice_slice secret_key,
+                                       uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f6 secret_as_ntt[3U];
   deserialize_secret_key_ab(/* sˆ := Decode_12(sk) */ secret_key,
                             secret_as_ntt);
@@ -5975,7 +5989,7 @@ with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static void generate_keypair_unpacked_22(
+static KRML_MUSTINLINE void generate_keypair_unpacked_22(
     Eurydice_slice key_generation_seed,
     IndCpaPrivateKeyUnpacked_39 *private_key,
     IndCpaPublicKeyUnpacked_39 *public_key) {
@@ -6034,8 +6048,8 @@ with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair1024 generate_keypair_bb0(
-    Eurydice_slice key_generation_seed) {
+static KRML_MUSTINLINE libcrux_ml_kem_utils_extraction_helper_Keypair1024
+generate_keypair_bb0(Eurydice_slice key_generation_seed) {
   IndCpaPrivateKeyUnpacked_39 private_key = default_1a_42();
   IndCpaPublicKeyUnpacked_39 public_key = default_8d_42();
   generate_keypair_unpacked_22(key_generation_seed, &private_key, &public_key);
@@ -6425,7 +6439,7 @@ with const generics
 - COMPRESSION_FACTOR= 11
 - BLOCK_LEN= 352
 */
-static void compress_then_serialize_u_c9(
+static KRML_MUSTINLINE void compress_then_serialize_u_c9(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f6 input[4U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -6523,9 +6537,9 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_74(IndCpaPublicKeyUnpacked_39 *public_key,
-                                uint8_t message[32U], Eurydice_slice randomness,
-                                uint8_t ret[1568U]) {
+static KRML_MUSTINLINE void encrypt_unpacked_74(
+    IndCpaPublicKeyUnpacked_39 *public_key, uint8_t message[32U],
+    Eurydice_slice randomness, uint8_t ret[1568U]) {
   uint8_t prf_input[33U];
   libcrux_ml_kem_utils_into_padded_array_c8(/* for i from 0 to k−1 do r[i] :=
                                                CBD{η1}(PRF(r, N)) N := N + 1 end
@@ -6605,8 +6619,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_740(Eurydice_slice public_key, uint8_t message[32U],
-                        Eurydice_slice randomness, uint8_t ret[1568U]) {
+static KRML_MUSTINLINE void encrypt_740(Eurydice_slice public_key,
+                                        uint8_t message[32U],
+                                        Eurydice_slice randomness,
+                                        uint8_t ret[1568U]) {
   IndCpaPublicKeyUnpacked_39 unpacked_public_key = default_8d_42();
   deserialize_ring_elements_reduced_3c(
       Eurydice_slice_subslice_to(/* tˆ := Decode_12(pk) */
@@ -6901,8 +6917,9 @@ with const generics
 - U_COMPRESSION_FACTOR= 11
 - V_COMPRESSION_FACTOR= 5
 */
-static void decrypt_unpacked_37(IndCpaPrivateKeyUnpacked_39 *secret_key,
-                                uint8_t *ciphertext, uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_unpacked_37(
+    IndCpaPrivateKeyUnpacked_39 *secret_key, uint8_t *ciphertext,
+    uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f6 u_as_ntt[4U];
   deserialize_then_decompress_u_1e(
       /* u := Decompress_q(Decode_{d_u}(c), d_u) */ ciphertext, u_as_ntt);
@@ -6929,8 +6946,8 @@ with const generics
 - U_COMPRESSION_FACTOR= 11
 - V_COMPRESSION_FACTOR= 5
 */
-static void decrypt_37(Eurydice_slice secret_key, uint8_t *ciphertext,
-                       uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_37(Eurydice_slice secret_key,
+                                       uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f6 secret_as_ntt[4U];
   deserialize_secret_key_42(/* sˆ := Decode_12(sk) */ secret_key,
                             secret_as_ntt);
@@ -8017,7 +8034,7 @@ with const generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static void generate_keypair_unpacked_220(
+static KRML_MUSTINLINE void generate_keypair_unpacked_220(
     Eurydice_slice key_generation_seed,
     IndCpaPrivateKeyUnpacked_94 *private_key,
     IndCpaPublicKeyUnpacked_94 *public_key) {
@@ -8076,8 +8093,8 @@ with const generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair512 generate_keypair_bb(
-    Eurydice_slice key_generation_seed) {
+static KRML_MUSTINLINE libcrux_ml_kem_utils_extraction_helper_Keypair512
+generate_keypair_bb(Eurydice_slice key_generation_seed) {
   IndCpaPrivateKeyUnpacked_94 private_key = default_1a_89();
   IndCpaPublicKeyUnpacked_94 public_key = default_8d_89();
   generate_keypair_unpacked_220(key_generation_seed, &private_key, &public_key);
@@ -8475,7 +8492,7 @@ with const generics
 - COMPRESSION_FACTOR= 10
 - BLOCK_LEN= 320
 */
-static void compress_then_serialize_u_2d(
+static KRML_MUSTINLINE void compress_then_serialize_u_2d(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f6 input[2U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -8561,9 +8578,9 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_740(IndCpaPublicKeyUnpacked_94 *public_key,
-                                 uint8_t message[32U],
-                                 Eurydice_slice randomness, uint8_t ret[768U]) {
+static KRML_MUSTINLINE void encrypt_unpacked_740(
+    IndCpaPublicKeyUnpacked_94 *public_key, uint8_t message[32U],
+    Eurydice_slice randomness, uint8_t ret[768U]) {
   uint8_t prf_input[33U];
   libcrux_ml_kem_utils_into_padded_array_c8(/* for i from 0 to k−1 do r[i] :=
                                                CBD{η1}(PRF(r, N)) N := N + 1 end
@@ -8643,8 +8660,10 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_74(Eurydice_slice public_key, uint8_t message[32U],
-                       Eurydice_slice randomness, uint8_t ret[768U]) {
+static KRML_MUSTINLINE void encrypt_74(Eurydice_slice public_key,
+                                       uint8_t message[32U],
+                                       Eurydice_slice randomness,
+                                       uint8_t ret[768U]) {
   IndCpaPublicKeyUnpacked_94 unpacked_public_key = default_8d_89();
   deserialize_ring_elements_reduced_09(
       Eurydice_slice_subslice_to(/* tˆ := Decode_12(pk) */
@@ -8898,8 +8917,9 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_unpacked_4b(IndCpaPrivateKeyUnpacked_94 *secret_key,
-                                uint8_t *ciphertext, uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_unpacked_4b(
+    IndCpaPrivateKeyUnpacked_94 *secret_key, uint8_t *ciphertext,
+    uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f6 u_as_ntt[2U];
   deserialize_then_decompress_u_ba(
       /* u := Decompress_q(Decode_{d_u}(c), d_u) */ ciphertext, u_as_ntt);
@@ -8926,8 +8946,8 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_4b(Eurydice_slice secret_key, uint8_t *ciphertext,
-                       uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_4b(Eurydice_slice secret_key,
+                                       uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f6 secret_as_ntt[2U];
   deserialize_secret_key_89(/* sˆ := Decode_12(sk) */ secret_key,
                             secret_as_ntt);

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "internal/libcrux_mlkem_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "internal/libcrux_mlkem_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "internal/libcrux_mlkem_portable.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "internal/libcrux_mlkem_portable.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "internal/libcrux_mlkem_portable.h"
@@ -2427,7 +2427,7 @@ libcrux_ml_kem.vector.traits.to_unsigned_representative with types
 libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
-static libcrux_ml_kem_vector_portable_vector_type_PortableVector
+static KRML_MUSTINLINE libcrux_ml_kem_vector_portable_vector_type_PortableVector
 to_unsigned_representative_8c(
     libcrux_ml_kem_vector_portable_vector_type_PortableVector a) {
   libcrux_ml_kem_vector_portable_vector_type_PortableVector t =
@@ -3371,7 +3371,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static libcrux_ml_kem_vector_portable_vector_type_PortableVector
+static KRML_MUSTINLINE libcrux_ml_kem_vector_portable_vector_type_PortableVector
 montgomery_multiply_fe_8c(
     libcrux_ml_kem_vector_portable_vector_type_PortableVector v, int16_t fer) {
   return libcrux_ml_kem_vector_portable_montgomery_multiply_by_constant_0d(v,
@@ -3727,7 +3727,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static libcrux_ml_kem_vector_portable_vector_type_PortableVector
+static KRML_MUSTINLINE libcrux_ml_kem_vector_portable_vector_type_PortableVector
 to_standard_domain_8c(
     libcrux_ml_kem_vector_portable_vector_type_PortableVector v) {
   return libcrux_ml_kem_vector_portable_montgomery_multiply_by_constant_0d(
@@ -3864,7 +3864,7 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static void generate_keypair_unpacked_1c(
+static KRML_MUSTINLINE void generate_keypair_unpacked_1c(
     Eurydice_slice key_generation_seed,
     IndCpaPrivateKeyUnpacked_af *private_key,
     IndCpaPublicKeyUnpacked_af *public_key) {
@@ -3923,8 +3923,8 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair1024 generate_keypair_151(
-    Eurydice_slice key_generation_seed) {
+static KRML_MUSTINLINE libcrux_ml_kem_utils_extraction_helper_Keypair1024
+generate_keypair_151(Eurydice_slice key_generation_seed) {
   IndCpaPrivateKeyUnpacked_af private_key = default_1a_d0();
   IndCpaPublicKeyUnpacked_af public_key = default_8d_d0();
   generate_keypair_unpacked_1c(key_generation_seed, &private_key, &public_key);
@@ -4413,7 +4413,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static libcrux_ml_kem_vector_portable_vector_type_PortableVector
+static KRML_MUSTINLINE libcrux_ml_kem_vector_portable_vector_type_PortableVector
 decompress_1_8c(libcrux_ml_kem_vector_portable_vector_type_PortableVector v) {
   libcrux_ml_kem_vector_portable_vector_type_PortableVector uu____0 =
       libcrux_ml_kem_vector_portable_ZERO_0d();
@@ -4637,7 +4637,7 @@ with const generics
 - COMPRESSION_FACTOR= 11
 - BLOCK_LEN= 352
 */
-static void compress_then_serialize_u_2f(
+static KRML_MUSTINLINE void compress_then_serialize_u_2f(
     libcrux_ml_kem_polynomial_PolynomialRingElement_1d input[4U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -4854,9 +4854,9 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_2a(IndCpaPublicKeyUnpacked_af *public_key,
-                                uint8_t message[32U], Eurydice_slice randomness,
-                                uint8_t ret[1568U]) {
+static KRML_MUSTINLINE void encrypt_unpacked_2a(
+    IndCpaPublicKeyUnpacked_af *public_key, uint8_t message[32U],
+    Eurydice_slice randomness, uint8_t ret[1568U]) {
   uint8_t prf_input[33U];
   libcrux_ml_kem_utils_into_padded_array_c8(/* for i from 0 to k−1 do r[i] :=
                                                CBD{η1}(PRF(r, N)) N := N + 1 end
@@ -4937,8 +4937,10 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_2a1(Eurydice_slice public_key, uint8_t message[32U],
-                        Eurydice_slice randomness, uint8_t ret[1568U]) {
+static KRML_MUSTINLINE void encrypt_2a1(Eurydice_slice public_key,
+                                        uint8_t message[32U],
+                                        Eurydice_slice randomness,
+                                        uint8_t ret[1568U]) {
   IndCpaPublicKeyUnpacked_af unpacked_public_key = default_8d_d0();
   deserialize_ring_elements_reduced_0d(
       Eurydice_slice_subslice_to(/* tˆ := Decode_12(pk) */
@@ -5566,8 +5568,9 @@ with const generics
 - U_COMPRESSION_FACTOR= 11
 - V_COMPRESSION_FACTOR= 5
 */
-static void decrypt_unpacked_7d(IndCpaPrivateKeyUnpacked_af *secret_key,
-                                uint8_t *ciphertext, uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_unpacked_7d(
+    IndCpaPrivateKeyUnpacked_af *secret_key, uint8_t *ciphertext,
+    uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_1d u_as_ntt[4U];
   deserialize_then_decompress_u_00(
       /* u := Decompress_q(Decode_{d_u}(c), d_u) */ ciphertext, u_as_ntt);
@@ -5594,8 +5597,8 @@ with const generics
 - U_COMPRESSION_FACTOR= 11
 - V_COMPRESSION_FACTOR= 5
 */
-static void decrypt_7d(Eurydice_slice secret_key, uint8_t *ciphertext,
-                       uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_7d(Eurydice_slice secret_key,
+                                       uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_1d secret_as_ntt[4U];
   deserialize_secret_key_d0(/* sˆ := Decode_12(sk) */ secret_key,
                             secret_as_ntt);
@@ -6688,7 +6691,7 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static void generate_keypair_unpacked_1c0(
+static KRML_MUSTINLINE void generate_keypair_unpacked_1c0(
     Eurydice_slice key_generation_seed,
     IndCpaPrivateKeyUnpacked_d4 *private_key,
     IndCpaPublicKeyUnpacked_d4 *public_key) {
@@ -6747,8 +6750,8 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA1= 3
 - ETA1_RANDOMNESS_SIZE= 192
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair512 generate_keypair_150(
-    Eurydice_slice key_generation_seed) {
+static KRML_MUSTINLINE libcrux_ml_kem_utils_extraction_helper_Keypair512
+generate_keypair_150(Eurydice_slice key_generation_seed) {
   IndCpaPrivateKeyUnpacked_d4 private_key = default_1a_a0();
   IndCpaPublicKeyUnpacked_d4 public_key = default_8d_a0();
   generate_keypair_unpacked_1c0(key_generation_seed, &private_key, &public_key);
@@ -7171,7 +7174,7 @@ with const generics
 - COMPRESSION_FACTOR= 10
 - BLOCK_LEN= 320
 */
-static void compress_then_serialize_u_6d(
+static KRML_MUSTINLINE void compress_then_serialize_u_6d(
     libcrux_ml_kem_polynomial_PolynomialRingElement_1d input[2U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -7270,9 +7273,9 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_2a0(IndCpaPublicKeyUnpacked_d4 *public_key,
-                                 uint8_t message[32U],
-                                 Eurydice_slice randomness, uint8_t ret[768U]) {
+static KRML_MUSTINLINE void encrypt_unpacked_2a0(
+    IndCpaPublicKeyUnpacked_d4 *public_key, uint8_t message[32U],
+    Eurydice_slice randomness, uint8_t ret[768U]) {
   uint8_t prf_input[33U];
   libcrux_ml_kem_utils_into_padded_array_c8(/* for i from 0 to k−1 do r[i] :=
                                                CBD{η1}(PRF(r, N)) N := N + 1 end
@@ -7354,8 +7357,10 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_2a0(Eurydice_slice public_key, uint8_t message[32U],
-                        Eurydice_slice randomness, uint8_t ret[768U]) {
+static KRML_MUSTINLINE void encrypt_2a0(Eurydice_slice public_key,
+                                        uint8_t message[32U],
+                                        Eurydice_slice randomness,
+                                        uint8_t ret[768U]) {
   IndCpaPublicKeyUnpacked_d4 unpacked_public_key = default_8d_a0();
   deserialize_ring_elements_reduced_5f(
       Eurydice_slice_subslice_to(/* tˆ := Decode_12(pk) */
@@ -7650,8 +7655,9 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_unpacked_d1(IndCpaPrivateKeyUnpacked_d4 *secret_key,
-                                uint8_t *ciphertext, uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_unpacked_d1(
+    IndCpaPrivateKeyUnpacked_d4 *secret_key, uint8_t *ciphertext,
+    uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_1d u_as_ntt[2U];
   deserialize_then_decompress_u_86(
       /* u := Decompress_q(Decode_{d_u}(c), d_u) */ ciphertext, u_as_ntt);
@@ -7678,8 +7684,8 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_d1(Eurydice_slice secret_key, uint8_t *ciphertext,
-                       uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_d1(Eurydice_slice secret_key,
+                                       uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_1d secret_as_ntt[2U];
   deserialize_secret_key_a0(/* sˆ := Decode_12(sk) */ secret_key,
                             secret_as_ntt);
@@ -8755,7 +8761,7 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static void generate_keypair_unpacked_1c1(
+static KRML_MUSTINLINE void generate_keypair_unpacked_1c1(
     Eurydice_slice key_generation_seed,
     IndCpaPrivateKeyUnpacked_a0 *private_key,
     IndCpaPublicKeyUnpacked_a0 *public_key) {
@@ -8814,8 +8820,8 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static libcrux_ml_kem_utils_extraction_helper_Keypair768 generate_keypair_15(
-    Eurydice_slice key_generation_seed) {
+static KRML_MUSTINLINE libcrux_ml_kem_utils_extraction_helper_Keypair768
+generate_keypair_15(Eurydice_slice key_generation_seed) {
   IndCpaPrivateKeyUnpacked_a0 private_key = default_1a_1b();
   IndCpaPublicKeyUnpacked_a0 public_key = default_8d_1b();
   generate_keypair_unpacked_1c1(key_generation_seed, &private_key, &public_key);
@@ -9168,7 +9174,7 @@ with const generics
 - COMPRESSION_FACTOR= 10
 - BLOCK_LEN= 320
 */
-static void compress_then_serialize_u_43(
+static KRML_MUSTINLINE void compress_then_serialize_u_43(
     libcrux_ml_kem_polynomial_PolynomialRingElement_1d input[3U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -9255,10 +9261,9 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_unpacked_2a1(IndCpaPublicKeyUnpacked_a0 *public_key,
-                                 uint8_t message[32U],
-                                 Eurydice_slice randomness,
-                                 uint8_t ret[1088U]) {
+static KRML_MUSTINLINE void encrypt_unpacked_2a1(
+    IndCpaPublicKeyUnpacked_a0 *public_key, uint8_t message[32U],
+    Eurydice_slice randomness, uint8_t ret[1088U]) {
   uint8_t prf_input[33U];
   libcrux_ml_kem_utils_into_padded_array_c8(/* for i from 0 to k−1 do r[i] :=
                                                CBD{η1}(PRF(r, N)) N := N + 1 end
@@ -9340,8 +9345,10 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static void encrypt_2a(Eurydice_slice public_key, uint8_t message[32U],
-                       Eurydice_slice randomness, uint8_t ret[1088U]) {
+static KRML_MUSTINLINE void encrypt_2a(Eurydice_slice public_key,
+                                       uint8_t message[32U],
+                                       Eurydice_slice randomness,
+                                       uint8_t ret[1088U]) {
   IndCpaPublicKeyUnpacked_a0 unpacked_public_key = default_8d_1b();
   deserialize_ring_elements_reduced_b3(
       Eurydice_slice_subslice_to(/* tˆ := Decode_12(pk) */
@@ -9595,8 +9602,9 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_unpacked_42(IndCpaPrivateKeyUnpacked_a0 *secret_key,
-                                uint8_t *ciphertext, uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_unpacked_42(
+    IndCpaPrivateKeyUnpacked_a0 *secret_key, uint8_t *ciphertext,
+    uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_1d u_as_ntt[3U];
   deserialize_then_decompress_u_6c(
       /* u := Decompress_q(Decode_{d_u}(c), d_u) */ ciphertext, u_as_ntt);
@@ -9623,8 +9631,8 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static void decrypt_42(Eurydice_slice secret_key, uint8_t *ciphertext,
-                       uint8_t ret[32U]) {
+static KRML_MUSTINLINE void decrypt_42(Eurydice_slice secret_key,
+                                       uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_1d secret_as_ntt[3U];
   deserialize_secret_key_1b(/* sˆ := Decode_12(sk) */ secret_key,
                             secret_as_ntt);

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_mlkem_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem_portable_H

--- a/libcrux-ml-kem/c/libcrux_sha3.h
+++ b/libcrux-ml-kem/c/libcrux_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_sha3_H

--- a/libcrux-ml-kem/c/libcrux_sha3.h
+++ b/libcrux-ml-kem/c/libcrux_sha3.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_sha3_H

--- a/libcrux-ml-kem/c/libcrux_sha3.h
+++ b/libcrux-ml-kem/c/libcrux_sha3.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_sha3_H

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "internal/libcrux_sha3_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "internal/libcrux_sha3_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "internal/libcrux_sha3_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/c/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_internal.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_sha3_internal_H

--- a/libcrux-ml-kem/c/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_internal.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_sha3_internal_H

--- a/libcrux-ml-kem/c/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_internal.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_sha3_internal_H

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.c
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #include "libcrux_sha3_neon.h"

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #include "libcrux_sha3_neon.h"

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.c
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #include "libcrux_sha3_neon.h"

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.h
@@ -7,8 +7,8 @@
  * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
- * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
- * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_sha3_neon_H

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 2e8f138dbcbfbfabf4bbd994c8587ec00d197102
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 58c915a86a2c07c8eca8d9deafd76cb7a91f0eb7
+ * Libcrux: de5cf36eb9ea4853d387d80f6b4385ce5275511b
  */
 
 #ifndef __libcrux_sha3_neon_H

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_sha3_neon_H

--- a/libcrux-ml-kem/cg/code_gen.txt
+++ b/libcrux-ml-kem/cg/code_gen.txt
@@ -3,4 +3,4 @@ Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
 Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
 Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
 F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
-Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664

--- a/libcrux-ml-kem/cg/code_gen.txt
+++ b/libcrux-ml-kem/cg/code_gen.txt
@@ -1,6 +1,6 @@
 This code was generated with the following revisions:
-Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
 Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
-Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
-F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
-Libcrux: 897008ee57eed9e4574222a5e96d306ce203ecee
+Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911

--- a/libcrux-ml-kem/cg/libcrux_core.h
+++ b/libcrux-ml-kem/cg/libcrux_core.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_core_H

--- a/libcrux-ml-kem/cg/libcrux_core.h
+++ b/libcrux-ml-kem/cg/libcrux_core.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 897008ee57eed9e4574222a5e96d306ce203ecee
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_core_H

--- a/libcrux-ml-kem/cg/libcrux_ct_ops.h
+++ b/libcrux-ml-kem/cg/libcrux_ct_ops.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 897008ee57eed9e4574222a5e96d306ce203ecee
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_ct_ops_H

--- a/libcrux-ml-kem/cg/libcrux_ct_ops.h
+++ b/libcrux-ml-kem/cg/libcrux_ct_ops.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_ct_ops_H

--- a/libcrux-ml-kem/cg/libcrux_mlkem768_avx2.h
+++ b/libcrux-ml-kem/cg/libcrux_mlkem768_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem768_avx2_H

--- a/libcrux-ml-kem/cg/libcrux_mlkem768_avx2.h
+++ b/libcrux-ml-kem/cg/libcrux_mlkem768_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 897008ee57eed9e4574222a5e96d306ce203ecee
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem768_avx2_H
@@ -56,7 +56,7 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_ZERO_ea(void) {
+static KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ZERO_ea(void) {
   return libcrux_ml_kem_vector_avx2_zero();
 }
 
@@ -71,8 +71,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_from_i16_array_ea(
-    Eurydice_slice array) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_from_i16_array_ea(Eurydice_slice array) {
   return libcrux_ml_kem_vector_avx2_from_i16_array(array);
 }
 
@@ -90,7 +90,7 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_vector_avx2_to_i16_array_ea(
+static KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_to_i16_array_ea(
     __m256i x, int16_t ret[16U]) {
   libcrux_ml_kem_vector_avx2_to_i16_array(x, ret);
 }
@@ -106,8 +106,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_add_ea(__m256i lhs,
-                                                        __m256i *rhs) {
+static KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_add_ea(__m256i lhs,
+                                                                 __m256i *rhs) {
   return libcrux_ml_kem_vector_avx2_arithmetic_add(lhs, rhs[0U]);
 }
 
@@ -122,8 +122,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_sub_ea(__m256i lhs,
-                                                        __m256i *rhs) {
+static KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_sub_ea(__m256i lhs,
+                                                                 __m256i *rhs) {
   return libcrux_ml_kem_vector_avx2_arithmetic_sub(lhs, rhs[0U]);
 }
 
@@ -140,8 +140,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_multiply_by_constant_ea(
-    __m256i v, int16_t c) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_multiply_by_constant_ea(__m256i v, int16_t c) {
   return libcrux_ml_kem_vector_avx2_arithmetic_multiply_by_constant(v, c);
 }
 
@@ -158,8 +158,9 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
-    __m256i vector, int16_t constant) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(__m256i vector,
+                                                        int16_t constant) {
   return libcrux_ml_kem_vector_avx2_arithmetic_bitwise_and_with_constant(
       vector, constant);
 }
@@ -189,8 +190,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_cond_subtract_3329_ea(
-    __m256i vector) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_cond_subtract_3329_ea(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_arithmetic_cond_subtract_3329(vector);
 }
 
@@ -224,8 +225,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_barrett_reduce_ea(
-    __m256i vector) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_barrett_reduce_ea(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_arithmetic_barrett_reduce(vector);
 }
 
@@ -254,7 +255,7 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i
+static KRML_MUSTINLINE __m256i
 libcrux_ml_kem_vector_avx2_montgomery_multiply_by_constant_ea(
     __m256i vector, int16_t constant) {
   return libcrux_ml_kem_vector_avx2_arithmetic_montgomery_multiply_by_constant(
@@ -287,7 +288,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_compress_1_ea(__m256i vector) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_compress_1_ea(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_compress_compress_message_coefficient(
       vector);
 }
@@ -344,7 +346,7 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_ntt_layer_1_step_ea(
+static KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_layer_1_step_ea(
     __m256i vector, int16_t zeta0, int16_t zeta1, int16_t zeta2,
     int16_t zeta3) {
   return libcrux_ml_kem_vector_avx2_ntt_ntt_layer_1_step(vector, zeta0, zeta1,
@@ -372,7 +374,7 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_ntt_layer_2_step_ea(
+static KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_layer_2_step_ea(
     __m256i vector, int16_t zeta0, int16_t zeta1) {
   return libcrux_ml_kem_vector_avx2_ntt_ntt_layer_2_step(vector, zeta0, zeta1);
 }
@@ -416,8 +418,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_ntt_layer_3_step_ea(
-    __m256i vector, int16_t zeta) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_ntt_layer_3_step_ea(__m256i vector, int16_t zeta) {
   return libcrux_ml_kem_vector_avx2_ntt_ntt_layer_3_step(vector, zeta);
 }
 
@@ -455,9 +457,11 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_inv_ntt_layer_1_step_ea(
-    __m256i vector, int16_t zeta0, int16_t zeta1, int16_t zeta2,
-    int16_t zeta3) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_inv_ntt_layer_1_step_ea(__m256i vector,
+                                                   int16_t zeta0, int16_t zeta1,
+                                                   int16_t zeta2,
+                                                   int16_t zeta3) {
   return libcrux_ml_kem_vector_avx2_ntt_inv_ntt_layer_1_step(
       vector, zeta0, zeta1, zeta2, zeta3);
 }
@@ -493,8 +497,10 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_inv_ntt_layer_2_step_ea(
-    __m256i vector, int16_t zeta0, int16_t zeta1) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_inv_ntt_layer_2_step_ea(__m256i vector,
+                                                   int16_t zeta0,
+                                                   int16_t zeta1) {
   return libcrux_ml_kem_vector_avx2_ntt_inv_ntt_layer_2_step(vector, zeta0,
                                                              zeta1);
 }
@@ -522,8 +528,9 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_inv_ntt_layer_3_step_ea(
-    __m256i vector, int16_t zeta) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_inv_ntt_layer_3_step_ea(__m256i vector,
+                                                   int16_t zeta) {
   return libcrux_ml_kem_vector_avx2_ntt_inv_ntt_layer_3_step(vector, zeta);
 }
 
@@ -622,7 +629,7 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_ntt_multiply_ea(
+static KRML_MUSTINLINE __m256i libcrux_ml_kem_vector_avx2_ntt_multiply_ea(
     __m256i *lhs, __m256i *rhs, int16_t zeta0, int16_t zeta1, int16_t zeta2,
     int16_t zeta3) {
   return libcrux_ml_kem_vector_avx2_ntt_ntt_multiply(lhs[0U], rhs[0U], zeta0,
@@ -697,8 +704,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_vector_avx2_serialize_1_ea(__m256i vector,
-                                                             uint8_t ret[2U]) {
+static KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_1_ea(
+    __m256i vector, uint8_t ret[2U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_1(vector, ret);
 }
 
@@ -753,8 +760,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_deserialize_1_ea(
-    Eurydice_slice bytes) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_1_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_1(bytes);
 }
 
@@ -856,8 +863,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_vector_avx2_serialize_4_ea(__m256i vector,
-                                                             uint8_t ret[8U]) {
+static KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_4_ea(
+    __m256i vector, uint8_t ret[8U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_4(vector, ret);
 }
 
@@ -919,8 +926,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_deserialize_4_ea(
-    Eurydice_slice bytes) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_4_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_4(bytes);
 }
 
@@ -1046,8 +1053,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_vector_avx2_serialize_5_ea(__m256i vector,
-                                                             uint8_t ret[10U]) {
+static KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_5_ea(
+    __m256i vector, uint8_t ret[10U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_5(vector, ret);
 }
 
@@ -1101,8 +1108,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_deserialize_5_ea(
-    Eurydice_slice bytes) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_5_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_5(bytes);
 }
 
@@ -1239,7 +1246,7 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_vector_avx2_serialize_10_ea(
+static KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_10_ea(
     __m256i vector, uint8_t ret[20U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_10(vector, ret);
 }
@@ -1282,8 +1289,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_deserialize_10_ea(
-    Eurydice_slice bytes) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_10_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_10(bytes);
 }
 
@@ -1306,7 +1313,7 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_vector_avx2_serialize_11_ea(
+static KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_11_ea(
     __m256i vector, uint8_t ret[22U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_11(vector, ret);
 }
@@ -1327,8 +1334,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_deserialize_11_ea(
-    Eurydice_slice bytes) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_11_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_11(bytes);
 }
 
@@ -1384,7 +1391,7 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_vector_avx2_serialize_12_ea(
+static KRML_MUSTINLINE void libcrux_ml_kem_vector_avx2_serialize_12_ea(
     __m256i vector, uint8_t ret[24U]) {
   libcrux_ml_kem_vector_avx2_serialize_serialize_12(vector, ret);
 }
@@ -1427,8 +1434,8 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_deserialize_12_ea(
-    Eurydice_slice bytes) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_deserialize_12_ea(Eurydice_slice bytes) {
   return libcrux_ml_kem_vector_avx2_serialize_deserialize_12(bytes);
 }
 
@@ -1525,7 +1532,7 @@ This function found in impl {(libcrux_ml_kem::vector::traits::Operations for
 libcrux_ml_kem::vector::avx2::SIMD256Vector)}
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline size_t libcrux_ml_kem_vector_avx2_rej_sample_ea(
+static KRML_MUSTINLINE size_t libcrux_ml_kem_vector_avx2_rej_sample_ea(
     Eurydice_slice input, Eurydice_slice output) {
   return libcrux_ml_kem_vector_avx2_sampling_rejection_sample(input, output);
 }
@@ -1730,7 +1737,7 @@ generics
 - COEFFICIENT_BITS= 10
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i
+static KRML_MUSTINLINE __m256i
 libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_ef(
     __m256i vector) {
   return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_ef(
@@ -1843,7 +1850,7 @@ generics
 - COEFFICIENT_BITS= 11
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i
+static KRML_MUSTINLINE __m256i
 libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_c4(
     __m256i vector) {
   return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_c4(
@@ -1900,8 +1907,8 @@ with const generics
 
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_traits_montgomery_multiply_fe_79(
-    __m256i v, int16_t fer) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_traits_montgomery_multiply_fe_79(__m256i v, int16_t fer) {
   return libcrux_ml_kem_vector_avx2_montgomery_multiply_by_constant_ea(v, fer);
 }
 
@@ -2199,7 +2206,7 @@ generics
 - COEFFICIENT_BITS= 4
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i
+static KRML_MUSTINLINE __m256i
 libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_d1(
     __m256i vector) {
   return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_d1(
@@ -2312,7 +2319,7 @@ generics
 - COEFFICIENT_BITS= 5
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i
+static KRML_MUSTINLINE __m256i
 libcrux_ml_kem_vector_avx2_decompress_ciphertext_coefficient_ea_f4(
     __m256i vector) {
   return libcrux_ml_kem_vector_avx2_compress_decompress_ciphertext_coefficient_f4(
@@ -2698,8 +2705,8 @@ with const generics
 - SHIFT_BY= 15
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_shift_right_ea_ef(
-    __m256i vector) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_shift_right_ea_ef(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_arithmetic_shift_right_ef(vector);
 }
 
@@ -2710,7 +2717,7 @@ libcrux_ml_kem_vector_avx2_SIMD256Vector with const generics
 
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i
+static KRML_MUSTINLINE __m256i
 libcrux_ml_kem_vector_traits_to_unsigned_representative_79(__m256i a) {
   __m256i t = libcrux_ml_kem_vector_avx2_shift_right_ea_ef(a);
   __m256i fm = libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
@@ -2781,7 +2788,7 @@ with const generics
 - V_COMPRESSION_FACTOR= 4
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_decrypt_unpacked_2f(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_decrypt_unpacked_2f(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_63 *secret_key,
     uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f6 u_as_ntt[3U];
@@ -2814,9 +2821,8 @@ with const generics
 - V_COMPRESSION_FACTOR= 4
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_decrypt_2f(Eurydice_slice secret_key,
-                                                     uint8_t *ciphertext,
-                                                     uint8_t ret[32U]) {
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_decrypt_2f(
+    Eurydice_slice secret_key, uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f6 secret_as_ntt[3U];
   libcrux_ml_kem_ind_cpa_deserialize_secret_key_ab(
       /* sˆ := Decode_12(sk) */ secret_key, secret_as_ntt);
@@ -3991,7 +3997,8 @@ with const generics
 
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_traits_decompress_1_79(__m256i v) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_traits_decompress_1_79(__m256i v) {
   return libcrux_ml_kem_vector_avx2_bitwise_and_with_constant_ea(
       libcrux_ml_kem_vector_avx2_sub_ea(libcrux_ml_kem_vector_avx2_ZERO_ea(),
                                         &v),
@@ -4200,8 +4207,8 @@ with const generics
 - COEFFICIENT_BITS= 10
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_ef(
-    __m256i vector) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_compress_ea_ef(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_ef(
       vector);
 }
@@ -4329,8 +4336,8 @@ with const generics
 - COEFFICIENT_BITS= 11
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_c4(
-    __m256i vector) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_compress_ea_c4(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_c4(
       vector);
 }
@@ -4391,7 +4398,7 @@ with const generics
 - BLOCK_LEN= 320
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_compress_then_serialize_u_8c(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_compress_then_serialize_u_8c(
     libcrux_ml_kem_polynomial_PolynomialRingElement_f6 input[3U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -4515,8 +4522,8 @@ with const generics
 - COEFFICIENT_BITS= 4
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_d1(
-    __m256i vector) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_compress_ea_d1(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_d1(
       vector);
 }
@@ -4647,8 +4654,8 @@ with const generics
 - COEFFICIENT_BITS= 5
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_avx2_compress_ea_f4(
-    __m256i vector) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_avx2_compress_ea_f4(__m256i vector) {
   return libcrux_ml_kem_vector_avx2_compress_compress_ciphertext_coefficient_f4(
       vector);
 }
@@ -4756,7 +4763,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_encrypt_unpacked_74(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_encrypt_unpacked_74(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_63 *public_key,
     uint8_t message[32U], Eurydice_slice randomness, uint8_t ret[1088U]) {
   uint8_t prf_input[33U];
@@ -4841,10 +4848,9 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_encrypt_74(Eurydice_slice public_key,
-                                                     uint8_t message[32U],
-                                                     Eurydice_slice randomness,
-                                                     uint8_t ret[1088U]) {
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_encrypt_74(
+    Eurydice_slice public_key, uint8_t message[32U], Eurydice_slice randomness,
+    uint8_t ret[1088U]) {
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_63
       unpacked_public_key = libcrux_ml_kem_ind_cpa_unpacked_default_8d_ab();
   libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_98(
@@ -4916,7 +4922,7 @@ with const generics
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cca_decapsulate_a1(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_decapsulate_a1(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -4990,8 +4996,33 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_a1(
 }
 
 /**
- Portable decapsulate
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.decapsulate_avx2 with const generics
+- K= 3
+- SECRET_KEY_SIZE= 2400
+- CPA_SECRET_KEY_SIZE= 1152
+- PUBLIC_KEY_SIZE= 1184
+- CIPHERTEXT_SIZE= 1088
+- T_AS_NTT_ENCODED_SIZE= 1152
+- C1_SIZE= 960
+- C2_SIZE= 128
+- VECTOR_U_COMPRESSION_FACTOR= 10
+- VECTOR_V_COMPRESSION_FACTOR= 4
+- C1_BLOCK_SIZE= 320
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+- IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline void
+libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_avx2_35(
+    libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
+    libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
+  libcrux_ml_kem_ind_cca_decapsulate_a1(private_key, ciphertext, ret);
+}
+
 /**
 A monomorphic instance of libcrux_ml_kem.ind_cca.instantiations.avx2.decapsulate
 with const generics
@@ -5016,7 +5047,8 @@ KRML_ATTRIBUTE_TARGET("avx2")
 static inline void libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_35(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_a1(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_instantiations_avx2_decapsulate_avx2_35(
+      private_key, ciphertext, ret);
 }
 
 /**
@@ -5088,7 +5120,7 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline tuple_c2 libcrux_ml_kem_ind_cca_encapsulate_70(
+static KRML_MUSTINLINE tuple_c2 libcrux_ml_kem_ind_cca_encapsulate_70(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
@@ -5145,6 +5177,35 @@ static inline tuple_c2 libcrux_ml_kem_ind_cca_encapsulate_70(
 }
 
 /**
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.encapsulate_avx2 with const generics
+- K= 3
+- CIPHERTEXT_SIZE= 1088
+- PUBLIC_KEY_SIZE= 1184
+- T_AS_NTT_ENCODED_SIZE= 1152
+- C1_SIZE= 960
+- C2_SIZE= 128
+- VECTOR_U_COMPRESSION_FACTOR= 10
+- VECTOR_V_COMPRESSION_FACTOR= 4
+- VECTOR_U_BLOCK_LEN= 320
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline tuple_c2
+libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_avx2_cd(
+    libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
+    uint8_t randomness[32U]) {
+  libcrux_ml_kem_types_MlKemPublicKey_30 *uu____0 = public_key;
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[32U];
+  memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_encapsulate_70(uu____0, copy_of_randomness);
+}
+
+/**
 A monomorphic instance of libcrux_ml_kem.ind_cca.instantiations.avx2.encapsulate
 with const generics
 - K= 3
@@ -5170,7 +5231,8 @@ libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_cd(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_70(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_encapsulate_avx2_cd(
+      uu____0, copy_of_randomness);
 }
 
 /**
@@ -5247,8 +5309,8 @@ with const generics
 
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline __m256i libcrux_ml_kem_vector_traits_to_standard_domain_79(
-    __m256i v) {
+static KRML_MUSTINLINE __m256i
+libcrux_ml_kem_vector_traits_to_standard_domain_79(__m256i v) {
   return libcrux_ml_kem_vector_avx2_montgomery_multiply_by_constant_ea(
       v, LIBCRUX_ML_KEM_VECTOR_TRAITS_MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS);
 }
@@ -5389,7 +5451,7 @@ with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_22(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_22(
     Eurydice_slice key_generation_seed,
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_63 *private_key,
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_63 *public_key) {
@@ -5562,7 +5624,7 @@ with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline libcrux_ml_kem_utils_extraction_helper_Keypair768
+static KRML_MUSTINLINE libcrux_ml_kem_utils_extraction_helper_Keypair768
 libcrux_ml_kem_ind_cpa_generate_keypair_bb(Eurydice_slice key_generation_seed) {
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_63 private_key =
       libcrux_ml_kem_ind_cpa_unpacked_default_1a_ab();
@@ -5675,7 +5737,7 @@ with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+static KRML_MUSTINLINE libcrux_ml_kem_mlkem768_MlKem768KeyPair
 libcrux_ml_kem_ind_cca_generate_keypair_d6(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
@@ -5714,6 +5776,28 @@ libcrux_ml_kem_ind_cca_generate_keypair_d6(uint8_t randomness[64U]) {
 */
 /**
 A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair_avx2 with const
+generics
+- K= 3
+- CPA_PRIVATE_KEY_SIZE= 1152
+- PRIVATE_KEY_SIZE= 2400
+- PUBLIC_KEY_SIZE= 1184
+- BYTES_PER_RING_ELEMENT= 1152
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_avx2_c6(
+    uint8_t randomness[64U]) {
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[64U];
+  memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_generate_keypair_d6(copy_of_randomness);
+}
+
+/**
+A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.generate_keypair with const generics
 - K= 3
 - CPA_PRIVATE_KEY_SIZE= 1152
@@ -5730,7 +5814,8 @@ libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_c6(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_d6(copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_generate_keypair_avx2_c6(
+      copy_of_randomness);
 }
 
 /**
@@ -5803,7 +5888,7 @@ with const generics
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cca_decapsulate_a10(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_decapsulate_a10(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -5877,8 +5962,34 @@ static inline void libcrux_ml_kem_ind_cca_decapsulate_a10(
 }
 
 /**
- Portable decapsulate
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.kyber_decapsulate_avx2 with const
+generics
+- K= 3
+- SECRET_KEY_SIZE= 2400
+- CPA_SECRET_KEY_SIZE= 1152
+- PUBLIC_KEY_SIZE= 1184
+- CIPHERTEXT_SIZE= 1088
+- T_AS_NTT_ENCODED_SIZE= 1152
+- C1_SIZE= 960
+- C2_SIZE= 128
+- VECTOR_U_COMPRESSION_FACTOR= 10
+- VECTOR_V_COMPRESSION_FACTOR= 4
+- C1_BLOCK_SIZE= 320
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+- IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline void
+libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_decapsulate_avx2_35(
+    libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
+    libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
+  libcrux_ml_kem_ind_cca_decapsulate_a10(private_key, ciphertext, ret);
+}
+
 /**
 A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.kyber_decapsulate with const generics
@@ -5904,7 +6015,8 @@ static inline void
 libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_decapsulate_35(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_decapsulate_a10(private_key, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_decapsulate_avx2_35(
+      private_key, ciphertext, ret);
 }
 
 /**
@@ -5958,7 +6070,7 @@ with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline tuple_c2 libcrux_ml_kem_ind_cca_encapsulate_700(
+static KRML_MUSTINLINE tuple_c2 libcrux_ml_kem_ind_cca_encapsulate_700(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
@@ -6015,8 +6127,35 @@ static inline tuple_c2 libcrux_ml_kem_ind_cca_encapsulate_700(
 }
 
 /**
- Portable encapsulate
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.kyber_encapsulate_avx2 with const
+generics
+- K= 3
+- CIPHERTEXT_SIZE= 1088
+- PUBLIC_KEY_SIZE= 1184
+- T_AS_NTT_ENCODED_SIZE= 1152
+- C1_SIZE= 960
+- C2_SIZE= 128
+- VECTOR_U_COMPRESSION_FACTOR= 10
+- VECTOR_V_COMPRESSION_FACTOR= 4
+- VECTOR_U_BLOCK_LEN= 320
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
 */
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline tuple_c2
+libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_encapsulate_avx2_cd(
+    libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
+    uint8_t randomness[32U]) {
+  libcrux_ml_kem_types_MlKemPublicKey_30 *uu____0 = public_key;
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[32U];
+  memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_encapsulate_700(uu____0, copy_of_randomness);
+}
+
 /**
 A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.kyber_encapsulate with const generics
@@ -6043,7 +6182,8 @@ libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_encapsulate_cd(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_encapsulate_700(uu____0, copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_encapsulate_avx2_cd(
+      uu____0, copy_of_randomness);
 }
 
 /**
@@ -6132,7 +6272,8 @@ with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_220(
+static KRML_MUSTINLINE void
+libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_220(
     Eurydice_slice key_generation_seed,
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_63 *private_key,
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_63 *public_key) {
@@ -6194,7 +6335,7 @@ with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline libcrux_ml_kem_utils_extraction_helper_Keypair768
+static KRML_MUSTINLINE libcrux_ml_kem_utils_extraction_helper_Keypair768
 libcrux_ml_kem_ind_cpa_generate_keypair_bb0(
     Eurydice_slice key_generation_seed) {
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_63 private_key =
@@ -6255,7 +6396,7 @@ with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+static KRML_MUSTINLINE libcrux_ml_kem_mlkem768_MlKem768KeyPair
 libcrux_ml_kem_ind_cca_generate_keypair_d60(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
@@ -6291,6 +6432,28 @@ libcrux_ml_kem_ind_cca_generate_keypair_d60(uint8_t randomness[64U]) {
 
 /**
 A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.kyber_generate_keypair_avx2 with
+const generics
+- K= 3
+- CPA_PRIVATE_KEY_SIZE= 1152
+- PRIVATE_KEY_SIZE= 2400
+- PUBLIC_KEY_SIZE= 1184
+- BYTES_PER_RING_ELEMENT= 1152
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_generate_keypair_avx2_c6(
+    uint8_t randomness[64U]) {
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[64U];
+  memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_generate_keypair_d60(copy_of_randomness);
+}
+
+/**
+A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.kyber_generate_keypair with const
 generics
 - K= 3
@@ -6308,7 +6471,8 @@ libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_generate_keypair_c6(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_generate_keypair_d60(copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_kyber_generate_keypair_avx2_c6(
+      copy_of_randomness);
 }
 
 /**
@@ -6360,8 +6524,22 @@ static KRML_MUSTINLINE bool libcrux_ml_kem_ind_cca_validate_private_key_12(
 }
 
 /**
- Portable private key validation
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.validate_private_key_avx2 with const
+generics
+- K= 3
+- SECRET_KEY_SIZE= 2400
+- CIPHERTEXT_SIZE= 1088
 */
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline bool
+libcrux_ml_kem_ind_cca_instantiations_avx2_validate_private_key_avx2_31(
+    libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
+    libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext) {
+  return libcrux_ml_kem_ind_cca_validate_private_key_12(private_key,
+                                                        ciphertext);
+}
+
 /**
 A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.validate_private_key with const
@@ -6371,12 +6549,12 @@ generics
 - CIPHERTEXT_SIZE= 1088
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE bool
+static inline bool
 libcrux_ml_kem_ind_cca_instantiations_avx2_validate_private_key_31(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext) {
-  return libcrux_ml_kem_ind_cca_validate_private_key_12(private_key,
-                                                        ciphertext);
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_validate_private_key_avx2_31(
+      private_key, ciphertext);
 }
 
 /**
@@ -6502,8 +6680,20 @@ static KRML_MUSTINLINE bool libcrux_ml_kem_ind_cca_validate_public_key_ed(
 }
 
 /**
- Portable public key validation
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.validate_public_key_avx2 with const
+generics
+- K= 3
+- RANKED_BYTES_PER_RING_ELEMENT= 1152
+- PUBLIC_KEY_SIZE= 1184
 */
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline bool
+libcrux_ml_kem_ind_cca_instantiations_avx2_validate_public_key_avx2_31(
+    uint8_t *public_key) {
+  return libcrux_ml_kem_ind_cca_validate_public_key_ed(public_key);
+}
+
 /**
 A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.validate_public_key with const
@@ -6513,10 +6703,11 @@ generics
 - PUBLIC_KEY_SIZE= 1184
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static KRML_MUSTINLINE bool
+static inline bool
 libcrux_ml_kem_ind_cca_instantiations_avx2_validate_public_key_31(
     uint8_t *public_key) {
-  return libcrux_ml_kem_ind_cca_validate_public_key_ed(public_key);
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_validate_public_key_avx2_31(
+      public_key);
 }
 
 /**
@@ -6553,7 +6744,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cca_unpacked_decapsulate_12(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_unpacked_decapsulate_12(
     libcrux_ml_kem_mlkem768_avx2_unpacked_MlKem768KeyPairUnpacked *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   uint8_t decrypted[32U];
@@ -6615,6 +6806,35 @@ static inline void libcrux_ml_kem_ind_cca_unpacked_decapsulate_12(
 }
 
 /**
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.unpacked.decapsulate_avx2 with const
+generics
+- K= 3
+- SECRET_KEY_SIZE= 2400
+- CPA_SECRET_KEY_SIZE= 1152
+- PUBLIC_KEY_SIZE= 1184
+- CIPHERTEXT_SIZE= 1088
+- T_AS_NTT_ENCODED_SIZE= 1152
+- C1_SIZE= 960
+- C2_SIZE= 128
+- VECTOR_U_COMPRESSION_FACTOR= 10
+- VECTOR_V_COMPRESSION_FACTOR= 4
+- C1_BLOCK_SIZE= 320
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+- IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline void
+libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_decapsulate_avx2_35(
+    libcrux_ml_kem_mlkem768_avx2_unpacked_MlKem768KeyPairUnpacked *key_pair,
+    libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
+  libcrux_ml_kem_ind_cca_unpacked_decapsulate_12(key_pair, ciphertext, ret);
+}
+
+/**
  Unpacked decapsulate
 */
 /**
@@ -6643,7 +6863,8 @@ static inline void
 libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_decapsulate_35(
     libcrux_ml_kem_mlkem768_avx2_unpacked_MlKem768KeyPairUnpacked *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
-  libcrux_ml_kem_ind_cca_unpacked_decapsulate_12(key_pair, ciphertext, ret);
+  libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_decapsulate_avx2_35(
+      key_pair, ciphertext, ret);
 }
 
 /**
@@ -6680,7 +6901,7 @@ libcrux_ml_kem_hash_functions_avx2_Simd256Hash with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline tuple_c2 libcrux_ml_kem_ind_cca_unpacked_encapsulate_70(
+static KRML_MUSTINLINE tuple_c2 libcrux_ml_kem_ind_cca_unpacked_encapsulate_70(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_63 *public_key,
     uint8_t randomness[32U]) {
   uint8_t to_hash[64U];
@@ -6730,6 +6951,38 @@ static inline tuple_c2 libcrux_ml_kem_ind_cca_unpacked_encapsulate_70(
 }
 
 /**
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.unpacked.encapsulate_avx2 with const
+generics
+- K= 3
+- CIPHERTEXT_SIZE= 1088
+- PUBLIC_KEY_SIZE= 1184
+- T_AS_NTT_ENCODED_SIZE= 1152
+- C1_SIZE= 960
+- C2_SIZE= 128
+- VECTOR_U_COMPRESSION_FACTOR= 10
+- VECTOR_V_COMPRESSION_FACTOR= 4
+- VECTOR_U_BLOCK_LEN= 320
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+- ETA2= 2
+- ETA2_RANDOMNESS_SIZE= 128
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline tuple_c2
+libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_encapsulate_avx2_cd(
+    libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_63 *public_key,
+    uint8_t randomness[32U]) {
+  libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_63 *uu____0 =
+      public_key;
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[32U];
+  memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
+  return libcrux_ml_kem_ind_cca_unpacked_encapsulate_70(uu____0,
+                                                        copy_of_randomness);
+}
+
+/**
  Unpacked encapsulate
 */
 /**
@@ -6760,8 +7013,8 @@ libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_encapsulate_cd(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[32U];
   memcpy(copy_of_randomness, randomness, (size_t)32U * sizeof(uint8_t));
-  return libcrux_ml_kem_ind_cca_unpacked_encapsulate_70(uu____0,
-                                                        copy_of_randomness);
+  return libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_encapsulate_avx2_cd(
+      uu____0, copy_of_randomness);
 }
 
 /**
@@ -6867,7 +7120,7 @@ with const generics
 - ETA1_RANDOMNESS_SIZE= 128
 */
 KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_kem_ind_cca_unpacked_generate_keypair_d6(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_unpacked_generate_keypair_d6(
     uint8_t randomness[64U],
     libcrux_ml_kem_mlkem768_avx2_unpacked_MlKem768KeyPairUnpacked *out) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
@@ -6922,6 +7175,29 @@ static inline void libcrux_ml_kem_ind_cca_unpacked_generate_keypair_d6(
 }
 
 /**
+A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.unpacked.generate_keypair_avx2 with
+const generics
+- K= 3
+- CPA_PRIVATE_KEY_SIZE= 1152
+- PRIVATE_KEY_SIZE= 2400
+- PUBLIC_KEY_SIZE= 1184
+- BYTES_PER_RING_ELEMENT= 1152
+- ETA1= 2
+- ETA1_RANDOMNESS_SIZE= 128
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline void
+libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_generate_keypair_avx2_c6(
+    uint8_t randomness[64U],
+    libcrux_ml_kem_mlkem768_avx2_unpacked_MlKem768KeyPairUnpacked *out) {
+  /* Passing arrays by value in Rust generates a copy in C */
+  uint8_t copy_of_randomness[64U];
+  memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
+  libcrux_ml_kem_ind_cca_unpacked_generate_keypair_d6(copy_of_randomness, out);
+}
+
+/**
  Generate a key pair
 */
 /**
@@ -6944,7 +7220,8 @@ libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_generate_keypair_c6(
   /* Passing arrays by value in Rust generates a copy in C */
   uint8_t copy_of_randomness[64U];
   memcpy(copy_of_randomness, randomness, (size_t)64U * sizeof(uint8_t));
-  libcrux_ml_kem_ind_cca_unpacked_generate_keypair_d6(copy_of_randomness, out);
+  libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_generate_keypair_avx2_c6(
+      copy_of_randomness, out);
 }
 
 /**
@@ -7309,6 +7586,28 @@ libcrux_ml_kem_ind_cca_unpacked_unpack_public_key_6d(
 */
 /**
 A monomorphic instance of
+libcrux_ml_kem.ind_cca.instantiations.avx2.unpacked.unpack_public_key_avx2 with
+const generics
+- K= 3
+- T_AS_NTT_ENCODED_SIZE= 1152
+- RANKED_BYTES_PER_RING_ELEMENT= 1152
+- PUBLIC_KEY_SIZE= 1184
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline void
+libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_unpack_public_key_avx2_a5(
+    libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
+    libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_63
+        *unpacked_public_key) {
+  libcrux_ml_kem_ind_cca_unpacked_unpack_public_key_6d(public_key,
+                                                       unpacked_public_key);
+}
+
+/**
+ Get the unpacked public key.
+*/
+/**
+A monomorphic instance of
 libcrux_ml_kem.ind_cca.instantiations.avx2.unpacked.unpack_public_key with const
 generics
 - K= 3
@@ -7322,8 +7621,8 @@ libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_unpack_public_key_a5(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_63
         *unpacked_public_key) {
-  libcrux_ml_kem_ind_cca_unpacked_unpack_public_key_6d(public_key,
-                                                       unpacked_public_key);
+  libcrux_ml_kem_ind_cca_instantiations_avx2_unpacked_unpack_public_key_avx2_a5(
+      public_key, unpacked_public_key);
 }
 
 /**

--- a/libcrux-ml-kem/cg/libcrux_mlkem768_avx2_types.h
+++ b/libcrux-ml-kem/cg/libcrux_mlkem768_avx2_types.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem768_avx2_types_H

--- a/libcrux-ml-kem/cg/libcrux_mlkem768_avx2_types.h
+++ b/libcrux-ml-kem/cg/libcrux_mlkem768_avx2_types.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 897008ee57eed9e4574222a5e96d306ce203ecee
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem768_avx2_types_H

--- a/libcrux-ml-kem/cg/libcrux_mlkem768_portable.h
+++ b/libcrux-ml-kem/cg/libcrux_mlkem768_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem768_portable_H
@@ -5451,7 +5451,7 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static KRML_MUSTINLINE void
+static inline void
 libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_35(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
@@ -5596,7 +5596,7 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE tuple_c2
+static inline tuple_c2
 libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_cd(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     uint8_t randomness[32U]) {
@@ -6149,7 +6149,7 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE libcrux_ml_kem_mlkem768_MlKem768KeyPair
+static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
 libcrux_ml_kem_ind_cca_instantiations_portable_generate_keypair_c6(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
@@ -6322,7 +6322,7 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static KRML_MUSTINLINE void
+static inline void
 libcrux_ml_kem_ind_cca_instantiations_portable_kyber_decapsulate_35(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
@@ -6454,7 +6454,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE tuple_c2
+static inline tuple_c2
 libcrux_ml_kem_ind_cca_instantiations_portable_kyber_encapsulate_cd(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     uint8_t randomness[32U]) {
@@ -6716,7 +6716,7 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE libcrux_ml_kem_mlkem768_MlKem768KeyPair
+static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
 libcrux_ml_kem_ind_cca_instantiations_portable_kyber_generate_keypair_c6(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
@@ -6783,7 +6783,7 @@ generics
 - SECRET_KEY_SIZE= 2400
 - CIPHERTEXT_SIZE= 1088
 */
-static KRML_MUSTINLINE bool
+static inline bool
 libcrux_ml_kem_ind_cca_instantiations_portable_validate_private_key_31(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext) {
@@ -6920,7 +6920,7 @@ generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-static KRML_MUSTINLINE bool
+static inline bool
 libcrux_ml_kem_ind_cca_instantiations_portable_validate_public_key_31(
     uint8_t *public_key) {
   return libcrux_ml_kem_ind_cca_validate_public_key_6c(public_key);
@@ -7044,7 +7044,7 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static KRML_MUSTINLINE void
+static inline void
 libcrux_ml_kem_ind_cca_instantiations_portable_unpacked_decapsulate_35(
     libcrux_ml_kem_mlkem768_portable_unpacked_MlKem768KeyPairUnpacked *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
@@ -7155,7 +7155,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE tuple_c2
+static inline tuple_c2
 libcrux_ml_kem_ind_cca_instantiations_portable_unpacked_encapsulate_cd(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0 *public_key,
     uint8_t randomness[32U]) {
@@ -7338,7 +7338,7 @@ const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static KRML_MUSTINLINE void
+static inline void
 libcrux_ml_kem_ind_cca_instantiations_portable_unpacked_generate_keypair_c6(
     uint8_t randomness[64U],
     libcrux_ml_kem_mlkem768_portable_unpacked_MlKem768KeyPairUnpacked *out) {
@@ -7705,7 +7705,7 @@ const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-static KRML_MUSTINLINE void
+static inline void
 libcrux_ml_kem_ind_cca_instantiations_portable_unpacked_unpack_public_key_a5(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0

--- a/libcrux-ml-kem/cg/libcrux_mlkem768_portable.h
+++ b/libcrux-ml-kem/cg/libcrux_mlkem768_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 897008ee57eed9e4574222a5e96d306ce203ecee
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem768_portable_H
@@ -2724,7 +2724,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static inline libcrux_ml_kem_vector_portable_vector_type_PortableVector
+static KRML_MUSTINLINE libcrux_ml_kem_vector_portable_vector_type_PortableVector
 libcrux_ml_kem_vector_traits_montgomery_multiply_fe_8c(
     libcrux_ml_kem_vector_portable_vector_type_PortableVector v, int16_t fer) {
   return libcrux_ml_kem_vector_portable_montgomery_multiply_by_constant_0d(v,
@@ -3455,7 +3455,7 @@ libcrux_ml_kem.vector.traits.to_unsigned_representative with types
 libcrux_ml_kem_vector_portable_vector_type_PortableVector with const generics
 
 */
-static inline libcrux_ml_kem_vector_portable_vector_type_PortableVector
+static KRML_MUSTINLINE libcrux_ml_kem_vector_portable_vector_type_PortableVector
 libcrux_ml_kem_vector_traits_to_unsigned_representative_8c(
     libcrux_ml_kem_vector_portable_vector_type_PortableVector a) {
   libcrux_ml_kem_vector_portable_vector_type_PortableVector t =
@@ -3529,7 +3529,7 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static inline void libcrux_ml_kem_ind_cpa_decrypt_unpacked_42(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_decrypt_unpacked_42(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_a0 *secret_key,
     uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_1d u_as_ntt[3U];
@@ -3561,9 +3561,8 @@ with const generics
 - U_COMPRESSION_FACTOR= 10
 - V_COMPRESSION_FACTOR= 4
 */
-static inline void libcrux_ml_kem_ind_cpa_decrypt_42(Eurydice_slice secret_key,
-                                                     uint8_t *ciphertext,
-                                                     uint8_t ret[32U]) {
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_decrypt_42(
+    Eurydice_slice secret_key, uint8_t *ciphertext, uint8_t ret[32U]) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_1d secret_as_ntt[3U];
   libcrux_ml_kem_ind_cpa_deserialize_secret_key_1b(
       /* sˆ := Decode_12(sk) */ secret_key, secret_as_ntt);
@@ -4702,7 +4701,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static inline libcrux_ml_kem_vector_portable_vector_type_PortableVector
+static KRML_MUSTINLINE libcrux_ml_kem_vector_portable_vector_type_PortableVector
 libcrux_ml_kem_vector_traits_decompress_1_8c(
     libcrux_ml_kem_vector_portable_vector_type_PortableVector v) {
   libcrux_ml_kem_vector_portable_vector_type_PortableVector uu____0 =
@@ -4971,7 +4970,7 @@ with const generics
 - COMPRESSION_FACTOR= 10
 - BLOCK_LEN= 320
 */
-static inline void libcrux_ml_kem_ind_cpa_compress_then_serialize_u_43(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_compress_then_serialize_u_43(
     libcrux_ml_kem_polynomial_PolynomialRingElement_1d input[3U],
     Eurydice_slice out) {
   for (size_t i = (size_t)0U;
@@ -5199,7 +5198,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline void libcrux_ml_kem_ind_cpa_encrypt_unpacked_2a(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_encrypt_unpacked_2a(
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_a0 *public_key,
     uint8_t message[32U], Eurydice_slice randomness, uint8_t ret[1088U]) {
   uint8_t prf_input[33U];
@@ -5284,10 +5283,9 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline void libcrux_ml_kem_ind_cpa_encrypt_2a(Eurydice_slice public_key,
-                                                     uint8_t message[32U],
-                                                     Eurydice_slice randomness,
-                                                     uint8_t ret[1088U]) {
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_encrypt_2a(
+    Eurydice_slice public_key, uint8_t message[32U], Eurydice_slice randomness,
+    uint8_t ret[1088U]) {
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_a0
       unpacked_public_key = libcrux_ml_kem_ind_cpa_unpacked_default_8d_1b();
   libcrux_ml_kem_serialize_deserialize_ring_elements_reduced_b3(
@@ -5357,7 +5355,7 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static inline void libcrux_ml_kem_ind_cca_decapsulate_62(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_decapsulate_62(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -5453,7 +5451,7 @@ libcrux_ml_kem.ind_cca.instantiations.portable.decapsulate with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static inline void
+static KRML_MUSTINLINE void
 libcrux_ml_kem_ind_cca_instantiations_portable_decapsulate_35(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
@@ -5525,7 +5523,7 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline tuple_c2 libcrux_ml_kem_ind_cca_encapsulate_ca(
+static KRML_MUSTINLINE tuple_c2 libcrux_ml_kem_ind_cca_encapsulate_ca(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
@@ -5598,7 +5596,7 @@ libcrux_ml_kem.ind_cca.instantiations.portable.encapsulate with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline tuple_c2
+static KRML_MUSTINLINE tuple_c2
 libcrux_ml_kem_ind_cca_instantiations_portable_encapsulate_cd(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     uint8_t randomness[32U]) {
@@ -5679,7 +5677,7 @@ with types libcrux_ml_kem_vector_portable_vector_type_PortableVector
 with const generics
 
 */
-static inline libcrux_ml_kem_vector_portable_vector_type_PortableVector
+static KRML_MUSTINLINE libcrux_ml_kem_vector_portable_vector_type_PortableVector
 libcrux_ml_kem_vector_traits_to_standard_domain_8c(
     libcrux_ml_kem_vector_portable_vector_type_PortableVector v) {
   return libcrux_ml_kem_vector_portable_montgomery_multiply_by_constant_0d(
@@ -5823,7 +5821,7 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline void libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_1c(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_1c(
     Eurydice_slice key_generation_seed,
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_a0 *private_key,
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_a0 *public_key) {
@@ -5991,7 +5989,7 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline libcrux_ml_kem_utils_extraction_helper_Keypair768
+static KRML_MUSTINLINE libcrux_ml_kem_utils_extraction_helper_Keypair768
 libcrux_ml_kem_ind_cpa_generate_keypair_15(Eurydice_slice key_generation_seed) {
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_a0 private_key =
       libcrux_ml_kem_ind_cpa_unpacked_default_1a_1b();
@@ -6102,7 +6100,7 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+static KRML_MUSTINLINE libcrux_ml_kem_mlkem768_MlKem768KeyPair
 libcrux_ml_kem_ind_cca_generate_keypair_f8(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
@@ -6151,7 +6149,7 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+static KRML_MUSTINLINE libcrux_ml_kem_mlkem768_MlKem768KeyPair
 libcrux_ml_kem_ind_cca_instantiations_portable_generate_keypair_c6(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
@@ -6227,7 +6225,7 @@ libcrux_ml_kem_variant_Kyber with const generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static inline void libcrux_ml_kem_ind_cca_decapsulate_620(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_decapsulate_620(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   Eurydice_slice_uint8_t_x2 uu____0 = Eurydice_slice_split_at(
@@ -6324,7 +6322,7 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static inline void
+static KRML_MUSTINLINE void
 libcrux_ml_kem_ind_cca_instantiations_portable_kyber_decapsulate_35(
     libcrux_ml_kem_types_MlKemPrivateKey_d9 *private_key,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
@@ -6379,7 +6377,7 @@ libcrux_ml_kem_variant_Kyber with const generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline tuple_c2 libcrux_ml_kem_ind_cca_encapsulate_ca0(
+static KRML_MUSTINLINE tuple_c2 libcrux_ml_kem_ind_cca_encapsulate_ca0(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     uint8_t randomness[32U]) {
   uint8_t randomness0[32U];
@@ -6456,7 +6454,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline tuple_c2
+static KRML_MUSTINLINE tuple_c2
 libcrux_ml_kem_ind_cca_instantiations_portable_kyber_encapsulate_cd(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     uint8_t randomness[32U]) {
@@ -6550,7 +6548,8 @@ libcrux_ml_kem_variant_Kyber with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline void libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_1c0(
+static KRML_MUSTINLINE void
+libcrux_ml_kem_ind_cpa_generate_keypair_unpacked_1c0(
     Eurydice_slice key_generation_seed,
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_a0 *private_key,
     libcrux_ml_kem_ind_cpa_unpacked_IndCpaPublicKeyUnpacked_a0 *public_key) {
@@ -6611,7 +6610,7 @@ libcrux_ml_kem_variant_Kyber with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline libcrux_ml_kem_utils_extraction_helper_Keypair768
+static KRML_MUSTINLINE libcrux_ml_kem_utils_extraction_helper_Keypair768
 libcrux_ml_kem_ind_cpa_generate_keypair_150(
     Eurydice_slice key_generation_seed) {
   libcrux_ml_kem_ind_cpa_unpacked_IndCpaPrivateKeyUnpacked_a0 private_key =
@@ -6671,7 +6670,7 @@ libcrux_ml_kem_variant_Kyber with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+static KRML_MUSTINLINE libcrux_ml_kem_mlkem768_MlKem768KeyPair
 libcrux_ml_kem_ind_cca_generate_keypair_f80(uint8_t randomness[64U]) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
       randomness, (size_t)0U,
@@ -6717,7 +6716,7 @@ generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline libcrux_ml_kem_mlkem768_MlKem768KeyPair
+static KRML_MUSTINLINE libcrux_ml_kem_mlkem768_MlKem768KeyPair
 libcrux_ml_kem_ind_cca_instantiations_portable_kyber_generate_keypair_c6(
     uint8_t randomness[64U]) {
   /* Passing arrays by value in Rust generates a copy in C */
@@ -6960,7 +6959,7 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static inline void libcrux_ml_kem_ind_cca_unpacked_decapsulate_51(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_unpacked_decapsulate_51(
     libcrux_ml_kem_mlkem768_portable_unpacked_MlKem768KeyPairUnpacked *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
   uint8_t decrypted[32U];
@@ -7045,7 +7044,7 @@ generics
 - ETA2_RANDOMNESS_SIZE= 128
 - IMPLICIT_REJECTION_HASH_INPUT_SIZE= 1120
 */
-static inline void
+static KRML_MUSTINLINE void
 libcrux_ml_kem_ind_cca_instantiations_portable_unpacked_decapsulate_35(
     libcrux_ml_kem_mlkem768_portable_unpacked_MlKem768KeyPairUnpacked *key_pair,
     libcrux_ml_kem_mlkem768_MlKem768Ciphertext *ciphertext, uint8_t ret[32U]) {
@@ -7086,7 +7085,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline tuple_c2 libcrux_ml_kem_ind_cca_unpacked_encapsulate_0c(
+static KRML_MUSTINLINE tuple_c2 libcrux_ml_kem_ind_cca_unpacked_encapsulate_0c(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0 *public_key,
     uint8_t randomness[32U]) {
   uint8_t to_hash[64U];
@@ -7156,7 +7155,7 @@ generics
 - ETA2= 2
 - ETA2_RANDOMNESS_SIZE= 128
 */
-static inline tuple_c2
+static KRML_MUSTINLINE tuple_c2
 libcrux_ml_kem_ind_cca_instantiations_portable_unpacked_encapsulate_cd(
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0 *public_key,
     uint8_t randomness[32U]) {
@@ -7270,7 +7269,7 @@ libcrux_ml_kem_variant_MlKem with const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline void libcrux_ml_kem_ind_cca_unpacked_generate_keypair_f8(
+static KRML_MUSTINLINE void libcrux_ml_kem_ind_cca_unpacked_generate_keypair_f8(
     uint8_t randomness[64U],
     libcrux_ml_kem_mlkem768_portable_unpacked_MlKem768KeyPairUnpacked *out) {
   Eurydice_slice ind_cpa_keypair_randomness = Eurydice_array_to_subslice2(
@@ -7339,7 +7338,7 @@ const generics
 - ETA1= 2
 - ETA1_RANDOMNESS_SIZE= 128
 */
-static inline void
+static KRML_MUSTINLINE void
 libcrux_ml_kem_ind_cca_instantiations_portable_unpacked_generate_keypair_c6(
     uint8_t randomness[64U],
     libcrux_ml_kem_mlkem768_portable_unpacked_MlKem768KeyPairUnpacked *out) {
@@ -7706,7 +7705,7 @@ const generics
 - RANKED_BYTES_PER_RING_ELEMENT= 1152
 - PUBLIC_KEY_SIZE= 1184
 */
-static inline void
+static KRML_MUSTINLINE void
 libcrux_ml_kem_ind_cca_instantiations_portable_unpacked_unpack_public_key_a5(
     libcrux_ml_kem_types_MlKemPublicKey_30 *public_key,
     libcrux_ml_kem_ind_cca_unpacked_MlKemPublicKeyUnpacked_a0

--- a/libcrux-ml-kem/cg/libcrux_mlkem768_portable_types.h
+++ b/libcrux-ml-kem/cg/libcrux_mlkem768_portable_types.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_mlkem768_portable_types_H

--- a/libcrux-ml-kem/cg/libcrux_mlkem768_portable_types.h
+++ b/libcrux-ml-kem/cg/libcrux_mlkem768_portable_types.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 897008ee57eed9e4574222a5e96d306ce203ecee
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_mlkem768_portable_types_H

--- a/libcrux-ml-kem/cg/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/cg/libcrux_sha3_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/cg/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/cg/libcrux_sha3_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 897008ee57eed9e4574222a5e96d306ce203ecee
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/cg/libcrux_sha3_portable.h
+++ b/libcrux-ml-kem/cg/libcrux_sha3_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
  * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
  * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
- * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
+ * Libcrux: 99b4e0ae6147eb731652e0ee355fc77d2c160664
  */
 
 #ifndef __libcrux_sha3_portable_H

--- a/libcrux-ml-kem/cg/libcrux_sha3_portable.h
+++ b/libcrux-ml-kem/cg/libcrux_sha3_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: 45f5a34f336e35c6cc2253bc90cbdb8d812cefa9
+ * Charon: 3a133fe0eee9bd3928d5bb16c24ddd2dd0f3ee7f
  * Eurydice: 1fff1c51ae6e6c87eafd28ec9d5594f54bc91c0c
- * Karamel: 8c3612018c25889288da6857771be3ad03b75bcd
- * F*: 5643e656b989aca7629723653a2570c7df6252b9-dirty
- * Libcrux: 897008ee57eed9e4574222a5e96d306ce203ecee
+ * Karamel: c31a22c1e07d2118c07ee5cebb640d863e31a198
+ * F*: 2c32d6e230851bbceadac7a21fc418fa2bb7e4bc
+ * Libcrux: 905a91e1fa80823be8a3ae493778a59dbc0aa911
  */
 
 #ifndef __libcrux_sha3_portable_H

--- a/libcrux-ml-kem/src/hash_functions.rs
+++ b/libcrux-ml-kem/src/hash_functions.rs
@@ -213,48 +213,44 @@ pub(crate) mod avx2 {
 
     #[inline(always)]
     fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
-        #[target_feature(enable = "avx2")]
-        unsafe fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
-            debug_assert!(K == 2 || K == 3 || K == 4);
-            let mut out = [[0u8; LEN]; K];
-            let mut out0 = [0u8; LEN];
-            let mut out1 = [0u8; LEN];
-            let mut out2 = [0u8; LEN];
-            let mut out3 = [0u8; LEN];
+        debug_assert!(K == 2 || K == 3 || K == 4);
+        let mut out = [[0u8; LEN]; K];
+        let mut out0 = [0u8; LEN];
+        let mut out1 = [0u8; LEN];
+        let mut out2 = [0u8; LEN];
+        let mut out3 = [0u8; LEN];
 
-            match K as u8 {
-                2 => {
-                    x4::shake256(
-                        &input[0], &input[1], &input[0], &input[0], &mut out0, &mut out1,
-                        &mut out2, &mut out3,
-                    );
-                    out[0] = out0;
-                    out[1] = out1;
-                }
-                3 => {
-                    x4::shake256(
-                        &input[0], &input[1], &input[2], &input[0], &mut out0, &mut out1,
-                        &mut out2, &mut out3,
-                    );
-                    out[0] = out0;
-                    out[1] = out1;
-                    out[2] = out2;
-                }
-                4 => {
-                    x4::shake256(
-                        &input[0], &input[1], &input[2], &input[3], &mut out0, &mut out1,
-                        &mut out2, &mut out3,
-                    );
-                    out[0] = out0;
-                    out[1] = out1;
-                    out[2] = out2;
-                    out[3] = out3;
-                }
-                _ => unreachable!("This function must only be called with N = 2, 3, 4"),
+        match K as u8 {
+            2 => {
+                x4::shake256(
+                    &input[0], &input[1], &input[0], &input[0], &mut out0, &mut out1, &mut out2,
+                    &mut out3,
+                );
+                out[0] = out0;
+                out[1] = out1;
             }
-            out
+            3 => {
+                x4::shake256(
+                    &input[0], &input[1], &input[2], &input[0], &mut out0, &mut out1, &mut out2,
+                    &mut out3,
+                );
+                out[0] = out0;
+                out[1] = out1;
+                out[2] = out2;
+            }
+            4 => {
+                x4::shake256(
+                    &input[0], &input[1], &input[2], &input[3], &mut out0, &mut out1, &mut out2,
+                    &mut out3,
+                );
+                out[0] = out0;
+                out[1] = out1;
+                out[2] = out2;
+                out[3] = out3;
+            }
+            _ => unreachable!("This function must only be called with N = 2, 3, 4"),
         }
-        unsafe { PRFxN(input) }
+        out
     }
 
     #[inline(always)]

--- a/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux-ml-kem/src/ind_cca.rs
@@ -450,6 +450,7 @@ pub(crate) mod unpacked {
     }
 
     /// Generate Unpacked Keys
+    #[inline(always)]
     pub(crate) fn generate_keypair<
         const K: usize,
         const CPA_PRIVATE_KEY_SIZE: usize,
@@ -501,6 +502,7 @@ pub(crate) mod unpacked {
     }
 
     // Encapsulate with Unpacked Public Key
+    #[inline(always)]
     pub(crate) fn encapsulate<
         const K: usize,
         const CIPHERTEXT_SIZE: usize,
@@ -549,6 +551,7 @@ pub(crate) mod unpacked {
     }
 
     // Decapsulate with Unpacked Private Key
+    #[inline(always)]
     pub(crate) fn decapsulate<
         const K: usize,
         const SECRET_KEY_SIZE: usize,

--- a/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux-ml-kem/src/ind_cca.rs
@@ -108,6 +108,7 @@ fn validate_private_key<
 ///
 /// Depending on the `Vector` and `Hasher` used, this requires different hardware
 /// features
+#[inline(always)]
 fn generate_keypair<
     const K: usize,
     const CPA_PRIVATE_KEY_SIZE: usize,
@@ -148,6 +149,7 @@ fn generate_keypair<
     MlKemKeyPair::from(private_key, MlKemPublicKey::from(public_key))
 }
 
+#[inline(always)]
 fn encapsulate<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
@@ -199,6 +201,7 @@ fn encapsulate<
     (ciphertext, shared_secret_array)
 }
 
+#[inline(always)]
 pub(crate) fn decapsulate<
     const K: usize,
     const SECRET_KEY_SIZE: usize,

--- a/libcrux-ml-kem/src/ind_cca/instantiations.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations.rs
@@ -405,9 +405,10 @@ macro_rules! instantiate {
 // Portable generic implementations.
 instantiate! {portable, crate::vector::portable::PortableVector, crate::hash_functions::portable::PortableHash<K>}
 
-// AVX2 generic implementation.
+// // AVX2 generic implementation.
+// instantiate! {avx2, crate::vector::SIMD256Vector, crate::hash_functions::avx2::Simd256Hash}
 #[cfg(feature = "simd256")]
-instantiate! {avx2, crate::vector::SIMD256Vector, crate::hash_functions::avx2::Simd256Hash}
+pub mod avx2;
 
 // NEON generic implementation.
 #[cfg(feature = "simd128")]

--- a/libcrux-ml-kem/src/ind_cca/instantiations.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations.rs
@@ -415,7 +415,7 @@ macro_rules! instantiate {
 // Portable generic implementations.
 instantiate! {portable, crate::vector::portable::PortableVector, crate::hash_functions::portable::PortableHash<K>}
 
-// // AVX2 generic implementation.
+// AVX2 generic implementation.
 #[cfg(feature = "simd256")]
 pub mod avx2;
 

--- a/libcrux-ml-kem/src/ind_cca/instantiations.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations.rs
@@ -7,7 +7,6 @@ macro_rules! instantiate {
             };
 
             /// Portable generate key pair.
-            #[inline(always)]
             pub(crate) fn generate_keypair<
                 const K: usize,
                 const CPA_PRIVATE_KEY_SIZE: usize,
@@ -34,7 +33,6 @@ macro_rules! instantiate {
             }
 
             #[cfg(feature = "kyber")]
-            #[inline(always)]
             pub(crate) fn kyber_generate_keypair<
                 const K: usize,
                 const CPA_PRIVATE_KEY_SIZE: usize,
@@ -61,7 +59,6 @@ macro_rules! instantiate {
             }
 
             /// Portable public key validation
-            #[inline(always)]
             pub(crate) fn validate_public_key<
                 const K: usize,
                 const RANKED_BYTES_PER_RING_ELEMENT: usize,
@@ -78,7 +75,6 @@ macro_rules! instantiate {
             }
 
             /// Portable private key validation
-            #[inline(always)]
             pub(crate) fn validate_private_key<
                 const K: usize,
                 const SECRET_KEY_SIZE: usize,
@@ -95,7 +91,6 @@ macro_rules! instantiate {
 
             /// Portable encapsulate
             #[cfg(feature = "kyber")]
-            #[inline(always)]
             pub(crate) fn kyber_encapsulate<
                 const K: usize,
                 const CIPHERTEXT_SIZE: usize,
@@ -134,7 +129,6 @@ macro_rules! instantiate {
                 >(public_key, randomness)
             }
 
-            #[inline(always)]
             pub(crate) fn encapsulate<
                 const K: usize,
                 const CIPHERTEXT_SIZE: usize,
@@ -175,7 +169,6 @@ macro_rules! instantiate {
 
             /// Portable decapsulate
             #[cfg(feature = "kyber")]
-            #[inline(always)]
             pub fn kyber_decapsulate<
                 const K: usize,
                 const SECRET_KEY_SIZE: usize,
@@ -221,7 +214,6 @@ macro_rules! instantiate {
             }
 
             /// Portable decapsulate
-            #[inline(always)]
             pub fn decapsulate<
                 const K: usize,
                 const SECRET_KEY_SIZE: usize,
@@ -276,7 +268,6 @@ macro_rules! instantiate {
                     crate::ind_cca::unpacked::MlKemPublicKeyUnpacked<K, $vector>;
 
                 /// Get the unpacked public key.
-                #[inline(always)]
                 pub(crate) fn unpack_public_key<
                     const K: usize,
                     const T_AS_NTT_ENCODED_SIZE: usize,
@@ -297,7 +288,6 @@ macro_rules! instantiate {
                 }
 
                 /// Generate a key pair
-                #[inline(always)]
                 pub(crate) fn generate_keypair<
                     const K: usize,
                     const CPA_PRIVATE_KEY_SIZE: usize,
@@ -325,7 +315,6 @@ macro_rules! instantiate {
                 }
 
                 /// Unpacked encapsulate
-                #[inline(always)]
                 pub(crate) fn encapsulate<
                     const K: usize,
                     const CIPHERTEXT_SIZE: usize,
@@ -364,7 +353,6 @@ macro_rules! instantiate {
                 }
 
                 /// Unpacked decapsulate
-                #[inline(always)]
                 pub(crate) fn decapsulate<
                     const K: usize,
                     const SECRET_KEY_SIZE: usize,

--- a/libcrux-ml-kem/src/ind_cca/instantiations.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations.rs
@@ -7,6 +7,7 @@ macro_rules! instantiate {
             };
 
             /// Portable generate key pair.
+            #[inline(always)]
             pub(crate) fn generate_keypair<
                 const K: usize,
                 const CPA_PRIVATE_KEY_SIZE: usize,
@@ -33,6 +34,7 @@ macro_rules! instantiate {
             }
 
             #[cfg(feature = "kyber")]
+            #[inline(always)]
             pub(crate) fn kyber_generate_keypair<
                 const K: usize,
                 const CPA_PRIVATE_KEY_SIZE: usize,
@@ -93,6 +95,7 @@ macro_rules! instantiate {
 
             /// Portable encapsulate
             #[cfg(feature = "kyber")]
+            #[inline(always)]
             pub(crate) fn kyber_encapsulate<
                 const K: usize,
                 const CIPHERTEXT_SIZE: usize,
@@ -131,6 +134,7 @@ macro_rules! instantiate {
                 >(public_key, randomness)
             }
 
+            #[inline(always)]
             pub(crate) fn encapsulate<
                 const K: usize,
                 const CIPHERTEXT_SIZE: usize,
@@ -171,6 +175,7 @@ macro_rules! instantiate {
 
             /// Portable decapsulate
             #[cfg(feature = "kyber")]
+            #[inline(always)]
             pub fn kyber_decapsulate<
                 const K: usize,
                 const SECRET_KEY_SIZE: usize,
@@ -216,6 +221,7 @@ macro_rules! instantiate {
             }
 
             /// Portable decapsulate
+            #[inline(always)]
             pub fn decapsulate<
                 const K: usize,
                 const SECRET_KEY_SIZE: usize,
@@ -270,6 +276,7 @@ macro_rules! instantiate {
                     crate::ind_cca::unpacked::MlKemPublicKeyUnpacked<K, $vector>;
 
                 /// Get the unpacked public key.
+                #[inline(always)]
                 pub(crate) fn unpack_public_key<
                     const K: usize,
                     const T_AS_NTT_ENCODED_SIZE: usize,
@@ -290,6 +297,7 @@ macro_rules! instantiate {
                 }
 
                 /// Generate a key pair
+                #[inline(always)]
                 pub(crate) fn generate_keypair<
                     const K: usize,
                     const CPA_PRIVATE_KEY_SIZE: usize,
@@ -317,6 +325,7 @@ macro_rules! instantiate {
                 }
 
                 /// Unpacked encapsulate
+                #[inline(always)]
                 pub(crate) fn encapsulate<
                     const K: usize,
                     const CIPHERTEXT_SIZE: usize,
@@ -355,6 +364,7 @@ macro_rules! instantiate {
                 }
 
                 /// Unpacked decapsulate
+                #[inline(always)]
                 pub(crate) fn decapsulate<
                     const K: usize,
                     const SECRET_KEY_SIZE: usize,

--- a/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
@@ -215,7 +215,6 @@ unsafe fn kyber_encapsulate_avx2<
 
 #[allow(unsafe_code)]
 #[cfg(feature = "kyber")]
-#[target_feature(enable = "avx2")]
 pub(crate) fn kyber_encapsulate<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,

--- a/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
@@ -1,0 +1,409 @@
+use crate::{
+    MlKemCiphertext, MlKemKeyPair, MlKemPrivateKey, MlKemPublicKey, MlKemSharedSecret,
+    KEY_GENERATION_SEED_SIZE, SHARED_SECRET_SIZE,
+};
+
+/// Portable generate key pair.
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn generate_keypair<
+    const K: usize,
+    const CPA_PRIVATE_KEY_SIZE: usize,
+    const PRIVATE_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const BYTES_PER_RING_ELEMENT: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+>(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
+    crate::ind_cca::generate_keypair::<
+        K,
+        CPA_PRIVATE_KEY_SIZE,
+        PRIVATE_KEY_SIZE,
+        PUBLIC_KEY_SIZE,
+        BYTES_PER_RING_ELEMENT,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        crate::vector::SIMD256Vector,
+        crate::hash_functions::avx2::Simd256Hash,
+        crate::variant::MlKem,
+    >(randomness)
+}
+
+#[cfg(feature = "kyber")]
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn kyber_generate_keypair<
+    const K: usize,
+    const CPA_PRIVATE_KEY_SIZE: usize,
+    const PRIVATE_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const BYTES_PER_RING_ELEMENT: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+>(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
+    crate::ind_cca::generate_keypair::<
+        K,
+        CPA_PRIVATE_KEY_SIZE,
+        PRIVATE_KEY_SIZE,
+        PUBLIC_KEY_SIZE,
+        BYTES_PER_RING_ELEMENT,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        crate::vector::SIMD256Vector,
+        crate::hash_functions::avx2::Simd256Hash,
+        crate::variant::Kyber,
+    >(randomness)
+}
+
+/// Portable public key validation
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn validate_public_key<
+    const K: usize,
+    const RANKED_BYTES_PER_RING_ELEMENT: usize,
+    const PUBLIC_KEY_SIZE: usize,
+>(
+    public_key: &[u8; PUBLIC_KEY_SIZE],
+) -> bool {
+    crate::ind_cca::validate_public_key::<
+        K,
+        RANKED_BYTES_PER_RING_ELEMENT,
+        PUBLIC_KEY_SIZE,
+        crate::vector::SIMD256Vector,
+    >(public_key)
+}
+
+/// Portable private key validation
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn validate_private_key<
+    const K: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+>(
+    private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
+    ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+) -> bool {
+    crate::ind_cca::validate_private_key::<
+        K,
+        SECRET_KEY_SIZE,
+        CIPHERTEXT_SIZE,
+        crate::hash_functions::avx2::Simd256Hash,
+    >(private_key, ciphertext)
+}
+
+/// Portable encapsulate
+#[cfg(feature = "kyber")]
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn kyber_encapsulate<
+    const K: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const VECTOR_U_BLOCK_LEN: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+>(
+    public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
+    randomness: [u8; SHARED_SECRET_SIZE],
+) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
+    crate::ind_cca::encapsulate::<
+        K,
+        CIPHERTEXT_SIZE,
+        PUBLIC_KEY_SIZE,
+        T_AS_NTT_ENCODED_SIZE,
+        C1_SIZE,
+        C2_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_V_COMPRESSION_FACTOR,
+        VECTOR_U_BLOCK_LEN,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        crate::vector::SIMD256Vector,
+        crate::hash_functions::avx2::Simd256Hash,
+        crate::variant::Kyber,
+    >(public_key, randomness)
+}
+
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn encapsulate<
+    const K: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const VECTOR_U_BLOCK_LEN: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+>(
+    public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
+    randomness: [u8; SHARED_SECRET_SIZE],
+) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
+    crate::ind_cca::encapsulate::<
+        K,
+        CIPHERTEXT_SIZE,
+        PUBLIC_KEY_SIZE,
+        T_AS_NTT_ENCODED_SIZE,
+        C1_SIZE,
+        C2_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_V_COMPRESSION_FACTOR,
+        VECTOR_U_BLOCK_LEN,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        crate::vector::SIMD256Vector,
+        crate::hash_functions::avx2::Simd256Hash,
+        crate::variant::MlKem,
+    >(public_key, randomness)
+}
+
+/// Portable decapsulate
+#[cfg(feature = "kyber")]
+#[target_feature(enable = "avx2")]
+pub unsafe fn kyber_decapsulate<
+    const K: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CPA_SECRET_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const C1_BLOCK_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+>(
+    private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
+    ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+) -> MlKemSharedSecret {
+    crate::ind_cca::decapsulate::<
+        K,
+        SECRET_KEY_SIZE,
+        CPA_SECRET_KEY_SIZE,
+        PUBLIC_KEY_SIZE,
+        CIPHERTEXT_SIZE,
+        T_AS_NTT_ENCODED_SIZE,
+        C1_SIZE,
+        C2_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_V_COMPRESSION_FACTOR,
+        C1_BLOCK_SIZE,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        crate::vector::SIMD256Vector,
+        crate::hash_functions::avx2::Simd256Hash,
+        crate::variant::Kyber,
+    >(private_key, ciphertext)
+}
+
+/// Portable decapsulate
+#[target_feature(enable = "avx2")]
+pub unsafe fn decapsulate<
+    const K: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CPA_SECRET_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const C1_BLOCK_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+>(
+    private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
+    ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+) -> MlKemSharedSecret {
+    crate::ind_cca::decapsulate::<
+        K,
+        SECRET_KEY_SIZE,
+        CPA_SECRET_KEY_SIZE,
+        PUBLIC_KEY_SIZE,
+        CIPHERTEXT_SIZE,
+        T_AS_NTT_ENCODED_SIZE,
+        C1_SIZE,
+        C2_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_V_COMPRESSION_FACTOR,
+        C1_BLOCK_SIZE,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        crate::vector::SIMD256Vector,
+        crate::hash_functions::avx2::Simd256Hash,
+        crate::variant::MlKem,
+    >(private_key, ciphertext)
+}
+
+/// Unpacked API
+pub(crate) mod unpacked {
+    use super::*;
+
+    pub(crate) type MlKemKeyPairUnpacked<const K: usize> =
+        crate::ind_cca::unpacked::MlKemKeyPairUnpacked<K, crate::vector::SIMD256Vector>;
+    pub(crate) type MlKemPublicKeyUnpacked<const K: usize> =
+        crate::ind_cca::unpacked::MlKemPublicKeyUnpacked<K, crate::vector::SIMD256Vector>;
+
+    /// Get the unpacked public key.
+    #[target_feature(enable = "avx2")]
+    pub(crate) unsafe fn unpack_public_key<
+        const K: usize,
+        const T_AS_NTT_ENCODED_SIZE: usize,
+        const RANKED_BYTES_PER_RING_ELEMENT: usize,
+        const PUBLIC_KEY_SIZE: usize,
+    >(
+        public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
+        unpacked_public_key: &mut MlKemPublicKeyUnpacked<K>,
+    ) {
+        crate::ind_cca::unpacked::unpack_public_key::<
+            K,
+            T_AS_NTT_ENCODED_SIZE,
+            RANKED_BYTES_PER_RING_ELEMENT,
+            PUBLIC_KEY_SIZE,
+            crate::hash_functions::avx2::Simd256Hash,
+            crate::vector::SIMD256Vector,
+        >(public_key, unpacked_public_key)
+    }
+
+    /// Generate a key pair
+    #[target_feature(enable = "avx2")]
+    pub(crate) unsafe fn generate_keypair<
+        const K: usize,
+        const CPA_PRIVATE_KEY_SIZE: usize,
+        const PRIVATE_KEY_SIZE: usize,
+        const PUBLIC_KEY_SIZE: usize,
+        const BYTES_PER_RING_ELEMENT: usize,
+        const ETA1: usize,
+        const ETA1_RANDOMNESS_SIZE: usize,
+    >(
+        randomness: [u8; KEY_GENERATION_SEED_SIZE],
+        out: &mut MlKemKeyPairUnpacked<K>,
+    ) {
+        crate::ind_cca::unpacked::generate_keypair::<
+            K,
+            CPA_PRIVATE_KEY_SIZE,
+            PRIVATE_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            BYTES_PER_RING_ELEMENT,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            crate::vector::SIMD256Vector,
+            crate::hash_functions::avx2::Simd256Hash,
+            crate::variant::MlKem,
+        >(randomness, out)
+    }
+
+    /// Unpacked encapsulate
+    #[target_feature(enable = "avx2")]
+    pub(crate) unsafe fn encapsulate<
+        const K: usize,
+        const CIPHERTEXT_SIZE: usize,
+        const PUBLIC_KEY_SIZE: usize,
+        const T_AS_NTT_ENCODED_SIZE: usize,
+        const C1_SIZE: usize,
+        const C2_SIZE: usize,
+        const VECTOR_U_COMPRESSION_FACTOR: usize,
+        const VECTOR_V_COMPRESSION_FACTOR: usize,
+        const VECTOR_U_BLOCK_LEN: usize,
+        const ETA1: usize,
+        const ETA1_RANDOMNESS_SIZE: usize,
+        const ETA2: usize,
+        const ETA2_RANDOMNESS_SIZE: usize,
+    >(
+        public_key: &MlKemPublicKeyUnpacked<K>,
+        randomness: [u8; SHARED_SECRET_SIZE],
+    ) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
+        crate::ind_cca::unpacked::encapsulate::<
+            K,
+            CIPHERTEXT_SIZE,
+            PUBLIC_KEY_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            VECTOR_U_BLOCK_LEN,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+            crate::vector::SIMD256Vector,
+            crate::hash_functions::avx2::Simd256Hash,
+        >(public_key, randomness)
+    }
+
+    /// Unpacked decapsulate
+    #[target_feature(enable = "avx2")]
+    pub(crate) unsafe fn decapsulate<
+        const K: usize,
+        const SECRET_KEY_SIZE: usize,
+        const CPA_SECRET_KEY_SIZE: usize,
+        const PUBLIC_KEY_SIZE: usize,
+        const CIPHERTEXT_SIZE: usize,
+        const T_AS_NTT_ENCODED_SIZE: usize,
+        const C1_SIZE: usize,
+        const C2_SIZE: usize,
+        const VECTOR_U_COMPRESSION_FACTOR: usize,
+        const VECTOR_V_COMPRESSION_FACTOR: usize,
+        const C1_BLOCK_SIZE: usize,
+        const ETA1: usize,
+        const ETA1_RANDOMNESS_SIZE: usize,
+        const ETA2: usize,
+        const ETA2_RANDOMNESS_SIZE: usize,
+        const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+    >(
+        key_pair: &MlKemKeyPairUnpacked<K>,
+        ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+    ) -> MlKemSharedSecret {
+        crate::ind_cca::unpacked::decapsulate::<
+            K,
+            SECRET_KEY_SIZE,
+            CPA_SECRET_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            CIPHERTEXT_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            C1_BLOCK_SIZE,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+            crate::vector::SIMD256Vector,
+            crate::hash_functions::avx2::Simd256Hash,
+        >(key_pair, ciphertext)
+    }
+}

--- a/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
@@ -3,9 +3,10 @@ use crate::{
     KEY_GENERATION_SEED_SIZE, SHARED_SECRET_SIZE,
 };
 
+#[allow(unsafe_code)]
 /// Portable generate key pair.
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn generate_keypair<
+unsafe fn generate_keypair_avx2<
     const K: usize,
     const CPA_PRIVATE_KEY_SIZE: usize,
     const PRIVATE_KEY_SIZE: usize,
@@ -30,9 +31,35 @@ pub(crate) unsafe fn generate_keypair<
     >(randomness)
 }
 
+#[allow(unsafe_code)]
+pub(crate) fn generate_keypair<
+    const K: usize,
+    const CPA_PRIVATE_KEY_SIZE: usize,
+    const PRIVATE_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const BYTES_PER_RING_ELEMENT: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+>(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
+    unsafe {
+        generate_keypair_avx2::<
+            K,
+            CPA_PRIVATE_KEY_SIZE,
+            PRIVATE_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            BYTES_PER_RING_ELEMENT,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+        >(randomness)
+    }
+}
+
+#[allow(unsafe_code)]
 #[cfg(feature = "kyber")]
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn kyber_generate_keypair<
+unsafe fn kyber_generate_keypair_avx2<
     const K: usize,
     const CPA_PRIVATE_KEY_SIZE: usize,
     const PRIVATE_KEY_SIZE: usize,
@@ -57,9 +84,35 @@ pub(crate) unsafe fn kyber_generate_keypair<
     >(randomness)
 }
 
-/// Portable public key validation
+#[allow(unsafe_code)]
+#[cfg(feature = "kyber")]
+pub(crate) fn kyber_generate_keypair<
+    const K: usize,
+    const CPA_PRIVATE_KEY_SIZE: usize,
+    const PRIVATE_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const BYTES_PER_RING_ELEMENT: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+>(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
+    unsafe {
+        kyber_generate_keypair::<
+            K,
+            CPA_PRIVATE_KEY_SIZE,
+            PRIVATE_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            BYTES_PER_RING_ELEMENT,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+        >(randomness)
+    }
+}
+
+#[allow(unsafe_code)]
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn validate_public_key<
+unsafe fn validate_public_key_avx2<
     const K: usize,
     const RANKED_BYTES_PER_RING_ELEMENT: usize,
     const PUBLIC_KEY_SIZE: usize,
@@ -74,9 +127,22 @@ pub(crate) unsafe fn validate_public_key<
     >(public_key)
 }
 
-/// Portable private key validation
+#[allow(unsafe_code)]
+pub(crate) fn validate_public_key<
+    const K: usize,
+    const RANKED_BYTES_PER_RING_ELEMENT: usize,
+    const PUBLIC_KEY_SIZE: usize,
+>(
+    public_key: &[u8; PUBLIC_KEY_SIZE],
+) -> bool {
+    unsafe {
+        validate_public_key_avx2::<K, RANKED_BYTES_PER_RING_ELEMENT, PUBLIC_KEY_SIZE>(public_key)
+    }
+}
+
+#[allow(unsafe_code)]
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn validate_private_key<
+unsafe fn validate_private_key_avx2<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
     const CIPHERTEXT_SIZE: usize,
@@ -92,10 +158,24 @@ pub(crate) unsafe fn validate_private_key<
     >(private_key, ciphertext)
 }
 
-/// Portable encapsulate
+#[allow(unsafe_code)]
+pub(crate) fn validate_private_key<
+    const K: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+>(
+    private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
+    ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+) -> bool {
+    unsafe {
+        validate_private_key_avx2::<K, SECRET_KEY_SIZE, CIPHERTEXT_SIZE>(private_key, ciphertext)
+    }
+}
+
+#[allow(unsafe_code)]
 #[cfg(feature = "kyber")]
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn kyber_encapsulate<
+unsafe fn kyber_encapsulate_avx2<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
@@ -133,8 +213,49 @@ pub(crate) unsafe fn kyber_encapsulate<
     >(public_key, randomness)
 }
 
+#[allow(unsafe_code)]
+#[cfg(feature = "kyber")]
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn encapsulate<
+pub(crate) fn kyber_encapsulate<
+    const K: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const VECTOR_U_BLOCK_LEN: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+>(
+    public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
+    randomness: [u8; SHARED_SECRET_SIZE],
+) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
+    unsafe {
+        kyber_encapsulate_avx2::<
+            K,
+            CIPHERTEXT_SIZE,
+            PUBLIC_KEY_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            VECTOR_U_BLOCK_LEN,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+        >(public_key, randomness)
+    }
+}
+
+#[allow(unsafe_code)]
+#[target_feature(enable = "avx2")]
+unsafe fn encapsulate_avx2<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
@@ -172,10 +293,48 @@ pub(crate) unsafe fn encapsulate<
     >(public_key, randomness)
 }
 
-/// Portable decapsulate
+#[allow(unsafe_code)]
+pub(crate) fn encapsulate<
+    const K: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const VECTOR_U_BLOCK_LEN: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+>(
+    public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
+    randomness: [u8; SHARED_SECRET_SIZE],
+) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
+    unsafe {
+        encapsulate_avx2::<
+            K,
+            CIPHERTEXT_SIZE,
+            PUBLIC_KEY_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            VECTOR_U_BLOCK_LEN,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+        >(public_key, randomness)
+    }
+}
+
+#[allow(unsafe_code)]
 #[cfg(feature = "kyber")]
 #[target_feature(enable = "avx2")]
-pub unsafe fn kyber_decapsulate<
+unsafe fn kyber_decapsulate_avx2<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
     const CPA_SECRET_KEY_SIZE: usize,
@@ -219,9 +378,54 @@ pub unsafe fn kyber_decapsulate<
     >(private_key, ciphertext)
 }
 
-/// Portable decapsulate
+#[allow(unsafe_code)]
+#[cfg(feature = "kyber")]
+pub fn kyber_decapsulate<
+    const K: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CPA_SECRET_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const C1_BLOCK_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+>(
+    private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
+    ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+) -> MlKemSharedSecret {
+    unsafe {
+        kyber_decapsulate_avx2::<
+            K,
+            SECRET_KEY_SIZE,
+            CPA_SECRET_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            CIPHERTEXT_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            C1_BLOCK_SIZE,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        >(private_key, ciphertext)
+    }
+}
+
+#[allow(unsafe_code)]
 #[target_feature(enable = "avx2")]
-pub unsafe fn decapsulate<
+unsafe fn decapsulate_avx2<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
     const CPA_SECRET_KEY_SIZE: usize,
@@ -263,6 +467,50 @@ pub unsafe fn decapsulate<
         crate::hash_functions::avx2::Simd256Hash,
         crate::variant::MlKem,
     >(private_key, ciphertext)
+}
+
+#[allow(unsafe_code)]
+pub fn decapsulate<
+    const K: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CPA_SECRET_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const C1_BLOCK_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+>(
+    private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
+    ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+) -> MlKemSharedSecret {
+    unsafe {
+        decapsulate_avx2::<
+            K,
+            SECRET_KEY_SIZE,
+            CPA_SECRET_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            CIPHERTEXT_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            C1_BLOCK_SIZE,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        >(private_key, ciphertext)
+    }
 }
 
 /// Unpacked API
@@ -276,7 +524,8 @@ pub(crate) mod unpacked {
 
     /// Get the unpacked public key.
     #[target_feature(enable = "avx2")]
-    pub(crate) unsafe fn unpack_public_key<
+    #[allow(unsafe_code)]
+    unsafe fn unpack_public_key_avx2<
         const K: usize,
         const T_AS_NTT_ENCODED_SIZE: usize,
         const RANKED_BYTES_PER_RING_ELEMENT: usize,
@@ -295,9 +544,30 @@ pub(crate) mod unpacked {
         >(public_key, unpacked_public_key)
     }
 
-    /// Generate a key pair
+    /// Get the unpacked public key.
+    #[allow(unsafe_code)]
+    pub(crate) fn unpack_public_key<
+        const K: usize,
+        const T_AS_NTT_ENCODED_SIZE: usize,
+        const RANKED_BYTES_PER_RING_ELEMENT: usize,
+        const PUBLIC_KEY_SIZE: usize,
+    >(
+        public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
+        unpacked_public_key: &mut MlKemPublicKeyUnpacked<K>,
+    ) {
+        unsafe {
+            unpack_public_key_avx2::<
+                K,
+                T_AS_NTT_ENCODED_SIZE,
+                RANKED_BYTES_PER_RING_ELEMENT,
+                PUBLIC_KEY_SIZE,
+            >(public_key, unpacked_public_key)
+        }
+    }
+
+    #[allow(unsafe_code)]
     #[target_feature(enable = "avx2")]
-    pub(crate) unsafe fn generate_keypair<
+    unsafe fn generate_keypair_avx2<
         const K: usize,
         const CPA_PRIVATE_KEY_SIZE: usize,
         const PRIVATE_KEY_SIZE: usize,
@@ -323,9 +593,36 @@ pub(crate) mod unpacked {
         >(randomness, out)
     }
 
-    /// Unpacked encapsulate
+    /// Generate a key pair
+    #[allow(unsafe_code)]
+    pub(crate) fn generate_keypair<
+        const K: usize,
+        const CPA_PRIVATE_KEY_SIZE: usize,
+        const PRIVATE_KEY_SIZE: usize,
+        const PUBLIC_KEY_SIZE: usize,
+        const BYTES_PER_RING_ELEMENT: usize,
+        const ETA1: usize,
+        const ETA1_RANDOMNESS_SIZE: usize,
+    >(
+        randomness: [u8; KEY_GENERATION_SEED_SIZE],
+        out: &mut MlKemKeyPairUnpacked<K>,
+    ) {
+        unsafe {
+            generate_keypair_avx2::<
+                K,
+                CPA_PRIVATE_KEY_SIZE,
+                PRIVATE_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                BYTES_PER_RING_ELEMENT,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+            >(randomness, out)
+        }
+    }
+
+    #[allow(unsafe_code)]
     #[target_feature(enable = "avx2")]
-    pub(crate) unsafe fn encapsulate<
+    unsafe fn encapsulate_avx2<
         const K: usize,
         const CIPHERTEXT_SIZE: usize,
         const PUBLIC_KEY_SIZE: usize,
@@ -362,9 +659,48 @@ pub(crate) mod unpacked {
         >(public_key, randomness)
     }
 
-    /// Unpacked decapsulate
+    /// Unpacked encapsulate
+    #[allow(unsafe_code)]
+    pub(crate) fn encapsulate<
+        const K: usize,
+        const CIPHERTEXT_SIZE: usize,
+        const PUBLIC_KEY_SIZE: usize,
+        const T_AS_NTT_ENCODED_SIZE: usize,
+        const C1_SIZE: usize,
+        const C2_SIZE: usize,
+        const VECTOR_U_COMPRESSION_FACTOR: usize,
+        const VECTOR_V_COMPRESSION_FACTOR: usize,
+        const VECTOR_U_BLOCK_LEN: usize,
+        const ETA1: usize,
+        const ETA1_RANDOMNESS_SIZE: usize,
+        const ETA2: usize,
+        const ETA2_RANDOMNESS_SIZE: usize,
+    >(
+        public_key: &MlKemPublicKeyUnpacked<K>,
+        randomness: [u8; SHARED_SECRET_SIZE],
+    ) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
+        unsafe {
+            encapsulate_avx2::<
+                K,
+                CIPHERTEXT_SIZE,
+                PUBLIC_KEY_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                VECTOR_U_BLOCK_LEN,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+            >(public_key, randomness)
+        }
+    }
+
     #[target_feature(enable = "avx2")]
-    pub(crate) unsafe fn decapsulate<
+    #[allow(unsafe_code)]
+    unsafe fn decapsulate_avx2<
         const K: usize,
         const SECRET_KEY_SIZE: usize,
         const CPA_SECRET_KEY_SIZE: usize,
@@ -405,5 +741,50 @@ pub(crate) mod unpacked {
             crate::vector::SIMD256Vector,
             crate::hash_functions::avx2::Simd256Hash,
         >(key_pair, ciphertext)
+    }
+
+    /// Unpacked decapsulate
+    #[allow(unsafe_code)]
+    pub(crate) fn decapsulate<
+        const K: usize,
+        const SECRET_KEY_SIZE: usize,
+        const CPA_SECRET_KEY_SIZE: usize,
+        const PUBLIC_KEY_SIZE: usize,
+        const CIPHERTEXT_SIZE: usize,
+        const T_AS_NTT_ENCODED_SIZE: usize,
+        const C1_SIZE: usize,
+        const C2_SIZE: usize,
+        const VECTOR_U_COMPRESSION_FACTOR: usize,
+        const VECTOR_V_COMPRESSION_FACTOR: usize,
+        const C1_BLOCK_SIZE: usize,
+        const ETA1: usize,
+        const ETA1_RANDOMNESS_SIZE: usize,
+        const ETA2: usize,
+        const ETA2_RANDOMNESS_SIZE: usize,
+        const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+    >(
+        key_pair: &MlKemKeyPairUnpacked<K>,
+        ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
+    ) -> MlKemSharedSecret {
+        unsafe {
+            decapsulate_avx2::<
+                K,
+                SECRET_KEY_SIZE,
+                CPA_SECRET_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+            >(key_pair, ciphertext)
+        }
     }
 }

--- a/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
@@ -98,7 +98,7 @@ pub(crate) fn kyber_generate_keypair<
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
     unsafe {
-        kyber_generate_keypair::<
+        kyber_generate_keypair_avx2::<
             K,
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,

--- a/libcrux-ml-kem/src/ind_cca/multiplexing.rs
+++ b/libcrux-ml-kem/src/ind_cca/multiplexing.rs
@@ -139,15 +139,17 @@ pub(crate) fn generate_keypair<
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
     // Runtime feature detection.
     if libcrux_platform::simd256_support() {
-        generate_keypair_avx2::<
-            K,
-            CPA_PRIVATE_KEY_SIZE,
-            PRIVATE_KEY_SIZE,
-            PUBLIC_KEY_SIZE,
-            BYTES_PER_RING_ELEMENT,
-            ETA1,
-            ETA1_RANDOMNESS_SIZE,
-        >(randomness)
+        unsafe {
+            generate_keypair_avx2::<
+                K,
+                CPA_PRIVATE_KEY_SIZE,
+                PRIVATE_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                BYTES_PER_RING_ELEMENT,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+            >(randomness)
+        }
     } else if libcrux_platform::simd128_support() {
         generate_keypair_neon::<
             K,
@@ -260,21 +262,23 @@ pub(crate) fn encapsulate<
     randomness: [u8; SHARED_SECRET_SIZE],
 ) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
     if libcrux_platform::simd256_support() {
-        encapsulate_avx2::<
-            K,
-            CIPHERTEXT_SIZE,
-            PUBLIC_KEY_SIZE,
-            T_AS_NTT_ENCODED_SIZE,
-            C1_SIZE,
-            C2_SIZE,
-            VECTOR_U_COMPRESSION_FACTOR,
-            VECTOR_V_COMPRESSION_FACTOR,
-            VECTOR_U_BLOCK_LEN,
-            ETA1,
-            ETA1_RANDOMNESS_SIZE,
-            ETA2,
-            ETA2_RANDOMNESS_SIZE,
-        >(public_key, randomness)
+        unsafe {
+            encapsulate_avx2::<
+                K,
+                CIPHERTEXT_SIZE,
+                PUBLIC_KEY_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                VECTOR_U_BLOCK_LEN,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+            >(public_key, randomness)
+        }
     } else if libcrux_platform::simd128_support() {
         encapsulate_neon::<
             K,
@@ -414,24 +418,26 @@ pub(crate) fn decapsulate<
     ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
 ) -> MlKemSharedSecret {
     if libcrux_platform::simd256_support() {
-        decapsulate_avx2::<
-            K,
-            SECRET_KEY_SIZE,
-            CPA_SECRET_KEY_SIZE,
-            PUBLIC_KEY_SIZE,
-            CIPHERTEXT_SIZE,
-            T_AS_NTT_ENCODED_SIZE,
-            C1_SIZE,
-            C2_SIZE,
-            VECTOR_U_COMPRESSION_FACTOR,
-            VECTOR_V_COMPRESSION_FACTOR,
-            C1_BLOCK_SIZE,
-            ETA1,
-            ETA1_RANDOMNESS_SIZE,
-            ETA2,
-            ETA2_RANDOMNESS_SIZE,
-            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-        >(private_key, ciphertext)
+        unsafe {
+            decapsulate_avx2::<
+                K,
+                SECRET_KEY_SIZE,
+                CPA_SECRET_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+            >(private_key, ciphertext)
+        }
     } else if libcrux_platform::simd128_support() {
         decapsulate_neon::<
             K,

--- a/libcrux-ml-kem/src/ind_cca/multiplexing.rs
+++ b/libcrux-ml-kem/src/ind_cca/multiplexing.rs
@@ -139,17 +139,15 @@ pub(crate) fn generate_keypair<
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
     // Runtime feature detection.
     if libcrux_platform::simd256_support() {
-        unsafe {
-            generate_keypair_avx2::<
-                K,
-                CPA_PRIVATE_KEY_SIZE,
-                PRIVATE_KEY_SIZE,
-                PUBLIC_KEY_SIZE,
-                BYTES_PER_RING_ELEMENT,
-                ETA1,
-                ETA1_RANDOMNESS_SIZE,
-            >(randomness)
-        }
+        generate_keypair_avx2::<
+            K,
+            CPA_PRIVATE_KEY_SIZE,
+            PRIVATE_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            BYTES_PER_RING_ELEMENT,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+        >(randomness)
     } else if libcrux_platform::simd128_support() {
         generate_keypair_neon::<
             K,
@@ -262,23 +260,21 @@ pub(crate) fn encapsulate<
     randomness: [u8; SHARED_SECRET_SIZE],
 ) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
     if libcrux_platform::simd256_support() {
-        unsafe {
-            encapsulate_avx2::<
-                K,
-                CIPHERTEXT_SIZE,
-                PUBLIC_KEY_SIZE,
-                T_AS_NTT_ENCODED_SIZE,
-                C1_SIZE,
-                C2_SIZE,
-                VECTOR_U_COMPRESSION_FACTOR,
-                VECTOR_V_COMPRESSION_FACTOR,
-                VECTOR_U_BLOCK_LEN,
-                ETA1,
-                ETA1_RANDOMNESS_SIZE,
-                ETA2,
-                ETA2_RANDOMNESS_SIZE,
-            >(public_key, randomness)
-        }
+        encapsulate_avx2::<
+            K,
+            CIPHERTEXT_SIZE,
+            PUBLIC_KEY_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            VECTOR_U_BLOCK_LEN,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+        >(public_key, randomness)
     } else if libcrux_platform::simd128_support() {
         encapsulate_neon::<
             K,
@@ -418,26 +414,24 @@ pub(crate) fn decapsulate<
     ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
 ) -> MlKemSharedSecret {
     if libcrux_platform::simd256_support() {
-        unsafe {
-            decapsulate_avx2::<
-                K,
-                SECRET_KEY_SIZE,
-                CPA_SECRET_KEY_SIZE,
-                PUBLIC_KEY_SIZE,
-                CIPHERTEXT_SIZE,
-                T_AS_NTT_ENCODED_SIZE,
-                C1_SIZE,
-                C2_SIZE,
-                VECTOR_U_COMPRESSION_FACTOR,
-                VECTOR_V_COMPRESSION_FACTOR,
-                C1_BLOCK_SIZE,
-                ETA1,
-                ETA1_RANDOMNESS_SIZE,
-                ETA2,
-                ETA2_RANDOMNESS_SIZE,
-                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-            >(private_key, ciphertext)
-        }
+        decapsulate_avx2::<
+            K,
+            SECRET_KEY_SIZE,
+            CPA_SECRET_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            CIPHERTEXT_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            C1_BLOCK_SIZE,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        >(private_key, ciphertext)
     } else if libcrux_platform::simd128_support() {
         decapsulate_neon::<
             K,

--- a/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux-ml-kem/src/ind_cpa.rs
@@ -571,6 +571,7 @@ fn deserialize_secret_key<const K: usize, Vector: Operations>(
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
+#[inline(always)]
 pub(crate) fn decrypt_unpacked<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
@@ -598,6 +599,7 @@ pub(crate) fn decrypt_unpacked<
 }
 
 #[allow(non_snake_case)]
+#[inline(always)]
 pub(crate) fn decrypt<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,

--- a/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux-ml-kem/src/ind_cpa.rs
@@ -226,6 +226,7 @@ fn sample_vector_cbd_then_ntt_out<
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
+#[inline(always)]
 pub(crate) fn generate_keypair_unpacked<
     const K: usize,
     const ETA1: usize,
@@ -273,6 +274,7 @@ pub(crate) fn generate_keypair_unpacked<
 }
 
 #[allow(non_snake_case)]
+#[inline(always)]
 pub(crate) fn generate_keypair<
     const K: usize,
     const PRIVATE_KEY_SIZE: usize,

--- a/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux-ml-kem/src/ind_cpa.rs
@@ -309,6 +309,7 @@ pub(crate) fn generate_keypair<
 }
 
 /// Call [`compress_then_serialize_ring_element_u`] on each ring element.
+#[inline(always)]
 fn compress_then_serialize_u<
     const K: usize,
     const OUT_LEN: usize,
@@ -371,6 +372,7 @@ fn compress_then_serialize_u<
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
+#[inline(always)]
 pub(crate) fn encrypt_unpacked<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
@@ -447,6 +449,7 @@ pub(crate) fn encrypt_unpacked<
 }
 
 #[allow(non_snake_case)]
+#[inline(always)]
 pub(crate) fn encrypt<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,

--- a/libcrux-ml-kem/src/lib.rs
+++ b/libcrux-ml-kem/src/lib.rs
@@ -10,14 +10,14 @@
 Functions in this crate use CPU feature detection to pick the most efficient version
 on each platform. To use a specific version with your own feature detection
 use e.g. one of the following
-- `mlkem512::avx2::generate_key_pair`,
-- `mlkem512::neon::generate_key_pair`,
-- `mlkem512::portable::generate_key_pair`,
+- `mlkem768::avx2::generate_key_pair`,
+- `mlkem768::neon::generate_key_pair`,
+- `mlkem768::portable::generate_key_pair`,
 
 analogously for encapsulation and decapsulation."##
 )]
 #![cfg_attr(
-    feature = "mlkem512",
+    feature = "mlkem768",
     doc = r##"
 ```
  use rand::{rngs::OsRng, RngCore};
@@ -35,22 +35,22 @@ analogously for encapsulation and decapsulation."##
 
  use libcrux_ml_kem::*;
 
- // This example uses ML-KEM 512. The other variants can be used the same way.
+ // This example uses ML-KEM 768. The other variants can be used the same way.
 
  // Generate a key pair.
  let key_pair = {
     let randomness = random_array();
-    mlkem512::generate_key_pair(randomness)
+    mlkem768::generate_key_pair(randomness)
  };
 
  // Encapsulating a shared secret to a public key.
  let (ciphertext, shared_secret) = {
     let randomness = random_array();
-    mlkem512::encapsulate(key_pair.public_key(), randomness)
+    mlkem768::encapsulate(key_pair.public_key(), randomness)
  };
 
  // Decapsulating a shared secret with a private key.
- let shared_secret_decapsulated = mlkem512::decapsulate(key_pair.private_key(), &ciphertext);
+ let shared_secret_decapsulated = mlkem768::decapsulate(key_pair.private_key(), &ciphertext);
 
  assert_eq!(shared_secret_decapsulated, shared_secret);
 ```"##

--- a/libcrux-ml-kem/src/lib.rs
+++ b/libcrux-ml-kem/src/lib.rs
@@ -38,15 +38,21 @@ analogously for encapsulation and decapsulation."##
  // This example uses ML-KEM 768. The other variants can be used the same way.
 
  // Generate a key pair.
- let randomness = random_array();
- let key_pair = mlkem768::generate_key_pair(randomness);
+ let key_pair = {
+    let randomness = random_array();
+    mlkem768::generate_key_pair(randomness)
+ };
 
  // Encapsulating a shared secret to a public key.
- let randomness = random_array();
- let (ciphertext, shared_secret) = mlkem768::encapsulate(key_pair.public_key(), randomness);
+ let (ciphertext, shared_secret) = {
+    let randomness = random_array();
+    mlkem768::encapsulate(key_pair.public_key(), randomness)
+ };
 
  // Decapsulating a shared secret with a private key.
  let shared_secret_decapsulated = mlkem768::decapsulate(key_pair.private_key(), &ciphertext);
+
+ assert_eq!(shared_secret_decapsulated, shared_secret);
 ```"##
 )]
 //!
@@ -68,7 +74,7 @@ analogously for encapsulation and decapsulation."##
 
 #![no_std]
 #![deny(missing_docs)]
-#![warn(unsafe_code)]
+#![deny(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
 #![allow(clippy::needless_range_loop)]
 #![warn(missing_docs)]

--- a/libcrux-ml-kem/src/lib.rs
+++ b/libcrux-ml-kem/src/lib.rs
@@ -68,7 +68,7 @@ analogously for encapsulation and decapsulation."##
 
 #![no_std]
 #![deny(missing_docs)]
-// #![forbid(unsafe_code)]
+#![warn(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
 #![allow(clippy::needless_range_loop)]
 #![warn(missing_docs)]

--- a/libcrux-ml-kem/src/lib.rs
+++ b/libcrux-ml-kem/src/lib.rs
@@ -68,7 +68,7 @@ analogously for encapsulation and decapsulation."##
 
 #![no_std]
 #![deny(missing_docs)]
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
 #![allow(clippy::needless_range_loop)]
 #![warn(missing_docs)]

--- a/libcrux-ml-kem/src/lib.rs
+++ b/libcrux-ml-kem/src/lib.rs
@@ -10,14 +10,14 @@
 Functions in this crate use CPU feature detection to pick the most efficient version
 on each platform. To use a specific version with your own feature detection
 use e.g. one of the following
-- `mlkem768::avx2::generate_key_pair`,
-- `mlkem768::neon::generate_key_pair`,
-- `mlkem768::portable::generate_key_pair`,
+- `mlkem512::avx2::generate_key_pair`,
+- `mlkem512::neon::generate_key_pair`,
+- `mlkem512::portable::generate_key_pair`,
 
 analogously for encapsulation and decapsulation."##
 )]
 #![cfg_attr(
-    feature = "mlkem768",
+    feature = "mlkem512",
     doc = r##"
 ```
  use rand::{rngs::OsRng, RngCore};
@@ -35,22 +35,22 @@ analogously for encapsulation and decapsulation."##
 
  use libcrux_ml_kem::*;
 
- // This example uses ML-KEM 768. The other variants can be used the same way.
+ // This example uses ML-KEM 512. The other variants can be used the same way.
 
  // Generate a key pair.
  let key_pair = {
     let randomness = random_array();
-    mlkem768::generate_key_pair(randomness)
+    mlkem512::generate_key_pair(randomness)
  };
 
  // Encapsulating a shared secret to a public key.
  let (ciphertext, shared_secret) = {
     let randomness = random_array();
-    mlkem768::encapsulate(key_pair.public_key(), randomness)
+    mlkem512::encapsulate(key_pair.public_key(), randomness)
  };
 
  // Decapsulating a shared secret with a private key.
- let shared_secret_decapsulated = mlkem768::decapsulate(key_pair.private_key(), &ciphertext);
+ let shared_secret_decapsulated = mlkem512::decapsulate(key_pair.private_key(), &ciphertext);
 
  assert_eq!(shared_secret_decapsulated, shared_secret);
 ```"##

--- a/libcrux-ml-kem/src/mlkem1024.rs
+++ b/libcrux-ml-kem/src/mlkem1024.rs
@@ -56,11 +56,14 @@ macro_rules! instantiate {
             ///
             /// Returns `true` if valid, and `false` otherwise.
             pub fn validate_public_key(public_key: &MlKem1024PublicKey) -> bool {
-                p::validate_public_key::<
-                    RANK_1024,
-                    RANKED_BYTES_PER_RING_ELEMENT_1024,
-                    CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                >(&public_key.value)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::validate_public_key::<
+                        RANK_1024,
+                        RANKED_BYTES_PER_RING_ELEMENT_1024,
+                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                    >(&public_key.value)
+                }
             }
 
             /// Validate a private key.
@@ -70,11 +73,14 @@ macro_rules! instantiate {
                 private_key: &MlKem1024PrivateKey,
                 ciphertext: &MlKem1024Ciphertext,
             ) -> bool {
-                p::validate_private_key::<
-                    RANK_1024,
-                    SECRET_KEY_SIZE_1024,
-                    CPA_PKE_CIPHERTEXT_SIZE_1024,
-                >(private_key, ciphertext)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::validate_private_key::<
+                        RANK_1024,
+                        SECRET_KEY_SIZE_1024,
+                        CPA_PKE_CIPHERTEXT_SIZE_1024,
+                    >(private_key, ciphertext)
+                }
             }
 
             /// Generate Kyber 1024 Key Pair
@@ -83,30 +89,36 @@ macro_rules! instantiate {
             pub fn kyber_generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem1024KeyPair {
-                p::kyber_generate_keypair::<
-                    RANK_1024,
-                    CPA_PKE_SECRET_KEY_SIZE_1024,
-                    SECRET_KEY_SIZE_1024,
-                    CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                    RANKED_BYTES_PER_RING_ELEMENT_1024,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                >(randomness)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::kyber_generate_keypair::<
+                        RANK_1024,
+                        CPA_PKE_SECRET_KEY_SIZE_1024,
+                        SECRET_KEY_SIZE_1024,
+                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                        RANKED_BYTES_PER_RING_ELEMENT_1024,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                    >(randomness)
+                }
             }
 
             /// Generate ML-KEM 1024 Key Pair
             pub fn generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem1024KeyPair {
-                p::generate_keypair::<
-                    RANK_1024,
-                    CPA_PKE_SECRET_KEY_SIZE_1024,
-                    SECRET_KEY_SIZE_1024,
-                    CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                    RANKED_BYTES_PER_RING_ELEMENT_1024,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                >(randomness)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::generate_keypair::<
+                        RANK_1024,
+                        CPA_PKE_SECRET_KEY_SIZE_1024,
+                        SECRET_KEY_SIZE_1024,
+                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                        RANKED_BYTES_PER_RING_ELEMENT_1024,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                    >(randomness)
+                }
             }
 
             /// Encapsulate ML-KEM 1024
@@ -118,21 +130,24 @@ macro_rules! instantiate {
                 public_key: &MlKem1024PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
-                p::encapsulate::<
-                    RANK_1024,
-                    CPA_PKE_CIPHERTEXT_SIZE_1024,
-                    CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                    T_AS_NTT_ENCODED_SIZE_1024,
-                    C1_SIZE_1024,
-                    C2_SIZE_1024,
-                    VECTOR_U_COMPRESSION_FACTOR_1024,
-                    VECTOR_V_COMPRESSION_FACTOR_1024,
-                    C1_BLOCK_SIZE_1024,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                    ETA2,
-                    ETA2_RANDOMNESS_SIZE,
-                >(public_key, randomness)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::encapsulate::<
+                        RANK_1024,
+                        CPA_PKE_CIPHERTEXT_SIZE_1024,
+                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                        T_AS_NTT_ENCODED_SIZE_1024,
+                        C1_SIZE_1024,
+                        C2_SIZE_1024,
+                        VECTOR_U_COMPRESSION_FACTOR_1024,
+                        VECTOR_V_COMPRESSION_FACTOR_1024,
+                        C1_BLOCK_SIZE_1024,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                        ETA2,
+                        ETA2_RANDOMNESS_SIZE,
+                    >(public_key, randomness)
+                }
             }
 
             /// Encapsulate Kyber 1024
@@ -146,21 +161,24 @@ macro_rules! instantiate {
                 public_key: &MlKem1024PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
-                p::kyber_encapsulate::<
-                    RANK_1024,
-                    CPA_PKE_CIPHERTEXT_SIZE_1024,
-                    CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                    T_AS_NTT_ENCODED_SIZE_1024,
-                    C1_SIZE_1024,
-                    C2_SIZE_1024,
-                    VECTOR_U_COMPRESSION_FACTOR_1024,
-                    VECTOR_V_COMPRESSION_FACTOR_1024,
-                    C1_BLOCK_SIZE_1024,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                    ETA2,
-                    ETA2_RANDOMNESS_SIZE,
-                >(public_key, randomness)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::kyber_encapsulate::<
+                        RANK_1024,
+                        CPA_PKE_CIPHERTEXT_SIZE_1024,
+                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                        T_AS_NTT_ENCODED_SIZE_1024,
+                        C1_SIZE_1024,
+                        C2_SIZE_1024,
+                        VECTOR_U_COMPRESSION_FACTOR_1024,
+                        VECTOR_V_COMPRESSION_FACTOR_1024,
+                        C1_BLOCK_SIZE_1024,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                        ETA2,
+                        ETA2_RANDOMNESS_SIZE,
+                    >(public_key, randomness)
+                }
             }
 
             /// Decapsulate ML-KEM 1024
@@ -171,24 +189,27 @@ macro_rules! instantiate {
                 private_key: &MlKem1024PrivateKey,
                 ciphertext: &MlKem1024Ciphertext,
             ) -> MlKemSharedSecret {
-                p::decapsulate::<
-                    RANK_1024,
-                    SECRET_KEY_SIZE_1024,
-                    CPA_PKE_SECRET_KEY_SIZE_1024,
-                    CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                    CPA_PKE_CIPHERTEXT_SIZE_1024,
-                    T_AS_NTT_ENCODED_SIZE_1024,
-                    C1_SIZE_1024,
-                    C2_SIZE_1024,
-                    VECTOR_U_COMPRESSION_FACTOR_1024,
-                    VECTOR_V_COMPRESSION_FACTOR_1024,
-                    C1_BLOCK_SIZE_1024,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                    ETA2,
-                    ETA2_RANDOMNESS_SIZE,
-                    IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                >(private_key, ciphertext)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::decapsulate::<
+                        RANK_1024,
+                        SECRET_KEY_SIZE_1024,
+                        CPA_PKE_SECRET_KEY_SIZE_1024,
+                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                        CPA_PKE_CIPHERTEXT_SIZE_1024,
+                        T_AS_NTT_ENCODED_SIZE_1024,
+                        C1_SIZE_1024,
+                        C2_SIZE_1024,
+                        VECTOR_U_COMPRESSION_FACTOR_1024,
+                        VECTOR_V_COMPRESSION_FACTOR_1024,
+                        C1_BLOCK_SIZE_1024,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                        ETA2,
+                        ETA2_RANDOMNESS_SIZE,
+                        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+                    >(private_key, ciphertext)
+                }
             }
 
             /// Decapsulate Kyber 1024
@@ -201,24 +222,27 @@ macro_rules! instantiate {
                 private_key: &MlKem1024PrivateKey,
                 ciphertext: &MlKem1024Ciphertext,
             ) -> MlKemSharedSecret {
-                p::kyber_decapsulate::<
-                    RANK_1024,
-                    SECRET_KEY_SIZE_1024,
-                    CPA_PKE_SECRET_KEY_SIZE_1024,
-                    CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                    CPA_PKE_CIPHERTEXT_SIZE_1024,
-                    T_AS_NTT_ENCODED_SIZE_1024,
-                    C1_SIZE_1024,
-                    C2_SIZE_1024,
-                    VECTOR_U_COMPRESSION_FACTOR_1024,
-                    VECTOR_V_COMPRESSION_FACTOR_1024,
-                    C1_BLOCK_SIZE_1024,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                    ETA2,
-                    ETA2_RANDOMNESS_SIZE,
-                    IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                >(private_key, ciphertext)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::kyber_decapsulate::<
+                        RANK_1024,
+                        SECRET_KEY_SIZE_1024,
+                        CPA_PKE_SECRET_KEY_SIZE_1024,
+                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                        CPA_PKE_CIPHERTEXT_SIZE_1024,
+                        T_AS_NTT_ENCODED_SIZE_1024,
+                        C1_SIZE_1024,
+                        C2_SIZE_1024,
+                        VECTOR_U_COMPRESSION_FACTOR_1024,
+                        VECTOR_V_COMPRESSION_FACTOR_1024,
+                        C1_BLOCK_SIZE_1024,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                        ETA2,
+                        ETA2_RANDOMNESS_SIZE,
+                        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+                    >(private_key, ciphertext)
+                }
             }
 
             /// Unpacked APIs that don't use serialized keys.
@@ -248,9 +272,9 @@ macro_rules! instantiate {
                     serialized: &mut MlKem1024PublicKey,
                 ) {
                     public_key.serialized_public_key_mut::<
-                        RANKED_BYTES_PER_RING_ELEMENT_1024,
-                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                    >(serialized);
+                                                                RANKED_BYTES_PER_RING_ELEMENT_1024,
+                                                                CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                                                            >(serialized);
                 }
 
                 /// Get the unpacked public key.
@@ -258,12 +282,15 @@ macro_rules! instantiate {
                     public_key: &MlKem1024PublicKey,
                     unpacked_public_key: &mut MlKem1024PublicKeyUnpacked,
                 ) {
-                    p::unpacked::unpack_public_key::<
-                        RANK_1024,
-                        T_AS_NTT_ENCODED_SIZE_1024,
-                        RANKED_BYTES_PER_RING_ELEMENT_1024,
-                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                    >(public_key, unpacked_public_key)
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        p::unpacked::unpack_public_key::<
+                            RANK_1024,
+                            T_AS_NTT_ENCODED_SIZE_1024,
+                            RANKED_BYTES_PER_RING_ELEMENT_1024,
+                            CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                        >(public_key, unpacked_public_key)
+                    }
                 }
 
                 /// Generate ML-KEM 1024 Key Pair in "unpacked" form
@@ -271,15 +298,18 @@ macro_rules! instantiate {
                     randomness: [u8; KEY_GENERATION_SEED_SIZE],
                     key_pair: &mut MlKem1024KeyPairUnpacked,
                 ) {
-                    p::unpacked::generate_keypair::<
-                        RANK_1024,
-                        CPA_PKE_SECRET_KEY_SIZE_1024,
-                        SECRET_KEY_SIZE_1024,
-                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                        RANKED_BYTES_PER_RING_ELEMENT_1024,
-                        ETA1,
-                        ETA1_RANDOMNESS_SIZE,
-                    >(randomness, key_pair)
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        p::unpacked::generate_keypair::<
+                            RANK_1024,
+                            CPA_PKE_SECRET_KEY_SIZE_1024,
+                            SECRET_KEY_SIZE_1024,
+                            CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                            RANKED_BYTES_PER_RING_ELEMENT_1024,
+                            ETA1,
+                            ETA1_RANDOMNESS_SIZE,
+                        >(randomness, key_pair)
+                    }
                 }
 
                 /// Encapsulate ML-KEM 1024 (unpacked)
@@ -306,21 +336,24 @@ macro_rules! instantiate {
                     public_key: &MlKem1024PublicKeyUnpacked,
                     randomness: [u8; SHARED_SECRET_SIZE],
                 ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
-                    p::unpacked::encapsulate::<
-                        RANK_1024,
-                        CPA_PKE_CIPHERTEXT_SIZE_1024,
-                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                        T_AS_NTT_ENCODED_SIZE_1024,
-                        C1_SIZE_1024,
-                        C2_SIZE_1024,
-                        VECTOR_U_COMPRESSION_FACTOR_1024,
-                        VECTOR_V_COMPRESSION_FACTOR_1024,
-                        C1_BLOCK_SIZE_1024,
-                        ETA1,
-                        ETA1_RANDOMNESS_SIZE,
-                        ETA2,
-                        ETA2_RANDOMNESS_SIZE,
-                    >(public_key, randomness)
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        p::unpacked::encapsulate::<
+                            RANK_1024,
+                            CPA_PKE_CIPHERTEXT_SIZE_1024,
+                            CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                            T_AS_NTT_ENCODED_SIZE_1024,
+                            C1_SIZE_1024,
+                            C2_SIZE_1024,
+                            VECTOR_U_COMPRESSION_FACTOR_1024,
+                            VECTOR_V_COMPRESSION_FACTOR_1024,
+                            C1_BLOCK_SIZE_1024,
+                            ETA1,
+                            ETA1_RANDOMNESS_SIZE,
+                            ETA2,
+                            ETA2_RANDOMNESS_SIZE,
+                        >(public_key, randomness)
+                    }
                 }
 
                 /// Decapsulate ML-KEM 1024 (unpacked)
@@ -332,24 +365,27 @@ macro_rules! instantiate {
                     private_key: &MlKem1024KeyPairUnpacked,
                     ciphertext: &MlKem1024Ciphertext,
                 ) -> MlKemSharedSecret {
-                    p::unpacked::decapsulate::<
-                        RANK_1024,
-                        SECRET_KEY_SIZE_1024,
-                        CPA_PKE_SECRET_KEY_SIZE_1024,
-                        CPA_PKE_PUBLIC_KEY_SIZE_1024,
-                        CPA_PKE_CIPHERTEXT_SIZE_1024,
-                        T_AS_NTT_ENCODED_SIZE_1024,
-                        C1_SIZE_1024,
-                        C2_SIZE_1024,
-                        VECTOR_U_COMPRESSION_FACTOR_1024,
-                        VECTOR_V_COMPRESSION_FACTOR_1024,
-                        C1_BLOCK_SIZE_1024,
-                        ETA1,
-                        ETA1_RANDOMNESS_SIZE,
-                        ETA2,
-                        ETA2_RANDOMNESS_SIZE,
-                        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                    >(private_key, ciphertext)
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        p::unpacked::decapsulate::<
+                            RANK_1024,
+                            SECRET_KEY_SIZE_1024,
+                            CPA_PKE_SECRET_KEY_SIZE_1024,
+                            CPA_PKE_PUBLIC_KEY_SIZE_1024,
+                            CPA_PKE_CIPHERTEXT_SIZE_1024,
+                            T_AS_NTT_ENCODED_SIZE_1024,
+                            C1_SIZE_1024,
+                            C2_SIZE_1024,
+                            VECTOR_U_COMPRESSION_FACTOR_1024,
+                            VECTOR_V_COMPRESSION_FACTOR_1024,
+                            C1_BLOCK_SIZE_1024,
+                            ETA1,
+                            ETA1_RANDOMNESS_SIZE,
+                            ETA2,
+                            ETA2_RANDOMNESS_SIZE,
+                            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+                        >(private_key, ciphertext)
+                    }
                 }
             }
         }

--- a/libcrux-ml-kem/src/mlkem1024.rs
+++ b/libcrux-ml-kem/src/mlkem1024.rs
@@ -56,14 +56,12 @@ macro_rules! instantiate {
             ///
             /// Returns `true` if valid, and `false` otherwise.
             pub fn validate_public_key(public_key: &MlKem1024PublicKey) -> bool {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::validate_public_key::<
                         RANK_1024,
                         RANKED_BYTES_PER_RING_ELEMENT_1024,
                         CPA_PKE_PUBLIC_KEY_SIZE_1024,
                     >(&public_key.value)
-                }
+                
             }
 
             /// Validate a private key.
@@ -73,14 +71,12 @@ macro_rules! instantiate {
                 private_key: &MlKem1024PrivateKey,
                 ciphertext: &MlKem1024Ciphertext,
             ) -> bool {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::validate_private_key::<
                         RANK_1024,
                         SECRET_KEY_SIZE_1024,
                         CPA_PKE_CIPHERTEXT_SIZE_1024,
                     >(private_key, ciphertext)
-                }
+                
             }
 
             /// Generate Kyber 1024 Key Pair
@@ -89,8 +85,6 @@ macro_rules! instantiate {
             pub fn kyber_generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem1024KeyPair {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::kyber_generate_keypair::<
                         RANK_1024,
                         CPA_PKE_SECRET_KEY_SIZE_1024,
@@ -100,15 +94,13 @@ macro_rules! instantiate {
                         ETA1,
                         ETA1_RANDOMNESS_SIZE,
                     >(randomness)
-                }
+                
             }
 
             /// Generate ML-KEM 1024 Key Pair
             pub fn generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem1024KeyPair {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::generate_keypair::<
                         RANK_1024,
                         CPA_PKE_SECRET_KEY_SIZE_1024,
@@ -118,7 +110,7 @@ macro_rules! instantiate {
                         ETA1,
                         ETA1_RANDOMNESS_SIZE,
                     >(randomness)
-                }
+                
             }
 
             /// Encapsulate ML-KEM 1024
@@ -130,8 +122,6 @@ macro_rules! instantiate {
                 public_key: &MlKem1024PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::encapsulate::<
                         RANK_1024,
                         CPA_PKE_CIPHERTEXT_SIZE_1024,
@@ -147,7 +137,7 @@ macro_rules! instantiate {
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
                     >(public_key, randomness)
-                }
+                
             }
 
             /// Encapsulate Kyber 1024
@@ -161,8 +151,6 @@ macro_rules! instantiate {
                 public_key: &MlKem1024PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::kyber_encapsulate::<
                         RANK_1024,
                         CPA_PKE_CIPHERTEXT_SIZE_1024,
@@ -178,7 +166,7 @@ macro_rules! instantiate {
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
                     >(public_key, randomness)
-                }
+                
             }
 
             /// Decapsulate ML-KEM 1024
@@ -189,8 +177,6 @@ macro_rules! instantiate {
                 private_key: &MlKem1024PrivateKey,
                 ciphertext: &MlKem1024Ciphertext,
             ) -> MlKemSharedSecret {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::decapsulate::<
                         RANK_1024,
                         SECRET_KEY_SIZE_1024,
@@ -209,7 +195,7 @@ macro_rules! instantiate {
                         ETA2_RANDOMNESS_SIZE,
                         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                     >(private_key, ciphertext)
-                }
+                
             }
 
             /// Decapsulate Kyber 1024
@@ -222,8 +208,6 @@ macro_rules! instantiate {
                 private_key: &MlKem1024PrivateKey,
                 ciphertext: &MlKem1024Ciphertext,
             ) -> MlKemSharedSecret {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::kyber_decapsulate::<
                         RANK_1024,
                         SECRET_KEY_SIZE_1024,
@@ -242,7 +226,7 @@ macro_rules! instantiate {
                         ETA2_RANDOMNESS_SIZE,
                         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                     >(private_key, ciphertext)
-                }
+                
             }
 
             /// Unpacked APIs that don't use serialized keys.
@@ -282,15 +266,13 @@ macro_rules! instantiate {
                     public_key: &MlKem1024PublicKey,
                     unpacked_public_key: &mut MlKem1024PublicKeyUnpacked,
                 ) {
-                    #[allow(unused_unsafe)]
-                    unsafe {
                         p::unpacked::unpack_public_key::<
                             RANK_1024,
                             T_AS_NTT_ENCODED_SIZE_1024,
                             RANKED_BYTES_PER_RING_ELEMENT_1024,
                             CPA_PKE_PUBLIC_KEY_SIZE_1024,
                         >(public_key, unpacked_public_key)
-                    }
+                    
                 }
 
                 /// Generate ML-KEM 1024 Key Pair in "unpacked" form
@@ -298,8 +280,6 @@ macro_rules! instantiate {
                     randomness: [u8; KEY_GENERATION_SEED_SIZE],
                     key_pair: &mut MlKem1024KeyPairUnpacked,
                 ) {
-                    #[allow(unused_unsafe)]
-                    unsafe {
                         p::unpacked::generate_keypair::<
                             RANK_1024,
                             CPA_PKE_SECRET_KEY_SIZE_1024,
@@ -309,7 +289,7 @@ macro_rules! instantiate {
                             ETA1,
                             ETA1_RANDOMNESS_SIZE,
                         >(randomness, key_pair)
-                    }
+                    
                 }
 
                 /// Encapsulate ML-KEM 1024 (unpacked)
@@ -336,8 +316,6 @@ macro_rules! instantiate {
                     public_key: &MlKem1024PublicKeyUnpacked,
                     randomness: [u8; SHARED_SECRET_SIZE],
                 ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
-                    #[allow(unused_unsafe)]
-                    unsafe {
                         p::unpacked::encapsulate::<
                             RANK_1024,
                             CPA_PKE_CIPHERTEXT_SIZE_1024,
@@ -353,7 +331,7 @@ macro_rules! instantiate {
                             ETA2,
                             ETA2_RANDOMNESS_SIZE,
                         >(public_key, randomness)
-                    }
+                    
                 }
 
                 /// Decapsulate ML-KEM 1024 (unpacked)
@@ -365,8 +343,6 @@ macro_rules! instantiate {
                     private_key: &MlKem1024KeyPairUnpacked,
                     ciphertext: &MlKem1024Ciphertext,
                 ) -> MlKemSharedSecret {
-                    #[allow(unused_unsafe)]
-                    unsafe {
                         p::unpacked::decapsulate::<
                             RANK_1024,
                             SECRET_KEY_SIZE_1024,
@@ -385,7 +361,7 @@ macro_rules! instantiate {
                             ETA2_RANDOMNESS_SIZE,
                             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                         >(private_key, ciphertext)
-                    }
+                    
                 }
             }
         }

--- a/libcrux-ml-kem/src/mlkem512.rs
+++ b/libcrux-ml-kem/src/mlkem512.rs
@@ -54,11 +54,14 @@ macro_rules! instantiate {
             ///
             /// Returns `true` if valid, and `false` otherwise.
             pub fn validate_public_key(public_key: &MlKem512PublicKey) -> bool {
-                p::validate_public_key::<
-                    RANK_512,
-                    RANKED_BYTES_PER_RING_ELEMENT_512,
-                    CPA_PKE_PUBLIC_KEY_SIZE_512,
-                >(&public_key.value)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::validate_public_key::<
+                        RANK_512,
+                        RANKED_BYTES_PER_RING_ELEMENT_512,
+                        CPA_PKE_PUBLIC_KEY_SIZE_512,
+                    >(&public_key.value)
+                }
             }
 
             /// Validate a private key.
@@ -68,26 +71,32 @@ macro_rules! instantiate {
                 private_key: &MlKem512PrivateKey,
                 ciphertext: &MlKem512Ciphertext,
             ) -> bool {
-                p::validate_private_key::<
-                    RANK_512,
-                    SECRET_KEY_SIZE_512,
-                    CPA_PKE_CIPHERTEXT_SIZE_512,
-                >(private_key, ciphertext)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::validate_private_key::<
+                        RANK_512,
+                        SECRET_KEY_SIZE_512,
+                        CPA_PKE_CIPHERTEXT_SIZE_512,
+                    >(private_key, ciphertext)
+                }
             }
 
             /// Generate ML-KEM 512 Key Pair
             pub fn generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem512KeyPair {
-                p::generate_keypair::<
-                    RANK_512,
-                    CPA_PKE_SECRET_KEY_SIZE_512,
-                    SECRET_KEY_SIZE_512,
-                    CPA_PKE_PUBLIC_KEY_SIZE_512,
-                    RANKED_BYTES_PER_RING_ELEMENT_512,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                >(randomness)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::generate_keypair::<
+                        RANK_512,
+                        CPA_PKE_SECRET_KEY_SIZE_512,
+                        SECRET_KEY_SIZE_512,
+                        CPA_PKE_PUBLIC_KEY_SIZE_512,
+                        RANKED_BYTES_PER_RING_ELEMENT_512,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                    >(randomness)
+                }
             }
 
             /// Generate Kyber 512 Key Pair
@@ -96,15 +105,18 @@ macro_rules! instantiate {
             pub fn kyber_generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem512KeyPair {
-                p::kyber_generate_keypair::<
-                    RANK_512,
-                    CPA_PKE_SECRET_KEY_SIZE_512,
-                    SECRET_KEY_SIZE_512,
-                    CPA_PKE_PUBLIC_KEY_SIZE_512,
-                    RANKED_BYTES_PER_RING_ELEMENT_512,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                >(randomness)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::kyber_generate_keypair::<
+                        RANK_512,
+                        CPA_PKE_SECRET_KEY_SIZE_512,
+                        SECRET_KEY_SIZE_512,
+                        CPA_PKE_PUBLIC_KEY_SIZE_512,
+                        RANKED_BYTES_PER_RING_ELEMENT_512,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                    >(randomness)
+                }
             }
             /// Encapsulate ML-KEM 512
             ///
@@ -115,21 +127,24 @@ macro_rules! instantiate {
                 public_key: &MlKem512PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem512Ciphertext, MlKemSharedSecret) {
-                p::encapsulate::<
-                    RANK_512,
-                    CPA_PKE_CIPHERTEXT_SIZE_512,
-                    CPA_PKE_PUBLIC_KEY_SIZE_512,
-                    T_AS_NTT_ENCODED_SIZE_512,
-                    C1_SIZE_512,
-                    C2_SIZE_512,
-                    VECTOR_U_COMPRESSION_FACTOR_512,
-                    VECTOR_V_COMPRESSION_FACTOR_512,
-                    C1_BLOCK_SIZE_512,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                    ETA2,
-                    ETA2_RANDOMNESS_SIZE,
-                >(public_key, randomness)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::encapsulate::<
+                        RANK_512,
+                        CPA_PKE_CIPHERTEXT_SIZE_512,
+                        CPA_PKE_PUBLIC_KEY_SIZE_512,
+                        T_AS_NTT_ENCODED_SIZE_512,
+                        C1_SIZE_512,
+                        C2_SIZE_512,
+                        VECTOR_U_COMPRESSION_FACTOR_512,
+                        VECTOR_V_COMPRESSION_FACTOR_512,
+                        C1_BLOCK_SIZE_512,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                        ETA2,
+                        ETA2_RANDOMNESS_SIZE,
+                    >(public_key, randomness)
+                }
             }
 
             /// Encapsulate Kyber 512
@@ -143,21 +158,24 @@ macro_rules! instantiate {
                 public_key: &MlKem512PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem512Ciphertext, MlKemSharedSecret) {
-                p::kyber_encapsulate::<
-                    RANK_512,
-                    CPA_PKE_CIPHERTEXT_SIZE_512,
-                    CPA_PKE_PUBLIC_KEY_SIZE_512,
-                    T_AS_NTT_ENCODED_SIZE_512,
-                    C1_SIZE_512,
-                    C2_SIZE_512,
-                    VECTOR_U_COMPRESSION_FACTOR_512,
-                    VECTOR_V_COMPRESSION_FACTOR_512,
-                    C1_BLOCK_SIZE_512,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                    ETA2,
-                    ETA2_RANDOMNESS_SIZE,
-                >(public_key, randomness)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::kyber_encapsulate::<
+                        RANK_512,
+                        CPA_PKE_CIPHERTEXT_SIZE_512,
+                        CPA_PKE_PUBLIC_KEY_SIZE_512,
+                        T_AS_NTT_ENCODED_SIZE_512,
+                        C1_SIZE_512,
+                        C2_SIZE_512,
+                        VECTOR_U_COMPRESSION_FACTOR_512,
+                        VECTOR_V_COMPRESSION_FACTOR_512,
+                        C1_BLOCK_SIZE_512,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                        ETA2,
+                        ETA2_RANDOMNESS_SIZE,
+                    >(public_key, randomness)
+                }
             }
 
             /// Decapsulate ML-KEM 512
@@ -168,24 +186,27 @@ macro_rules! instantiate {
                 private_key: &MlKem512PrivateKey,
                 ciphertext: &MlKem512Ciphertext,
             ) -> MlKemSharedSecret {
-                p::decapsulate::<
-                    RANK_512,
-                    SECRET_KEY_SIZE_512,
-                    CPA_PKE_SECRET_KEY_SIZE_512,
-                    CPA_PKE_PUBLIC_KEY_SIZE_512,
-                    CPA_PKE_CIPHERTEXT_SIZE_512,
-                    T_AS_NTT_ENCODED_SIZE_512,
-                    C1_SIZE_512,
-                    C2_SIZE_512,
-                    VECTOR_U_COMPRESSION_FACTOR_512,
-                    VECTOR_V_COMPRESSION_FACTOR_512,
-                    C1_BLOCK_SIZE_512,
-                    ETA1,
-                    ETA1_RANDOMNESS_SIZE,
-                    ETA2,
-                    ETA2_RANDOMNESS_SIZE,
-                    IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                >(private_key, ciphertext)
+                #[allow(unused_unsafe)]
+                unsafe {
+                    p::decapsulate::<
+                        RANK_512,
+                        SECRET_KEY_SIZE_512,
+                        CPA_PKE_SECRET_KEY_SIZE_512,
+                        CPA_PKE_PUBLIC_KEY_SIZE_512,
+                        CPA_PKE_CIPHERTEXT_SIZE_512,
+                        T_AS_NTT_ENCODED_SIZE_512,
+                        C1_SIZE_512,
+                        C2_SIZE_512,
+                        VECTOR_U_COMPRESSION_FACTOR_512,
+                        VECTOR_V_COMPRESSION_FACTOR_512,
+                        C1_BLOCK_SIZE_512,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                        ETA2,
+                        ETA2_RANDOMNESS_SIZE,
+                        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+                    >(private_key, ciphertext)
+                }
             }
 
             /// Decapsulate Kyber 512
@@ -218,7 +239,6 @@ macro_rules! instantiate {
                 >(private_key, ciphertext)
             }
 
-
             /// Unpacked APIs that don't use serialized keys.
             pub mod unpacked {
                 use super::*;
@@ -242,25 +262,28 @@ macro_rules! instantiate {
                 /// Get the serialized public key.
                 pub fn serialized_public_key(
                     public_key: &MlKem512PublicKeyUnpacked,
-                    serialized: &mut MlKem512PublicKey
+                    serialized: &mut MlKem512PublicKey,
                 ) {
                     public_key.serialized_public_key_mut::<
-                        RANKED_BYTES_PER_RING_ELEMENT_512,
-                        CPA_PKE_PUBLIC_KEY_SIZE_512
-                    >(serialized)
+                                                        RANKED_BYTES_PER_RING_ELEMENT_512,
+                                                        CPA_PKE_PUBLIC_KEY_SIZE_512
+                                                    >(serialized)
                 }
 
                 /// Get the unpacked public key.
                 pub fn unpacked_public_key(
                     public_key: &MlKem512PublicKey,
-                    unpacked_public_key: &mut MlKem512PublicKeyUnpacked ,
+                    unpacked_public_key: &mut MlKem512PublicKeyUnpacked,
                 ) {
-                    p::unpacked::unpack_public_key::<
-                        RANK_512,
-                        T_AS_NTT_ENCODED_SIZE_512,
-                        RANKED_BYTES_PER_RING_ELEMENT_512,
-                        CPA_PKE_PUBLIC_KEY_SIZE_512,
-                    >(public_key, unpacked_public_key)
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        p::unpacked::unpack_public_key::<
+                            RANK_512,
+                            T_AS_NTT_ENCODED_SIZE_512,
+                            RANKED_BYTES_PER_RING_ELEMENT_512,
+                            CPA_PKE_PUBLIC_KEY_SIZE_512,
+                        >(public_key, unpacked_public_key)
+                    }
                 }
 
                 /// Generate ML-KEM 512 Key Pair in "unpacked" form
@@ -268,15 +291,18 @@ macro_rules! instantiate {
                     randomness: [u8; KEY_GENERATION_SEED_SIZE],
                     key_pair: &mut MlKem512KeyPairUnpacked,
                 ) {
-                    p::unpacked::generate_keypair::<
-                        RANK_512,
-                        CPA_PKE_SECRET_KEY_SIZE_512,
-                        SECRET_KEY_SIZE_512,
-                        CPA_PKE_PUBLIC_KEY_SIZE_512,
-                        RANKED_BYTES_PER_RING_ELEMENT_512,
-                        ETA1,
-                        ETA1_RANDOMNESS_SIZE,
-                    >(randomness, key_pair);
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        p::unpacked::generate_keypair::<
+                            RANK_512,
+                            CPA_PKE_SECRET_KEY_SIZE_512,
+                            SECRET_KEY_SIZE_512,
+                            CPA_PKE_PUBLIC_KEY_SIZE_512,
+                            RANKED_BYTES_PER_RING_ELEMENT_512,
+                            ETA1,
+                            ETA1_RANDOMNESS_SIZE,
+                        >(randomness, key_pair);
+                    }
                 }
 
                 /// Encapsulate ML-KEM 512 (unpacked)
@@ -301,21 +327,24 @@ macro_rules! instantiate {
                     public_key: &MlKem512PublicKeyUnpacked,
                     randomness: [u8; SHARED_SECRET_SIZE],
                 ) -> (MlKem512Ciphertext, MlKemSharedSecret) {
-                    p::unpacked::encapsulate::<
-                        RANK_512,
-                        CPA_PKE_CIPHERTEXT_SIZE_512,
-                        CPA_PKE_PUBLIC_KEY_SIZE_512,
-                        T_AS_NTT_ENCODED_SIZE_512,
-                        C1_SIZE_512,
-                        C2_SIZE_512,
-                        VECTOR_U_COMPRESSION_FACTOR_512,
-                        VECTOR_V_COMPRESSION_FACTOR_512,
-                        C1_BLOCK_SIZE_512,
-                        ETA1,
-                        ETA1_RANDOMNESS_SIZE,
-                        ETA2,
-                        ETA2_RANDOMNESS_SIZE,
-                    >(public_key, randomness)
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        p::unpacked::encapsulate::<
+                            RANK_512,
+                            CPA_PKE_CIPHERTEXT_SIZE_512,
+                            CPA_PKE_PUBLIC_KEY_SIZE_512,
+                            T_AS_NTT_ENCODED_SIZE_512,
+                            C1_SIZE_512,
+                            C2_SIZE_512,
+                            VECTOR_U_COMPRESSION_FACTOR_512,
+                            VECTOR_V_COMPRESSION_FACTOR_512,
+                            C1_BLOCK_SIZE_512,
+                            ETA1,
+                            ETA1_RANDOMNESS_SIZE,
+                            ETA2,
+                            ETA2_RANDOMNESS_SIZE,
+                        >(public_key, randomness)
+                    }
                 }
 
                 /// Decapsulate ML-KEM 512 (unpacked)
@@ -327,24 +356,27 @@ macro_rules! instantiate {
                     private_key: &MlKem512KeyPairUnpacked,
                     ciphertext: &MlKem512Ciphertext,
                 ) -> MlKemSharedSecret {
-                    p::unpacked::decapsulate::<
-                        RANK_512,
-                        SECRET_KEY_SIZE_512,
-                        CPA_PKE_SECRET_KEY_SIZE_512,
-                        CPA_PKE_PUBLIC_KEY_SIZE_512,
-                        CPA_PKE_CIPHERTEXT_SIZE_512,
-                        T_AS_NTT_ENCODED_SIZE_512,
-                        C1_SIZE_512,
-                        C2_SIZE_512,
-                        VECTOR_U_COMPRESSION_FACTOR_512,
-                        VECTOR_V_COMPRESSION_FACTOR_512,
-                        C1_BLOCK_SIZE_512,
-                        ETA1,
-                        ETA1_RANDOMNESS_SIZE,
-                        ETA2,
-                        ETA2_RANDOMNESS_SIZE,
-                        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                    >(private_key, ciphertext)
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        p::unpacked::decapsulate::<
+                            RANK_512,
+                            SECRET_KEY_SIZE_512,
+                            CPA_PKE_SECRET_KEY_SIZE_512,
+                            CPA_PKE_PUBLIC_KEY_SIZE_512,
+                            CPA_PKE_CIPHERTEXT_SIZE_512,
+                            T_AS_NTT_ENCODED_SIZE_512,
+                            C1_SIZE_512,
+                            C2_SIZE_512,
+                            VECTOR_U_COMPRESSION_FACTOR_512,
+                            VECTOR_V_COMPRESSION_FACTOR_512,
+                            C1_BLOCK_SIZE_512,
+                            ETA1,
+                            ETA1_RANDOMNESS_SIZE,
+                            ETA2,
+                            ETA2_RANDOMNESS_SIZE,
+                            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+                        >(private_key, ciphertext)
+                    }
                 }
             }
         }

--- a/libcrux-ml-kem/src/mlkem512.rs
+++ b/libcrux-ml-kem/src/mlkem512.rs
@@ -99,8 +99,6 @@ macro_rules! instantiate {
             pub fn kyber_generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem512KeyPair {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::kyber_generate_keypair::<
                         RANK_512,
                         CPA_PKE_SECRET_KEY_SIZE_512,
@@ -110,7 +108,6 @@ macro_rules! instantiate {
                         ETA1,
                         ETA1_RANDOMNESS_SIZE,
                     >(randomness)
-                }
             }
             /// Encapsulate ML-KEM 512
             ///
@@ -152,8 +149,6 @@ macro_rules! instantiate {
                 public_key: &MlKem512PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem512Ciphertext, MlKemSharedSecret) {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::kyber_encapsulate::<
                         RANK_512,
                         CPA_PKE_CIPHERTEXT_SIZE_512,
@@ -169,7 +164,6 @@ macro_rules! instantiate {
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
                     >(public_key, randomness)
-                }
             }
 
             /// Decapsulate ML-KEM 512
@@ -180,8 +174,6 @@ macro_rules! instantiate {
                 private_key: &MlKem512PrivateKey,
                 ciphertext: &MlKem512Ciphertext,
             ) -> MlKemSharedSecret {
-                #[allow(unused_unsafe)]
-
                     p::decapsulate::<
                         RANK_512,
                         SECRET_KEY_SIZE_512,
@@ -269,15 +261,12 @@ macro_rules! instantiate {
                     public_key: &MlKem512PublicKey,
                     unpacked_public_key: &mut MlKem512PublicKeyUnpacked,
                 ) {
-                    #[allow(unused_unsafe)]
-
                         p::unpacked::unpack_public_key::<
                             RANK_512,
                             T_AS_NTT_ENCODED_SIZE_512,
                             RANKED_BYTES_PER_RING_ELEMENT_512,
                             CPA_PKE_PUBLIC_KEY_SIZE_512,
                         >(public_key, unpacked_public_key)
-
                 }
 
                 /// Generate ML-KEM 512 Key Pair in "unpacked" form
@@ -285,8 +274,6 @@ macro_rules! instantiate {
                     randomness: [u8; KEY_GENERATION_SEED_SIZE],
                     key_pair: &mut MlKem512KeyPairUnpacked,
                 ) {
-                    #[allow(unused_unsafe)]
-
                         p::unpacked::generate_keypair::<
                             RANK_512,
                             CPA_PKE_SECRET_KEY_SIZE_512,

--- a/libcrux-ml-kem/src/mlkem512.rs
+++ b/libcrux-ml-kem/src/mlkem512.rs
@@ -54,14 +54,11 @@ macro_rules! instantiate {
             ///
             /// Returns `true` if valid, and `false` otherwise.
             pub fn validate_public_key(public_key: &MlKem512PublicKey) -> bool {
-                #[allow(unused_unsafe)]
-                unsafe {
-                    p::validate_public_key::<
-                        RANK_512,
-                        RANKED_BYTES_PER_RING_ELEMENT_512,
-                        CPA_PKE_PUBLIC_KEY_SIZE_512,
-                    >(&public_key.value)
-                }
+                p::validate_public_key::<
+                    RANK_512,
+                    RANKED_BYTES_PER_RING_ELEMENT_512,
+                    CPA_PKE_PUBLIC_KEY_SIZE_512,
+                >(&public_key.value)
             }
 
             /// Validate a private key.
@@ -71,22 +68,19 @@ macro_rules! instantiate {
                 private_key: &MlKem512PrivateKey,
                 ciphertext: &MlKem512Ciphertext,
             ) -> bool {
-                #[allow(unused_unsafe)]
-                unsafe {
+
                     p::validate_private_key::<
                         RANK_512,
                         SECRET_KEY_SIZE_512,
                         CPA_PKE_CIPHERTEXT_SIZE_512,
                     >(private_key, ciphertext)
-                }
+
             }
 
             /// Generate ML-KEM 512 Key Pair
             pub fn generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem512KeyPair {
-                #[allow(unused_unsafe)]
-                unsafe {
                     p::generate_keypair::<
                         RANK_512,
                         CPA_PKE_SECRET_KEY_SIZE_512,
@@ -96,7 +90,7 @@ macro_rules! instantiate {
                         ETA1,
                         ETA1_RANDOMNESS_SIZE,
                     >(randomness)
-                }
+
             }
 
             /// Generate Kyber 512 Key Pair
@@ -127,8 +121,8 @@ macro_rules! instantiate {
                 public_key: &MlKem512PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem512Ciphertext, MlKemSharedSecret) {
-                #[allow(unused_unsafe)]
-                unsafe {
+
+
                     p::encapsulate::<
                         RANK_512,
                         CPA_PKE_CIPHERTEXT_SIZE_512,
@@ -144,7 +138,7 @@ macro_rules! instantiate {
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
                     >(public_key, randomness)
-                }
+
             }
 
             /// Encapsulate Kyber 512
@@ -187,7 +181,7 @@ macro_rules! instantiate {
                 ciphertext: &MlKem512Ciphertext,
             ) -> MlKemSharedSecret {
                 #[allow(unused_unsafe)]
-                unsafe {
+
                     p::decapsulate::<
                         RANK_512,
                         SECRET_KEY_SIZE_512,
@@ -206,7 +200,7 @@ macro_rules! instantiate {
                         ETA2_RANDOMNESS_SIZE,
                         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                     >(private_key, ciphertext)
-                }
+
             }
 
             /// Decapsulate Kyber 512
@@ -265,9 +259,9 @@ macro_rules! instantiate {
                     serialized: &mut MlKem512PublicKey,
                 ) {
                     public_key.serialized_public_key_mut::<
-                                                        RANKED_BYTES_PER_RING_ELEMENT_512,
-                                                        CPA_PKE_PUBLIC_KEY_SIZE_512
-                                                    >(serialized)
+                                                                RANKED_BYTES_PER_RING_ELEMENT_512,
+                                                                CPA_PKE_PUBLIC_KEY_SIZE_512
+                                                            >(serialized)
                 }
 
                 /// Get the unpacked public key.
@@ -276,14 +270,14 @@ macro_rules! instantiate {
                     unpacked_public_key: &mut MlKem512PublicKeyUnpacked,
                 ) {
                     #[allow(unused_unsafe)]
-                    unsafe {
+
                         p::unpacked::unpack_public_key::<
                             RANK_512,
                             T_AS_NTT_ENCODED_SIZE_512,
                             RANKED_BYTES_PER_RING_ELEMENT_512,
                             CPA_PKE_PUBLIC_KEY_SIZE_512,
                         >(public_key, unpacked_public_key)
-                    }
+
                 }
 
                 /// Generate ML-KEM 512 Key Pair in "unpacked" form
@@ -292,7 +286,7 @@ macro_rules! instantiate {
                     key_pair: &mut MlKem512KeyPairUnpacked,
                 ) {
                     #[allow(unused_unsafe)]
-                    unsafe {
+
                         p::unpacked::generate_keypair::<
                             RANK_512,
                             CPA_PKE_SECRET_KEY_SIZE_512,
@@ -302,7 +296,7 @@ macro_rules! instantiate {
                             ETA1,
                             ETA1_RANDOMNESS_SIZE,
                         >(randomness, key_pair);
-                    }
+
                 }
 
                 /// Encapsulate ML-KEM 512 (unpacked)
@@ -327,8 +321,8 @@ macro_rules! instantiate {
                     public_key: &MlKem512PublicKeyUnpacked,
                     randomness: [u8; SHARED_SECRET_SIZE],
                 ) -> (MlKem512Ciphertext, MlKemSharedSecret) {
-                    #[allow(unused_unsafe)]
-                    unsafe {
+
+
                         p::unpacked::encapsulate::<
                             RANK_512,
                             CPA_PKE_CIPHERTEXT_SIZE_512,
@@ -344,7 +338,7 @@ macro_rules! instantiate {
                             ETA2,
                             ETA2_RANDOMNESS_SIZE,
                         >(public_key, randomness)
-                    }
+
                 }
 
                 /// Decapsulate ML-KEM 512 (unpacked)
@@ -356,8 +350,6 @@ macro_rules! instantiate {
                     private_key: &MlKem512KeyPairUnpacked,
                     ciphertext: &MlKem512Ciphertext,
                 ) -> MlKemSharedSecret {
-                    #[allow(unused_unsafe)]
-                    unsafe {
                         p::unpacked::decapsulate::<
                             RANK_512,
                             SECRET_KEY_SIZE_512,
@@ -376,7 +368,7 @@ macro_rules! instantiate {
                             ETA2_RANDOMNESS_SIZE,
                             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                         >(private_key, ciphertext)
-                    }
+
                 }
             }
         }

--- a/libcrux-ml-kem/src/mlkem768.rs
+++ b/libcrux-ml-kem/src/mlkem768.rs
@@ -46,7 +46,7 @@ pub type MlKem768KeyPair = MlKemKeyPair<SECRET_KEY_SIZE_768, CPA_PKE_PUBLIC_KEY_
 
 // Instantiate the different functions.
 macro_rules! instantiate {
-    ($modp:ident, $p:path, $vec:path, $doc:expr) => {
+    ($modp:ident, $p:path, $doc:expr) => {
         #[doc = $doc]
         pub mod $modp {
             use super::*;
@@ -56,11 +56,13 @@ macro_rules! instantiate {
             ///
             /// Returns `true` if valid, and `false` otherwise.
             pub fn validate_public_key(public_key: &MlKem768PublicKey) -> bool {
+                #[allow(unused_unsafe)]
+                unsafe {
                 p::validate_public_key::<
                     RANK_768,
                     RANKED_BYTES_PER_RING_ELEMENT_768,
                     CPA_PKE_PUBLIC_KEY_SIZE_768,
-                >(&public_key.value)
+                >(&public_key.value)}
             }
 
             /// Validate a private key.
@@ -70,17 +72,21 @@ macro_rules! instantiate {
                 private_key: &MlKem768PrivateKey,
                 ciphertext: &MlKem768Ciphertext,
             ) -> bool {
+                #[allow(unused_unsafe)]
+                unsafe {
                 p::validate_private_key::<
                     RANK_768,
                     SECRET_KEY_SIZE_768,
                     CPA_PKE_CIPHERTEXT_SIZE_768,
-                >(private_key, ciphertext)
+                >(private_key, ciphertext)}
             }
 
             /// Generate ML-KEM 768 Key Pair
             pub fn generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem768KeyPair {
+                #[allow(unused_unsafe)]
+                unsafe {
                 p::generate_keypair::<
                     RANK_768,
                     CPA_PKE_SECRET_KEY_SIZE_768,
@@ -89,7 +95,7 @@ macro_rules! instantiate {
                     RANKED_BYTES_PER_RING_ELEMENT_768,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
-                >(randomness)
+                >(randomness)}
             }
 
             /// Generate Kyber 768 Key Pair
@@ -98,6 +104,8 @@ macro_rules! instantiate {
             pub fn kyber_generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem768KeyPair {
+                #[allow(unused_unsafe)]
+                unsafe {
                 p::kyber_generate_keypair::<
                     RANK_768,
                     CPA_PKE_SECRET_KEY_SIZE_768,
@@ -106,7 +114,7 @@ macro_rules! instantiate {
                     RANKED_BYTES_PER_RING_ELEMENT_768,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
-                >(randomness)
+                >(randomness)}
             }
 
             /// Encapsulate ML-KEM 768
@@ -118,6 +126,8 @@ macro_rules! instantiate {
                 public_key: &MlKem768PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
+                #[allow(unused_unsafe)]
+                unsafe {
                 p::encapsulate::<
                     RANK_768,
                     CPA_PKE_CIPHERTEXT_SIZE_768,
@@ -132,7 +142,7 @@ macro_rules! instantiate {
                     ETA1_RANDOMNESS_SIZE,
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
-                >(public_key, randomness)
+                >(public_key, randomness)}
             }
 
             /// Encapsulate Kyber 768
@@ -146,6 +156,8 @@ macro_rules! instantiate {
                 public_key: &MlKem768PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
+                #[allow(unused_unsafe)]
+                unsafe {
                 p::kyber_encapsulate::<
                     RANK_768,
                     CPA_PKE_CIPHERTEXT_SIZE_768,
@@ -160,7 +172,7 @@ macro_rules! instantiate {
                     ETA1_RANDOMNESS_SIZE,
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
-                >(public_key, randomness)
+                >(public_key, randomness)}
             }
 
             /// Decapsulate ML-KEM 768
@@ -171,6 +183,8 @@ macro_rules! instantiate {
                 private_key: &MlKem768PrivateKey,
                 ciphertext: &MlKem768Ciphertext,
             ) -> MlKemSharedSecret {
+                #[allow(unused_unsafe)]
+                unsafe {
                 p::decapsulate::<
                     RANK_768,
                     SECRET_KEY_SIZE_768,
@@ -188,7 +202,7 @@ macro_rules! instantiate {
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                >(private_key, ciphertext)
+                >(private_key, ciphertext)}
             }
 
             /// Decapsulate Kyber 768
@@ -201,6 +215,8 @@ macro_rules! instantiate {
                 private_key: &MlKem768PrivateKey,
                 ciphertext: &MlKem768Ciphertext,
             ) -> MlKemSharedSecret {
+                #[allow(unused_unsafe)]
+                unsafe {
                 p::kyber_decapsulate::<
                     RANK_768,
                     SECRET_KEY_SIZE_768,
@@ -218,7 +234,7 @@ macro_rules! instantiate {
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                >(private_key, ciphertext)
+                >(private_key, ciphertext)}
             }
 
             /// Unpacked APIs that don't use serialized keys.
@@ -261,12 +277,14 @@ macro_rules! instantiate {
                     public_key: &MlKem768PublicKey,
                     unpacked_public_key: &mut MlKem768PublicKeyUnpacked
                 ) {
+                    #[allow(unused_unsafe)]
+                    unsafe {
                     p::unpacked::unpack_public_key::<
                         RANK_768,
                         T_AS_NTT_ENCODED_SIZE_768,
                         RANKED_BYTES_PER_RING_ELEMENT_768,
                         CPA_PKE_PUBLIC_KEY_SIZE_768,
-                    >(public_key, unpacked_public_key)
+                    >(public_key, unpacked_public_key)}
                 }
 
                 /// Generate ML-KEM 768 Key Pair in "unpacked" form.
@@ -274,6 +292,8 @@ macro_rules! instantiate {
                     randomness: [u8; KEY_GENERATION_SEED_SIZE],
                     key_pair: &mut MlKem768KeyPairUnpacked,
                 ) {
+                    #[allow(unused_unsafe)]
+                    unsafe {
                     p::unpacked::generate_keypair::<
                         RANK_768,
                         CPA_PKE_SECRET_KEY_SIZE_768,
@@ -282,7 +302,7 @@ macro_rules! instantiate {
                         RANKED_BYTES_PER_RING_ELEMENT_768,
                         ETA1,
                         ETA1_RANDOMNESS_SIZE,
-                    >(randomness, key_pair);
+                    >(randomness, key_pair);}
                 }
 
                 /// Encapsulate ML-KEM 768 (unpacked)
@@ -307,6 +327,8 @@ macro_rules! instantiate {
                     public_key: &MlKem768PublicKeyUnpacked,
                     randomness: [u8; SHARED_SECRET_SIZE],
                 ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
+                    #[allow(unused_unsafe)]
+                    unsafe {
                     p::unpacked::encapsulate::<
                         RANK_768,
                         CPA_PKE_CIPHERTEXT_SIZE_768,
@@ -321,7 +343,7 @@ macro_rules! instantiate {
                         ETA1_RANDOMNESS_SIZE,
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
-                    >(public_key, randomness)
+                    >(public_key, randomness)}
                 }
 
                 /// Decapsulate ML-KEM 768 (unpacked)
@@ -333,6 +355,8 @@ macro_rules! instantiate {
                     private_key: &MlKem768KeyPairUnpacked,
                     ciphertext: &MlKem768Ciphertext,
                 ) -> MlKemSharedSecret {
+                    #[allow(unused_unsafe)]
+                    unsafe {
                     p::unpacked::decapsulate::<
                         RANK_768,
                         SECRET_KEY_SIZE_768,
@@ -350,7 +374,7 @@ macro_rules! instantiate {
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
                         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                    >(private_key, ciphertext)
+                    >(private_key, ciphertext)}
                 }
             }
         }
@@ -359,11 +383,11 @@ macro_rules! instantiate {
 
 // Instantiations
 
-instantiate! {portable, ind_cca::instantiations::portable, vector::portable::PortableVector, "Portable ML-KEM 768"}
+instantiate! {portable, ind_cca::instantiations::portable, "Portable ML-KEM 768"}
 #[cfg(feature = "simd256")]
-instantiate! {avx2, ind_cca::instantiations::avx2, vector::SIMD256Vector, "AVX2 Optimised ML-KEM 768"}
+instantiate! {avx2, ind_cca::instantiations::avx2, "AVX2 Optimised ML-KEM 768"}
 #[cfg(feature = "simd128")]
-instantiate! {neon, ind_cca::instantiations::neon, vector::SIMD128Vector, "Neon Optimised ML-KEM 768"}
+instantiate! {neon, ind_cca::instantiations::neon, "Neon Optimised ML-KEM 768"}
 
 /// Validate a public key.
 ///

--- a/libcrux-ml-kem/src/mlkem768.rs
+++ b/libcrux-ml-kem/src/mlkem768.rs
@@ -56,13 +56,11 @@ macro_rules! instantiate {
             ///
             /// Returns `true` if valid, and `false` otherwise.
             pub fn validate_public_key(public_key: &MlKem768PublicKey) -> bool {
-                #[allow(unused_unsafe)]
-                unsafe {
                 p::validate_public_key::<
                     RANK_768,
                     RANKED_BYTES_PER_RING_ELEMENT_768,
                     CPA_PKE_PUBLIC_KEY_SIZE_768,
-                >(&public_key.value)}
+                >(&public_key.value)
             }
 
             /// Validate a private key.
@@ -72,21 +70,17 @@ macro_rules! instantiate {
                 private_key: &MlKem768PrivateKey,
                 ciphertext: &MlKem768Ciphertext,
             ) -> bool {
-                #[allow(unused_unsafe)]
-                unsafe {
                 p::validate_private_key::<
                     RANK_768,
                     SECRET_KEY_SIZE_768,
                     CPA_PKE_CIPHERTEXT_SIZE_768,
-                >(private_key, ciphertext)}
+                >(private_key, ciphertext)
             }
 
             /// Generate ML-KEM 768 Key Pair
             pub fn generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem768KeyPair {
-                #[allow(unused_unsafe)]
-                unsafe {
                 p::generate_keypair::<
                     RANK_768,
                     CPA_PKE_SECRET_KEY_SIZE_768,
@@ -95,7 +89,7 @@ macro_rules! instantiate {
                     RANKED_BYTES_PER_RING_ELEMENT_768,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
-                >(randomness)}
+                >(randomness)
             }
 
             /// Generate Kyber 768 Key Pair
@@ -104,8 +98,6 @@ macro_rules! instantiate {
             pub fn kyber_generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem768KeyPair {
-                #[allow(unused_unsafe)]
-                unsafe {
                 p::kyber_generate_keypair::<
                     RANK_768,
                     CPA_PKE_SECRET_KEY_SIZE_768,
@@ -114,7 +106,7 @@ macro_rules! instantiate {
                     RANKED_BYTES_PER_RING_ELEMENT_768,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
-                >(randomness)}
+                >(randomness)
             }
 
             /// Encapsulate ML-KEM 768
@@ -126,8 +118,6 @@ macro_rules! instantiate {
                 public_key: &MlKem768PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
-                #[allow(unused_unsafe)]
-                unsafe {
                 p::encapsulate::<
                     RANK_768,
                     CPA_PKE_CIPHERTEXT_SIZE_768,
@@ -142,7 +132,7 @@ macro_rules! instantiate {
                     ETA1_RANDOMNESS_SIZE,
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
-                >(public_key, randomness)}
+                >(public_key, randomness)
             }
 
             /// Encapsulate Kyber 768
@@ -156,8 +146,6 @@ macro_rules! instantiate {
                 public_key: &MlKem768PublicKey,
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
-                #[allow(unused_unsafe)]
-                unsafe {
                 p::kyber_encapsulate::<
                     RANK_768,
                     CPA_PKE_CIPHERTEXT_SIZE_768,
@@ -172,7 +160,7 @@ macro_rules! instantiate {
                     ETA1_RANDOMNESS_SIZE,
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
-                >(public_key, randomness)}
+                >(public_key, randomness)
             }
 
             /// Decapsulate ML-KEM 768
@@ -183,8 +171,6 @@ macro_rules! instantiate {
                 private_key: &MlKem768PrivateKey,
                 ciphertext: &MlKem768Ciphertext,
             ) -> MlKemSharedSecret {
-                #[allow(unused_unsafe)]
-                unsafe {
                 p::decapsulate::<
                     RANK_768,
                     SECRET_KEY_SIZE_768,
@@ -202,7 +188,7 @@ macro_rules! instantiate {
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                >(private_key, ciphertext)}
+                >(private_key, ciphertext)
             }
 
             /// Decapsulate Kyber 768
@@ -215,8 +201,6 @@ macro_rules! instantiate {
                 private_key: &MlKem768PrivateKey,
                 ciphertext: &MlKem768Ciphertext,
             ) -> MlKemSharedSecret {
-                #[allow(unused_unsafe)]
-                unsafe {
                 p::kyber_decapsulate::<
                     RANK_768,
                     SECRET_KEY_SIZE_768,
@@ -234,7 +218,7 @@ macro_rules! instantiate {
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                >(private_key, ciphertext)}
+                >(private_key, ciphertext)
             }
 
             /// Unpacked APIs that don't use serialized keys.
@@ -277,14 +261,12 @@ macro_rules! instantiate {
                     public_key: &MlKem768PublicKey,
                     unpacked_public_key: &mut MlKem768PublicKeyUnpacked
                 ) {
-                    #[allow(unused_unsafe)]
-                    unsafe {
                     p::unpacked::unpack_public_key::<
                         RANK_768,
                         T_AS_NTT_ENCODED_SIZE_768,
                         RANKED_BYTES_PER_RING_ELEMENT_768,
                         CPA_PKE_PUBLIC_KEY_SIZE_768,
-                    >(public_key, unpacked_public_key)}
+                    >(public_key, unpacked_public_key)
                 }
 
                 /// Generate ML-KEM 768 Key Pair in "unpacked" form.
@@ -292,8 +274,6 @@ macro_rules! instantiate {
                     randomness: [u8; KEY_GENERATION_SEED_SIZE],
                     key_pair: &mut MlKem768KeyPairUnpacked,
                 ) {
-                    #[allow(unused_unsafe)]
-                    unsafe {
                     p::unpacked::generate_keypair::<
                         RANK_768,
                         CPA_PKE_SECRET_KEY_SIZE_768,
@@ -302,7 +282,7 @@ macro_rules! instantiate {
                         RANKED_BYTES_PER_RING_ELEMENT_768,
                         ETA1,
                         ETA1_RANDOMNESS_SIZE,
-                    >(randomness, key_pair);}
+                    >(randomness, key_pair);
                 }
 
                 /// Encapsulate ML-KEM 768 (unpacked)
@@ -327,8 +307,6 @@ macro_rules! instantiate {
                     public_key: &MlKem768PublicKeyUnpacked,
                     randomness: [u8; SHARED_SECRET_SIZE],
                 ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
-                    #[allow(unused_unsafe)]
-                    unsafe {
                     p::unpacked::encapsulate::<
                         RANK_768,
                         CPA_PKE_CIPHERTEXT_SIZE_768,
@@ -343,7 +321,7 @@ macro_rules! instantiate {
                         ETA1_RANDOMNESS_SIZE,
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
-                    >(public_key, randomness)}
+                    >(public_key, randomness)
                 }
 
                 /// Decapsulate ML-KEM 768 (unpacked)
@@ -355,8 +333,6 @@ macro_rules! instantiate {
                     private_key: &MlKem768KeyPairUnpacked,
                     ciphertext: &MlKem768Ciphertext,
                 ) -> MlKemSharedSecret {
-                    #[allow(unused_unsafe)]
-                    unsafe {
                     p::unpacked::decapsulate::<
                         RANK_768,
                         SECRET_KEY_SIZE_768,
@@ -374,7 +350,7 @@ macro_rules! instantiate {
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
                         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-                    >(private_key, ciphertext)}
+                    >(private_key, ciphertext)
                 }
             }
         }

--- a/libcrux-ml-kem/src/vector/avx2.rs
+++ b/libcrux-ml-kem/src/vector/avx2.rs
@@ -36,72 +36,85 @@ fn from_i16_array(array: &[i16]) -> SIMD256Vector {
 }
 
 impl Operations for SIMD256Vector {
+    #[inline(always)]
     fn ZERO() -> Self {
         zero()
     }
 
+    #[inline(always)]
     fn from_i16_array(array: &[i16]) -> Self {
         from_i16_array(array)
     }
 
+    #[inline(always)]
     fn to_i16_array(x: Self) -> [i16; 16] {
         to_i16_array(x)
     }
 
+    #[inline(always)]
     fn add(lhs: Self, rhs: &Self) -> Self {
         Self {
             elements: arithmetic::add(lhs.elements, rhs.elements),
         }
     }
 
+    #[inline(always)]
     fn sub(lhs: Self, rhs: &Self) -> Self {
         Self {
             elements: arithmetic::sub(lhs.elements, rhs.elements),
         }
     }
 
+    #[inline(always)]
     fn multiply_by_constant(v: Self, c: i16) -> Self {
         Self {
             elements: arithmetic::multiply_by_constant(v.elements, c),
         }
     }
 
+    #[inline(always)]
     fn bitwise_and_with_constant(vector: Self, constant: i16) -> Self {
         Self {
             elements: arithmetic::bitwise_and_with_constant(vector.elements, constant),
         }
     }
 
+    #[inline(always)]
     fn shift_right<const SHIFT_BY: i32>(vector: Self) -> Self {
         Self {
             elements: arithmetic::shift_right::<{ SHIFT_BY }>(vector.elements),
         }
     }
 
+    #[inline(always)]
     fn cond_subtract_3329(vector: Self) -> Self {
         Self {
             elements: arithmetic::cond_subtract_3329(vector.elements),
         }
     }
 
+    #[inline(always)]
     fn barrett_reduce(vector: Self) -> Self {
         Self {
             elements: arithmetic::barrett_reduce(vector.elements),
         }
     }
 
+    #[inline(always)]
     fn montgomery_multiply_by_constant(vector: Self, constant: i16) -> Self {
         Self {
             elements: arithmetic::montgomery_multiply_by_constant(vector.elements, constant),
         }
     }
 
+    #[inline(always)]
     fn compress_1(vector: Self) -> Self {
         Self {
             elements: compress::compress_message_coefficient(vector.elements),
         }
     }
 
+    #[inline(always)]
     fn compress<const COEFFICIENT_BITS: i32>(vector: Self) -> Self {
         Self {
             elements: compress::compress_ciphertext_coefficient::<COEFFICIENT_BITS>(
@@ -110,6 +123,7 @@ impl Operations for SIMD256Vector {
         }
     }
 
+    #[inline(always)]
     fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(vector: Self) -> Self {
         Self {
             elements: compress::decompress_ciphertext_coefficient::<COEFFICIENT_BITS>(
@@ -118,42 +132,49 @@ impl Operations for SIMD256Vector {
         }
     }
 
+    #[inline(always)]
     fn ntt_layer_1_step(vector: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self {
         Self {
             elements: ntt::ntt_layer_1_step(vector.elements, zeta0, zeta1, zeta2, zeta3),
         }
     }
 
+    #[inline(always)]
     fn ntt_layer_2_step(vector: Self, zeta0: i16, zeta1: i16) -> Self {
         Self {
             elements: ntt::ntt_layer_2_step(vector.elements, zeta0, zeta1),
         }
     }
 
+    #[inline(always)]
     fn ntt_layer_3_step(vector: Self, zeta: i16) -> Self {
         Self {
             elements: ntt::ntt_layer_3_step(vector.elements, zeta),
         }
     }
 
+    #[inline(always)]
     fn inv_ntt_layer_1_step(vector: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self {
         Self {
             elements: ntt::inv_ntt_layer_1_step(vector.elements, zeta0, zeta1, zeta2, zeta3),
         }
     }
 
+    #[inline(always)]
     fn inv_ntt_layer_2_step(vector: Self, zeta0: i16, zeta1: i16) -> Self {
         Self {
             elements: ntt::inv_ntt_layer_2_step(vector.elements, zeta0, zeta1),
         }
     }
 
+    #[inline(always)]
     fn inv_ntt_layer_3_step(vector: Self, zeta: i16) -> Self {
         Self {
             elements: ntt::inv_ntt_layer_3_step(vector.elements, zeta),
         }
     }
 
+    #[inline(always)]
     fn ntt_multiply(
         lhs: &Self,
         rhs: &Self,
@@ -167,66 +188,79 @@ impl Operations for SIMD256Vector {
         }
     }
 
+    #[inline(always)]
     fn serialize_1(vector: Self) -> [u8; 2] {
         serialize::serialize_1(vector.elements)
     }
 
+    #[inline(always)]
     fn deserialize_1(bytes: &[u8]) -> Self {
         Self {
             elements: serialize::deserialize_1(bytes),
         }
     }
 
+    #[inline(always)]
     fn serialize_4(vector: Self) -> [u8; 8] {
         serialize::serialize_4(vector.elements)
     }
 
+    #[inline(always)]
     fn deserialize_4(bytes: &[u8]) -> Self {
         Self {
             elements: serialize::deserialize_4(bytes),
         }
     }
 
+    #[inline(always)]
     fn serialize_5(vector: Self) -> [u8; 10] {
         serialize::serialize_5(vector.elements)
     }
 
+    #[inline(always)]
     fn deserialize_5(bytes: &[u8]) -> Self {
         Self {
             elements: serialize::deserialize_5(bytes),
         }
     }
 
+    #[inline(always)]
     fn serialize_10(vector: Self) -> [u8; 20] {
         serialize::serialize_10(vector.elements)
     }
 
+    #[inline(always)]
     fn deserialize_10(bytes: &[u8]) -> Self {
         Self {
             elements: serialize::deserialize_10(bytes),
         }
     }
 
+    #[inline(always)]
     fn serialize_11(vector: Self) -> [u8; 22] {
         serialize::serialize_11(vector.elements)
     }
 
+    #[inline(always)]
     fn deserialize_11(bytes: &[u8]) -> Self {
         Self {
             elements: serialize::deserialize_11(bytes),
         }
     }
 
+    #[inline(always)]
     fn serialize_12(vector: Self) -> [u8; 24] {
         serialize::serialize_12(vector.elements)
     }
 
+    #[inline(always)]
     fn deserialize_12(bytes: &[u8]) -> Self {
         Self {
             elements: serialize::deserialize_12(bytes),
         }
     }
 
+    #[inline(always)]
     fn rej_sample(input: &[u8], output: &mut [i16]) -> usize {
         sampling::rejection_sample(input, output)
     }

--- a/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux-ml-kem/src/vector/traits.rs
@@ -65,19 +65,21 @@ pub trait Operations: Copy + Clone {
 }
 
 // hax does not support trait with default implementations, so we use the following pattern
+#[inline(always)]
 pub fn montgomery_multiply_fe<T: Operations>(v: T, fer: i16) -> T {
     T::montgomery_multiply_by_constant(v, fer)
 }
+#[inline(always)]
 pub fn to_standard_domain<T: Operations>(v: T) -> T {
     T::montgomery_multiply_by_constant(v, MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS as i16)
 }
-
+#[inline(always)]
 pub fn to_unsigned_representative<T: Operations>(a: T) -> T {
     let t = T::shift_right::<15>(a);
     let fm = T::bitwise_and_with_constant(t, FIELD_MODULUS);
     T::add(a, &fm)
 }
-
+#[inline(always)]
 pub fn decompress_1<T: Operations>(v: T) -> T {
     T::bitwise_and_with_constant(T::sub(T::ZERO(), &v), 1665)
 }


### PR DESCRIPTION
This is a first step of addressing #633.
It should get us most of the way back to reasonable performance, e.g. on my machine the difference between a `RUSTFLAGS="-C target-feature=+avx2" cargo bench --features pre-verification` and simply `cargo bench --features pre-verification` seems to be within 10-20% across keygen, encaps & decaps. 

So, there seem to be more things still, and I didn't particularly look at key validation, yet. But it should be a good first step, anyway.