### PR TITLE
ML-DSA: update benchmarks pqclean

### DIFF
--- a/.github/workflows/mldsa.yml
+++ b/.github/workflows/mldsa.yml
@@ -101,8 +101,6 @@ jobs:
 
       # Benchmarks
       - name: 🔨 Build Benchmarks
-        # Comparison benchmarks don't work on intel mac. Re-enable if we think it's worthwhile.
-        if: ${{ matrix.os != 'macos-13' }}
         run: |
           cargo clean
           cargo bench --no-run

--- a/.github/workflows/mldsa.yml
+++ b/.github/workflows/mldsa.yml
@@ -101,6 +101,8 @@ jobs:
 
       # Benchmarks
       - name: 🔨 Build Benchmarks
+        # Comparison benchmarks don't work on intel mac. Re-enable if we think it's worthwhile.
+        if: ${{ matrix.os != 'macos-13' }}
         run: |
           cargo clean
           cargo bench --no-run

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -28,7 +28,10 @@ hex = { version = "0.4.3", features = ["serde"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 criterion = "0.5"
-pqcrypto-mldsa = { version = "0.1.0" }             #, default-features = false
+
+# This doesn't build on intel macos.
+[target.'cfg(not(all(target_os = "macos", target_arch = "x86_64")))'.dev-dependencies]
+pqcrypto-mldsa = { version = "0.1.0" } #, default-features = false
 
 [features]
 default = ["std", "mldsa44", "mldsa65", "mldsa87"]

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -28,7 +28,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 criterion = "0.5"
-pqcrypto-mldsa = { version = "0.1.0" }         #, default-features = false
+pqcrypto-mldsa = { version = "0.1.0" }             #, default-features = false
 
 [features]
 default = ["std", "mldsa44", "mldsa65", "mldsa87"]

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -28,7 +28,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 criterion = "0.5"
-pqcrypto-dilithium = { version = "0.5.0" }         #, default-features = false
+pqcrypto-mldsa = { version = "0.1.0" }         #, default-features = false
 
 [features]
 default = ["std", "mldsa44", "mldsa65", "mldsa87"]

--- a/libcrux-ml-dsa/benches/bench_utils.rs
+++ b/libcrux-ml-dsa/benches/bench_utils.rs
@@ -133,19 +133,19 @@ macro_rules! bench_group_libcrux {
 macro_rules! bench_group_pqclean {
     ($variant:literal, $mod:ident) => {{
         bench!("(pqclean) KeyGen", $variant, (), |()| {}, |()| {
-            pqcrypto_dilithium::$mod::keypair()
+            pqcrypto_mldsa::$mod::keypair()
         });
         bench!(
             "(pqclean) Sign",
             $variant,
             (),
             |()| {
-                let (_, sk) = pqcrypto_dilithium::$mod::keypair();
+                let (_, sk) = pqcrypto_mldsa::$mod::keypair();
                 let message = bench_utils::random_array::<1023>();
                 (sk, message)
             },
-            |(sk, message): (pqcrypto_dilithium::$mod::SecretKey, [u8; 1023])| {
-                let _ = pqcrypto_dilithium::$mod::detached_sign(&message, &sk);
+            |(sk, message): (pqcrypto_mldsa::$mod::SecretKey, [u8; 1023])| {
+                let _ = pqcrypto_mldsa::$mod::detached_sign(&message, &sk);
             }
         );
         bench!(
@@ -153,19 +153,18 @@ macro_rules! bench_group_pqclean {
             $variant,
             (),
             |()| {
-                let (vk, sk) = pqcrypto_dilithium::$mod::keypair();
+                let (vk, sk) = pqcrypto_mldsa::$mod::keypair();
                 let message = bench_utils::random_array::<1023>();
-                let signature = pqcrypto_dilithium::$mod::detached_sign(&message, &sk);
+                let signature = pqcrypto_mldsa::$mod::detached_sign(&message, &sk);
                 (vk, message, signature)
             },
             |(vk, message, signature): (
-                pqcrypto_dilithium::$mod::PublicKey,
+                pqcrypto_mldsa::$mod::PublicKey,
                 [u8; 1023],
-                pqcrypto_dilithium::$mod::DetachedSignature
+                pqcrypto_mldsa::$mod::DetachedSignature
             )| {
-                let _ =
-                    pqcrypto_dilithium::$mod::verify_detached_signature(&signature, &message, &vk)
-                        .unwrap();
+                let _ = pqcrypto_mldsa::$mod::verify_detached_signature(&signature, &message, &vk)
+                    .unwrap();
             }
         );
     }};

--- a/libcrux-ml-dsa/benches/bench_utils.rs
+++ b/libcrux-ml-dsa/benches/bench_utils.rs
@@ -129,6 +129,7 @@ macro_rules! bench_group_libcrux {
     }};
 }
 
+#[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
 #[macro_export]
 macro_rules! bench_group_pqclean {
     ($variant:literal, $mod:ident) => {{

--- a/libcrux-ml-dsa/benches/manual44.rs
+++ b/libcrux-ml-dsa/benches/manual44.rs
@@ -3,7 +3,7 @@ use libcrux_ml_dsa::{
     KEY_GENERATION_RANDOMNESS_SIZE, SIGNING_RANDOMNESS_SIZE,
 };
 
-use pqcrypto_dilithium;
+use pqcrypto_mldsa;
 
 mod bench_utils;
 
@@ -28,5 +28,5 @@ fn main() {
         MLDSA44KeyPair,
         MLDSA44Signature
     );
-    bench_group_pqclean!("44", dilithium2);
+    bench_group_pqclean!("44", mldsa44);
 }

--- a/libcrux-ml-dsa/benches/manual44.rs
+++ b/libcrux-ml-dsa/benches/manual44.rs
@@ -3,8 +3,6 @@ use libcrux_ml_dsa::{
     KEY_GENERATION_RANDOMNESS_SIZE, SIGNING_RANDOMNESS_SIZE,
 };
 
-use pqcrypto_mldsa;
-
 mod bench_utils;
 
 fn main() {
@@ -28,5 +26,7 @@ fn main() {
         MLDSA44KeyPair,
         MLDSA44Signature
     );
+
+    #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
     bench_group_pqclean!("44", mldsa44);
 }

--- a/libcrux-ml-dsa/benches/manual65.rs
+++ b/libcrux-ml-dsa/benches/manual65.rs
@@ -3,7 +3,7 @@ use libcrux_ml_dsa::{
     KEY_GENERATION_RANDOMNESS_SIZE, SIGNING_RANDOMNESS_SIZE,
 };
 
-use pqcrypto_dilithium;
+use pqcrypto_mldsa;
 
 mod bench_utils;
 
@@ -28,5 +28,5 @@ fn main() {
         MLDSA65KeyPair,
         MLDSA65Signature
     );
-    bench_group_pqclean!("65", dilithium3);
+    bench_group_pqclean!("65", mldsa65);
 }

--- a/libcrux-ml-dsa/benches/manual65.rs
+++ b/libcrux-ml-dsa/benches/manual65.rs
@@ -3,8 +3,6 @@ use libcrux_ml_dsa::{
     KEY_GENERATION_RANDOMNESS_SIZE, SIGNING_RANDOMNESS_SIZE,
 };
 
-use pqcrypto_mldsa;
-
 mod bench_utils;
 
 fn main() {
@@ -28,5 +26,7 @@ fn main() {
         MLDSA65KeyPair,
         MLDSA65Signature
     );
+
+    #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
     bench_group_pqclean!("65", mldsa65);
 }

--- a/libcrux-ml-dsa/benches/manual87.rs
+++ b/libcrux-ml-dsa/benches/manual87.rs
@@ -3,7 +3,7 @@ use libcrux_ml_dsa::{
     KEY_GENERATION_RANDOMNESS_SIZE, SIGNING_RANDOMNESS_SIZE,
 };
 
-use pqcrypto_dilithium;
+use pqcrypto_mldsa;
 
 mod bench_utils;
 
@@ -28,5 +28,5 @@ fn main() {
         MLDSA87KeyPair,
         MLDSA87Signature
     );
-    bench_group_pqclean!("87", dilithium5);
+    bench_group_pqclean!("87", mldsa87);
 }

--- a/libcrux-ml-dsa/benches/manual87.rs
+++ b/libcrux-ml-dsa/benches/manual87.rs
@@ -3,8 +3,6 @@ use libcrux_ml_dsa::{
     KEY_GENERATION_RANDOMNESS_SIZE, SIGNING_RANDOMNESS_SIZE,
 };
 
-use pqcrypto_mldsa;
-
 mod bench_utils;
 
 fn main() {
@@ -28,5 +26,7 @@ fn main() {
         MLDSA87KeyPair,
         MLDSA87Signature
     );
+
+    #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
     bench_group_pqclean!("87", mldsa87);
 }

--- a/libcrux-ml-dsa/benches/ml-dsa.rs
+++ b/libcrux-ml-dsa/benches/ml-dsa.rs
@@ -19,6 +19,7 @@ pub fn comparisons_key_generation(c: &mut Criterion) {
         })
     });
 
+    #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
     group.bench_function("pqclean (internal random)", move |b| {
         b.iter(|| {
             let (_, _) = pqcrypto_mldsa::mldsa65::keypair();
@@ -46,12 +47,15 @@ pub fn comparisons_signing(c: &mut Criterion) {
         })
     });
 
-    let (_, sk) = pqcrypto_mldsa::mldsa65::keypair();
-    group.bench_function("pqclean (internal random)", move |b| {
-        b.iter(|| {
-            let _ = pqcrypto_mldsa::mldsa65::detached_sign(&message, &sk);
-        })
-    });
+    #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
+    {
+        let (_, sk) = pqcrypto_mldsa::mldsa65::keypair();
+        group.bench_function("pqclean (internal random)", move |b| {
+            b.iter(|| {
+                let _ = pqcrypto_mldsa::mldsa65::detached_sign(&message, &sk);
+            })
+        });
+    }
 }
 
 pub fn comparisons_verification(c: &mut Criterion) {
@@ -76,15 +80,19 @@ pub fn comparisons_verification(c: &mut Criterion) {
         })
     });
 
