### PR TITLE
Add tracing types and a proc macro for using it to measure functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "p256",
     "blake2",
     "fstar-helpers/minicore",
+    "test-utils",
 ]
 
 [workspace.package]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -11,5 +11,4 @@ repository.workspace = true
 readme.workspace = true
 
 [dev-dependencies]
-lazy_static = "1.5"
 libcrux-macros = { path = "../macros/" }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "libcrux-test-utils"
+description = "Utils for testing and benchmarking"
+
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+edition.workspace = true
+repository.workspace = true
+readme.workspace = true
+
+[dev-dependencies]
+lazy_static = "1.5"
+libcrux-macros = { path = "../macros/" }

--- a/test-utils/README.md
+++ b/test-utils/README.md
@@ -1,0 +1,42 @@
+# `libcrux-test-utils`
+
+This crate contains tools for testing, tracing, profiling and benchmarking.
+
+## Tracing (`tracing`)
+
+This module provides tools for annotating functions such that calls are traced.
+That means that whenever the function is called and when it returns, an entry
+is written to the specified trace.
+
+Usually, that trace will be a static variable with interior mutability. If in
+doubt, define it something like this:
+
+```rust
+lazy_static::lazy_static! {
+    static ref TRACE: MutexTrace<&'static str, Instant> = Default::default();
+}
+```
+
+The `MutexTrace` can be defined and used as a static variable without unsafe, but,
+depending on the setting, my introduce too much overhead. Any type that implements
+`Trace` works.
+
+Then, annotate a function like this:
+
+```rust
+#[libcrux_macros::trace_span("trace_me", TRACE)]
+fn this_function_is_traced() {
+  // ...
+}
+```
+
+The macro is called `trace_span` because it traces a start and end. There also
+are on-the-fly tracing facilities.
+
+After the code in question ran, the trace can be inspected. Due to the use
+of  interior mutability, there is no generic way to get a reference to the
+inner slice; therefore, it is easiest to just clone it.
+
+```rust
+println!((*TRACE).clone().report());
+```

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod tracing;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,1 +1,3 @@
+//! This crate contains tools for testing, tracing, profiling and benchmarking.
+//! So far, only helper for [`tracing`] are implemented.
 pub mod tracing;

