### PR TITLE
[merge queue] fix checks succeeding on failed predecessor

### DIFF
--- a/.github/workflows/mldsa-c.yml
+++ b/.github/workflows/mldsa-c.yml
@@ -36,18 +36,11 @@ jobs:
       should-run: ${{ steps.changes.outputs.docker-c == 'false' }}
       image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION_TAG }}
 
-  report-status-tests:
-    runs-on: ubuntu-latest
+  mldsa-c-tests-status:
+    if: ${{ always() }}
     needs:
       - diff-header-only
       - build-header-only
-    steps:
-      - name: Report status
-        run: echo "All tests completed successfully"
-
-  mldsa-c-tests-status:
-    if: ${{ always() }}
-    needs: [report-status-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Successful

--- a/.github/workflows/mlkem-c.yml
+++ b/.github/workflows/mlkem-c.yml
@@ -35,21 +35,14 @@ jobs:
       # only run if files in `.docker/c/` unchanged
       should-run: ${{ steps.changes.outputs.docker-c == 'false' }}
       image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION_TAG }}
-
-  report-status-tests:
-    runs-on: ubuntu-latest
+  
+  mlkem-c-tests-status:
+    if: ${{ always() }}
     needs:
       - diff
       - diff-header-only
       - build
       - build-header-only
-    steps:
-      - name: Report status
-        run: echo "All tests completed successfully"
-  
-  mlkem-c-tests-status:
-    if: ${{ always() }}
-    needs: [report-status-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Successful


### PR DESCRIPTION
This PR fixes a bug in the `mlkem-c.yml` and `mldsa-c.yml` workflows where the last status check job would succeed if its predecessor job was skipped, which could happen if one of its predecessor jobs failed. 

The fix is to remove the intermediate job and make the final check depend on the required jobs.