### PR TITLE
Adapt ed25519 tests to top-level crate API

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -16,3 +16,4 @@ libcrux-sha2 = { version = "=0.0.2-beta.2", path = "../sha2", features = [
     "expose-hacl",
 ] }
 libcrux-macros = { version = "=0.0.2-beta.2", path = "../macros" }
+wycheproof = "0.6.0"

--- a/ed25519/tests/ed25519.rs
+++ b/ed25519/tests/ed25519.rs
@@ -16,6 +16,9 @@ fn run_wycheproof() {
                     "Skipping test group {k}: public key length {} != 32",
                     pk.len()
                 );
+                for test in test_group.tests.into_iter() {
+                    assert_eq!(test.result, wycheproof::TestResult::Invalid);
+                }
                 continue;
             }
             let pk_buf: [u8; 32] = pk.as_slice().try_into().unwrap();
@@ -25,8 +28,9 @@ fn run_wycheproof() {
                 println!("Test {i}: {comment}");
 
                 let sig_len = test.sig.len();
-                if sig_len != 64 && test.result == wycheproof::TestResult::Invalid {
+                if sig_len != 64 {
                     println!("Skipping test {i}: signature length {} != 64", sig_len);
+                    assert_eq!(test.result, wycheproof::TestResult::Invalid);
                     continue;
                 }
                 let sig_buf: [u8; 64] = test.sig.as_slice().try_into().unwrap();

--- a/ed25519/tests/ed25519.rs
+++ b/ed25519/tests/ed25519.rs
@@ -13,7 +13,7 @@ fn run_wycheproof() {
         for (k, test_group) in test_set.test_groups.into_iter().enumerate() {
             let pk = &test_group.key.pk;
             if pk.len() != 32 {
-                println!("Skipping test group {k}: public key length {} != 32", pk.len());
+                println!("Skipping test group {k}: private key length {} != 32", pk.len());
                 continue;
             }
             let pk_buf: [u8; 32] = pk.as_slice().try_into().unwrap();

--- a/ed25519/tests/ed25519.rs
+++ b/ed25519/tests/ed25519.rs
@@ -1,0 +1,45 @@
+
+#[test]
+fn run_wycheproof() {
+    for test_name in wycheproof::eddsa::TestName::all() {
+        if !matches!(test_name, wycheproof::eddsa::TestName::Ed25519) {
+            continue;
+        }
+
+        let test_set = wycheproof::eddsa::TestSet::load(test_name)
+            .expect("error loading wycheproof test for name {test_name}");
+
+        println!("Test Set {test_name:?}");
+        for (k, test_group) in test_set.test_groups.into_iter().enumerate() {
+            let pk = &test_group.key.pk;
+            if pk.len() != 32 {
+                println!("Skipping test group {k}: public key length {} != 32", pk.len());
+                continue;
+            }
+            let pk_buf: [u8; 32] = pk.as_slice().try_into().unwrap();
+
+            for (i, test) in test_group.tests.into_iter().enumerate() {
+                let comment = &test.comment;
+                println!("Test {i}: {comment}");
+
+                let sig_len = test.sig.len();
+                if sig_len != 64 {
+                    println!("Skipping test {i}: signature length {} != 64", sig_len);
+                    continue;
+                }
+                let sig_buf: [u8; 64] = test.sig.as_slice().try_into().unwrap();
+
+                match test.result {
+                    wycheproof::TestResult::Valid => {
+                        libcrux_ed25519::verify(&test.msg, &pk_buf, &sig_buf).unwrap();
+                    }
+                    wycheproof::TestResult::Invalid => {
+                        libcrux_ed25519::verify(&test.msg, &pk_buf, &sig_buf)
+                            .expect_err("expected error");
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+}

--- a/ed25519/tests/ed25519.rs
+++ b/ed25519/tests/ed25519.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn run_wycheproof() {
     for test_name in wycheproof::eddsa::TestName::all() {
@@ -13,7 +12,10 @@ fn run_wycheproof() {
         for (k, test_group) in test_set.test_groups.into_iter().enumerate() {
             let pk = &test_group.key.pk;
             if pk.len() != 32 {
-                println!("Skipping test group {k}: public key length {} != 32", pk.len());
+                println!(
+                    "Skipping test group {k}: public key length {} != 32",
+                    pk.len()
+                );
                 continue;
             }
             let pk_buf: [u8; 32] = pk.as_slice().try_into().unwrap();

--- a/ed25519/tests/ed25519.rs
+++ b/ed25519/tests/ed25519.rs
@@ -25,7 +25,7 @@ fn run_wycheproof() {
                 println!("Test {i}: {comment}");
 
                 let sig_len = test.sig.len();
-                if sig_len != 64 {
+                if sig_len != 64 && test.result == wycheproof::TestResult::Invalid {
                     println!("Skipping test {i}: signature length {} != 64", sig_len);
                     continue;
                 }

--- a/ed25519/tests/ed25519.rs
+++ b/ed25519/tests/ed25519.rs
@@ -13,7 +13,7 @@ fn run_wycheproof() {
         for (k, test_group) in test_set.test_groups.into_iter().enumerate() {
             let pk = &test_group.key.pk;
             if pk.len() != 32 {
-                println!("Skipping test group {k}: private key length {} != 32", pk.len());
+                println!("Skipping test group {k}: public key length {} != 32", pk.len());
                 continue;
             }
             let pk_buf: [u8; 32] = pk.as_slice().try_into().unwrap();


### PR DESCRIPTION
This PR adds tests for the `libcrux-ed25519` crate, adapted from the tests in `tests/ed25519.rs`. 

- Skips `wycheproof` tests whose provided signature has a length not equal to 64 bytes
- Skips `wycheproof` test groups whose provided private key has a length not equal to 32 bytes

Resolves #798 