### PR TITLE
Use `std::error::Error` in `std` feature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,11 @@ libcrux uses the following configurations for its hardware abstractions
 - **simd256** assumes 256 bit SIMD instructions on the platform
   This implies AVX and AVX2 on x64 CPUs.
 
+## Minimum Supported Rust Version (MSRV)
+
+The default feature set has a MSRV of `1.78.0`. `no_std` environments
+are supported starting from Rust version `1.81.0`.
+
 ## Randomness
 
 libcrux provides a DRBG implementation that can be used standalone (`drbg::Drbg`)

--- a/src/drbg.rs
+++ b/src/drbg.rs
@@ -24,6 +24,10 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+#[cfg(not(feature = "std"))]
 impl core::error::Error for Error {}
 
 pub struct Drbg {


### PR DESCRIPTION
This allows users of the `std` to have a minimum supported Rust version of `1.78.0` as opposed to `1.81.0`.