### PR TITLE
Update `rand` and `rand_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ libcrux-ed25519 = { version = "=0.0.2-beta.2", path = "ed25519" }
 libcrux-ecdh = { version = "=0.0.2-beta.2", path = "libcrux-ecdh" }
 libcrux-ml-kem = { version = "=0.0.2-beta.2", path = "libcrux-ml-kem" }
 libcrux-kem = { version = "=0.0.2-beta.2", path = "libcrux-kem" }
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 log = { version = "0.4", optional = true }
 # WASM API
 wasm-bindgen = { version = "0.2.87", optional = true }
@@ -93,7 +93,7 @@ hax-lib = { version = "0.1.0", git = "https://github.com/hacspec/hax/" }
 [dev-dependencies]
 libcrux = { path = ".", features = ["rand", "tests"] }
 pretty_env_logger = "0.5"
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 rand_core = { version = "0.6" }
 quickcheck = "1"
 quickcheck_macros = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ hax-lib = { version = "0.1.0", git = "https://github.com/hacspec/hax/" }
 libcrux = { path = ".", features = ["rand", "tests"] }
 pretty_env_logger = "0.5"
 rand = { version = "0.9" }
-rand_core = { version = "0.6" }
+rand_core = { version = "0.9" }
 quickcheck = "1"
 quickcheck_macros = "1"
 serde_json = { version = "1.0" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -19,7 +19,7 @@ rand = { version = "0.9" }
 libcrux = { path = "../", features = ["rand", "tests"] }
 libcrux-kem = { path = "../libcrux-kem", features = ["tests"] }
 libcrux-ml-kem = { path = "../libcrux-ml-kem" }
-rand_core = { version = "0.6" }
+rand_core = { version = "0.9" }
 # Benchmarking "RustCrypto"
 chacha20poly1305 = "0.10"
 sha2 = "0.10"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 bench = false # so libtest doesn't eat the arguments for criterion
 
 [dependencies]
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 
 [dev-dependencies]
 libcrux = { path = "../", features = ["rand", "tests"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 
 [dependencies.libcrux]
 path = "../"

--- a/fuzz/fuzz_targets/fuzz_rng.rs
+++ b/fuzz/fuzz_targets/fuzz_rng.rs
@@ -34,11 +34,6 @@ impl RngCore for FuzzRng {
         dest.copy_from_slice(&self.data[0..dest.len()]);
         self.data = self.data.drain(dest.len()..).collect();
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
 
 impl CryptoRng for FuzzRng {}

--- a/libcrux-ecdh/Cargo.toml
+++ b/libcrux-ecdh/Cargo.toml
@@ -13,7 +13,7 @@ description = "Libcrux ECDH implementation"
 path = "src/ecdh.rs"
 
 [dependencies]
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 libcrux-hacl = { version = "=0.0.2-beta.2", path = "../sys/hacl" }
 libcrux-curve25519 = { version = "=0.0.2-beta.2", path = "../curve25519" }
 

--- a/libcrux-ecdh/Cargo.toml
+++ b/libcrux-ecdh/Cargo.toml
@@ -18,7 +18,7 @@ libcrux-hacl = { version = "=0.0.2-beta.2", path = "../sys/hacl" }
 libcrux-curve25519 = { version = "=0.0.2-beta.2", path = "../curve25519" }
 
 [dev-dependencies]
-rand_core = { version = "0.6" }
+rand_core = { version = "0.9" }
 hex = { version = "0.4.3", features = ["serde"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/libcrux-ecdh/src/ecdh.rs
+++ b/libcrux-ecdh/src/ecdh.rs
@@ -52,7 +52,7 @@ pub enum Algorithm {
 
 pub(crate) mod x25519_internal {
     use alloc::format;
-    use rand::{CryptoRng, Rng};
+    use rand::{CryptoRng, Rng, TryRngCore};
 
     use super::Error;
 
@@ -257,7 +257,7 @@ pub mod curve25519 {
 
 pub(crate) mod p256_internal {
     use alloc::format;
-    use rand::{CryptoRng, Rng};
+    use rand::{CryptoRng, Rng, TryRngCore};
 
     // P256 we only have in HACL
     use crate::hacl::p256;

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/kem.rs"
 libcrux-ml-kem = { version = "=0.0.2-beta.2", path = "../libcrux-ml-kem" }
 libcrux-sha3 = { version = "=0.0.2-beta.2", path = "../libcrux-sha3" }
 libcrux-ecdh = { version = "=0.0.2-beta.2", path = "../libcrux-ecdh" }
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 
 [features]
 tests = []                       # Expose functions for testing.

--- a/libcrux-kem/src/kem.rs
+++ b/libcrux-kem/src/kem.rs
@@ -36,7 +36,7 @@ extern crate alloc;
 
 use alloc::{vec, vec::Vec};
 
-use rand::{CryptoRng, Rng};
+use rand::{CryptoRng, Rng, TryRngCore};
 
 use libcrux_ecdh::{p256_derive, x25519_derive};
 use libcrux_ecdh::{

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -23,7 +23,7 @@ libcrux-macros = { version = "0.0.2-beta.2", path = "../macros" }
 hax-lib = { version = "0.1.0", git = "https://github.com/hacspec/hax/"}
 
 [dev-dependencies]
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 hex = { version = "0.4.3", features = ["serde"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 bench = false # so libtest doesn't eat the arguments to criterion
 
 [dependencies]
-rand = { version = "0.8", optional = true }
+rand = { version = "0.9", optional = true }
 libcrux-platform = { version = "0.0.2-beta.2", path = "../sys/platform" }
 libcrux-sha3 = { version = "0.0.2-beta.2", path = "../libcrux-sha3" }
 libcrux-intrinsics = { version = "0.0.2-beta.2", path = "../libcrux-intrinsics" }
@@ -53,7 +53,7 @@ rand = ["dep:rand"]
 std = []
 
 [dev-dependencies]
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 hex = { version = "0.4.3", features = ["serde"] }

--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -21,7 +21,7 @@ classic-mceliece-rust = { version = "2.0.0", features = [
     "mceliece460896f",
     "zeroize",
 ] }
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 libcrux-ecdh = { version = "0.0.2-beta.2", path = "../libcrux-ecdh" }
 libcrux = { version = "0.0.2-beta.2", path = ".." }
 

--- a/libcrux-sha3/Cargo.toml
+++ b/libcrux-sha3/Cargo.toml
@@ -33,7 +33,7 @@ harness = false
 [dev-dependencies]
 criterion = "0.5.1"
 hex = "0.4.3"
-rand = "0.8.5"
+rand = "0.9.0"
 cavp = { version = "0.0.2-beta.2", path = "../cavp" }
 pretty_env_logger = "0.5.0"
 

--- a/src/drbg.rs
+++ b/src/drbg.rs
@@ -193,10 +193,6 @@ impl RngCore for Drbg {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.generate(dest).unwrap()
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.generate(dest).map_err(rand::Error::new)
-    }
 }
 
 impl CryptoRng for Drbg {}

--- a/src/drbg.rs
+++ b/src/drbg.rs
@@ -16,8 +16,8 @@ pub enum Error {
     UnsupportedAlgorithm,
     /// Unable to generate the requested randomness.
     UnableToGenerate,
-    /// Not enough randomness available, e.g. to initialize or reseed
-    InsufficientRandomness,
+    /// Not enough OS randomness available, e.g. to initialize or reseed
+    InsufficientOSRandomness,
 }
 
 impl fmt::Display for Error {
@@ -48,7 +48,7 @@ impl Drbg {
         let mut entropy = [0u8; 16];
         rand::rngs::OsRng
             .try_fill_bytes(&mut entropy)
-            .map_err(|_| Error::InsufficientRandomness)?;
+            .map_err(|_| Error::InsufficientOSRandomness)?;
         Self::personalized(alg, &entropy, &[], "os seeded libcrux")
     }
 
@@ -94,7 +94,7 @@ impl Drbg {
             let mut entropy = [0u8; 16];
             rand::rngs::OsRng
                 .try_fill_bytes(&mut entropy)
-                .map_err(|_| Error::InsufficientRandomness)?;
+                .map_err(|_| Error::InsufficientOSRandomness)?;
             self.reseed(&entropy, b"reseed")?;
             self.ctr = 0;
         } else {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -10,7 +10,7 @@ use crate::{
     ecdh,
     hacl::{self, ed25519},
 };
-use rand::{CryptoRng, Rng, RngCore};
+use rand::{CryptoRng, Rng, RngCore, TryRngCore};
 
 use self::rsa_pss::RsaPssSignature;
 

--- a/tests/xwing_kem.rs
+++ b/tests/xwing_kem.rs
@@ -16,7 +16,7 @@ use libcrux::{
 
 #[cfg(not(target_arch = "wasm32"))]
 use libcrux::drbg;
-use rand::{CryptoRng, Error};
+use rand::CryptoRng;
 #[cfg(target_arch = "wasm32")]
 use rand_core::OsRng;
 use rand_core::RngCore;

--- a/tests/xwing_kem.rs
+++ b/tests/xwing_kem.rs
@@ -251,11 +251,6 @@ impl RngCore for DeterministicRng {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.fill_with_data(dest);
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_with_data(dest);
-        Ok(())
-    }
 }
 
 impl CryptoRng for DeterministicRng {}


### PR DESCRIPTION
This pull request updates the dependencies `rand` from 0.8 -> 0.9 and `rand_core` from 0.6 -> 0.9. It is based on dependabot's PRs (see #787 and #786).

- Use new trait `TryRngCore` where necessary
- Use `OsRng::try_fill_bytes()` instead of `OsRng::fill_bytes()`, which was removed. Also, to handle the case where `try_fill_bytes()` returns an error, add an `Error::InsufficientOSRandomness` variant