### PR TITLE
`no_std` support (via `alloc`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,8 @@ wasm-bindgen-test = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]
+default = ["std"]
+std = []
 hacspec = []                         # TODO: #7 Use specs instead of efficient implementations
 rand = []
 wasm = ["wasm-bindgen", "getrandom"]

--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,11 @@ libcrux uses the following configurations for its hardware abstractions
 libcrux provides a DRBG implementation that can be used standalone (`drbg::Drbg`)
 or through the `Rng` traits.
 
+## `no_std` support
+`libcrux` and the individual primitive crates it depends on support
+`no_std` environments given a global allocator for the target
+platform.
+
 ## Verification status
 
 As a quick indicator of overall verification status, subcrates in this workspace include the following badges:

--- a/libcrux-kem/src/kem.rs
+++ b/libcrux-kem/src/kem.rs
@@ -850,26 +850,6 @@ impl Ct {
                     ct_x.try_into().map_err(|_| Error::InvalidCiphertext)?,
                 ))
             }
-            #[cfg(feature = "kyber")]
-            Algorithm::X25519Kyber768Draft00 => {
-                let key: [u8; MlKem768Ciphertext::len() + 32] =
-                    bytes.try_into().map_err(|_| Error::InvalidCiphertext)?;
-                let (xct, kct) = key.split_at(32);
-                Ok(Self::X25519Kyber768Draft00(
-                    kct.try_into().map_err(|_| Error::InvalidCiphertext)?,
-                    xct.try_into().map_err(|_| Error::InvalidCiphertext)?,
-                ))
-            }
-            #[cfg(feature = "kyber")]
-            Algorithm::XWingKyberDraft02 => {
-                let key: [u8; MlKem768Ciphertext::len() + 32] =
-                    bytes.try_into().map_err(|_| Error::InvalidCiphertext)?;
-                let (ct_m, ct_x) = key.split_at(MlKem768Ciphertext::len());
-                Ok(Self::XWingKyberDraft02(
-                    ct_m.try_into().map_err(|_| Error::InvalidCiphertext)?,
-                    ct_x.try_into().map_err(|_| Error::InvalidCiphertext)?,
-                ))
-            }
             Algorithm::MlKem1024 => bytes
                 .try_into()
                 .map_err(|_| Error::InvalidCiphertext)

--- a/libcrux-kem/src/kem.rs
+++ b/libcrux-kem/src/kem.rs
@@ -850,6 +850,26 @@ impl Ct {
                     ct_x.try_into().map_err(|_| Error::InvalidCiphertext)?,
                 ))
             }
+            #[cfg(feature = "kyber")]
+            Algorithm::X25519Kyber768Draft00 => {
+                let key: [u8; MlKem768Ciphertext::len() + 32] =
+                    bytes.try_into().map_err(|_| Error::InvalidCiphertext)?;
+                let (xct, kct) = key.split_at(32);
+                Ok(Self::X25519Kyber768Draft00(
+                    kct.try_into().map_err(|_| Error::InvalidCiphertext)?,
+                    xct.try_into().map_err(|_| Error::InvalidCiphertext)?,
+                ))
+            }
+            #[cfg(feature = "kyber")]
+            Algorithm::XWingKyberDraft02 => {
+                let key: [u8; MlKem768Ciphertext::len() + 32] =
+                    bytes.try_into().map_err(|_| Error::InvalidCiphertext)?;
+                let (ct_m, ct_x) = key.split_at(MlKem768Ciphertext::len());
+                Ok(Self::XWingKyberDraft02(
+                    ct_m.try_into().map_err(|_| Error::InvalidCiphertext)?,
+                    ct_x.try_into().map_err(|_| Error::InvalidCiphertext)?,
+                ))
+            }
             Algorithm::MlKem1024 => bytes
                 .try_into()
                 .map_err(|_| Error::InvalidCiphertext)

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -17,6 +17,12 @@ use crate::hacl::chacha20_poly1305;
 
 use libcrux_platform::{aes_ni_support, simd128_support, simd256_support};
 
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// The caller has provided an invalid argument.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InvalidArgumentError {

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -17,11 +17,7 @@ use crate::hacl::chacha20_poly1305;
 
 use libcrux_platform::{aes_ni_support, simd128_support, simd256_support};
 
-#[cfg(feature = "std")]
-use std::vec::Vec;
-
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use crate::std::vec::Vec;
 
 /// The caller has provided an invalid argument.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -16,11 +16,8 @@
 use crate::hacl::{blake2, sha3};
 
 use libcrux_platform::{simd128_support, simd256_support};
