### PR TITLE
RSA: Add Wycheproof Test

### DIFF
--- a/rsa/Cargo.toml
+++ b/rsa/Cargo.toml
@@ -20,3 +20,8 @@ libcrux-macros = { version = "=0.0.2-beta.2", path = "../macros" }
 libcrux-sha2 = { version = "=0.0.2-beta.2", path = "../sha2", features = [
     "expose-hacl",
 ] }
+
+[dev-dependencies]
+hex = { version = "0.4.3", features = ["serde"] }
+serde = { version = "1.0.216", features = ["derive"] }
+serde_json = "1.0.133"

--- a/rsa/src/impl_hacl.rs
+++ b/rsa/src/impl_hacl.rs
@@ -167,7 +167,7 @@ macro_rules! impl_rsapss {
             salt: &[u8],
             sig: &mut [u8; $bytes],
         ) -> Result<(), Error> {
-            return sign_varlen(alg, &sk.into(), msg, salt, sig);
+            sign_varlen(alg, &sk.into(), msg, salt, sig)
         }
 
         /// Returns `Ok(())` if the provided signature is valid.
@@ -258,7 +258,7 @@ pub fn verify(
 ///   - checked explicitly
 /// - `msgLen `less_than_max_input_length` a`
 ///   - follows from the check that messages are shorter than `u32::MAX`.
-fn sign_varlen(
+pub fn sign_varlen(
     alg: crate::DigestAlgorithm,
     sk: &VarLenPrivateKey<'_>,
     msg: &[u8],
@@ -312,7 +312,7 @@ fn sign_varlen(
 ///     is less than `u32::MAX`.
 /// - `msgLen less_than_max_input_length a`
 ///   - follows from the check that messages are shorter than `u32::MAX`.
-fn verify_varlen(
+pub fn verify_varlen(
     alg: crate::DigestAlgorithm,
     pk: &VarLenPublicKey<'_>,
     msg: &[u8],


### PR DESCRIPTION
This PR adds the remaining test that `libcrux::digest` does that so far was not part of the test suite for `libcrux-rsa`: wycheproof. In order to do this, I also exposed the functions for verifying and signing with variable-length keys.

Originally I also wanted to adapt the RSA benchmarks to use `libcrux-rsa`, but then I realized that we don't have any yet, so I skipped that for now.