### PR TITLE
Add status at the end of `c.yml` workflow run

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -31,7 +31,13 @@ jobs:
 
   report-status-tests:
     runs-on: ubuntu-latest
-    needs: [diff, diff-header-only-ml-dsa, diff-header-only-ml-kem, build, build-header-only-ml-dsa, build-header-only-ml-kem]
+    needs:
+      - diff
+      - diff-header-only-ml-dsa
+      - diff-header-only-ml-kem
+      - build
+      - build-header-only-ml-dsa
+      - build-header-only-ml-kem
     steps:
       - name: Report status
         run: echo "All tests completed successfully"

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -29,6 +29,23 @@ jobs:
       # only run if files in `.docker/c/` unchanged
       should-run: ${{ steps.changes.outputs.docker-c == 'false' }}
 
+  report-status-tests:
+    runs-on: ubuntu-latest
+    needs: [diff, diff-header-only-ml-dsa, diff-header-only-ml-kem, build, build-header-only-ml-dsa, build-header-only-ml-kem]
+    steps:
+      - name: Report status
+        run: echo "All tests completed successfully"
+
+  report-status-all:
+    runs-on: ubuntu-latest
+    needs: [report-status-tests]
+    # run if all the tests succeeded, or...
+    # ...if they were not supposed to run.
+    if: ${{ always() && needs.report-status-tests.result == 'success' || needs.report-status-tests.result == 'skipped'}}
+    steps:
+      - name: Report status
+        run: echo "Tests completed successfully or were skipped"
+
   extract:
     needs: [setup]
     if: ${{ needs.setup.outputs.should-run == 'true' }}


### PR DESCRIPTION
This PR modifies the `c.yml` Github Actions workflow, adding a job (`report-status-all`) that returns a 'success' status if all of the tests ran successfully, or if they were skipped. This allows completion of this workflow to be easily required as a status check in the branch protection rules.

* Also adds an intermediate job (`report-status-tests`) that checks if all tests ran successfully.