-    let (vk, sk) = pqcrypto_mldsa::mldsa65::keypair();
-    let signature = pqcrypto_mldsa::mldsa65::detached_sign(&message, &sk);
+    #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
+    {
+        let (vk, sk) = pqcrypto_mldsa::mldsa65::keypair();
+        let signature = pqcrypto_mldsa::mldsa65::detached_sign(&message, &sk);
 
-    group.bench_function("pqclean", move |b| {
-        b.iter(|| {
-            let _ = pqcrypto_mldsa::mldsa65::verify_detached_signature(&signature, &message, &vk)
-                .unwrap();
-        })
-    });
+        group.bench_function("pqclean", move |b| {
+            b.iter(|| {
+                let _ =
+                    pqcrypto_mldsa::mldsa65::verify_detached_signature(&signature, &message, &vk)
+                        .unwrap();
+            })
+        });
+    }
 }
 
 pub fn comparisons(c: &mut Criterion) {

--- a/libcrux-ml-dsa/benches/ml-dsa.rs
+++ b/libcrux-ml-dsa/benches/ml-dsa.rs
@@ -21,7 +21,7 @@ pub fn comparisons_key_generation(c: &mut Criterion) {
 
     group.bench_function("pqclean (internal random)", move |b| {
         b.iter(|| {
-            let (_, _) = pqcrypto_dilithium::dilithium3::keypair();
+            let (_, _) = pqcrypto_mldsa::mldsa65::keypair();
         })
     });
 }
@@ -46,10 +46,10 @@ pub fn comparisons_signing(c: &mut Criterion) {
         })
     });
 
