### PR TITLE
Fix randomness consumption in XWing draft 2 implementation

### DIFF
--- a/src/hpke/hpke.rs
+++ b/src/hpke/hpke.rs
@@ -446,7 +446,7 @@ pub fn SetupBaseS(
                     .map_err(|_| HpkeError::EncapError)?,
             );
             let ek_x = libcrux_ecdh::X25519PrivateKey(
-                randomness[..32]
+                randomness[32..64]
                     .try_into()
                     .map_err(|_| HpkeError::EncapError)?,
             );

--- a/tests/xwing_kem.rs
+++ b/tests/xwing_kem.rs
@@ -65,7 +65,7 @@ fn xwing_hpke_selftest() {
     let aad = b"xwing hpke selftest aad";
     let ptxt = b"xwing hpke selftest plaintext";
 
-    let mut randomness = vec![0u8; 32];
+    let mut randomness = vec![0u8; 64];
     rng.fill_bytes(&mut randomness);
 
     let HPKECiphertext(enc, ct) =


### PR DESCRIPTION
Both in version 2 and in version 6 (the current version at the time of writing), encap of XWing should take 64 bytes of randomness, where it uses the first 32 bytes for ML-KEM and the second 32 bytes for X25519. Right now, it uses the first 32 bytes for both ML-KEM _and_ X25519. This PR fixes that.