### PR TITLE
Merge queue: fix indentation and do not run ML-KEM fuzz test on pull requests

### DIFF
--- a/.github/workflows/mlkem-build-test.yml
+++ b/.github/workflows/mlkem-build-test.yml
@@ -183,6 +183,7 @@ jobs:
         run: exit 1 
 
   fuzz:
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -215,3 +216,14 @@ jobs:
 
       - name: 🏃🏻‍♀️ KeyGen
         run: CARGO_PROFILE_RELEASE_LTO=false cargo +nightly fuzz run keygen -- -runs=1000000
+  mlkem-fuzz-status:
+    if: ${{ always() }}
+    needs: [fuzz]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Successful
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Failing
+        if: ${{ (contains(needs.*.result, 'failure')) }}
+        run: exit 1

--- a/.github/workflows/mlkem-c.yml
+++ b/.github/workflows/mlkem-c.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Report status
         run: echo "All tests completed successfully"
   
- mlkem-c-tests-status:
+  mlkem-c-tests-status:
     if: ${{ always() }}
     needs: [report-status-tests]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request implements two small fixes to the merge queue:
- Fix the incorrect indentation in `mlkem-c.yml` (syntax error that caused the workflow to fail)
- Do not run ML-KEM fuzz test job on pull requests
  - This fix also adds a new status check: `mlkem-fuzz-status` (complete list in #544)