### PR TITLE
Refresh C code + fix c.yaml following latest eurydice/krml changes

### DIFF
--- a/libcrux-ml-kem/c.yaml
+++ b/libcrux-ml-kem/c.yaml
@@ -107,6 +107,8 @@ files:
       monomorphizations_of:
         - [libcrux_ml_kem, vector, neon, "*"]
         - [libcrux_ml_kem, hash_functions, neon, "*"]
+    include_in_h:
+      - '"intrinsics/libcrux_intrinsics_arm64.h"'
 
   - name: libcrux_mlkem_avx2
     api:
@@ -119,6 +121,8 @@ files:
       monomorphizations_of:
         - [libcrux_ml_kem, vector, avx2, "*"]
         - [libcrux_ml_kem, hash_functions, avx2, "*"]
+    include_in_h:
+      - '"intrinsics/libcrux_intrinsics_avx2.h"'
 
   # This covers slightly more than the two bundles above, but this greatly
   # simplifies our lives.

--- a/libcrux-ml-kem/c/code_gen.txt
+++ b/libcrux-ml-kem/c/code_gen.txt
@@ -1,6 +1,6 @@
 This code was generated with the following revisions:
-Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
-Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
-Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
-F*: b0961063393215ca65927f017720cb365a193833-dirty
-Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+Charon: 30cab88265206f4fa849736e704983e39a404d96
+Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c

--- a/libcrux-ml-kem/c/code_gen.txt
+++ b/libcrux-ml-kem/c/code_gen.txt
@@ -1,6 +1,6 @@
 This code was generated with the following revisions:
 Charon: 30cab88265206f4fa849736e704983e39a404d96
-Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
-Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
 F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
-Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb

--- a/libcrux-ml-kem/c/internal/libcrux_core.h
+++ b/libcrux-ml-kem/c/internal/libcrux_core.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __internal_libcrux_core_H

