### PR TITLE
feat(ci/hax): allow manual workflows to specify hax version

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -11,6 +11,10 @@ on:
     - cron: "0 0 * * *"
 
   workflow_dispatch:
+    inputs:
+      hax_rev:
+        description: 'The hax revision you want this job to use'
+        default: 'main'
   merge_group:
 
 env:
@@ -42,6 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: hacspec/hax
+          ref: ${{ github.event.inputs.hax_rev || 'main' }}
           path: hax
 
       - name: ⤵ Install & confiure Cachix


### PR DESCRIPTION
This PR adds a `hax_rev` input for the workflow dispatch argument of the hax ci job.

This is useful for us on hax, e.g. for https://github.com/hacspec/hax/pull/1151, being able to run exactly the CI of libcrux:hax on a given branch is helping me a lot.