### PR TITLE
fix(nix ci): regression in nix-installer-action

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          source-tag: v0.32.3 # revert when https://github.com/DeterminateSystems/nix-installer-action/issues/133 is closed
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: ⤵ Install FStar


### PR DESCRIPTION
This commit pins the version of nix-installer, so that we don't hit https://github.com/DeterminateSystems/nix-installer-action/issues/133. We should revert this commit whenever https://github.com/DeterminateSystems/nix-installer-action/issues/133 is closed.

Fixes #747
