### PR TITLE
Update hax CI

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: hacspec/hax-actions@fstar-version
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
+          fstar: v2024.12.03
 
       - name: 🏃 Extract ML-KEM crate
         working-directory: libcrux-ml-kem
@@ -73,6 +74,7 @@ jobs:
       - uses: hacspec/hax-actions@fstar-version
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
+          fstar: v2024.12.03
 
       - name: 🏃 Lax ML-KEM crate
         working-directory: libcrux-ml-kem
@@ -86,6 +88,7 @@ jobs:
       - uses: hacspec/hax-actions@fstar-version
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
+          fstar: v2024.12.03
 
       - name: 🏃 Extract ML-DSA crate
         working-directory: libcrux-ml-dsa
@@ -126,6 +129,7 @@ jobs:
       - uses: hacspec/hax-actions@fstar-version
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
+          fstar: v2024.12.03
 
       - name: 🏃 Lax ML-DSA crate
         working-directory: libcrux-ml-dsa

--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hacspec/hax-actions@fstar-version
+      - uses: hacspec/hax-actions@main
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
           fstar: v2024.12.03
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hacspec/hax-actions@fstar-version
+      - uses: hacspec/hax-actions@main
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
           fstar: v2024.12.03
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hacspec/hax-actions@fstar-version
+      - uses: hacspec/hax-actions@main
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
           fstar: v2024.12.03
@@ -126,7 +126,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hacspec/hax-actions@fstar-version
+      - uses: hacspec/hax-actions@main
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
           fstar: v2024.12.03

--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hacspec/hax-actions@main
+      - uses: hacspec/hax-actions@fstar-version
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
 
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hacspec/hax-actions@main
+      - uses: hacspec/hax-actions@fstar-version
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
 
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hacspec/hax-actions@main
+      - uses: hacspec/hax-actions@fstar-version
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
 
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hacspec/hax-actions@main
+      - uses: hacspec/hax-actions@fstar-version
         with:
           hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
 

--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -13,8 +13,8 @@ on:
   workflow_dispatch:
     inputs:
       hax_rev:
-        description: 'The hax revision you want this job to use'
-        default: 'main'
+        description: "The hax revision you want this job to use"
+        default: "main"
   merge_group:
 
 env:
@@ -25,61 +25,108 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  hax:
-    runs-on: "ubuntu-latest"
+  mlkem-extract:
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-
-      - name: ⤵ Install FStar
-        run: nix profile install github:FStarLang/FStar/v2024.12.03
-
-      - name: ⤵ Clone HACL-star repository
-        uses: actions/checkout@v4
+      - uses: hacspec/hax-actions@main
         with:
-          repository: hacl-star/hacl-star
-          path: hacl-star
-
-      - name: ⤵ Clone hax repository
-        uses: actions/checkout@v4
-        with:
-          repository: hacspec/hax
-          ref: ${{ github.event.inputs.hax_rev || 'main' }}
-          path: hax
-
-      - name: ⤵ Install & confiure Cachix
-        run: |
-          nix profile install nixpkgs#cachix
-          cachix use hax
-
-      - name: ⤵ Install hax
-        run: |
-          nix profile install ./hax
+          hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
 
       - name: 🏃 Extract ML-KEM crate
         working-directory: libcrux-ml-kem
         run: ./hax.py extract
 
+      - name: ↑ Upload F* extraction
+        uses: actions/upload-artifact@v4
+        with:
+          name: fstar-extraction-mlkem
+          path: libcrux-ml-kem/proofs/
+          include-hidden-files: true
+          if-no-files-found: error
+
+  mlkem-diff:
+    needs: mlkem-extract
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: fstar-extraction-mlkem
+          path: ~/fstar-extraction-mlkem
+
+      - name: = Diff Extraction
+        run: |
+          diff -r libcrux-ml-kem/proofs/fstar/extraction/ \
+            ~/fstar-extraction-mlkem/fstar/extraction/
+
+  mlkem-lax:
+    runs-on: ubuntu-latest
+    needs:
+      - mlkem-extract
+      - mlkem-diff
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacspec/hax-actions@main
+        with:
+          hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
+
       - name: 🏃 Lax ML-KEM crate
         working-directory: libcrux-ml-kem
-        run: |
-          env FSTAR_HOME=${{ github.workspace }}/fstar \
-              HACL_HOME=${{ github.workspace }}/hacl-star \
-              HAX_HOME=${{ github.workspace }}/hax \
-              PATH="${PATH}:${{ github.workspace }}/fstar/bin" \
-              ./hax.py prove --admit
+        run: ./hax.py prove --admit
+
+  mldsa-extract:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacspec/hax-actions@main
+        with:
+          hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
 
       - name: 🏃 Extract ML-DSA crate
         working-directory: libcrux-ml-dsa
         run: ./hax.py extract
 
+      - name: ↑ Upload F* extraction
+        uses: actions/upload-artifact@v4
+        with:
+          name: fstar-extraction-mldsa
+          path: libcrux-ml-dsa/proofs/
+          include-hidden-files: true
+          if-no-files-found: error
+
+  mldsa-diff:
+    needs: mldsa-extract
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: fstar-extraction-mldsa
+          path: ~/fstar-extraction-mldsa
+
+      - name: = Diff Extraction
+        run: |
+          diff -r libcrux-ml-dsa/proofs/fstar/extraction/ \
+            ~/fstar-extraction-mldsa/fstar/extraction/
+
+  mldsa-lax:
+    runs-on: ubuntu-latest
+    needs:
+      - mldsa-extract
+      - mldsa-diff
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacspec/hax-actions@main
+        with:
+          hax_reference: ${{ github.event.inputs.hax_rev || 'main' }}
+
       - name: 🏃 Lax ML-DSA crate
         working-directory: libcrux-ml-dsa
-        run: |
-          env FSTAR_HOME=${{ github.workspace }}/fstar \
-              HACL_HOME=${{ github.workspace }}/hacl-star \
-              HAX_HOME=${{ github.workspace }}/hax \
-              PATH="${PATH}:${{ github.workspace }}/fstar/bin" \
-              ./hax.py prove --admit
+        run: ./hax.py prove --admit


### PR DESCRIPTION
Towards #585 and #733 

This PR uses the hax action and splits the action into multiple steps
- extraction: `hax.py extract`
- diff
- lax: `hax.py prove --admit`

Based on this we can add verification with `hax.py prove` for ML-KEM and ML-DSA.