--- a/test-utils/src/tracing.rs
+++ b/test-utils/src/tracing.rs
@@ -1,0 +1,180 @@
+//! This module contains types for producing timed traces of program runs. Make sure to also look
+//! at the `trace_span` macro from `libcrux_macros`.
+
+use std::{
+    borrow::Borrow,
+    cell::{Ref, RefCell},
+    fmt::Display,
+    sync::Mutex,
+};
+
+/// This trait descries a trace that is behind some sort of interior mutability mechanism. It can
+/// log trace events and later make these available. This is usually an argument to the
+/// `trace_span` function attribute macro in `libcrux-macros``, but it can also be called manually.
+///
+/// When used with the `trace_span` macros, this needs to be a global static. For defining and
+/// instantiating this, look into the `lazy_static` crate.
+pub trait Trace: Sized {
+    /// The label type used in events. Typically either `&'static str` or an enum.
+    type Label: Clone;
+
+    /// The type used for timing the events. Typically `std::time::Instant` or a cycle counter.
+    type TimeStamp: TimeStamp;
+
+    /// Writes an event to the trace.
+    fn emit(&self, ev: TraceEvent<Self::Label, Self::TimeStamp>);
+
+    /// Returns a vector of all entries in the trace.
+    fn report(self) -> Vec<TraceEvent<Self::Label, Self::TimeStamp>>;
+
+    /// Emits an event of type [EventType::SpanOpen] and returns a [`SpanHandle`] that emits another
+    /// [`EventType::SpanClose`] when dropped.
+    fn emit_span(&self, label: Self::Label) -> SpanHandle<Self> {
+        let event = TraceEvent {
+            ty: EventType::SpanOpen,
+            at: Self::TimeStamp::now(),
+            label: label.clone(),
+        };
+
+        self.emit(event);
+        SpanHandle(self, Some(label))
+    }
+
+    /// Emits an [`EventType::OnTheFly`] event.
+    fn emit_on_the_fly(&self, label: Self::Label) {
+        let event = TraceEvent {
+            ty: EventType::OnTheFly,
+            at: Self::TimeStamp::now(),
+            label: label.clone(),
+        };
+
+        self.emit(event);
+    }
+}
+
+/// Describes types that can be used for timestamping. This allows using the tracing facilities in
+/// no_std environments, where [`std::time::Instant`] is not available.
+pub trait TimeStamp {
+    /// Returns the current time
+    fn now() -> Self;
+}
+
+/// The type of the event
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventType {
+    SpanOpen,
+    SpanClose,
+    OnTheFly,
+}
+
+/// A trace event.
+#[derive(Debug, Clone)]
+pub struct TraceEvent<Label, TimeStamp> {
+    pub ty: EventType,
+    pub at: TimeStamp,
+    pub label: Label,
+}
+
+impl<Label: Display, TimeStamp: Display> Display for TraceEvent<Label, TimeStamp> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { ty, at, label } = self;
+        write!(f, "{ty:?}: {label}@{at}")
+    }
+}
+
+/// This type emits a [`EventType::SpanClose`] event on drop.
+pub struct SpanHandle<'a, T: Trace>(&'a T, Option<T::Label>);
+
+impl<'a, T: Trace> Drop for SpanHandle<'a, T> {
+    fn drop(&mut self) {
+        let event = TraceEvent {
+            ty: EventType::SpanClose,
+            at: T::TimeStamp::now(),
+            label: self.1.take().unwrap(),
+        };
+        self.0.emit(event)
+    }
+}
+
+/// An implementation of [`Trace`] using a [`Mutex`] for interior mutability.
+#[derive(Debug)]
+pub struct MutexTrace<Label, TimeStamp>(Mutex<Vec<TraceEvent<Label, TimeStamp>>>);
+
+impl<Label: Clone, TS: TimeStamp> Trace for MutexTrace<Label, TS> {
+    type Label = Label;
+    type TimeStamp = TS;
+
+    fn emit(&self, ev: TraceEvent<Self::Label, Self::TimeStamp>) {
+        self.0.lock().unwrap().push(ev)
+    }
+
+    fn report(self) -> Vec<TraceEvent<Self::Label, Self::TimeStamp>> {
+        self.0.into_inner().unwrap()
+    }
+}
+
+// This doesn't work yet because the method is still unstable;
+// see issue #117108 <https://github.com/rust-lang/rust/issues/117108>
+//
+// impl<Label: Clone, TS: TimeStamp> MutexTrace<Label, TS> {
+//     pub fn entries<'a>(&'a self) -> MappedMutexGuard<&'a [TraceEvent<Label, TS>]> {
+//         std::sync::MutexGuard::map(self.0.lock().unwrap(), |x| Vec::as_mut_slice(x))
+//     }
+// }
+
+impl<Label: Clone, TS: TimeStamp> Default for MutexTrace<Label, TS> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<Label: Clone, TS: TimeStamp + Clone> Clone for MutexTrace<Label, TS> {
+    fn clone(&self) -> Self {
+        let guard = self.0.lock().unwrap();
+        let vector: &Vec<_> = guard.borrow();
+        Self(Mutex::new(vector.clone()))
+    }
+}
+
+/// An implementation of [`Trace`] using a [`RefCell`] for interior mutability. Note that it is
+/// unsafe to use [`RefCell`] in static variables.
+#[derive(Debug)]
+pub struct RefCellTrace<Label, TimeStamp>(RefCell<Vec<TraceEvent<Label, TimeStamp>>>);
+
+impl<Label: Clone, TS: TimeStamp> Trace for RefCellTrace<Label, TS> {
+    type Label = Label;
+    type TimeStamp = TS;
+
+    fn emit(&self, ev: TraceEvent<Self::Label, Self::TimeStamp>) {
+        self.0.borrow_mut().push(ev);
+    }
+
+    fn report(self) -> Vec<TraceEvent<Self::Label, Self::TimeStamp>> {
+        self.0.into_inner()
+    }
+}
+
+impl<Label: Clone, TS: TimeStamp> RefCellTrace<Label, TS> {
+    pub fn entries(&self) -> Ref<'_, [TraceEvent<Label, TS>]> {
+        Ref::map(self.0.borrow(), Vec::as_slice)
+    }
+}
+
+impl<Label: Clone, TS: TimeStamp> Default for RefCellTrace<Label, TS> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<Label: Clone, TS: TimeStamp + Clone> Clone for RefCellTrace<Label, TS> {
+    fn clone(&self) -> Self {
+        let vector = self.0.borrow().as_slice().to_vec();
+        Self(RefCell::new(vector))
+    }
+}
+
+impl TimeStamp for std::time::Instant {
+    fn now() -> Self {
+        Self::now()
+    }
+}

