### PR TITLE
Update benchmarks to use `libcrux_ecdh` API

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -17,6 +17,7 @@ rand = { version = "0.8" }
 
 [dev-dependencies]
 libcrux = { path = "../", features = ["rand", "tests"] }
+libcrux-ecdh = { path = "../libcrux-ecdh" }
 libcrux-kem = { path = "../libcrux-kem", features = ["tests"] }
 libcrux-ml-kem = { path = "../libcrux-ml-kem" }
 libcrux-sha2 = { path = "../sha2" }

--- a/benchmarks/benches/p256.rs
+++ b/benchmarks/benches/p256.rs
@@ -1,5 +1,4 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use libcrux::ecdh;
 
 use rand_core::OsRng;
 
@@ -10,12 +9,14 @@ fn derive(c: &mut Criterion) {
     group.bench_function("libcrux", |b| {
         b.iter_batched(
             || {
-                let (_, pk1) = ecdh::key_gen(ecdh::Algorithm::P256, &mut OsRng).unwrap();
-                let (sk2, _) = ecdh::key_gen(ecdh::Algorithm::P256, &mut OsRng).unwrap();
+                let (_, pk1) =
+                    libcrux_ecdh::key_gen(libcrux_ecdh::Algorithm::P256, &mut OsRng).unwrap();
+                let (sk2, _) =
+                    libcrux_ecdh::key_gen(libcrux_ecdh::Algorithm::P256, &mut OsRng).unwrap();
                 (pk1, sk2)
             },
             |(pk1, sk2)| {
-                let _zz = ecdh::derive(ecdh::Algorithm::P256, &pk1, &sk2).unwrap();
+                let _zz = libcrux_ecdh::derive(libcrux_ecdh::Algorithm::P256, &pk1, &sk2).unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -72,11 +73,13 @@ fn secret_to_public(c: &mut Criterion) {
     group.bench_function("libcrux", |b| {
         b.iter_batched(
             || {
-                let (sk, _) = ecdh::key_gen(ecdh::Algorithm::P256, &mut OsRng).unwrap();
+                let (sk, _) =
+                    libcrux_ecdh::key_gen(libcrux_ecdh::Algorithm::P256, &mut OsRng).unwrap();
                 sk
             },
             |sk| {
-                let _pk = ecdh::secret_to_public(ecdh::Algorithm::P256, &sk).unwrap();
+                let _pk =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::P256, &sk).unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/benchmarks/benches/x25519.rs
+++ b/benchmarks/benches/x25519.rs
@@ -1,5 +1,4 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use libcrux::ecdh;
 
 use benchmarks::util::*;
 use rand::RngCore;
@@ -12,12 +11,14 @@ fn derive(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let sk1 = randombytes(32);
-                let pk1 = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk1).unwrap();
+                let pk1 =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk1).unwrap();
                 let sk2 = randombytes(32);
                 (pk1, sk2)
             },
             |(pk1, sk2)| {
-                let _zz = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &sk2).unwrap();
+                let _zz =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &sk2).unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -151,7 +152,8 @@ fn secret_to_public(c: &mut Criterion) {
                 sk
             },
             |sk| {
-                let _pk = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk).unwrap();
+                let _pk =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk).unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -251,7 +253,8 @@ fn nym_outfox_create(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let sk1 = randombytes(32);
-                let pk1 = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk1).unwrap();
+                let pk1 =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk1).unwrap();
                 let sk2a = randombytes(32);
                 let sk2b = randombytes(32);
                 let sk2c = randombytes(32);
@@ -259,14 +262,22 @@ fn nym_outfox_create(c: &mut Criterion) {
                 (pk1, sk2a, sk2b, sk2c, sk2d)
             },
             |(pk1, sk2a, sk2b, sk2c, sk2d)| {
-                let _pk2a = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk2a).unwrap();
-                let _pk2b = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk2b).unwrap();
-                let _pk2c = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk2c).unwrap();
-                let _pk2d = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk2d).unwrap();
-                let _zza = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &sk2a).unwrap();
-                let _zzb = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &sk2b).unwrap();
-                let _zzc = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &sk2c).unwrap();
-                let _zzd = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &sk2d).unwrap();
+                let _pk2a =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk2a).unwrap();
+                let _pk2b =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk2b).unwrap();
+                let _pk2c =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk2c).unwrap();
+                let _pk2d =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk2d).unwrap();
+                let _zza =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &sk2a).unwrap();
+                let _zzb =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &sk2b).unwrap();
+                let _zzc =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &sk2c).unwrap();
+                let _zzd =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &sk2d).unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -494,12 +505,14 @@ fn nym_outfox_process(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let sk1 = randombytes(32);
-                let pk1 = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk1).unwrap();
+                let pk1 =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk1).unwrap();
                 let sk2 = randombytes(32);
                 (pk1, sk2)
             },
             |(pk1, sk2)| {
-                let _zz = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &sk2).unwrap();
+                let _zz =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &sk2).unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -630,19 +643,28 @@ fn nym_sphinx_create(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let sk1 = randombytes(32);
-                let pk1 = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk1).unwrap();
+                let pk1 =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk1).unwrap();
                 let sk2 = randombytes(32);
                 (pk1, sk2)
             },
             |(pk1, sk2)| {
-                let _pk2a = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk2).unwrap();
-                let zza = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &sk2).unwrap();
-                let _pk2b = ecdh::secret_to_public(ecdh::Algorithm::X25519, &zza).unwrap();
-                let zzb = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &zza).unwrap();
-                let _pk2c = ecdh::secret_to_public(ecdh::Algorithm::X25519, &zzb).unwrap();
-                let zzc = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &zzb).unwrap();
-                let _pk2d = ecdh::secret_to_public(ecdh::Algorithm::X25519, &zzc).unwrap();
-                let _zzd = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &zzc).unwrap();
+                let _pk2a =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk2).unwrap();
+                let zza =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &sk2).unwrap();
+                let _pk2b =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &zza).unwrap();
+                let zzb =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &zza).unwrap();
+                let _pk2c =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &zzb).unwrap();
+                let zzc =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &zzb).unwrap();
+                let _pk2d =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &zzc).unwrap();
+                let _zzd =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &zzc).unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -867,13 +889,16 @@ fn nym_sphinx_process(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let sk1 = randombytes(32);
-                let pk1 = ecdh::secret_to_public(ecdh::Algorithm::X25519, &sk1).unwrap();
+                let pk1 =
+                    libcrux_ecdh::secret_to_public(libcrux_ecdh::Algorithm::X25519, &sk1).unwrap();
                 let sk2 = randombytes(32);
                 (pk1, sk2)
             },
             |(pk1, sk2)| {
-                let _zz1 = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &sk2).unwrap();
-                let _zz2 = ecdh::derive(ecdh::Algorithm::X25519, &pk1, &sk2).unwrap();
+                let _zz1 =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &sk2).unwrap();
+                let _zz2 =
+                    libcrux_ecdh::derive(libcrux_ecdh::Algorithm::X25519, &pk1, &sk2).unwrap();
             },
             BatchSize::SmallInput,
         )


### PR DESCRIPTION
This PR replaces the `libcrux::ecdh` API calls in the benchmarks with calls to the `libcrux_ecdh` (top-level crate) API.

Resolves #763 