### PR TITLE
[Merge queue] make status checks explicitly depend on all preceding jobs in graph

### DIFF
--- a/.github/workflows/mldsa-c.yml
+++ b/.github/workflows/mldsa-c.yml
@@ -39,6 +39,8 @@ jobs:
   mldsa-c-tests-status:
     if: ${{ always() }}
     needs:
+      - setup
+      - extract-header-only
       - diff-header-only
       - build-header-only
     runs-on: ubuntu-latest

--- a/.github/workflows/mlkem-c.yml
+++ b/.github/workflows/mlkem-c.yml
@@ -39,6 +39,9 @@ jobs:
   mlkem-c-tests-status:
     if: ${{ always() }}
     needs:
+      - setup
+      - extract
+      - extract-header-only
       - diff
       - diff-header-only
       - build


### PR DESCRIPTION
This PR fixes an issue in the GitHub Actions workflows `mlkem-c.yml` and `mldsa-c.yml` where, if one of the predecessors of a status check's needed jobs fails, the status check itself may succeed, due to the earlier predecessor not being included in its `needed` list. The fix is to explicitly include all predecessors of the status check in its `needed` list.

cc #544 