### PR TITLE
Revert "fix(nix ci): regression in nix-installer-action"

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -31,8 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          source-tag: v0.32.3 # revert when https://github.com/DeterminateSystems/nix-installer-action/issues/133 is closed
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: ⤵ Install FStar


### PR DESCRIPTION
https://github.com/DeterminateSystems/nix-installer-action/issues/133 is fixed (well, https://github.com/DeterminateSystems/nix-installer/issues/1388, but that's the same issue), thus this PR reverts cryspen/libcrux#748

Fixes #749.