-    let (_, sk) = pqcrypto_dilithium::dilithium3::keypair();
+    let (_, sk) = pqcrypto_mldsa::mldsa65::keypair();
     group.bench_function("pqclean (internal random)", move |b| {
         b.iter(|| {
-            let _ = pqcrypto_dilithium::dilithium3::detached_sign(&message, &sk);
+            let _ = pqcrypto_mldsa::mldsa65::detached_sign(&message, &sk);
         })
     });
 }
@@ -76,15 +76,13 @@ pub fn comparisons_verification(c: &mut Criterion) {
         })
     });
 
-    let (vk, sk) = pqcrypto_dilithium::dilithium3::keypair();
-    let signature = pqcrypto_dilithium::dilithium3::detached_sign(&message, &sk);
+    let (vk, sk) = pqcrypto_mldsa::mldsa65::keypair();
+    let signature = pqcrypto_mldsa::mldsa65::detached_sign(&message, &sk);
 
     group.bench_function("pqclean", move |b| {
         b.iter(|| {
-            let _ = pqcrypto_dilithium::dilithium3::verify_detached_signature(
-                &signature, &message, &vk,
-            )
-            .unwrap();
+            let _ = pqcrypto_mldsa::mldsa65::verify_detached_signature(&signature, &message, &vk)
+                .unwrap();
         })
     });
 }


### PR DESCRIPTION
This updates the pqclean benchmarks to use ml-dsa rather than dilithium.