--- a/test-utils/tests/trace.rs
+++ b/test-utils/tests/trace.rs
@@ -65,9 +65,7 @@ fn test_trace_report(trace: &(impl Clone + Trace<Label = &'static str, TimeStamp
     assert_eq!(close.ty, EventType::SpanClose);
     assert_eq!(close.label, "test block");
 
-    let run_time = close.at - open.at;
-    assert!(run_time.as_micros() > 2300);
-    assert!(run_time.as_micros() < 3700);
+    assert!(open.at < close.at);
 }
 
 fn test_nested_trace_report(
@@ -98,11 +96,7 @@ fn test_nested_trace_report(
     assert_eq!(close_inner.ty, EventType::SpanClose);
     assert_eq!(close_outer.ty, EventType::SpanClose);
 
-    let run_time_inner = close_inner.at - open_inner.at;
-    assert!(run_time_inner.as_micros() > 1300);
-    assert!(run_time_inner.as_micros() < 2700);
-
-    let run_time_outer = close_outer.at - open_outer.at;
-    assert!(run_time_outer.as_micros() > 4300);
-    assert!(run_time_outer.as_micros() < 5700);
+    assert!(open_outer.at < open_inner.at);
+    assert!(open_inner.at < close_inner.at);
+    assert!(close_inner.at < close_outer.at);
 }

--- a/test-utils/tests/trace.rs
+++ b/test-utils/tests/trace.rs
@@ -25,9 +25,7 @@ fn test_refcell_trace_entries() {
     assert_eq!(close.ty, EventType::SpanClose);
     assert_eq!(close.label, "test block");
 
-    let run_time = close.at - open.at;
-    assert!(run_time.as_micros() > 2300);
-    assert!(run_time.as_micros() < 3700);
+    assert!(open.at < close.at);
 }
 
 #[test]

--- a/test-utils/tests/trace.rs
+++ b/test-utils/tests/trace.rs
@@ -1,0 +1,62 @@
+use std::{
+    ops::Deref,
+    time::{Duration, Instant},
+};
+
+use libcrux_test_utils::tracing::{EventType, MutexTrace, RefCellTrace, Trace};
+
+#[test]
+fn test_refcell_trace_entries() {
+    let trace = RefCellTrace::<&str, Instant>::default();
+
+    {
+        let _handle = trace.emit_span("test block");
+        std::thread::sleep(Duration::from_millis(3));
+    }
+
+    let entries = trace.entries();
+    let [open, close] = entries.deref() else {
+        panic!("got wrong number of entries")
+    };
+
+    assert_eq!(open.ty, EventType::SpanOpen);
+    assert_eq!(open.label, "test block");
+
+    assert_eq!(close.ty, EventType::SpanClose);
+    assert_eq!(close.label, "test block");
+
+    let run_time = close.at - open.at;
+    assert!(run_time.as_micros() > 2500);
+    assert!(run_time.as_micros() < 3500);
+}
+
+#[test]
+fn test_mutex_trace_report() {
+    test_trace_report(&MutexTrace::default());
+}
+#[test]
+fn test_refcell_trace_report() {
+    test_trace_report(&RefCellTrace::default());
+}
+
+fn test_trace_report(trace: &(impl Clone + Trace<Label = &'static str, TimeStamp = Instant>)) {
+    {
+        let _handle = trace.emit_span("test block");
+        std::thread::sleep(Duration::from_millis(3));
+    }
+
+    let entries = trace.clone().report();
+    let [open, close] = entries.as_slice() else {
+        panic!("got wrong number of entries")
+    };
+
+    assert_eq!(open.ty, EventType::SpanOpen);
+    assert_eq!(open.label, "test block");
+
+    assert_eq!(close.ty, EventType::SpanClose);
+    assert_eq!(close.label, "test block");
+
+    let run_time = close.at - open.at;
+    assert!(run_time.as_micros() > 2500);
+    assert!(run_time.as_micros() < 3500);
+}

--- a/test-utils/tests/tracing_macros.rs
+++ b/test-utils/tests/tracing_macros.rs
@@ -15,7 +15,7 @@ mod str_labels {
 
     #[libcrux_macros::trace_span("maybe_slow", TRACE_STR)]
     fn maybe_slow_str() {
-        sleep(Duration::from_millis(100));
+        sleep(Duration::from_millis(10));
     }
 
     #[test]
@@ -32,8 +32,8 @@ mod str_labels {
         assert_eq!(close.label, "maybe_slow");
 
         let run_time = close.at - open.at;
-        assert!(run_time.as_micros() > 99500);
-        assert!(run_time.as_micros() < 100500);
+        assert!(run_time.as_micros() > 9300);
+        assert!(run_time.as_micros() < 10700);
     }
 }
 
@@ -51,7 +51,7 @@ mod enum_labels {
 
     #[libcrux_macros::trace_span(Label::MaybeSlow, TRACE_ENUM)]
     fn maybe_slow_enum() {
-        sleep(Duration::from_millis(100));
+        sleep(Duration::from_millis(10));
     }
 
     #[test]
@@ -68,7 +68,7 @@ mod enum_labels {
         assert_eq!(close.label, Label::MaybeSlow);
 
         let run_time = close.at - open.at;
-        assert!(run_time.as_micros() > 99500);
-        assert!(run_time.as_micros() < 100500);
+        assert!(run_time.as_micros() > 9300);
+        assert!(run_time.as_micros() < 10700);
     }
 }

--- a/test-utils/tests/tracing_macros.rs
+++ b/test-utils/tests/tracing_macros.rs
@@ -31,9 +31,7 @@ mod str_labels {
         assert_eq!(close.ty, EventType::SpanClose);
         assert_eq!(close.label, "maybe_slow");
 
-        let run_time = close.at - open.at;
-        assert!(run_time.as_micros() > 9300);
-        assert!(run_time.as_micros() < 10700);
+        assert!(open.at < close.at);
     }
 }
 
@@ -66,8 +64,6 @@ mod enum_labels {
         assert_eq!(close.ty, EventType::SpanClose);
         assert_eq!(close.label, Label::MaybeSlow);
 
-        let run_time = close.at - open.at;
-        assert!(run_time.as_micros() > 9300);
-        assert!(run_time.as_micros() < 10700);
+        assert!(open.at < close.at);
     }
 }

--- a/test-utils/tests/tracing_macros.rs
+++ b/test-utils/tests/tracing_macros.rs
@@ -1,4 +1,5 @@
 use std::{
+    sync::LazyLock,
     thread::sleep,
     time::{Duration, Instant},
 };
@@ -9,9 +10,8 @@ mod str_labels {
 
     use super::*;
 
-    lazy_static::lazy_static! {
-        static ref TRACE_STR: MutexTrace<&'static str, Instant> = Default::default();
-    }
+    static TRACE_STR: LazyLock<MutexTrace<&'static str, Instant>> =
+        LazyLock::new(|| MutexTrace::default());
 
     #[libcrux_macros::trace_span("maybe_slow", TRACE_STR)]
     fn maybe_slow_str() {
@@ -45,9 +45,8 @@ mod enum_labels {
         MaybeSlow,
     }
 
-    lazy_static::lazy_static! {
-        static ref TRACE_ENUM: MutexTrace<Label, Instant> = Default::default();
-    }
+    static TRACE_ENUM: LazyLock<MutexTrace<Label, Instant>> =
+        LazyLock::new(|| MutexTrace::default());
 
     #[libcrux_macros::trace_span(Label::MaybeSlow, TRACE_ENUM)]
     fn maybe_slow_enum() {

--- a/test-utils/tests/tracing_macros.rs
+++ b/test-utils/tests/tracing_macros.rs
@@ -1,0 +1,74 @@
+use std::{
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
+use libcrux_test_utils::tracing::{EventType, MutexTrace, Trace as _, TraceEvent};
+
+mod str_labels {
+
+    use super::*;
+
+    lazy_static::lazy_static! {
+        static ref TRACE_STR: MutexTrace<&'static str, Instant> = Default::default();
+    }
+
+    #[libcrux_macros::trace_span("maybe_slow", TRACE_STR)]
+    fn maybe_slow_str() {
+        sleep(Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_tracing_str() {
+        maybe_slow_str();
+
+        let [open, close]: [TraceEvent<_, _>; 2] =
+            (*TRACE_STR).clone().report().try_into().unwrap();
+
+        assert_eq!(open.ty, EventType::SpanOpen);
+        assert_eq!(open.label, "maybe_slow");
+
+        assert_eq!(close.ty, EventType::SpanClose);
+        assert_eq!(close.label, "maybe_slow");
+
+        let run_time = close.at - open.at;
+        assert!(run_time.as_micros() > 99500);
+        assert!(run_time.as_micros() < 100500);
+    }
+}
+
+mod enum_labels {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum Label {
+        MaybeSlow,
+    }
+
+    lazy_static::lazy_static! {
+        static ref TRACE_ENUM: MutexTrace<Label, Instant> = Default::default();
+    }
+
+    #[libcrux_macros::trace_span(Label::MaybeSlow, TRACE_ENUM)]
+    fn maybe_slow_enum() {
+        sleep(Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_tracing_enum() {
+        maybe_slow_enum();
+
+        let [open, close]: [TraceEvent<_, _>; 2] =
+            (*TRACE_ENUM).clone().report().try_into().unwrap();
+
+        assert_eq!(open.ty, EventType::SpanOpen);
+        assert_eq!(open.label, Label::MaybeSlow);
+
+        assert_eq!(close.ty, EventType::SpanClose);
+        assert_eq!(close.label, Label::MaybeSlow);
+
+        let run_time = close.at - open.at;
+        assert!(run_time.as_micros() > 99500);
+        assert!(run_time.as_micros() < 100500);
+    }
+}


### PR DESCRIPTION
This PR adds the tracing tools we agreed on adding at our meeting yesterday. It adds the new crate `libcrux-test-utils`, which contains  the tracing library, and the new `trace_span` proc macro to `libcrux-macros`.