### PR TITLE
[CI] Fix for ML-KEM benchmark: remove step to clear `Cargo.lock`

### DIFF
--- a/.github/workflows/mlkem-bench.yml
+++ b/.github/workflows/mlkem-bench.yml
@@ -92,8 +92,6 @@ jobs:
         run: |
           cargo clean
           LIBCRUX_DISABLE_SIMD128=1 LIBCRUX_DISABLE_SIMD256=1 cargo bench --verbose $RUST_TARGET_FLAG -- --output-format bencher | sed 's/^test \(.*\) \.\.\. bench/test portable \1 ... bench/' | tee -a bench.txt 
-      - name: Clear Cargo.lock so it doesn't interfere with git
-        run: git checkout Cargo.lock
       - name: Store benchmarks
         uses: benchmark-action/github-action-benchmark@v1
         with:


### PR DESCRIPTION
This PR removes the step to clear `Cargo.lock` in the ML-KEM benchmark workflow, since this file is no longer tracked in git.