### PR TITLE
fix: chachapoly: use the correct ciphertext length

### DIFF
--- a/chacha20poly1305/src/impl_hacl.rs
+++ b/chacha20poly1305/src/impl_hacl.rs
@@ -56,19 +56,26 @@ pub fn decrypt<'a>(
         return Err(AeadError::PlaintextTooShort);
     }
 
-    let ctxt_len: u32 = ctxt
-        .len()
-        .try_into()
-        .map_err(|_| AeadError::CiphertextTooLarge)?;
-
     let aad_len: u32 = aad.len().try_into().map_err(|_| AeadError::AadTooLarge)?;
 
     let (ctxt_cpa, tag) = ctxt.split_at(ctxt.len() - TAG_LEN);
     let ptxt = &mut ptxt[..ctxt_cpa.len()];
 
+    let ctxt_cpa_len: u32 = ctxt_cpa
+        .len()
+        .try_into()
+        .map_err(|_| AeadError::CiphertextTooLarge)?;
+
     // this call should only ever produce 0 or 1, where 0 is success and 1 is error
     match crate::hacl::aead_chacha20poly1305::decrypt(
-        ptxt, ctxt_cpa, ctxt_len, aad, aad_len, key, nonce, tag,
+        ptxt,
+        ctxt_cpa,
+        ctxt_cpa_len,
+        aad,
+        aad_len,
+        key,
+        nonce,
+        tag,
     ) {
         0 => Ok(ptxt),
         _ => Err(AeadError::InvalidCiphertext),

--- a/chacha20poly1305/tests/chachapoly.rs
+++ b/chacha20poly1305/tests/chachapoly.rs
@@ -82,7 +82,7 @@ fn wycheproof() {
             assert_eq!(testGroup.r#type, "AeadTest");
             assert_eq!(testGroup.keySize, 256);
 
-            let invalid_iv = if testGroup.ivSize != 96 { true } else { false };
+            let invalid_iv = testGroup.ivSize != 96;
 
             for test in testGroup.tests.iter() {
                 let valid = test.result.eq("valid");
@@ -102,7 +102,7 @@ fn wycheproof() {
                 let key = <&[u8; 32]>::try_from(&test.key[..]).unwrap();
 
                 let mut ctxt = msg.clone();
-                let tag = match libcrux_chacha20poly1305::encrypt(key, &msg, &mut ctxt, &aad, nonce)
+                let tag = match libcrux_chacha20poly1305::encrypt(key, msg, &mut ctxt, aad, nonce)
                 {
                     Ok((_v, t)) => t,
                     Err(_) => {
@@ -118,7 +118,7 @@ fn wycheproof() {
                 assert_eq!(ctxt, exp_cipher.as_slice());
 
                 let mut decrypted = vec![0; msg.len()];
-                match libcrux_chacha20poly1305::decrypt(&key, &mut decrypted, &ctxt, &aad, nonce) {
+                match libcrux_chacha20poly1305::decrypt(key, &mut decrypted, &ctxt, aad, nonce) {
                     Ok(m) => {
                         assert_eq!(m, msg);
                         assert_eq!(&decrypted, msg);

--- a/chacha20poly1305/tests/chachapoly.rs
+++ b/chacha20poly1305/tests/chachapoly.rs
@@ -102,8 +102,7 @@ fn wycheproof() {
                 let key = <&[u8; 32]>::try_from(&test.key[..]).unwrap();
 
                 let mut ctxt = msg.clone();
-                let tag = match libcrux_chacha20poly1305::encrypt(key, msg, &mut ctxt, aad, nonce)
-                {
+                let tag = match libcrux_chacha20poly1305::encrypt(key, msg, &mut ctxt, aad, nonce) {
                     Ok((_v, t)) => t,
                     Err(_) => {
                         *tests_run += 1;


### PR DESCRIPTION
@wysiwys pointed out that the decrypt benchmarks are failing, so we jumped on a call to fix this. The issue was that we were using passing the length including the MAC tag to the hacl function, but the buffer only contained the ciphertext without the tag.

This PR changes the code to use the correct length (the length of `ctxt_cpa` instead of `ctxt`).

As a followup I filed an issue to add a test that fails if we use the wrong value here: https://github.com/cryspen/libcrux/issues/822.