-#[cfg(feature = "std")]
-use std::vec::Vec;
 
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use crate::std::vec::Vec;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -16,6 +16,11 @@
 use crate::hacl::{blake2, sha3};
 
 use libcrux_platform::{simd128_support, simd256_support};
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/drbg.rs
+++ b/src/drbg.rs
@@ -5,11 +5,8 @@
 use crate::hacl::drbg;
 // re-export here for convenience
 pub use rand::{CryptoRng, RngCore};
-#[cfg(feature = "std")]
-use std::{fmt, vec, vec::Vec};
 
-#[cfg(not(feature = "std"))]
-use alloc::{fmt, vec, vec::Vec};
+use crate::std::{fmt, vec, vec::Vec};
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/drbg.rs
+++ b/src/drbg.rs
@@ -5,6 +5,11 @@
 use crate::hacl::drbg;
 // re-export here for convenience
 pub use rand::{CryptoRng, RngCore};
+#[cfg(feature = "std")]
+use std::{fmt, vec, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{fmt, vec, vec::Vec};
 
 #[derive(Debug)]
 pub enum Error {
@@ -16,13 +21,13 @@ pub enum Error {
     UnableToGenerate,
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("{self:?}"))
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 pub struct Drbg {
     state: drbg::Drbg,

--- a/src/hacl/aesgcm.rs
+++ b/src/hacl/aesgcm.rs
@@ -57,7 +57,7 @@ macro_rules! implement {
             let mut tag = Tag::default();
             hardware_support()?;
             let ok = unsafe {
-                let mut state_ptr: *mut EverCrypt_AEAD_state_s = std::ptr::null_mut();
+                let mut state_ptr: *mut EverCrypt_AEAD_state_s = core::ptr::null_mut();
                 let e = EverCrypt_AEAD_create_in($alg as u8, &mut state_ptr, key.as_ptr() as _);
                 if e != 0 {
                     return Err(Error::InvalidArgument);
@@ -99,7 +99,7 @@ macro_rules! implement {
         ) -> Result<(), Error> {
             hardware_support()?;
             let ok = unsafe {
-                let mut state_ptr: *mut EverCrypt_AEAD_state_s = std::ptr::null_mut();
+                let mut state_ptr: *mut EverCrypt_AEAD_state_s = core::ptr::null_mut();
                 let e = EverCrypt_AEAD_create_in($alg as u8, &mut state_ptr, key.as_ptr() as _);
                 if e != 0 {
                     return Err(Error::UnsupportedHardware);

--- a/src/hacl/sha3.rs
+++ b/src/hacl/sha3.rs
@@ -232,7 +232,7 @@ pub mod x4 {
 /// bytes in increments.
 /// TODO: This module should not be public, see: https://github.com/cryspen/libcrux/issues/157
 pub mod incremental {
-    use std::ptr::null_mut;
+    use core::ptr::null_mut;
 
     use libcrux_hacl::{
         Hacl_Hash_SHA3_Scalar_shake128_absorb_final, Hacl_Hash_SHA3_Scalar_shake128_absorb_nblocks,
@@ -322,7 +322,7 @@ pub mod incremental {
 }
 
 pub mod incremental_x4 {
-    use std::ptr::null_mut;
+    use core::ptr::null_mut;
 
     use libcrux_hacl::{
         Hacl_Hash_SHA3_Scalar_shake128_absorb_final, Hacl_Hash_SHA3_Scalar_shake128_absorb_nblocks,

--- a/src/hpke/aead.rs
+++ b/src/hpke/aead.rs
@@ -34,11 +34,8 @@ use crate::{
     aead::{self, *},
     hmac::tag_size,
 };
-#[cfg(feature = "std")]
-use std::{vec, vec::Vec};
 
-#[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use crate::std::{vec, vec::Vec};
 
 use super::errors::*;
 

--- a/src/hpke/aead.rs
+++ b/src/hpke/aead.rs
@@ -34,6 +34,11 @@ use crate::{
     aead::{self, *},
     hmac::tag_size,
 };
+#[cfg(feature = "std")]
+use std::{vec, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
 
 use super::errors::*;
 

--- a/src/hpke/errors.rs
+++ b/src/hpke/errors.rs
@@ -63,11 +63,7 @@
 //! - `CryptoError`: An opaque error happened in a crypto operation outside of this code.
 
 use crate::aead::InvalidArgumentError;
-#[cfg(feature = "std")]
-use std::vec::Vec;
-
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use crate::std::vec::Vec;
 
 /// Explicit errors generated throughout this specification.
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/src/hpke/errors.rs
+++ b/src/hpke/errors.rs
@@ -63,6 +63,11 @@
 //! - `CryptoError`: An opaque error happened in a crypto operation outside of this code.
 
 use crate::aead::InvalidArgumentError;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// Explicit errors generated throughout this specification.
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/src/hpke/hpke.rs
+++ b/src/hpke/hpke.rs
@@ -1,9 +1,6 @@
 #![allow(non_camel_case_types, non_snake_case, unused_imports)]
-#[cfg(feature = "std")]
-use std::{vec, vec::Vec};
 
-#[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use crate::std::{vec, vec::Vec};
 
 use libcrux_ecdh::{self, secret_to_public, x25519_derive, X25519PublicKey};
 use libcrux_ml_kem::mlkem768;

--- a/src/hpke/hpke.rs
+++ b/src/hpke/hpke.rs
@@ -1,4 +1,9 @@
 #![allow(non_camel_case_types, non_snake_case, unused_imports)]
+#[cfg(feature = "std")]
+use std::{vec, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
 
 use libcrux_ecdh::{self, secret_to_public, x25519_derive, X25519PublicKey};
 use libcrux_ml_kem::mlkem768;

--- a/src/hpke/kdf.rs
+++ b/src/hpke/kdf.rs
@@ -1,9 +1,13 @@
 #![doc = include_str!("KDF_Readme.md")]
 #![allow(non_snake_case, non_camel_case_types)]
 
-use crate::hkdf::Algorithm;
-
 use super::errors::*;
+use crate::hkdf::Algorithm;
+#[cfg(feature = "std")]
+use std::{vec, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
 
 /// ## Key Derivation Functions (KDFs)
 ///

--- a/src/hpke/kdf.rs
+++ b/src/hpke/kdf.rs
@@ -3,11 +3,8 @@
 
 use super::errors::*;
 use crate::hkdf::Algorithm;
-#[cfg(feature = "std")]
-use std::{vec, vec::Vec};
 
-#[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use crate::std::{vec, vec::Vec};
 
 /// ## Key Derivation Functions (KDFs)
 ///

--- a/src/hpke/kem.rs
+++ b/src/hpke/kem.rs
@@ -3,11 +3,8 @@
 #![allow(non_camel_case_types, non_snake_case)]
 
 use libcrux_ecdh::{X25519PrivateKey, X25519PublicKey};
-#[cfg(feature = "std")]
-use std::{vec, vec::Vec};
 
-#[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use crate::std::{vec, vec::Vec};
 
 use super::errors::*;
 use super::kdf::*;

--- a/src/hpke/kem.rs
+++ b/src/hpke/kem.rs
@@ -3,6 +3,11 @@
 #![allow(non_camel_case_types, non_snake_case)]
 
 use libcrux_ecdh::{X25519PrivateKey, X25519PublicKey};
+#[cfg(feature = "std")]
+use std::{vec, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
 
 use super::errors::*;
 use super::kdf::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ extern crate std;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[cfg(not(feature = "std"))]
+use alloc as std;
+
 pub use libcrux_platform::aes_ni_support;
 
 // Jasmin

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,14 @@
 //!
 //! The unified, formally verified, cryptography library.
 
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 pub use libcrux_platform::aes_ni_support;
 
 // Jasmin

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -4,6 +4,12 @@
 //! * EdDSA 25519
 //! * RSA PSS
 
+#[cfg(feature = "std")]
+use std::{vec, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
 use crate::{
     ecdh,
     hacl::{self, ed25519},
@@ -84,7 +90,7 @@ pub mod rsa_pss {
         Hacl_RSAPSS_rsapss_sign, Hacl_RSAPSS_rsapss_verify,
     };
 
-    use super::{DigestAlgorithm, Error};
+    use super::{vec, DigestAlgorithm, Error, Vec};
 
     /// A [`Algorithm::RsaPss`](super::Algorithm::RsaPss) Signature
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -4,11 +4,7 @@
 //! * EdDSA 25519
 //! * RSA PSS
 
-#[cfg(feature = "std")]
-use std::{vec, vec::Vec};
-
-#[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use crate::std::{vec, vec::Vec};
 
 use crate::{
     ecdh,


### PR DESCRIPTION
This is a quick step towards `no_std` support for libcrux, which is necessary e.g. for https://github.com/cryspen/bertie/issues/126

We do still assume presence of a global allocator for the `no_std` target in question, and I've made a note of that in the Readme.