--- a/libcrux-ml-kem/c/internal/libcrux_core.h
+++ b/libcrux-ml-kem/c/internal/libcrux_core.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __internal_libcrux_core_H

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __internal_libcrux_mlkem_avx2_H
@@ -20,9 +20,8 @@ extern "C" {
 
 #include "../libcrux_mlkem_avx2.h"
 #include "eurydice_glue.h"
-#include "internal/libcrux_core.h"
-#include "internal/libcrux_mlkem_portable.h"
-#include "internal/libcrux_sha3_avx2.h"
+#include "intrinsics/libcrux_intrinsics_avx2.h"
+#include "libcrux_core.h"
 
 /**
 A monomorphic instance of libcrux_ml_kem.polynomial.PolynomialRingElement

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_avx2.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __internal_libcrux_mlkem_avx2_H

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __internal_libcrux_mlkem_portable_H
@@ -20,8 +20,7 @@ extern "C" {
 
 #include "../libcrux_mlkem_portable.h"
 #include "eurydice_glue.h"
-#include "internal/libcrux_core.h"
-#include "internal/libcrux_sha3_internal.h"
+#include "libcrux_core.h"
 
 int16_t libcrux_ml_kem_polynomial_zeta(size_t i);
 

--- a/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/internal/libcrux_mlkem_portable.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __internal_libcrux_mlkem_portable_H

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __internal_libcrux_sha3_avx2_H
@@ -20,7 +20,6 @@ extern "C" {
 
 #include "../libcrux_sha3_avx2.h"
 #include "eurydice_glue.h"
-#include "internal/libcrux_core.h"
 #include "intrinsics/libcrux_intrinsics_avx2.h"
 
 typedef libcrux_sha3_generic_keccak_KeccakState_55

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_avx2.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __internal_libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __internal_libcrux_sha3_internal_H
@@ -20,6 +20,7 @@ extern "C" {
 
 #include "../libcrux_sha3_internal.h"
 #include "eurydice_glue.h"
+#include "libcrux_core.h"
 
 typedef libcrux_sha3_generic_keccak_KeccakState_17
     libcrux_sha3_portable_KeccakState;

--- a/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/internal/libcrux_sha3_internal.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __internal_libcrux_sha3_internal_H
@@ -299,9 +299,9 @@ static inline size_t libcrux_sha3_generic_keccak_absorb_full_8b_c6(
   if (input_consumed > (size_t)0U) {
     Eurydice_slice borrowed[1U];
     {
-      uint8_t buf[136U] = {0U};
+      uint8_t repeat_expression[136U] = {0U};
       borrowed[0U] = core_array___Array_T__N__23__as_slice(
-          (size_t)136U, buf, uint8_t, Eurydice_slice);
+          (size_t)136U, repeat_expression, uint8_t, Eurydice_slice);
     }
     {
       size_t i = (size_t)0U;
@@ -486,142 +486,8 @@ with const generics
 */
 static inline void libcrux_sha3_generic_keccak_zero_block_8b_c6(
     uint8_t ret[136U]) {
-  ret[0U] = 0U;
-  ret[1U] = 0U;
-  ret[2U] = 0U;
-  ret[3U] = 0U;
-  ret[4U] = 0U;
-  ret[5U] = 0U;
-  ret[6U] = 0U;
-  ret[7U] = 0U;
-  ret[8U] = 0U;
-  ret[9U] = 0U;
-  ret[10U] = 0U;
-  ret[11U] = 0U;
-  ret[12U] = 0U;
-  ret[13U] = 0U;
-  ret[14U] = 0U;
-  ret[15U] = 0U;
-  ret[16U] = 0U;
-  ret[17U] = 0U;
-  ret[18U] = 0U;
-  ret[19U] = 0U;
-  ret[20U] = 0U;
-  ret[21U] = 0U;
-  ret[22U] = 0U;
-  ret[23U] = 0U;
-  ret[24U] = 0U;
-  ret[25U] = 0U;
-  ret[26U] = 0U;
-  ret[27U] = 0U;
-  ret[28U] = 0U;
-  ret[29U] = 0U;
-  ret[30U] = 0U;
-  ret[31U] = 0U;
-  ret[32U] = 0U;
-  ret[33U] = 0U;
-  ret[34U] = 0U;
-  ret[35U] = 0U;
-  ret[36U] = 0U;
-  ret[37U] = 0U;
-  ret[38U] = 0U;
-  ret[39U] = 0U;
-  ret[40U] = 0U;
-  ret[41U] = 0U;
-  ret[42U] = 0U;
-  ret[43U] = 0U;
-  ret[44U] = 0U;
-  ret[45U] = 0U;
-  ret[46U] = 0U;
-  ret[47U] = 0U;
-  ret[48U] = 0U;
-  ret[49U] = 0U;
-  ret[50U] = 0U;
-  ret[51U] = 0U;
-  ret[52U] = 0U;
-  ret[53U] = 0U;
-  ret[54U] = 0U;
-  ret[55U] = 0U;
-  ret[56U] = 0U;
-  ret[57U] = 0U;
-  ret[58U] = 0U;
-  ret[59U] = 0U;
-  ret[60U] = 0U;
-  ret[61U] = 0U;
-  ret[62U] = 0U;
-  ret[63U] = 0U;
-  ret[64U] = 0U;
-  ret[65U] = 0U;
-  ret[66U] = 0U;
-  ret[67U] = 0U;
-  ret[68U] = 0U;
-  ret[69U] = 0U;
-  ret[70U] = 0U;
-  ret[71U] = 0U;
-  ret[72U] = 0U;
-  ret[73U] = 0U;
-  ret[74U] = 0U;
-  ret[75U] = 0U;
-  ret[76U] = 0U;
-  ret[77U] = 0U;
-  ret[78U] = 0U;
-  ret[79U] = 0U;
-  ret[80U] = 0U;
-  ret[81U] = 0U;
-  ret[82U] = 0U;
-  ret[83U] = 0U;
-  ret[84U] = 0U;
-  ret[85U] = 0U;
-  ret[86U] = 0U;
-  ret[87U] = 0U;
-  ret[88U] = 0U;
-  ret[89U] = 0U;
-  ret[90U] = 0U;
-  ret[91U] = 0U;
-  ret[92U] = 0U;
-  ret[93U] = 0U;
-  ret[94U] = 0U;
-  ret[95U] = 0U;
-  ret[96U] = 0U;
-  ret[97U] = 0U;
-  ret[98U] = 0U;
-  ret[99U] = 0U;
-  ret[100U] = 0U;
-  ret[101U] = 0U;
-  ret[102U] = 0U;
-  ret[103U] = 0U;
-  ret[104U] = 0U;
-  ret[105U] = 0U;
-  ret[106U] = 0U;
-  ret[107U] = 0U;
-  ret[108U] = 0U;
-  ret[109U] = 0U;
-  ret[110U] = 0U;
-  ret[111U] = 0U;
-  ret[112U] = 0U;
-  ret[113U] = 0U;
-  ret[114U] = 0U;
-  ret[115U] = 0U;
-  ret[116U] = 0U;
-  ret[117U] = 0U;
-  ret[118U] = 0U;
-  ret[119U] = 0U;
-  ret[120U] = 0U;
-  ret[121U] = 0U;
-  ret[122U] = 0U;
-  ret[123U] = 0U;
-  ret[124U] = 0U;
-  ret[125U] = 0U;
-  ret[126U] = 0U;
-  ret[127U] = 0U;
-  ret[128U] = 0U;
-  ret[129U] = 0U;
-  ret[130U] = 0U;
-  ret[131U] = 0U;
-  ret[132U] = 0U;
-  ret[133U] = 0U;
-  ret[134U] = 0U;
-  ret[135U] = 0U;
+  uint8_t repeat_expression[136U] = {0U};
+  memcpy(ret, repeat_expression, (size_t)136U * sizeof(uint8_t));
 }
 
 /**
@@ -642,9 +508,11 @@ static inline libcrux_sha3_generic_keccak_KeccakXofState_e2
 libcrux_sha3_generic_keccak_new_8b_c6(void) {
   libcrux_sha3_generic_keccak_KeccakXofState_e2 lit;
   lit.inner = libcrux_sha3_generic_keccak_new_89_04();
-  uint8_t ret[136U];
-  libcrux_sha3_generic_keccak_zero_block_8b_c6(ret);
-  memcpy(lit.buf[0U], ret, (size_t)136U * sizeof(uint8_t));
+  uint8_t repeat_expression[1U][136U];
+  {
+    libcrux_sha3_generic_keccak_zero_block_8b_c6(repeat_expression[0U]);
+  }
+  memcpy(lit.buf, repeat_expression, (size_t)1U * sizeof(uint8_t[136U]));
   lit.buf_len = (size_t)0U;
   lit.sponge = false;
   return lit;
@@ -863,9 +731,9 @@ static inline size_t libcrux_sha3_generic_keccak_absorb_full_8b_c60(
   if (input_consumed > (size_t)0U) {
     Eurydice_slice borrowed[1U];
     {
-      uint8_t buf[168U] = {0U};
+      uint8_t repeat_expression[168U] = {0U};
       borrowed[0U] = core_array___Array_T__N__23__as_slice(
-          (size_t)168U, buf, uint8_t, Eurydice_slice);
+          (size_t)168U, repeat_expression, uint8_t, Eurydice_slice);
     }
     {
       size_t i = (size_t)0U;
@@ -1044,174 +912,8 @@ with const generics
 */
 static inline void libcrux_sha3_generic_keccak_zero_block_8b_c60(
     uint8_t ret[168U]) {
-  ret[0U] = 0U;
-  ret[1U] = 0U;
-  ret[2U] = 0U;
-  ret[3U] = 0U;
-  ret[4U] = 0U;
-  ret[5U] = 0U;
-  ret[6U] = 0U;
-  ret[7U] = 0U;
-  ret[8U] = 0U;
-  ret[9U] = 0U;
-  ret[10U] = 0U;
-  ret[11U] = 0U;
-  ret[12U] = 0U;
-  ret[13U] = 0U;
-  ret[14U] = 0U;
-  ret[15U] = 0U;
-  ret[16U] = 0U;
-  ret[17U] = 0U;
-  ret[18U] = 0U;
-  ret[19U] = 0U;
-  ret[20U] = 0U;
-  ret[21U] = 0U;
-  ret[22U] = 0U;
-  ret[23U] = 0U;
-  ret[24U] = 0U;
-  ret[25U] = 0U;
-  ret[26U] = 0U;
-  ret[27U] = 0U;
-  ret[28U] = 0U;
-  ret[29U] = 0U;
-  ret[30U] = 0U;
-  ret[31U] = 0U;
-  ret[32U] = 0U;
-  ret[33U] = 0U;
-  ret[34U] = 0U;
-  ret[35U] = 0U;
-  ret[36U] = 0U;
-  ret[37U] = 0U;
-  ret[38U] = 0U;
-  ret[39U] = 0U;
-  ret[40U] = 0U;
-  ret[41U] = 0U;
-  ret[42U] = 0U;
-  ret[43U] = 0U;
-  ret[44U] = 0U;
-  ret[45U] = 0U;
-  ret[46U] = 0U;
-  ret[47U] = 0U;
-  ret[48U] = 0U;
-  ret[49U] = 0U;
-  ret[50U] = 0U;
-  ret[51U] = 0U;
-  ret[52U] = 0U;
-  ret[53U] = 0U;
-  ret[54U] = 0U;
-  ret[55U] = 0U;
-  ret[56U] = 0U;
-  ret[57U] = 0U;
-  ret[58U] = 0U;
-  ret[59U] = 0U;
-  ret[60U] = 0U;
-  ret[61U] = 0U;
-  ret[62U] = 0U;
-  ret[63U] = 0U;
-  ret[64U] = 0U;
-  ret[65U] = 0U;
-  ret[66U] = 0U;
-  ret[67U] = 0U;
-  ret[68U] = 0U;
-  ret[69U] = 0U;
-  ret[70U] = 0U;
-  ret[71U] = 0U;
-  ret[72U] = 0U;
-  ret[73U] = 0U;
-  ret[74U] = 0U;
-  ret[75U] = 0U;
-  ret[76U] = 0U;
-  ret[77U] = 0U;
-  ret[78U] = 0U;
-  ret[79U] = 0U;
-  ret[80U] = 0U;
-  ret[81U] = 0U;
-  ret[82U] = 0U;
-  ret[83U] = 0U;
-  ret[84U] = 0U;
-  ret[85U] = 0U;
-  ret[86U] = 0U;
-  ret[87U] = 0U;
-  ret[88U] = 0U;
-  ret[89U] = 0U;
-  ret[90U] = 0U;
-  ret[91U] = 0U;
-  ret[92U] = 0U;
-  ret[93U] = 0U;
-  ret[94U] = 0U;
-  ret[95U] = 0U;
-  ret[96U] = 0U;
-  ret[97U] = 0U;
-  ret[98U] = 0U;
-  ret[99U] = 0U;
-  ret[100U] = 0U;
-  ret[101U] = 0U;
-  ret[102U] = 0U;
-  ret[103U] = 0U;
-  ret[104U] = 0U;
-  ret[105U] = 0U;
-  ret[106U] = 0U;
-  ret[107U] = 0U;
-  ret[108U] = 0U;
-  ret[109U] = 0U;
-  ret[110U] = 0U;
-  ret[111U] = 0U;
-  ret[112U] = 0U;
-  ret[113U] = 0U;
-  ret[114U] = 0U;
-  ret[115U] = 0U;
-  ret[116U] = 0U;
-  ret[117U] = 0U;
-  ret[118U] = 0U;
-  ret[119U] = 0U;
-  ret[120U] = 0U;
-  ret[121U] = 0U;
-  ret[122U] = 0U;
-  ret[123U] = 0U;
-  ret[124U] = 0U;
-  ret[125U] = 0U;
-  ret[126U] = 0U;
-  ret[127U] = 0U;
-  ret[128U] = 0U;
-  ret[129U] = 0U;
-  ret[130U] = 0U;
-  ret[131U] = 0U;
-  ret[132U] = 0U;
-  ret[133U] = 0U;
-  ret[134U] = 0U;
-  ret[135U] = 0U;
-  ret[136U] = 0U;
-  ret[137U] = 0U;
-  ret[138U] = 0U;
-  ret[139U] = 0U;
-  ret[140U] = 0U;
-  ret[141U] = 0U;
-  ret[142U] = 0U;
-  ret[143U] = 0U;
-  ret[144U] = 0U;
-  ret[145U] = 0U;
-  ret[146U] = 0U;
-  ret[147U] = 0U;
-  ret[148U] = 0U;
-  ret[149U] = 0U;
-  ret[150U] = 0U;
-  ret[151U] = 0U;
-  ret[152U] = 0U;
-  ret[153U] = 0U;
-  ret[154U] = 0U;
-  ret[155U] = 0U;
-  ret[156U] = 0U;
-  ret[157U] = 0U;
-  ret[158U] = 0U;
-  ret[159U] = 0U;
-  ret[160U] = 0U;
-  ret[161U] = 0U;
-  ret[162U] = 0U;
-  ret[163U] = 0U;
-  ret[164U] = 0U;
-  ret[165U] = 0U;
-  ret[166U] = 0U;
-  ret[167U] = 0U;
+  uint8_t repeat_expression[168U] = {0U};
+  memcpy(ret, repeat_expression, (size_t)168U * sizeof(uint8_t));
 }
 
 /**
@@ -1232,9 +934,11 @@ static inline libcrux_sha3_generic_keccak_KeccakXofState_97
 libcrux_sha3_generic_keccak_new_8b_c60(void) {
   libcrux_sha3_generic_keccak_KeccakXofState_97 lit;
   lit.inner = libcrux_sha3_generic_keccak_new_89_04();
-  uint8_t ret[168U];
-  libcrux_sha3_generic_keccak_zero_block_8b_c60(ret);
-  memcpy(lit.buf[0U], ret, (size_t)168U * sizeof(uint8_t));
+  uint8_t repeat_expression[1U][168U];
+  {
+    libcrux_sha3_generic_keccak_zero_block_8b_c60(repeat_expression[0U]);
+  }
+  memcpy(lit.buf, repeat_expression, (size_t)1U * sizeof(uint8_t[168U]));
   lit.buf_len = (size_t)0U;
   lit.sponge = false;
   return lit;

--- a/libcrux-ml-kem/c/libcrux_core.c
+++ b/libcrux-ml-kem/c/libcrux_core.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "internal/libcrux_core.h"

--- a/libcrux-ml-kem/c/libcrux_core.c
+++ b/libcrux-ml-kem/c/libcrux_core.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "internal/libcrux_core.h"

--- a/libcrux-ml-kem/c/libcrux_core.h
+++ b/libcrux-ml-kem/c/libcrux_core.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_core_H

--- a/libcrux-ml-kem/c/libcrux_core.h
+++ b/libcrux-ml-kem/c/libcrux_core.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_core_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem1024_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem1024_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
@@ -4,16 +4,17 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "libcrux_mlkem1024_avx2.h"
 
 #include "internal/libcrux_mlkem_avx2.h"
+#include "libcrux_core.h"
 
 /**
 A monomorphic instance of

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "libcrux_mlkem1024_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem1024_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem1024_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "libcrux_mlkem1024_portable.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.c
@@ -4,16 +4,17 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "libcrux_mlkem1024_portable.h"
 
 #include "internal/libcrux_mlkem_portable.h"
+#include "libcrux_core.h"
 
 /**
  Portable decapsulate

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem1024_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem1024_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem1024_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem512_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem512_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
@@ -4,16 +4,17 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "libcrux_mlkem512_avx2.h"
 
 #include "internal/libcrux_mlkem_avx2.h"
+#include "libcrux_core.h"
 
 /**
 A monomorphic instance of

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "libcrux_mlkem512_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem512_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_avx2.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem512_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "libcrux_mlkem512_portable.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.c
@@ -4,16 +4,17 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "libcrux_mlkem512_portable.h"
 
 #include "internal/libcrux_mlkem_portable.h"
+#include "libcrux_core.h"
 
 /**
  Portable decapsulate

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem512_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem512_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem512_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem768_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem768_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
@@ -4,16 +4,17 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "libcrux_mlkem768_avx2.h"
 
 #include "internal/libcrux_mlkem_avx2.h"
+#include "libcrux_core.h"
 
 /**
 A monomorphic instance of

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "libcrux_mlkem768_avx2.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem768_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem768_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
@@ -4,16 +4,17 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "libcrux_mlkem768_portable.h"
 
 #include "internal/libcrux_mlkem_portable.h"
+#include "libcrux_core.h"
 
 /**
  Portable decapsulate

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "libcrux_mlkem768_portable.h"

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem768_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem768_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem768_portable_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "internal/libcrux_mlkem_avx2.h"
@@ -1221,22 +1221,11 @@ with const generics
 */
 static libcrux_ml_kem_polynomial_PolynomialRingElement_f6 ZERO_ef_79(void) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f6 lit;
-  lit.coefficients[0U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[1U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[2U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[3U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[4U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[5U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[6U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[7U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[8U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[9U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[10U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[11U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[12U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[13U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[14U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[15U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
+  __m256i repeat_expression[16U];
+  KRML_MAYBE_FOR16(
+      i, (size_t)0U, (size_t)16U, (size_t)1U,
+      repeat_expression[i] = libcrux_ml_kem_vector_avx2_ZERO_9a(););
+  memcpy(lit.coefficients, repeat_expression, (size_t)16U * sizeof(__m256i));
   return lit;
 }
 
@@ -1582,9 +1571,12 @@ with const generics
 */
 static IndCpaPrivateKeyUnpacked_63 default_1a_ab(void) {
   IndCpaPrivateKeyUnpacked_63 lit;
-  lit.secret_as_ntt[0U] = ZERO_ef_79();
-  lit.secret_as_ntt[1U] = ZERO_ef_79();
-  lit.secret_as_ntt[2U] = ZERO_ef_79();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_f6 repeat_expression[3U];
+  KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U,
+                  repeat_expression[i] = ZERO_ef_79(););
+  memcpy(
+      lit.secret_as_ntt, repeat_expression,
+      (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6));
   return lit;
 }
 
@@ -1621,15 +1613,18 @@ static IndCpaPublicKeyUnpacked_63 default_8d_ab(void) {
       lit.t_as_ntt, uu____0,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6));
   memcpy(lit.seed_for_A, uu____1, (size_t)32U * sizeof(uint8_t));
-  lit.A[0U][0U] = ZERO_ef_79();
-  lit.A[0U][1U] = ZERO_ef_79();
-  lit.A[0U][2U] = ZERO_ef_79();
-  lit.A[1U][0U] = ZERO_ef_79();
-  lit.A[1U][1U] = ZERO_ef_79();
-  lit.A[1U][2U] = ZERO_ef_79();
-  lit.A[2U][0U] = ZERO_ef_79();
-  lit.A[2U][1U] = ZERO_ef_79();
-  lit.A[2U][2U] = ZERO_ef_79();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_f6 repeat_expression0[3U][3U];
+  KRML_MAYBE_FOR3(
+      i0, (size_t)0U, (size_t)3U, (size_t)1U,
+      libcrux_ml_kem_polynomial_PolynomialRingElement_f6 repeat_expression[3U];
+      KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U,
+                      repeat_expression[i] = ZERO_ef_79(););
+      memcpy(repeat_expression0[i0], repeat_expression,
+             (size_t)3U *
+                 sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6)););
+  memcpy(lit.A, repeat_expression0,
+         (size_t)3U *
+             sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6[3U]));
   return lit;
 }
 
@@ -1965,22 +1960,11 @@ with const generics
 */
 static libcrux_ml_kem_polynomial_PolynomialRingElement_f6 ZERO_79(void) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_f6 lit;
-  lit.coefficients[0U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[1U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[2U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[3U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[4U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[5U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[6U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[7U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[8U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[9U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[10U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[11U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[12U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[13U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[14U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
-  lit.coefficients[15U] = libcrux_ml_kem_vector_avx2_ZERO_9a();
+  __m256i repeat_expression[16U];
+  KRML_MAYBE_FOR16(
+      i, (size_t)0U, (size_t)16U, (size_t)1U,
+      repeat_expression[i] = libcrux_ml_kem_vector_avx2_ZERO_9a(););
+  memcpy(lit.coefficients, repeat_expression, (size_t)16U * sizeof(__m256i));
   return lit;
 }
 
@@ -5098,10 +5082,12 @@ with const generics
 */
 static IndCpaPrivateKeyUnpacked_39 default_1a_42(void) {
   IndCpaPrivateKeyUnpacked_39 lit;
-  lit.secret_as_ntt[0U] = ZERO_ef_79();
-  lit.secret_as_ntt[1U] = ZERO_ef_79();
-  lit.secret_as_ntt[2U] = ZERO_ef_79();
-  lit.secret_as_ntt[3U] = ZERO_ef_79();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_f6 repeat_expression[4U];
+  KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U,
+                  repeat_expression[i] = ZERO_ef_79(););
+  memcpy(
+      lit.secret_as_ntt, repeat_expression,
+      (size_t)4U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6));
   return lit;
 }
 
@@ -5138,22 +5124,18 @@ static IndCpaPublicKeyUnpacked_39 default_8d_42(void) {
       lit.t_as_ntt, uu____0,
       (size_t)4U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6));
   memcpy(lit.seed_for_A, uu____1, (size_t)32U * sizeof(uint8_t));
-  lit.A[0U][0U] = ZERO_ef_79();
-  lit.A[0U][1U] = ZERO_ef_79();
-  lit.A[0U][2U] = ZERO_ef_79();
-  lit.A[0U][3U] = ZERO_ef_79();
-  lit.A[1U][0U] = ZERO_ef_79();
-  lit.A[1U][1U] = ZERO_ef_79();
-  lit.A[1U][2U] = ZERO_ef_79();
-  lit.A[1U][3U] = ZERO_ef_79();
-  lit.A[2U][0U] = ZERO_ef_79();
-  lit.A[2U][1U] = ZERO_ef_79();
-  lit.A[2U][2U] = ZERO_ef_79();
-  lit.A[2U][3U] = ZERO_ef_79();
-  lit.A[3U][0U] = ZERO_ef_79();
-  lit.A[3U][1U] = ZERO_ef_79();
-  lit.A[3U][2U] = ZERO_ef_79();
-  lit.A[3U][3U] = ZERO_ef_79();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_f6 repeat_expression0[4U][4U];
+  KRML_MAYBE_FOR4(
+      i0, (size_t)0U, (size_t)4U, (size_t)1U,
+      libcrux_ml_kem_polynomial_PolynomialRingElement_f6 repeat_expression[4U];
+      KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U,
+                      repeat_expression[i] = ZERO_ef_79(););
+      memcpy(repeat_expression0[i0], repeat_expression,
+             (size_t)4U *
+                 sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6)););
+  memcpy(lit.A, repeat_expression0,
+         (size_t)4U *
+             sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6[4U]));
   return lit;
 }
 
@@ -7172,8 +7154,12 @@ with const generics
 */
 static IndCpaPrivateKeyUnpacked_94 default_1a_89(void) {
   IndCpaPrivateKeyUnpacked_94 lit;
-  lit.secret_as_ntt[0U] = ZERO_ef_79();
-  lit.secret_as_ntt[1U] = ZERO_ef_79();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_f6 repeat_expression[2U];
+  KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U,
+                  repeat_expression[i] = ZERO_ef_79(););
+  memcpy(
+      lit.secret_as_ntt, repeat_expression,
+      (size_t)2U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6));
   return lit;
 }
 
@@ -7210,10 +7196,18 @@ static IndCpaPublicKeyUnpacked_94 default_8d_89(void) {
       lit.t_as_ntt, uu____0,
       (size_t)2U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6));
   memcpy(lit.seed_for_A, uu____1, (size_t)32U * sizeof(uint8_t));
-  lit.A[0U][0U] = ZERO_ef_79();
-  lit.A[0U][1U] = ZERO_ef_79();
-  lit.A[1U][0U] = ZERO_ef_79();
-  lit.A[1U][1U] = ZERO_ef_79();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_f6 repeat_expression0[2U][2U];
+  KRML_MAYBE_FOR2(
+      i0, (size_t)0U, (size_t)2U, (size_t)1U,
+      libcrux_ml_kem_polynomial_PolynomialRingElement_f6 repeat_expression[2U];
+      KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U,
+                      repeat_expression[i] = ZERO_ef_79(););
+      memcpy(repeat_expression0[i0], repeat_expression,
+             (size_t)2U *
+                 sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6)););
+  memcpy(lit.A, repeat_expression0,
+         (size_t)2U *
+             sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_f6[2U]));
   return lit;
 }
 

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "internal/libcrux_mlkem_avx2.h"
@@ -16,6 +16,10 @@
 #include "internal/libcrux_core.h"
 #include "internal/libcrux_mlkem_portable.h"
 #include "internal/libcrux_sha3_avx2.h"
+#include "libcrux_core.h"
+#include "libcrux_mlkem_portable.h"
+#include "libcrux_sha3.h"
+#include "libcrux_sha3_avx2.h"
 
 KRML_MUSTINLINE void libcrux_ml_kem_hash_functions_avx2_G(Eurydice_slice input,
                                                           uint8_t ret[64U]) {

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem_avx2_H

--- a/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem_avx2_H
@@ -19,10 +19,7 @@ extern "C" {
 #endif
 
 #include "eurydice_glue.h"
-#include "libcrux_core.h"
-#include "libcrux_mlkem_portable.h"
-#include "libcrux_sha3.h"
-#include "libcrux_sha3_avx2.h"
+#include "intrinsics/libcrux_intrinsics_avx2.h"
 
 void libcrux_ml_kem_hash_functions_avx2_G(Eurydice_slice input,
                                           uint8_t ret[64U]);

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.c
@@ -4,17 +4,20 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "internal/libcrux_mlkem_portable.h"
 
 #include "internal/libcrux_core.h"
 #include "internal/libcrux_sha3_internal.h"
+#include "libcrux_core.h"
+#include "libcrux_sha3.h"
+#include "libcrux_sha3_internal.h"
 
 KRML_MUSTINLINE void libcrux_ml_kem_hash_functions_portable_G(
     Eurydice_slice input, uint8_t ret[64U]) {
@@ -2312,46 +2315,16 @@ KRML_MUSTINLINE size_t libcrux_ml_kem_vector_portable_sampling_rej_sample(
                                                uint8_t, uint8_t *);
     int16_t d1 = (b2 & (int16_t)15) << 8U | b1;
     int16_t d2 = b3 << 4U | b2 >> 4U;
-    bool uu____0;
-    int16_t uu____1;
-    bool uu____2;
-    size_t uu____3;
-    int16_t uu____4;
-    size_t uu____5;
-    int16_t uu____6;
     if (d1 < LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS) {
       if (sampled < (size_t)16U) {
         Eurydice_slice_index(result, sampled, int16_t, int16_t *) = d1;
         sampled++;
-        uu____1 = d2;
-        uu____6 = LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS;
-        uu____0 = uu____1 < uu____6;
-        if (uu____0) {
-          uu____3 = sampled;
-          uu____2 = uu____3 < (size_t)16U;
-          if (uu____2) {
-            uu____4 = d2;
-            uu____5 = sampled;
-            Eurydice_slice_index(result, uu____5, int16_t, int16_t *) = uu____4;
-            sampled++;
-            continue;
-          }
-        }
-        continue;
       }
     }
-    uu____1 = d2;
-    uu____6 = LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS;
-    uu____0 = uu____1 < uu____6;
-    if (uu____0) {
-      uu____3 = sampled;
-      uu____2 = uu____3 < (size_t)16U;
-      if (uu____2) {
-        uu____4 = d2;
-        uu____5 = sampled;
-        Eurydice_slice_index(result, uu____5, int16_t, int16_t *) = uu____4;
+    if (d2 < LIBCRUX_ML_KEM_VECTOR_TRAITS_FIELD_MODULUS) {
+      if (sampled < (size_t)16U) {
+        Eurydice_slice_index(result, sampled, int16_t, int16_t *) = d2;
         sampled++;
-        continue;
       }
     }
   }

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.c
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "internal/libcrux_mlkem_portable.h"
@@ -856,22 +856,8 @@ const uint8_t
 KRML_MUSTINLINE libcrux_ml_kem_vector_portable_vector_type_PortableVector
 libcrux_ml_kem_vector_portable_vector_type_zero(void) {
   libcrux_ml_kem_vector_portable_vector_type_PortableVector lit;
-  lit.elements[0U] = (int16_t)0;
-  lit.elements[1U] = (int16_t)0;
-  lit.elements[2U] = (int16_t)0;
-  lit.elements[3U] = (int16_t)0;
-  lit.elements[4U] = (int16_t)0;
-  lit.elements[5U] = (int16_t)0;
-  lit.elements[6U] = (int16_t)0;
-  lit.elements[7U] = (int16_t)0;
-  lit.elements[8U] = (int16_t)0;
-  lit.elements[9U] = (int16_t)0;
-  lit.elements[10U] = (int16_t)0;
-  lit.elements[11U] = (int16_t)0;
-  lit.elements[12U] = (int16_t)0;
-  lit.elements[13U] = (int16_t)0;
-  lit.elements[14U] = (int16_t)0;
-  lit.elements[15U] = (int16_t)0;
+  int16_t repeat_expression[16U] = {0U};
+  memcpy(lit.elements, repeat_expression, (size_t)16U * sizeof(int16_t));
   return lit;
 }
 
@@ -2373,22 +2359,14 @@ with const generics
 */
 static libcrux_ml_kem_polynomial_PolynomialRingElement_1d ZERO_ef_96(void) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_1d lit;
-  lit.coefficients[0U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[1U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[2U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[3U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[4U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[5U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[6U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[7U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[8U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[9U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[10U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[11U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[12U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[13U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[14U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[15U] = libcrux_ml_kem_vector_portable_ZERO_2c();
+  libcrux_ml_kem_vector_portable_vector_type_PortableVector
+      repeat_expression[16U];
+  KRML_MAYBE_FOR16(
+      i, (size_t)0U, (size_t)16U, (size_t)1U,
+      repeat_expression[i] = libcrux_ml_kem_vector_portable_ZERO_2c(););
+  memcpy(lit.coefficients, repeat_expression,
+         (size_t)16U *
+             sizeof(libcrux_ml_kem_vector_portable_vector_type_PortableVector));
   return lit;
 }
 
@@ -2750,10 +2728,12 @@ with const generics
 */
 static IndCpaPrivateKeyUnpacked_af default_1a_d0(void) {
   IndCpaPrivateKeyUnpacked_af lit;
-  lit.secret_as_ntt[0U] = ZERO_ef_96();
-  lit.secret_as_ntt[1U] = ZERO_ef_96();
-  lit.secret_as_ntt[2U] = ZERO_ef_96();
-  lit.secret_as_ntt[3U] = ZERO_ef_96();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_1d repeat_expression[4U];
+  KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U,
+                  repeat_expression[i] = ZERO_ef_96(););
+  memcpy(
+      lit.secret_as_ntt, repeat_expression,
+      (size_t)4U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d));
   return lit;
 }
 
@@ -2790,22 +2770,18 @@ static IndCpaPublicKeyUnpacked_af default_8d_d0(void) {
       lit.t_as_ntt, uu____0,
       (size_t)4U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d));
   memcpy(lit.seed_for_A, uu____1, (size_t)32U * sizeof(uint8_t));
-  lit.A[0U][0U] = ZERO_ef_96();
-  lit.A[0U][1U] = ZERO_ef_96();
-  lit.A[0U][2U] = ZERO_ef_96();
-  lit.A[0U][3U] = ZERO_ef_96();
-  lit.A[1U][0U] = ZERO_ef_96();
-  lit.A[1U][1U] = ZERO_ef_96();
-  lit.A[1U][2U] = ZERO_ef_96();
-  lit.A[1U][3U] = ZERO_ef_96();
-  lit.A[2U][0U] = ZERO_ef_96();
-  lit.A[2U][1U] = ZERO_ef_96();
-  lit.A[2U][2U] = ZERO_ef_96();
-  lit.A[2U][3U] = ZERO_ef_96();
-  lit.A[3U][0U] = ZERO_ef_96();
-  lit.A[3U][1U] = ZERO_ef_96();
-  lit.A[3U][2U] = ZERO_ef_96();
-  lit.A[3U][3U] = ZERO_ef_96();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_1d repeat_expression0[4U][4U];
+  KRML_MAYBE_FOR4(
+      i0, (size_t)0U, (size_t)4U, (size_t)1U,
+      libcrux_ml_kem_polynomial_PolynomialRingElement_1d repeat_expression[4U];
+      KRML_MAYBE_FOR4(i, (size_t)0U, (size_t)4U, (size_t)1U,
+                      repeat_expression[i] = ZERO_ef_96(););
+      memcpy(repeat_expression0[i0], repeat_expression,
+             (size_t)4U *
+                 sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d)););
+  memcpy(lit.A, repeat_expression0,
+         (size_t)4U *
+             sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d[4U]));
   return lit;
 }
 
@@ -3133,22 +3109,14 @@ with const generics
 */
 static libcrux_ml_kem_polynomial_PolynomialRingElement_1d ZERO_96(void) {
   libcrux_ml_kem_polynomial_PolynomialRingElement_1d lit;
-  lit.coefficients[0U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[1U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[2U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[3U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[4U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[5U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[6U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[7U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[8U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[9U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[10U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[11U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[12U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[13U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[14U] = libcrux_ml_kem_vector_portable_ZERO_2c();
-  lit.coefficients[15U] = libcrux_ml_kem_vector_portable_ZERO_2c();
+  libcrux_ml_kem_vector_portable_vector_type_PortableVector
+      repeat_expression[16U];
+  KRML_MAYBE_FOR16(
+      i, (size_t)0U, (size_t)16U, (size_t)1U,
+      repeat_expression[i] = libcrux_ml_kem_vector_portable_ZERO_2c(););
+  memcpy(lit.coefficients, repeat_expression,
+         (size_t)16U *
+             sizeof(libcrux_ml_kem_vector_portable_vector_type_PortableVector));
   return lit;
 }
 
@@ -6113,8 +6081,12 @@ with const generics
 */
 static IndCpaPrivateKeyUnpacked_d4 default_1a_a0(void) {
   IndCpaPrivateKeyUnpacked_d4 lit;
-  lit.secret_as_ntt[0U] = ZERO_ef_96();
-  lit.secret_as_ntt[1U] = ZERO_ef_96();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_1d repeat_expression[2U];
+  KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U,
+                  repeat_expression[i] = ZERO_ef_96(););
+  memcpy(
+      lit.secret_as_ntt, repeat_expression,
+      (size_t)2U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d));
   return lit;
 }
 
@@ -6151,10 +6123,18 @@ static IndCpaPublicKeyUnpacked_d4 default_8d_a0(void) {
       lit.t_as_ntt, uu____0,
       (size_t)2U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d));
   memcpy(lit.seed_for_A, uu____1, (size_t)32U * sizeof(uint8_t));
-  lit.A[0U][0U] = ZERO_ef_96();
-  lit.A[0U][1U] = ZERO_ef_96();
-  lit.A[1U][0U] = ZERO_ef_96();
-  lit.A[1U][1U] = ZERO_ef_96();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_1d repeat_expression0[2U][2U];
+  KRML_MAYBE_FOR2(
+      i0, (size_t)0U, (size_t)2U, (size_t)1U,
+      libcrux_ml_kem_polynomial_PolynomialRingElement_1d repeat_expression[2U];
+      KRML_MAYBE_FOR2(i, (size_t)0U, (size_t)2U, (size_t)1U,
+                      repeat_expression[i] = ZERO_ef_96(););
+      memcpy(repeat_expression0[i0], repeat_expression,
+             (size_t)2U *
+                 sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d)););
+  memcpy(lit.A, repeat_expression0,
+         (size_t)2U *
+             sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d[2U]));
   return lit;
 }
 
@@ -8196,9 +8176,12 @@ with const generics
 */
 static IndCpaPrivateKeyUnpacked_a0 default_1a_1b(void) {
   IndCpaPrivateKeyUnpacked_a0 lit;
-  lit.secret_as_ntt[0U] = ZERO_ef_96();
-  lit.secret_as_ntt[1U] = ZERO_ef_96();
-  lit.secret_as_ntt[2U] = ZERO_ef_96();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_1d repeat_expression[3U];
+  KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U,
+                  repeat_expression[i] = ZERO_ef_96(););
+  memcpy(
+      lit.secret_as_ntt, repeat_expression,
+      (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d));
   return lit;
 }
 
@@ -8235,15 +8218,18 @@ static IndCpaPublicKeyUnpacked_a0 default_8d_1b(void) {
       lit.t_as_ntt, uu____0,
       (size_t)3U * sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d));
   memcpy(lit.seed_for_A, uu____1, (size_t)32U * sizeof(uint8_t));
-  lit.A[0U][0U] = ZERO_ef_96();
-  lit.A[0U][1U] = ZERO_ef_96();
-  lit.A[0U][2U] = ZERO_ef_96();
-  lit.A[1U][0U] = ZERO_ef_96();
-  lit.A[1U][1U] = ZERO_ef_96();
-  lit.A[1U][2U] = ZERO_ef_96();
-  lit.A[2U][0U] = ZERO_ef_96();
-  lit.A[2U][1U] = ZERO_ef_96();
-  lit.A[2U][2U] = ZERO_ef_96();
+  libcrux_ml_kem_polynomial_PolynomialRingElement_1d repeat_expression0[3U][3U];
+  KRML_MAYBE_FOR3(
+      i0, (size_t)0U, (size_t)3U, (size_t)1U,
+      libcrux_ml_kem_polynomial_PolynomialRingElement_1d repeat_expression[3U];
+      KRML_MAYBE_FOR3(i, (size_t)0U, (size_t)3U, (size_t)1U,
+                      repeat_expression[i] = ZERO_ef_96(););
+      memcpy(repeat_expression0[i0], repeat_expression,
+             (size_t)3U *
+                 sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d)););
+  memcpy(lit.A, repeat_expression0,
+         (size_t)3U *
+             sizeof(libcrux_ml_kem_polynomial_PolynomialRingElement_1d[3U]));
   return lit;
 }
 

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_mlkem_portable_H
@@ -19,9 +19,6 @@ extern "C" {
 #endif
 
 #include "eurydice_glue.h"
-#include "libcrux_core.h"
-#include "libcrux_sha3.h"
-#include "libcrux_sha3_internal.h"
 
 void libcrux_ml_kem_hash_functions_portable_G(Eurydice_slice input,
                                               uint8_t ret[64U]);

--- a/libcrux-ml-kem/c/libcrux_mlkem_portable.h
+++ b/libcrux-ml-kem/c/libcrux_mlkem_portable.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_mlkem_portable_H

--- a/libcrux-ml-kem/c/libcrux_sha3.h
+++ b/libcrux-ml-kem/c/libcrux_sha3.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_sha3_H

--- a/libcrux-ml-kem/c/libcrux_sha3.h
+++ b/libcrux-ml-kem/c/libcrux_sha3.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_sha3_H

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.c
@@ -4,16 +4,18 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "internal/libcrux_sha3_avx2.h"
 
 #include "internal/libcrux_core.h"
+#include "libcrux_core.h"
+#include "libcrux_sha3_internal.h"
 
 /**
 This function found in impl {(libcrux_sha3::traits::internal::KeccakItem<4:

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "internal/libcrux_sha3_avx2.h"
@@ -180,31 +180,14 @@ with const generics
 static KRML_MUSTINLINE libcrux_sha3_generic_keccak_KeccakState_55
 new_89_a6(void) {
   libcrux_sha3_generic_keccak_KeccakState_55 lit;
-  lit.st[0U][0U] = zero_ef();
-  lit.st[0U][1U] = zero_ef();
-  lit.st[0U][2U] = zero_ef();
-  lit.st[0U][3U] = zero_ef();
-  lit.st[0U][4U] = zero_ef();
-  lit.st[1U][0U] = zero_ef();
-  lit.st[1U][1U] = zero_ef();
-  lit.st[1U][2U] = zero_ef();
-  lit.st[1U][3U] = zero_ef();
-  lit.st[1U][4U] = zero_ef();
-  lit.st[2U][0U] = zero_ef();
-  lit.st[2U][1U] = zero_ef();
-  lit.st[2U][2U] = zero_ef();
-  lit.st[2U][3U] = zero_ef();
-  lit.st[2U][4U] = zero_ef();
-  lit.st[3U][0U] = zero_ef();
-  lit.st[3U][1U] = zero_ef();
-  lit.st[3U][2U] = zero_ef();
-  lit.st[3U][3U] = zero_ef();
-  lit.st[3U][4U] = zero_ef();
-  lit.st[4U][0U] = zero_ef();
-  lit.st[4U][1U] = zero_ef();
-  lit.st[4U][2U] = zero_ef();
-  lit.st[4U][3U] = zero_ef();
-  lit.st[4U][4U] = zero_ef();
+  __m256i repeat_expression0[5U][5U];
+  KRML_MAYBE_FOR5(i0, (size_t)0U, (size_t)5U, (size_t)1U,
+                  __m256i repeat_expression[5U];
+                  KRML_MAYBE_FOR5(i, (size_t)0U, (size_t)5U, (size_t)1U,
+                                  repeat_expression[i] = zero_ef(););
+                  memcpy(repeat_expression0[i0], repeat_expression,
+                         (size_t)5U * sizeof(__m256i)););
+  memcpy(lit.st, repeat_expression0, (size_t)5U * sizeof(__m256i[5U]));
   return lit;
 }
 

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_sha3_avx2_H
@@ -20,8 +20,6 @@ extern "C" {
 
 #include "eurydice_glue.h"
 #include "intrinsics/libcrux_intrinsics_avx2.h"
-#include "libcrux_core.h"
-#include "libcrux_sha3_internal.h"
 
 /**
 A monomorphic instance of libcrux_sha3.generic_keccak.KeccakState

--- a/libcrux-ml-kem/c/libcrux_sha3_avx2.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_avx2.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_sha3_avx2_H

--- a/libcrux-ml-kem/c/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_internal.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_sha3_internal_H

--- a/libcrux-ml-kem/c/libcrux_sha3_internal.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_internal.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_sha3_internal_H
@@ -203,31 +203,15 @@ with const generics
 static KRML_MUSTINLINE libcrux_sha3_generic_keccak_KeccakState_17
 libcrux_sha3_generic_keccak_new_89_04(void) {
   libcrux_sha3_generic_keccak_KeccakState_17 lit;
-  lit.st[0U][0U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[0U][1U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[0U][2U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[0U][3U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[0U][4U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[1U][0U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[1U][1U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[1U][2U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[1U][3U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[1U][4U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[2U][0U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[2U][1U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[2U][2U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[2U][3U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[2U][4U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[3U][0U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[3U][1U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[3U][2U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[3U][3U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[3U][4U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[4U][0U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[4U][1U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[4U][2U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[4U][3U] = libcrux_sha3_portable_keccak_zero_5a();
-  lit.st[4U][4U] = libcrux_sha3_portable_keccak_zero_5a();
+  uint64_t repeat_expression0[5U][5U];
+  KRML_MAYBE_FOR5(
+      i0, (size_t)0U, (size_t)5U, (size_t)1U, uint64_t repeat_expression[5U];
+      KRML_MAYBE_FOR5(
+          i, (size_t)0U, (size_t)5U, (size_t)1U,
+          repeat_expression[i] = libcrux_sha3_portable_keccak_zero_5a(););
+      memcpy(repeat_expression0[i0], repeat_expression,
+             (size_t)5U * sizeof(uint64_t)););
+  memcpy(lit.st, repeat_expression0, (size_t)5U * sizeof(uint64_t[5U]));
   return lit;
 }
 

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.c
@@ -4,14 +4,16 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #include "libcrux_sha3_neon.h"
+
+#include "libcrux_sha3_internal.h"
 
 /**
  A portable SHA3 224 implementation.

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.c
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.c
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #include "libcrux_sha3_neon.h"

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.h
@@ -5,10 +5,10 @@
  *
  * This code was generated with the following revisions:
  * Charon: 30cab88265206f4fa849736e704983e39a404d96
- * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
- * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * Eurydice: c56c8e9064adf185d0b238410ad26c7cacad5ea9
+ * Karamel: 9d54cd127aa59cc88e399a0247b4091d1819909b
  * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
- * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
+ * Libcrux: 62dc8d63df5a2c0d0008ef12cf7d98d7c53a8feb
  */
 
 #ifndef __libcrux_sha3_neon_H

--- a/libcrux-ml-kem/c/libcrux_sha3_neon.h
+++ b/libcrux-ml-kem/c/libcrux_sha3_neon.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT or Apache-2.0
  *
  * This code was generated with the following revisions:
- * Charon: db4e045d4597d06d854ce7a2c10e8dcfda6ecd25
- * Eurydice: 75eae2e2534a16f5ba5430e6ee5c69d8a46f3bea
- * Karamel: 3823e3d82fa0b271d799b61c59ffb4742ddc1e65
- * F*: b0961063393215ca65927f017720cb365a193833-dirty
- * Libcrux: 834b7f51701fa4e8695a784c138ed230f49f0c4e
+ * Charon: 30cab88265206f4fa849736e704983e39a404d96
+ * Eurydice: e1ef8138cb02de6d110aa5d2d2ad6c2d07c3a6b4
+ * Karamel: e098c05f84f94f665d40f86afbfde281e4fdd523
+ * F*: ef93b7d15a315f3eb0864cb7bb93074582524e2a
+ * Libcrux: 59fcb15a95eb34a4e4776aa96505d2ea078c0d5c
  */
 
 #ifndef __libcrux_sha3_neon_H


### PR DESCRIPTION
The latest changes in krml/eurydice generate more precise header inclusion, meaning the mlkem avx2 public header no longer includes the sha3 avx2 public header (this is not necessary: only the mlkem avx2 C file needs that header), meaning that the intrinsics need to be directly included from the mlkem avx2 public header.