### PR TITLE
[PSQ] Implement `Credential` for Ed25519 signatures

### DIFF
--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -25,10 +25,12 @@ classic-mceliece-rust = { version = "2.0.0", features = [
 rand = { version = "0.9" }
 rand_old = { version = "0.8", package = "rand", optional = true }
 libcrux-ecdh = { version = "0.0.2-beta.3", path = "../libcrux-ecdh" }
+libcrux-ed25519 = { version = "0.0.2-beta.3", path = "../ed25519" }
 libcrux = { version = "0.0.2-beta.3", path = ".." }
 
 [dev-dependencies]
 criterion = "0.5"
+openssl = "0.10" # for generating Ed25519 private keys
 
 [features]
 classic-mceliece = ["dep:classic-mceliece-rust", "rand_old"]

--- a/libcrux-psq/src/psk_registration.rs
+++ b/libcrux-psq/src/psk_registration.rs
@@ -74,13 +74,11 @@ impl Initiator {
         let ts_ttl = serialize_ts_ttl(&ts, &psk_ttl);
 
         let (signature, verification_key) = C::sign(signing_key, &enc_pq.encode())?;
-        let signature_bytes = C::serialize_signature(&signature);
-        let vk_bytes = C::serialize_verification_key(&verification_key);
 
         let mut message = Vec::new();
         message.extend_from_slice(&ts_ttl);
-        message.extend_from_slice(&vk_bytes);
-        message.extend_from_slice(&signature_bytes);
+        message.extend_from_slice(verification_key.as_ref());
+        message.extend_from_slice(signature.as_ref());
 
         let (tag, ctxt) = encrypt_detached(&initiator_key, &mut message, initiator_iv, b"")
             .map_err(|_| Error::CryptoError)?;
@@ -287,7 +285,7 @@ mod tests {
             sctx,
             Duration::from_secs(3600),
             &receiver_pqpk,
-            &(),
+            &[0; 0],
             &mut rng,
         )
         .unwrap();


### PR DESCRIPTION
This PR adds an implementation of the `Credential` trait for Ed25519 signatures.

I'm not sure `Credential` is generic enough to go into the `traits` crate as an interface for signatures. I think it would require some more work to make it so, and that should probably go into a follow-up.

Fixes #720 