### PR TITLE
`hax-lib`: update to `0.2.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ readme = "Readme.md"
 allow-branch = ["main"]
 
 [workspace.dependencies]
-hax-lib = { version = "0.2", git = "https://github.com/hacspec/hax/" }
+hax-lib = { version = "0.2", git = "https://github.com/cryspen/hax/" }
 
 [package]
 name = "libcrux"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ readme = "Readme.md"
 allow-branch = ["main"]
 
 [workspace.dependencies]
-hax-lib = { version = "0.1.0", git = "https://github.com/hacspec/hax/" }
+hax-lib = { version = "0.2", git = "https://github.com/hacspec/hax/" }
 
 [package]
 name = "libcrux"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ readme = "Readme.md"
 [workspace.metadata.release]
 allow-branch = ["main"]
 
+[workspace.dependencies]
+hax-lib = { version = "0.1.0", git = "https://github.com/hacspec/hax/" }
+
 [package]
 name = "libcrux"
 version.workspace = true
@@ -91,7 +94,7 @@ log = { version = "0.4", optional = true }
 # WASM API
 wasm-bindgen = { version = "0.2.87", optional = true }
 getrandom = { version = "0.3", optional = true }
-hax-lib = { version = "0.1.0", git = "https://github.com/hacspec/hax/" }
+hax-lib.workspace = true
 
 [dev-dependencies]
 libcrux = { path = ".", features = ["rand", "tests"] }

--- a/libcrux-intrinsics/Cargo.toml
+++ b/libcrux-intrinsics/Cargo.toml
@@ -11,7 +11,7 @@ description = "Libcrux intrinsics crate"
 exclude = ["/proofs"]
 
 [dependencies]
-hax-lib = { version = "0.1.0-alpha.1", git = "https://github.com/hacspec/hax/" }
+hax-lib.workspace = true
 
 [features]
 simd128 = []

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -20,7 +20,7 @@ libcrux-sha3 = { version = "0.0.2-beta.3", path = "../libcrux-sha3" }
 libcrux-intrinsics = { version = "0.0.2-beta.3", path = "../libcrux-intrinsics" }
 libcrux-platform = { version = "0.0.2-beta.3", path = "../sys/platform" }
 libcrux-macros = { version = "0.0.2-beta.3", path = "../macros" }
-hax-lib = { version = "0.1.0", git = "https://github.com/hacspec/hax/"}
+hax-lib.workspace = true
 
 [dev-dependencies]
 rand = { version = "0.9" }

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -30,7 +30,7 @@ rand = { version = "0.9", optional = true }
 libcrux-platform = { version = "0.0.2-beta.3", path = "../sys/platform" }
 libcrux-sha3 = { version = "0.0.2-beta.3", path = "../libcrux-sha3" }
 libcrux-intrinsics = { version = "0.0.2-beta.3", path = "../libcrux-intrinsics" }
-hax-lib = { version = "0.1.0", git = "https://github.com/hacspec/hax/" }
+hax-lib.workspace = true
 
 [features]
 # By default all variants and std are enabled.

--- a/libcrux-sha3/Cargo.toml
+++ b/libcrux-sha3/Cargo.toml
@@ -20,7 +20,7 @@ libcrux-intrinsics = { version = "0.0.2-beta.3", path = "../libcrux-intrinsics" 
 # This is only required for verification.
 # The hax config is set by the hax toolchain.
 [target.'cfg(hax)'.dependencies]
-hax-lib = { version = "0.1.0-alpha.1", git = "https://github.com/hacspec/hax/" }
+hax-lib.workspace = true
 
 [features]
 simd128 = []


### PR DESCRIPTION
This PR:
 - updates `hax-lib`
 - defines a workspace dependency `hax-lib`, so that there is only one version of `hax-lib` in the repo