### PR TITLE
Flatten SHA-3 state and switch row/column

### DIFF
--- a/libcrux-sha3/benches/sha3.rs
+++ b/libcrux-sha3/benches/sha3.rs
@@ -19,7 +19,7 @@ pub fn fmt(x: usize) -> String {
 }
 
 macro_rules! impl_comp {
-    ($fun:ident, $libcrux:expr, $neon_fun:ident) => {
+    ($fun:ident, $libcrux:expr, $rust_fun:ident) => {
         // Comparing libcrux performance for different payload sizes and other implementations.
         fn $fun(c: &mut Criterion) {
             const PAYLOAD_SIZES: [usize; 3] = [128, 1024, 1024 * 1024 * 10];
@@ -43,6 +43,21 @@ macro_rules! impl_comp {
                     },
                 );
 
+                group.bench_with_input(
+                    BenchmarkId::new("rust version (portable)", fmt(*payload_size)),
+                    payload_size,
+                    |b, payload_size| {
+                        b.iter_batched(
+                            || randombytes(*payload_size),
+                            |payload| {
+                                let mut digest = [0u8; digest_size($libcrux)];
+                                portable::$rust_fun(&mut digest, &payload);
+                            },
+                            BatchSize::SmallInput,
+                        )
+                    },
+                );
+
                 #[cfg(all(feature = "simd128", target_arch = "aarch64"))]
                 group.bench_with_input(
                     BenchmarkId::new("rust version (simd128)", fmt(*payload_size)),
@@ -52,22 +67,7 @@ macro_rules! impl_comp {
                             || randombytes(*payload_size),
                             |payload| {
                                 let mut digest = [0u8; digest_size($libcrux)];
-                                neon::$neon_fun(&mut digest, &payload);
-                            },
-                            BatchSize::SmallInput,
-                        )
-                    },
-                );
-
-                group.bench_with_input(
-                    BenchmarkId::new("rust version (portable)", fmt(*payload_size)),
-                    payload_size,
-                    |b, payload_size| {
-                        b.iter_batched(
-                            || randombytes(*payload_size),
-                            |payload| {
-                                let mut digest = [0u8; digest_size($libcrux)];
-                                portable::$neon_fun(&mut digest, &payload);
+                                neon::$rust_fun(&mut digest, &payload);
                             },
                             BatchSize::SmallInput,
                         )

--- a/libcrux-sha3/src/generic_keccak.rs
+++ b/libcrux-sha3/src/generic_keccak.rs
@@ -240,11 +240,11 @@ const _ROTC: [usize; 24] = [
 #[inline(always)]
 pub(crate) fn theta_rho<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
     let c: [T; 5] = [
-        T::xor5(s.st[0][0], s.st[1][0], s.st[2][0], s.st[3][0], s.st[4][0]),
-        T::xor5(s.st[0][1], s.st[1][1], s.st[2][1], s.st[3][1], s.st[4][1]),
-        T::xor5(s.st[0][2], s.st[1][2], s.st[2][2], s.st[3][2], s.st[4][2]),
-        T::xor5(s.st[0][3], s.st[1][3], s.st[2][3], s.st[3][3], s.st[4][3]),
-        T::xor5(s.st[0][4], s.st[1][4], s.st[2][4], s.st[3][4], s.st[4][4]),
+        T::xor5(s.st[0][0], s.st[0][1], s.st[0][2], s.st[0][3], s.st[0][4]),
+        T::xor5(s.st[1][0], s.st[1][1], s.st[1][2], s.st[1][3], s.st[1][4]),
+        T::xor5(s.st[2][0], s.st[2][1], s.st[2][2], s.st[2][3], s.st[2][4]),
+        T::xor5(s.st[3][0], s.st[3][1], s.st[3][2], s.st[3][3], s.st[3][4]),
+        T::xor5(s.st[4][0], s.st[4][1], s.st[4][2], s.st[4][3], s.st[4][4]),
     ];
     #[allow(clippy::identity_op)]
     let t: [T; 5] = [
@@ -256,33 +256,33 @@ pub(crate) fn theta_rho<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakSta
     ];
 
     s.st[0][0] = T::xor(s.st[0][0], t[0]);
-    s.st[1][0] = T::xor_and_rotate::<36, 28>(s.st[1][0], t[0]);
-    s.st[2][0] = T::xor_and_rotate::<3, 61>(s.st[2][0], t[0]);
-    s.st[3][0] = T::xor_and_rotate::<41, 23>(s.st[3][0], t[0]);
-    s.st[4][0] = T::xor_and_rotate::<18, 46>(s.st[4][0], t[0]);
+    s.st[0][1] = T::xor_and_rotate::<36, 28>(s.st[0][1], t[0]);
+    s.st[0][2] = T::xor_and_rotate::<3, 61>(s.st[0][2], t[0]);
+    s.st[0][3] = T::xor_and_rotate::<41, 23>(s.st[0][3], t[0]);
+    s.st[0][4] = T::xor_and_rotate::<18, 46>(s.st[0][4], t[0]);
 
-    s.st[0][1] = T::xor_and_rotate::<1, 63>(s.st[0][1], t[1]);
+    s.st[1][0] = T::xor_and_rotate::<1, 63>(s.st[1][0], t[1]);
     s.st[1][1] = T::xor_and_rotate::<44, 20>(s.st[1][1], t[1]);
-    s.st[2][1] = T::xor_and_rotate::<10, 54>(s.st[2][1], t[1]);
-    s.st[3][1] = T::xor_and_rotate::<45, 19>(s.st[3][1], t[1]);
-    s.st[4][1] = T::xor_and_rotate::<2, 62>(s.st[4][1], t[1]);
+    s.st[1][2] = T::xor_and_rotate::<10, 54>(s.st[1][2], t[1]);
+    s.st[1][3] = T::xor_and_rotate::<45, 19>(s.st[1][3], t[1]);
+    s.st[1][4] = T::xor_and_rotate::<2, 62>(s.st[1][4], t[1]);
 
-    s.st[0][2] = T::xor_and_rotate::<62, 2>(s.st[0][2], t[2]);
-    s.st[1][2] = T::xor_and_rotate::<6, 58>(s.st[1][2], t[2]);
+    s.st[2][0] = T::xor_and_rotate::<62, 2>(s.st[2][0], t[2]);
+    s.st[2][1] = T::xor_and_rotate::<6, 58>(s.st[2][1], t[2]);
     s.st[2][2] = T::xor_and_rotate::<43, 21>(s.st[2][2], t[2]);
-    s.st[3][2] = T::xor_and_rotate::<15, 49>(s.st[3][2], t[2]);
-    s.st[4][2] = T::xor_and_rotate::<61, 3>(s.st[4][2], t[2]);
+    s.st[2][3] = T::xor_and_rotate::<15, 49>(s.st[2][3], t[2]);
+    s.st[2][4] = T::xor_and_rotate::<61, 3>(s.st[2][4], t[2]);
 
-    s.st[0][3] = T::xor_and_rotate::<28, 36>(s.st[0][3], t[3]);
-    s.st[1][3] = T::xor_and_rotate::<55, 9>(s.st[1][3], t[3]);
-    s.st[2][3] = T::xor_and_rotate::<25, 39>(s.st[2][3], t[3]);
+    s.st[3][0] = T::xor_and_rotate::<28, 36>(s.st[3][0], t[3]);
+    s.st[3][1] = T::xor_and_rotate::<55, 9>(s.st[3][1], t[3]);
+    s.st[3][2] = T::xor_and_rotate::<25, 39>(s.st[3][2], t[3]);
     s.st[3][3] = T::xor_and_rotate::<21, 43>(s.st[3][3], t[3]);
-    s.st[4][3] = T::xor_and_rotate::<56, 8>(s.st[4][3], t[3]);
+    s.st[3][4] = T::xor_and_rotate::<56, 8>(s.st[3][4], t[3]);
 
-    s.st[0][4] = T::xor_and_rotate::<27, 37>(s.st[0][4], t[4]);
-    s.st[1][4] = T::xor_and_rotate::<20, 44>(s.st[1][4], t[4]);
-    s.st[2][4] = T::xor_and_rotate::<39, 25>(s.st[2][4], t[4]);
-    s.st[3][4] = T::xor_and_rotate::<8, 56>(s.st[3][4], t[4]);
+    s.st[4][0] = T::xor_and_rotate::<27, 37>(s.st[4][0], t[4]);
+    s.st[4][1] = T::xor_and_rotate::<20, 44>(s.st[4][1], t[4]);
+    s.st[4][2] = T::xor_and_rotate::<39, 25>(s.st[4][2], t[4]);
+    s.st[4][3] = T::xor_and_rotate::<8, 56>(s.st[4][3], t[4]);
     s.st[4][4] = T::xor_and_rotate::<14, 50>(s.st[4][4], t[4]);
 }
 
@@ -293,30 +293,30 @@ const _PI: [usize; 24] = [
 #[inline(always)]
 pub(crate) fn pi<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
     let old = s.st;
-    s.st[0][1] = old[1][1];
-    s.st[0][2] = old[2][2];
-    s.st[0][3] = old[3][3];
-    s.st[0][4] = old[4][4];
-    s.st[1][0] = old[0][3];
-    s.st[1][1] = old[1][4];
-    s.st[1][2] = old[2][0];
-    s.st[1][3] = old[3][1];
-    s.st[1][4] = old[4][2];
-    s.st[2][0] = old[0][1];
-    s.st[2][1] = old[1][2];
-    s.st[2][2] = old[2][3];
-    s.st[2][3] = old[3][4];
-    s.st[2][4] = old[4][0];
-    s.st[3][0] = old[0][4];
-    s.st[3][1] = old[1][0];
-    s.st[3][2] = old[2][1];
-    s.st[3][3] = old[3][2];
-    s.st[3][4] = old[4][3];
-    s.st[4][0] = old[0][2];
-    s.st[4][1] = old[1][3];
-    s.st[4][2] = old[2][4];
-    s.st[4][3] = old[3][0];
-    s.st[4][4] = old[4][1];
+    s.st[1][0] = old[1][1];
+    s.st[2][0] = old[2][2];
+    s.st[3][0] = old[3][3];
+    s.st[4][0] = old[4][4];
+    s.st[0][1] = old[3][0];
+    s.st[1][1] = old[4][1];
+    s.st[2][1] = old[0][2];
+    s.st[3][1] = old[1][3];
+    s.st[4][1] = old[2][4];
+    s.st[0][2] = old[1][0];
+    s.st[1][2] = old[2][1];
+    s.st[2][2] = old[3][2];
+    s.st[3][2] = old[4][3];
+    s.st[4][2] = old[0][4];
+    s.st[0][3] = old[4][0];
+    s.st[1][3] = old[0][1];
+    s.st[2][3] = old[1][2];
+    s.st[3][3] = old[2][3];
+    s.st[4][3] = old[3][4];
+    s.st[0][4] = old[2][0];
+    s.st[1][4] = old[3][1];
+    s.st[2][4] = old[4][2];
+    s.st[3][4] = old[0][3];
+    s.st[4][4] = old[1][4];
 }
 
 #[inline(always)]
@@ -326,7 +326,7 @@ pub(crate) fn chi<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, 
     #[allow(clippy::needless_range_loop)]
     for i in 0..5 {
         for j in 0..5 {
-            s.st[i][j] = T::and_not_xor(s.st[i][j], old[i][(j + 2) % 5], old[i][(j + 1) % 5]);
+            s.st[i][j] = T::and_not_xor(s.st[i][j], old[(i + 2) % 5][j], old[(i + 1) % 5][j]);
         }
     }
 }

--- a/libcrux-sha3/src/generic_keccak.rs
+++ b/libcrux-sha3/src/generic_keccak.rs
@@ -12,10 +12,10 @@ pub(crate) struct KeccakState<const N: usize, T: KeccakStateItem<N>> {
 }
 
 impl<const N: usize, T: KeccakStateItem<N>> KeccakState<N, T> {
-    fn get(&self, i:usize, j:usize) -> T {
+    fn get(&self, i: usize, j: usize) -> T {
         get_ij(&self.st, i, j)
     }
-    fn set(&mut self, i:usize, j:usize, v:T) {
+    fn set(&mut self, i: usize, j: usize, v: T) {
         set_ij(&mut self.st, i, j, v);
     }
 }
@@ -241,11 +241,41 @@ const _ROTC: [usize; 24] = [
 #[inline(always)]
 pub(crate) fn theta_rho<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
     let c: [T; 5] = [
-        T::xor5(s.get(0, 0), s.get(1, 0), s.get(2, 0), s.get(3, 0), s.get(4, 0)),
-        T::xor5(s.get(0, 1), s.get(1, 1), s.get(2, 1), s.get(3, 1), s.get(4, 1)),
-        T::xor5(s.get(0, 2), s.get(1, 2), s.get(2, 2), s.get(3, 2), s.get(4, 2)),
-        T::xor5(s.get(0, 3), s.get(1, 3), s.get(2, 3), s.get(3, 3), s.get(4, 3)),
-        T::xor5(s.get(0, 4), s.get(1, 4), s.get(2, 4), s.get(3, 4), s.get(4, 4)),
+        T::xor5(
+            s.get(0, 0),
+            s.get(1, 0),
+            s.get(2, 0),
+            s.get(3, 0),
+            s.get(4, 0),
+        ),
+        T::xor5(
+            s.get(0, 1),
+            s.get(1, 1),
+            s.get(2, 1),
+            s.get(3, 1),
+            s.get(4, 1),
+        ),
+        T::xor5(
+            s.get(0, 2),
+            s.get(1, 2),
+            s.get(2, 2),
+            s.get(3, 2),
+            s.get(4, 2),
+        ),
+        T::xor5(
+            s.get(0, 3),
+            s.get(1, 3),
+            s.get(2, 3),
+            s.get(3, 3),
+            s.get(4, 3),
+        ),
+        T::xor5(
+            s.get(0, 4),
+            s.get(1, 4),
+            s.get(2, 4),
+            s.get(3, 4),
+            s.get(4, 4),
+        ),
     ];
     #[allow(clippy::identity_op)]
     let t: [T; 5] = [
@@ -256,34 +286,34 @@ pub(crate) fn theta_rho<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakSta
         T::rotate_left1_and_xor(c[(4 + 4) % 5], c[(4 + 1) % 5]),
     ];
 
-    s.set(0, 0,T::xor(s.get(0, 0), t[0]));
+    s.set(0, 0, T::xor(s.get(0, 0), t[0]));
     s.set(1, 0, T::xor_and_rotate::<36, 28>(s.get(1, 0), t[0]));
-    s.set(2, 0, T::xor_and_rotate::<3, 61> (s.get(2, 0), t[0]));
+    s.set(2, 0, T::xor_and_rotate::<3, 61>(s.get(2, 0), t[0]));
     s.set(3, 0, T::xor_and_rotate::<41, 23>(s.get(3, 0), t[0]));
     s.set(4, 0, T::xor_and_rotate::<18, 46>(s.get(4, 0), t[0]));
 
-    s.set(0, 1, T::xor_and_rotate::<1, 63> (s.get(0, 1), t[1]));
+    s.set(0, 1, T::xor_and_rotate::<1, 63>(s.get(0, 1), t[1]));
     s.set(1, 1, T::xor_and_rotate::<44, 20>(s.get(1, 1), t[1]));
     s.set(2, 1, T::xor_and_rotate::<10, 54>(s.get(2, 1), t[1]));
     s.set(3, 1, T::xor_and_rotate::<45, 19>(s.get(3, 1), t[1]));
-    s.set(4, 1, T::xor_and_rotate::<2, 62> (s.get(4, 1), t[1]));
+    s.set(4, 1, T::xor_and_rotate::<2, 62>(s.get(4, 1), t[1]));
 
-    s.set(0, 2, T::xor_and_rotate::<62, 2> (s.get(0, 2), t[2]));
-    s.set(1, 2, T::xor_and_rotate::<6, 58> (s.get(1, 2), t[2]));
+    s.set(0, 2, T::xor_and_rotate::<62, 2>(s.get(0, 2), t[2]));
+    s.set(1, 2, T::xor_and_rotate::<6, 58>(s.get(1, 2), t[2]));
     s.set(2, 2, T::xor_and_rotate::<43, 21>(s.get(2, 2), t[2]));
     s.set(3, 2, T::xor_and_rotate::<15, 49>(s.get(3, 2), t[2]));
-    s.set(4, 2, T::xor_and_rotate::<61, 3> (s.get(4, 2), t[2]));
+    s.set(4, 2, T::xor_and_rotate::<61, 3>(s.get(4, 2), t[2]));
 
     s.set(0, 3, T::xor_and_rotate::<28, 36>(s.get(0, 3), t[3]));
-    s.set(1, 3, T::xor_and_rotate::<55, 9> (s.get(1, 3), t[3]));
+    s.set(1, 3, T::xor_and_rotate::<55, 9>(s.get(1, 3), t[3]));
     s.set(2, 3, T::xor_and_rotate::<25, 39>(s.get(2, 3), t[3]));
     s.set(3, 3, T::xor_and_rotate::<21, 43>(s.get(3, 3), t[3]));
-    s.set(4, 3, T::xor_and_rotate::<56, 8> (s.get(4, 3), t[3]));
+    s.set(4, 3, T::xor_and_rotate::<56, 8>(s.get(4, 3), t[3]));
 
     s.set(0, 4, T::xor_and_rotate::<27, 37>(s.get(0, 4), t[4]));
     s.set(1, 4, T::xor_and_rotate::<20, 44>(s.get(1, 4), t[4]));
     s.set(2, 4, T::xor_and_rotate::<39, 25>(s.get(2, 4), t[4]));
-    s.set(3, 4, T::xor_and_rotate::<8, 56> (s.get(3, 4), t[4]));
+    s.set(3, 4, T::xor_and_rotate::<8, 56>(s.get(3, 4), t[4]));
     s.set(4, 4, T::xor_and_rotate::<14, 50>(s.get(4, 4), t[4]));
 }
 
@@ -327,7 +357,15 @@ pub(crate) fn chi<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, 
     #[allow(clippy::needless_range_loop)]
     for i in 0..5 {
         for j in 0..5 {
-            s.set(i, j, T::and_not_xor(s.get(i,j), old.get(i, (j + 2) % 5), old.get(i, (j + 1) % 5)));
+            s.set(
+                i,
+                j,
+                T::and_not_xor(
+                    s.get(i, j),
+                    old.get(i, (j + 2) % 5),
+                    old.get(i, (j + 1) % 5),
+                ),
+            );
         }
     }
 }

--- a/libcrux-sha3/src/generic_keccak.rs
+++ b/libcrux-sha3/src/generic_keccak.rs
@@ -13,10 +13,10 @@ pub(crate) struct KeccakState<const N: usize, T: KeccakStateItem<N>> {
 
 impl<const N: usize, T: KeccakStateItem<N>> KeccakState<N, T> {
     fn get(&self, i:usize, j:usize) -> T {
-        self.st[5*i + j]
+        get_ij(&self.st, i, j)
     }
     fn set(&mut self, i:usize, j:usize, v:T) {
-        self.st[5*i + j] = v; 
+        set_ij(&mut self.st, i, j, v);
     }
 }
 
@@ -241,11 +241,11 @@ const _ROTC: [usize; 24] = [
 #[inline(always)]
 pub(crate) fn theta_rho<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
     let c: [T; 5] = [
-        T::xor5(s.get(0,0), s.get(0,1), s.get(0,2), s.get(0,3), s.get(0,4)),
-        T::xor5(s.get(1,0), s.get(1,1), s.get(1,2), s.get(1,3), s.get(1,4)),
-        T::xor5(s.get(2,0), s.get(2,1), s.get(2,2), s.get(2,3), s.get(2,4)),
-        T::xor5(s.get(3,0), s.get(3,1), s.get(3,2), s.get(3,3), s.get(3,4)),
-        T::xor5(s.get(4,0), s.get(4,1), s.get(4,2), s.get(4,3), s.get(4,4)),
+        T::xor5(s.get(0, 0), s.get(1, 0), s.get(2, 0), s.get(3, 0), s.get(4, 0)),
+        T::xor5(s.get(0, 1), s.get(1, 1), s.get(2, 1), s.get(3, 1), s.get(4, 1)),
+        T::xor5(s.get(0, 2), s.get(1, 2), s.get(2, 2), s.get(3, 2), s.get(4, 2)),
+        T::xor5(s.get(0, 3), s.get(1, 3), s.get(2, 3), s.get(3, 3), s.get(4, 3)),
+        T::xor5(s.get(0, 4), s.get(1, 4), s.get(2, 4), s.get(3, 4), s.get(4, 4)),
     ];
     #[allow(clippy::identity_op)]
     let t: [T; 5] = [
@@ -256,31 +256,35 @@ pub(crate) fn theta_rho<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakSta
         T::rotate_left1_and_xor(c[(4 + 4) % 5], c[(4 + 1) % 5]),
     ];
 
-    s.set(0,0,T::xor(s.get(0,0), t[0]));
-    s.set(0,1,T::xor_and_rotate::<36, 28>(s.get(0,1), t[0]));
-    s.set(0,2,T::xor_and_rotate::<3, 61> (s.get(0,2), t[0]));
-    s.set(0,3,T::xor_and_rotate::<41, 23>(s.get(0,3), t[0]));
-    s.set(0,4,T::xor_and_rotate::<18, 46>(s.get(0,4), t[0]));
-    s.set(1,0,T::xor_and_rotate::<1, 63> (s.get(1,0), t[1]));
-    s.set(1,1,T::xor_and_rotate::<44, 20>(s.get(1,1), t[1]));
-    s.set(1,2,T::xor_and_rotate::<10, 54>(s.get(1,2), t[1]));
-    s.set(1,3,T::xor_and_rotate::<45, 19>(s.get(1,3), t[1]));
-    s.set(1,4,T::xor_and_rotate::<2, 62> (s.get(1,4), t[1]));
-    s.set(2,0,T::xor_and_rotate::<62, 2> (s.get(2,0), t[2]));
-    s.set(2,1,T::xor_and_rotate::<6, 58> (s.get(2,1), t[2]));
-    s.set(2,2,T::xor_and_rotate::<43, 21>(s.get(2,2), t[2]));
-    s.set(2,3,T::xor_and_rotate::<15, 49>(s.get(2,3), t[2]));
-    s.set(2,4,T::xor_and_rotate::<61, 3> (s.get(2,4), t[2]));
-    s.set(3,0,T::xor_and_rotate::<28, 36>(s.get(3,0), t[3]));
-    s.set(3,1,T::xor_and_rotate::<55, 9> (s.get(3,1), t[3]));
-    s.set(3,2,T::xor_and_rotate::<25, 39>(s.get(3,2), t[3]));
-    s.set(3,3,T::xor_and_rotate::<21, 43>(s.get(3,3), t[3]));
-    s.set(3,4,T::xor_and_rotate::<56, 8> (s.get(3,4), t[3]));
-    s.set(4,0,T::xor_and_rotate::<27, 37>(s.get(4,0), t[4]));
-    s.set(4,1,T::xor_and_rotate::<20, 44>(s.get(4,1), t[4]));
-    s.set(4,2,T::xor_and_rotate::<39, 25>(s.get(4,2), t[4]));
-    s.set(4,3,T::xor_and_rotate::<8, 56> (s.get(4,3), t[4]));
-    s.set(4,4,T::xor_and_rotate::<14, 50>(s.get(4,4), t[4]));
+    s.set(0, 0,T::xor(s.get(0, 0), t[0]));
+    s.set(1, 0, T::xor_and_rotate::<36, 28>(s.get(1, 0), t[0]));
+    s.set(2, 0, T::xor_and_rotate::<3, 61> (s.get(2, 0), t[0]));
+    s.set(3, 0, T::xor_and_rotate::<41, 23>(s.get(3, 0), t[0]));
+    s.set(4, 0, T::xor_and_rotate::<18, 46>(s.get(4, 0), t[0]));
+
+    s.set(0, 1, T::xor_and_rotate::<1, 63> (s.get(0, 1), t[1]));
+    s.set(1, 1, T::xor_and_rotate::<44, 20>(s.get(1, 1), t[1]));
+    s.set(2, 1, T::xor_and_rotate::<10, 54>(s.get(2, 1), t[1]));
+    s.set(3, 1, T::xor_and_rotate::<45, 19>(s.get(3, 1), t[1]));
+    s.set(4, 1, T::xor_and_rotate::<2, 62> (s.get(4, 1), t[1]));
+
+    s.set(0, 2, T::xor_and_rotate::<62, 2> (s.get(0, 2), t[2]));
+    s.set(1, 2, T::xor_and_rotate::<6, 58> (s.get(1, 2), t[2]));
+    s.set(2, 2, T::xor_and_rotate::<43, 21>(s.get(2, 2), t[2]));
+    s.set(3, 2, T::xor_and_rotate::<15, 49>(s.get(3, 2), t[2]));
+    s.set(4, 2, T::xor_and_rotate::<61, 3> (s.get(4, 2), t[2]));
+
+    s.set(0, 3, T::xor_and_rotate::<28, 36>(s.get(0, 3), t[3]));
+    s.set(1, 3, T::xor_and_rotate::<55, 9> (s.get(1, 3), t[3]));
+    s.set(2, 3, T::xor_and_rotate::<25, 39>(s.get(2, 3), t[3]));
+    s.set(3, 3, T::xor_and_rotate::<21, 43>(s.get(3, 3), t[3]));
+    s.set(4, 3, T::xor_and_rotate::<56, 8> (s.get(4, 3), t[3]));
+
+    s.set(0, 4, T::xor_and_rotate::<27, 37>(s.get(0, 4), t[4]));
+    s.set(1, 4, T::xor_and_rotate::<20, 44>(s.get(1, 4), t[4]));
+    s.set(2, 4, T::xor_and_rotate::<39, 25>(s.get(2, 4), t[4]));
+    s.set(3, 4, T::xor_and_rotate::<8, 56> (s.get(3, 4), t[4]));
+    s.set(4, 4, T::xor_and_rotate::<14, 50>(s.get(4, 4), t[4]));
 }
 
 const _PI: [usize; 24] = [
@@ -290,30 +294,30 @@ const _PI: [usize; 24] = [
 #[inline(always)]
 pub(crate) fn pi<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
     let old = s.clone();
-    s.set(0,1,old.get(3,0));
-    s.set(0,2,old.get(1,0));
-    s.set(0,3,old.get(4,0));
-    s.set(0,4,old.get(2,0));
-    s.set(1,0,old.get(1,1));
-    s.set(1,1,old.get(4,1));
-    s.set(1,2,old.get(2,1));
-    s.set(1,3,old.get(0,1));
-    s.set(1,4,old.get(3,1));
-    s.set(2,0,old.get(2,2));
-    s.set(2,1,old.get(0,2));
-    s.set(2,2,old.get(3,2));
-    s.set(2,3,old.get(1,2));
-    s.set(2,4,old.get(4,2));
-    s.set(3,0,old.get(3,3));
-    s.set(3,1,old.get(1,3));
-    s.set(3,2,old.get(4,3));
-    s.set(3,3,old.get(2,3));
-    s.set(3,4,old.get(0,3));
-    s.set(4,0,old.get(4,4));
-    s.set(4,1,old.get(2,4));
-    s.set(4,2,old.get(0,4));
-    s.set(4,3,old.get(3,4));
-    s.set(4,4,old.get(1,4));
+    s.set(1, 0, old.get(0, 3));
+    s.set(2, 0, old.get(0, 1));
+    s.set(3, 0, old.get(0, 4));
+    s.set(4, 0, old.get(0, 2));
+    s.set(0, 1, old.get(1, 1));
+    s.set(1, 1, old.get(1, 4));
+    s.set(2, 1, old.get(1, 2));
+    s.set(3, 1, old.get(1, 0));
+    s.set(4, 1, old.get(1, 3));
+    s.set(0, 2, old.get(2, 2));
+    s.set(1, 2, old.get(2, 0));
+    s.set(2, 2, old.get(2, 3));
+    s.set(3, 2, old.get(2, 1));
+    s.set(4, 2, old.get(2, 4));
+    s.set(0, 3, old.get(3, 3));
+    s.set(1, 3, old.get(3, 1));
+    s.set(2, 3, old.get(3, 4));
+    s.set(3, 3, old.get(3, 2));
+    s.set(4, 3, old.get(3, 0));
+    s.set(0, 4, old.get(4, 4));
+    s.set(1, 4, old.get(4, 2));
+    s.set(2, 4, old.get(4, 0));
+    s.set(3, 4, old.get(4, 3));
+    s.set(4, 4, old.get(4, 1));
 }
 
 #[inline(always)]
@@ -323,7 +327,7 @@ pub(crate) fn chi<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, 
     #[allow(clippy::needless_range_loop)]
     for i in 0..5 {
         for j in 0..5 {
-            s.set(i, j, T::and_not_xor(s.get(i,j), old.get((i + 2) % 5,j), old.get((i + 1) % 5,j)));
+            s.set(i, j, T::and_not_xor(s.get(i,j), old.get(i, (j + 2) % 5), old.get(i, (j + 1) % 5)));
         }
     }
 }

--- a/libcrux-sha3/src/generic_keccak.rs
+++ b/libcrux-sha3/src/generic_keccak.rs
@@ -8,14 +8,15 @@ use crate::traits::*;
 #[cfg_attr(hax, hax_lib::opaque)]
 #[derive(Clone, Copy)]
 pub(crate) struct KeccakState<const N: usize, T: KeccakStateItem<N>> {
-    st: [[T; 5]; 5],
+    st: [T; 25],
 }
 
-impl<const N: usize, T: KeccakStateItem<N>> Index<usize> for KeccakState<N, T> {
-    type Output = [T; 5];
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.st[index]
+impl<const N: usize, T: KeccakStateItem<N>> KeccakState<N, T> {
+    fn get(&self, i:usize, j:usize) -> T {
+        self.st[5*i + j]
+    }
+    fn set(&mut self, i:usize, j:usize, v:T) {
+        self.st[5*i + j] = v; 
     }
 }
 
@@ -24,7 +25,7 @@ impl<const N: usize, T: KeccakStateItem<N>> KeccakState<N, T> {
     #[inline(always)]
     pub(crate) fn new() -> Self {
         Self {
-            st: [[T::zero(); 5]; 5],
+            st: [T::zero(); 25],
         }
     }
 }
@@ -240,11 +241,11 @@ const _ROTC: [usize; 24] = [
 #[inline(always)]
 pub(crate) fn theta_rho<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
     let c: [T; 5] = [
-        T::xor5(s.st[0][0], s.st[0][1], s.st[0][2], s.st[0][3], s.st[0][4]),
-        T::xor5(s.st[1][0], s.st[1][1], s.st[1][2], s.st[1][3], s.st[1][4]),
-        T::xor5(s.st[2][0], s.st[2][1], s.st[2][2], s.st[2][3], s.st[2][4]),
-        T::xor5(s.st[3][0], s.st[3][1], s.st[3][2], s.st[3][3], s.st[3][4]),
-        T::xor5(s.st[4][0], s.st[4][1], s.st[4][2], s.st[4][3], s.st[4][4]),
+        T::xor5(s.get(0,0), s.get(0,1), s.get(0,2), s.get(0,3), s.get(0,4)),
+        T::xor5(s.get(1,0), s.get(1,1), s.get(1,2), s.get(1,3), s.get(1,4)),
+        T::xor5(s.get(2,0), s.get(2,1), s.get(2,2), s.get(2,3), s.get(2,4)),
+        T::xor5(s.get(3,0), s.get(3,1), s.get(3,2), s.get(3,3), s.get(3,4)),
+        T::xor5(s.get(4,0), s.get(4,1), s.get(4,2), s.get(4,3), s.get(4,4)),
     ];
     #[allow(clippy::identity_op)]
     let t: [T; 5] = [
@@ -255,35 +256,31 @@ pub(crate) fn theta_rho<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakSta
         T::rotate_left1_and_xor(c[(4 + 4) % 5], c[(4 + 1) % 5]),
     ];
 
-    s.st[0][0] = T::xor(s.st[0][0], t[0]);
-    s.st[0][1] = T::xor_and_rotate::<36, 28>(s.st[0][1], t[0]);
-    s.st[0][2] = T::xor_and_rotate::<3, 61>(s.st[0][2], t[0]);
-    s.st[0][3] = T::xor_and_rotate::<41, 23>(s.st[0][3], t[0]);
-    s.st[0][4] = T::xor_and_rotate::<18, 46>(s.st[0][4], t[0]);
-
-    s.st[1][0] = T::xor_and_rotate::<1, 63>(s.st[1][0], t[1]);
-    s.st[1][1] = T::xor_and_rotate::<44, 20>(s.st[1][1], t[1]);
-    s.st[1][2] = T::xor_and_rotate::<10, 54>(s.st[1][2], t[1]);
-    s.st[1][3] = T::xor_and_rotate::<45, 19>(s.st[1][3], t[1]);
-    s.st[1][4] = T::xor_and_rotate::<2, 62>(s.st[1][4], t[1]);
-
-    s.st[2][0] = T::xor_and_rotate::<62, 2>(s.st[2][0], t[2]);
-    s.st[2][1] = T::xor_and_rotate::<6, 58>(s.st[2][1], t[2]);
-    s.st[2][2] = T::xor_and_rotate::<43, 21>(s.st[2][2], t[2]);
-    s.st[2][3] = T::xor_and_rotate::<15, 49>(s.st[2][3], t[2]);
-    s.st[2][4] = T::xor_and_rotate::<61, 3>(s.st[2][4], t[2]);
-
-    s.st[3][0] = T::xor_and_rotate::<28, 36>(s.st[3][0], t[3]);
-    s.st[3][1] = T::xor_and_rotate::<55, 9>(s.st[3][1], t[3]);
-    s.st[3][2] = T::xor_and_rotate::<25, 39>(s.st[3][2], t[3]);
-    s.st[3][3] = T::xor_and_rotate::<21, 43>(s.st[3][3], t[3]);
-    s.st[3][4] = T::xor_and_rotate::<56, 8>(s.st[3][4], t[3]);
-
-    s.st[4][0] = T::xor_and_rotate::<27, 37>(s.st[4][0], t[4]);
-    s.st[4][1] = T::xor_and_rotate::<20, 44>(s.st[4][1], t[4]);
-    s.st[4][2] = T::xor_and_rotate::<39, 25>(s.st[4][2], t[4]);
-    s.st[4][3] = T::xor_and_rotate::<8, 56>(s.st[4][3], t[4]);
-    s.st[4][4] = T::xor_and_rotate::<14, 50>(s.st[4][4], t[4]);
+    s.set(0,0,T::xor(s.get(0,0), t[0]));
+    s.set(0,1,T::xor_and_rotate::<36, 28>(s.get(0,1), t[0]));
+    s.set(0,2,T::xor_and_rotate::<3, 61> (s.get(0,2), t[0]));
+    s.set(0,3,T::xor_and_rotate::<41, 23>(s.get(0,3), t[0]));
+    s.set(0,4,T::xor_and_rotate::<18, 46>(s.get(0,4), t[0]));
+    s.set(1,0,T::xor_and_rotate::<1, 63> (s.get(1,0), t[1]));
+    s.set(1,1,T::xor_and_rotate::<44, 20>(s.get(1,1), t[1]));
+    s.set(1,2,T::xor_and_rotate::<10, 54>(s.get(1,2), t[1]));
+    s.set(1,3,T::xor_and_rotate::<45, 19>(s.get(1,3), t[1]));
+    s.set(1,4,T::xor_and_rotate::<2, 62> (s.get(1,4), t[1]));
+    s.set(2,0,T::xor_and_rotate::<62, 2> (s.get(2,0), t[2]));
+    s.set(2,1,T::xor_and_rotate::<6, 58> (s.get(2,1), t[2]));
+    s.set(2,2,T::xor_and_rotate::<43, 21>(s.get(2,2), t[2]));
+    s.set(2,3,T::xor_and_rotate::<15, 49>(s.get(2,3), t[2]));
+    s.set(2,4,T::xor_and_rotate::<61, 3> (s.get(2,4), t[2]));
+    s.set(3,0,T::xor_and_rotate::<28, 36>(s.get(3,0), t[3]));
+    s.set(3,1,T::xor_and_rotate::<55, 9> (s.get(3,1), t[3]));
+    s.set(3,2,T::xor_and_rotate::<25, 39>(s.get(3,2), t[3]));
+    s.set(3,3,T::xor_and_rotate::<21, 43>(s.get(3,3), t[3]));
+    s.set(3,4,T::xor_and_rotate::<56, 8> (s.get(3,4), t[3]));
+    s.set(4,0,T::xor_and_rotate::<27, 37>(s.get(4,0), t[4]));
+    s.set(4,1,T::xor_and_rotate::<20, 44>(s.get(4,1), t[4]));
+    s.set(4,2,T::xor_and_rotate::<39, 25>(s.get(4,2), t[4]));
+    s.set(4,3,T::xor_and_rotate::<8, 56> (s.get(4,3), t[4]));
+    s.set(4,4,T::xor_and_rotate::<14, 50>(s.get(4,4), t[4]));
 }
 
 const _PI: [usize; 24] = [
@@ -292,41 +289,41 @@ const _PI: [usize; 24] = [
 
 #[inline(always)]
 pub(crate) fn pi<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
-    let old = s.st;
-    s.st[1][0] = old[1][1];
-    s.st[2][0] = old[2][2];
-    s.st[3][0] = old[3][3];
-    s.st[4][0] = old[4][4];
-    s.st[0][1] = old[3][0];
-    s.st[1][1] = old[4][1];
-    s.st[2][1] = old[0][2];
-    s.st[3][1] = old[1][3];
-    s.st[4][1] = old[2][4];
-    s.st[0][2] = old[1][0];
-    s.st[1][2] = old[2][1];
-    s.st[2][2] = old[3][2];
-    s.st[3][2] = old[4][3];
-    s.st[4][2] = old[0][4];
-    s.st[0][3] = old[4][0];
-    s.st[1][3] = old[0][1];
-    s.st[2][3] = old[1][2];
-    s.st[3][3] = old[2][3];
-    s.st[4][3] = old[3][4];
-    s.st[0][4] = old[2][0];
-    s.st[1][4] = old[3][1];
-    s.st[2][4] = old[4][2];
-    s.st[3][4] = old[0][3];
-    s.st[4][4] = old[1][4];
+    let old = s.clone();
+    s.set(0,1,old.get(3,0));
+    s.set(0,2,old.get(1,0));
+    s.set(0,3,old.get(4,0));
+    s.set(0,4,old.get(2,0));
+    s.set(1,0,old.get(1,1));
+    s.set(1,1,old.get(4,1));
+    s.set(1,2,old.get(2,1));
+    s.set(1,3,old.get(0,1));
+    s.set(1,4,old.get(3,1));
+    s.set(2,0,old.get(2,2));
+    s.set(2,1,old.get(0,2));
+    s.set(2,2,old.get(3,2));
+    s.set(2,3,old.get(1,2));
+    s.set(2,4,old.get(4,2));
+    s.set(3,0,old.get(3,3));
+    s.set(3,1,old.get(1,3));
+    s.set(3,2,old.get(4,3));
+    s.set(3,3,old.get(2,3));
+    s.set(3,4,old.get(0,3));
+    s.set(4,0,old.get(4,4));
+    s.set(4,1,old.get(2,4));
+    s.set(4,2,old.get(0,4));
+    s.set(4,3,old.get(3,4));
+    s.set(4,4,old.get(1,4));
 }
 
 #[inline(always)]
 pub(crate) fn chi<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
-    let old = s.st;
+    let old = s.clone();
 
     #[allow(clippy::needless_range_loop)]
     for i in 0..5 {
         for j in 0..5 {
-            s.st[i][j] = T::and_not_xor(s.st[i][j], old[(i + 2) % 5][j], old[(i + 1) % 5][j]);
+            s.set(i, j, T::and_not_xor(s.get(i,j), old.get((i + 2) % 5,j), old.get((i + 1) % 5,j)));
         }
     }
 }
@@ -360,7 +357,7 @@ const ROUNDCONSTANTS: [u64; 24] = [
 
 #[inline(always)]
 pub(crate) fn iota<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>, i: usize) {
-    s.st[0][0] = T::xor_constant(s.st[0][0], ROUNDCONSTANTS[i]);
+    s.set(0, 0, T::xor_constant(s.get(0, 0), ROUNDCONSTANTS[i]));
 }
 
 #[inline(always)]

--- a/libcrux-sha3/src/portable_keccak.rs
+++ b/libcrux-sha3/src/portable_keccak.rs
@@ -1,6 +1,6 @@
 //! A portable SHA3 implementation using the generic implementation.
 
-use crate::traits::internal::*;
+use crate::traits::{*, internal::*};
 
 #[inline(always)]
 fn rotate_left<const LEFT: i32, const RIGHT: i32>(x: u64) -> u64 {
@@ -46,7 +46,7 @@ pub(crate) fn load_block<const RATE: usize>(
         state_flat[i] = u64::from_le_bytes(blocks[offset..offset + 8].try_into().unwrap());
     }
     for i in 0..RATE / 8 {
-        state[5 * (i % 5) + (i / 5)] ^= state_flat[i];
+        set_ij(state, i / 5, i % 5, get_ij(state, i / 5, i % 5) ^ state_flat[i]);
     }
 }
 
@@ -62,7 +62,7 @@ pub(crate) fn load_block_full<const RATE: usize>(
 #[inline(always)]
 pub(crate) fn store_block<const RATE: usize>(s: &[u64; 25], out: &mut [u8]) {
     for i in 0..RATE / 8 {
-        out[8 * i..8 * i + 8].copy_from_slice(&s[5 * (i % 5) + (i / 5)].to_le_bytes());
+        out[8 * i..8 * i + 8].copy_from_slice(&get_ij(s, i / 5, i % 5).to_le_bytes());
     }
 }
 
@@ -145,11 +145,11 @@ impl KeccakItem<1> for u64 {
         let last_block_len = out[0].len() % 8;
 
         for i in 0..num_full_blocks {
-            out[0][i * 8..i * 8 + 8].copy_from_slice(&state[5 * (i % 5) + (i / 5)].to_le_bytes());
+            out[0][i * 8..i * 8 + 8].copy_from_slice(&get_ij(state, i / 5, i % 5).to_le_bytes());
         }
         if last_block_len != 0 {
             out[0][num_full_blocks * 8..num_full_blocks * 8 + last_block_len].copy_from_slice(
-                &state[5 * (num_full_blocks % 5) + (num_full_blocks / 5)].to_le_bytes()[0..last_block_len],
+                &get_ij(state, num_full_blocks / 5, num_full_blocks % 5).to_le_bytes()[0..last_block_len],
             );
         }
     }

--- a/libcrux-sha3/src/portable_keccak.rs
+++ b/libcrux-sha3/src/portable_keccak.rs
@@ -1,6 +1,6 @@
 //! A portable SHA3 implementation using the generic implementation.
 
-use crate::traits::{*, internal::*};
+use crate::traits::{internal::*, *};
 
 #[inline(always)]
 fn rotate_left<const LEFT: i32, const RIGHT: i32>(x: u64) -> u64 {
@@ -34,11 +34,7 @@ fn _veorq_n_u64(a: u64, c: u64) -> u64 {
 }
 
 #[inline(always)]
-pub(crate) fn load_block<const RATE: usize>(
-    state: &mut [u64; 25],
-    blocks: &[u8],
-    start: usize,
-) {
+pub(crate) fn load_block<const RATE: usize>(state: &mut [u64; 25], blocks: &[u8], start: usize) {
     debug_assert!(RATE <= blocks.len() && RATE % 8 == 0);
     let mut state_flat = [0u64; 25];
     for i in 0..RATE / 8 {
@@ -46,7 +42,12 @@ pub(crate) fn load_block<const RATE: usize>(
         state_flat[i] = u64::from_le_bytes(blocks[offset..offset + 8].try_into().unwrap());
     }
     for i in 0..RATE / 8 {
-        set_ij(state, i / 5, i % 5, get_ij(state, i / 5, i % 5) ^ state_flat[i]);
+        set_ij(
+            state,
+            i / 5,
+            i % 5,
+            get_ij(state, i / 5, i % 5) ^ state_flat[i],
+        );
     }
 }
 
@@ -106,11 +107,7 @@ impl KeccakItem<1> for u64 {
         a ^ b
     }
     #[inline(always)]
-    fn load_block<const RATE: usize>(
-        state: &mut [Self; 25],
-        blocks: &[&[u8]; 1],
-        start: usize,
-    ) {
+    fn load_block<const RATE: usize>(state: &mut [Self; 25], blocks: &[&[u8]; 1], start: usize) {
         load_block::<RATE>(state, blocks[0], start)
     }
     #[inline(always)]
@@ -149,7 +146,8 @@ impl KeccakItem<1> for u64 {
         }
         if last_block_len != 0 {
             out[0][num_full_blocks * 8..num_full_blocks * 8 + last_block_len].copy_from_slice(
-                &get_ij(state, num_full_blocks / 5, num_full_blocks % 5).to_le_bytes()[0..last_block_len],
+                &get_ij(state, num_full_blocks / 5, num_full_blocks % 5).to_le_bytes()
+                    [0..last_block_len],
             );
         }
     }

--- a/libcrux-sha3/src/portable_keccak.rs
+++ b/libcrux-sha3/src/portable_keccak.rs
@@ -46,7 +46,7 @@ pub(crate) fn load_block<const RATE: usize>(
         state_flat[i] = u64::from_le_bytes(blocks[offset..offset + 8].try_into().unwrap());
     }
     for i in 0..RATE / 8 {
-        state[i / 5][i % 5] ^= state_flat[i];
+        state[i % 5][i / 5] ^= state_flat[i];
     }
 }
 
@@ -62,7 +62,7 @@ pub(crate) fn load_block_full<const RATE: usize>(
 #[inline(always)]
 pub(crate) fn store_block<const RATE: usize>(s: &[[u64; 5]; 5], out: &mut [u8]) {
     for i in 0..RATE / 8 {
-        out[8 * i..8 * i + 8].copy_from_slice(&s[i / 5][i % 5].to_le_bytes());
+        out[8 * i..8 * i + 8].copy_from_slice(&s[i % 5][i / 5].to_le_bytes());
     }
 }
 
@@ -145,11 +145,11 @@ impl KeccakItem<1> for u64 {
         let last_block_len = out[0].len() % 8;
 
         for i in 0..num_full_blocks {
-            out[0][i * 8..i * 8 + 8].copy_from_slice(&state[i / 5][i % 5].to_le_bytes());
+            out[0][i * 8..i * 8 + 8].copy_from_slice(&state[i % 5][i / 5].to_le_bytes());
         }
         if last_block_len != 0 {
             out[0][num_full_blocks * 8..num_full_blocks * 8 + last_block_len].copy_from_slice(
-                &state[num_full_blocks / 5][num_full_blocks % 5].to_le_bytes()[0..last_block_len],
+                &state[num_full_blocks % 5][num_full_blocks / 5].to_le_bytes()[0..last_block_len],
             );
         }
     }

--- a/libcrux-sha3/src/simd/arm64.rs
+++ b/libcrux-sha3/src/simd/arm64.rs
@@ -1,6 +1,6 @@
 use libcrux_intrinsics::arm64::*;
 
-use crate::traits::internal::KeccakItem;
+use crate::traits::{get_ij, set_ij, internal::KeccakItem};
 
 #[allow(non_camel_case_types)]
 pub type uint64x2_t = _uint64x2_t;
@@ -48,10 +48,12 @@ pub(crate) fn load_block<const RATE: usize>(
         let start = offset + 16 * i;
         let v0 = _vld1q_bytes_u64(&blocks[0][start..start + 16]);
         let v1 = _vld1q_bytes_u64(&blocks[1][start..start + 16]);
-        let idx0 = 5 * ((2 * i) % 5) + ((2 * i) / 5);
-        let idx1 = 5 * ((2 * i + 1) % 5) + ((2 * i + 1) / 5);
-        s[idx0] = _veorq_u64(s[idx0], _vtrn1q_u64(v0, v1));
-        s[idx1] = _veorq_u64(s[idx1], _vtrn2q_u64(v0, v1));
+        let i0 = (2 * i) / 5;
+        let j0 = (2 * i) % 5;
+        let i1 = (2 * i + 1) / 5;
+        let j1 = (2 * i + 1) % 5;
+        set_ij(s, i0, j0, _veorq_u64(get_ij(s, i0, j0), _vtrn1q_u64(v0, v1)));
+        set_ij(s, i1, j1, _veorq_u64(get_ij(s, i1, j1), _vtrn2q_u64(v0, v1)));
     }
     if RATE % 16 != 0 {
         let i = RATE / 8 - 1;
@@ -60,7 +62,7 @@ pub(crate) fn load_block<const RATE: usize>(
         u[0] = u64::from_le_bytes(blocks[0][start..start + 8].try_into().unwrap());
         u[1] = u64::from_le_bytes(blocks[1][start..start + 8].try_into().unwrap());
         let uvec = _vld1q_u64(&u);
-        s[i] = _veorq_u64(s[5 * (i % 5) + (i / 5)], uvec);
+        set_ij(s, i / 5, i % 5, _veorq_u64(get_ij(s, i / 5, i % 5), uvec));
     }
 }
 
@@ -76,15 +78,17 @@ pub(crate) fn load_block_full<const RATE: usize>(
 #[inline(always)]
 pub(crate) fn store_block<const RATE: usize>(s: &[uint64x2_t; 25], out: &mut [&mut [u8]; 2]) {
     for i in 0..RATE / 16 {
-        let idx0 = 5 * ((2 * i) % 5) + ((2 * i) / 5);
-        let idx1 = 5 * ((2 * i + 1) % 5) + ((2 * i + 1) / 5);
+        let i0 = (2 * i) / 5;
+        let j0 = (2 * i) % 5;
+        let i1 = (2 * i + 1) / 5;
+        let j1 = (2 * i + 1) % 5;
         let v0 = _vtrn1q_u64(
-            s[idx0],
-            s[idx1],
+            get_ij(s, i0, j0),
+            get_ij(s, i1, j1)
         );
         let v1 = _vtrn2q_u64(
-            s[idx0],
-            s[idx1],
+            get_ij(s, i0, j0),
+            get_ij(s, i1, j1)
         );
         _vst1q_bytes_u64(&mut out[0][16 * i..16 * (i + 1)], v0);
         _vst1q_bytes_u64(&mut out[1][16 * i..16 * (i + 1)], v1);
@@ -93,7 +97,7 @@ pub(crate) fn store_block<const RATE: usize>(s: &[uint64x2_t; 25], out: &mut [&m
         debug_assert!(RATE % 8 == 0);
         let i = RATE / 8 - 1;
         let mut u = [0u8; 16];
-        _vst1q_bytes_u64(&mut u, s[5 * (i % 5) + (i / 5)]);
+        _vst1q_bytes_u64(&mut u, get_ij(s, i / 5, i % 5));
         out[0][RATE - 8..RATE].copy_from_slice(&u[0..8]);
         out[1][RATE - 8..RATE].copy_from_slice(&u[8..16]);
     }

--- a/libcrux-sha3/src/simd/arm64.rs
+++ b/libcrux-sha3/src/simd/arm64.rs
@@ -48,13 +48,13 @@ pub(crate) fn load_block<const RATE: usize>(
         let start = offset + 16 * i;
         let v0 = _vld1q_bytes_u64(&blocks[0][start..start + 16]);
         let v1 = _vld1q_bytes_u64(&blocks[1][start..start + 16]);
-        s[(2 * i) / 5][(2 * i) % 5] = _veorq_u64(s[(2 * i) / 5][(2 * i) % 5], _vtrn1q_u64(v0, v1));
-        s[(2 * i + 1) / 5][(2 * i + 1) % 5] =
-            _veorq_u64(s[(2 * i + 1) / 5][(2 * i + 1) % 5], _vtrn2q_u64(v0, v1));
+        s[(2 * i) % 5][(2 * i) / 5] = _veorq_u64(s[(2 * i) % 5][(2 * i) / 5], _vtrn1q_u64(v0, v1));
+        s[(2 * i + 1) % 5][(2 * i + 1) / 5] =
+            _veorq_u64(s[(2 * i + 1) % 5][(2 * i + 1) / 5], _vtrn2q_u64(v0, v1));
     }
     if RATE % 16 != 0 {
-        let i = (RATE / 8 - 1) / 5;
-        let j = (RATE / 8 - 1) % 5;
+        let i = (RATE / 8 - 1) % 5;
+        let j = (RATE / 8 - 1) / 5;
         let mut u = [0u64; 2];
         let start = offset + RATE - 8;
         u[0] = u64::from_le_bytes(blocks[0][start..start + 8].try_into().unwrap());
@@ -77,20 +77,20 @@ pub(crate) fn load_block_full<const RATE: usize>(
 pub(crate) fn store_block<const RATE: usize>(s: &[[uint64x2_t; 5]; 5], out: &mut [&mut [u8]; 2]) {
     for i in 0..RATE / 16 {
         let v0 = _vtrn1q_u64(
-            s[(2 * i) / 5][(2 * i) % 5],
-            s[(2 * i + 1) / 5][(2 * i + 1) % 5],
+            s[(2 * i) % 5][(2 * i) / 5],
+            s[(2 * i + 1) % 5][(2 * i + 1) / 5],
         );
         let v1 = _vtrn2q_u64(
-            s[(2 * i) / 5][(2 * i) % 5],
-            s[(2 * i + 1) / 5][(2 * i + 1) % 5],
+            s[(2 * i) % 5][(2 * i) / 5],
+            s[(2 * i + 1) % 5][(2 * i + 1) / 5],
         );
         _vst1q_bytes_u64(&mut out[0][16 * i..16 * (i + 1)], v0);
         _vst1q_bytes_u64(&mut out[1][16 * i..16 * (i + 1)], v1);
     }
     if RATE % 16 != 0 {
         debug_assert!(RATE % 8 == 0);
-        let i = (RATE / 8 - 1) / 5;
-        let j = (RATE / 8 - 1) % 5;
+        let i = (RATE / 8 - 1) % 5;
+        let j = (RATE / 8 - 1) / 5;
         let mut u = [0u8; 16];
         _vst1q_bytes_u64(&mut u, s[i][j]);
         out[0][RATE - 8..RATE].copy_from_slice(&u[0..8]);

--- a/libcrux-sha3/src/simd/avx2.rs
+++ b/libcrux-sha3/src/simd/avx2.rs
@@ -1,4 +1,4 @@
-use crate::traits::internal::*;
+use crate::traits::{internal::*, *};
 use libcrux_intrinsics::avx2::*;
 
 #[inline(always)]

--- a/libcrux-sha3/src/simd/avx2.rs
+++ b/libcrux-sha3/src/simd/avx2.rs
@@ -69,12 +69,9 @@ pub(crate) fn load_block<const RATE: usize>(
         let idx3 = 5 * ((4 * i + 3) % 5) + ((4 * i + 3) / 5);
 
         state[idx0] = mm256_xor_si256(state[idx0], v0);
-        state[idx1] =
-            mm256_xor_si256(state[idx1], v1);
-        state[idx2] =
-            mm256_xor_si256(state[idx2], v2);
-        state[idx3] =
-            mm256_xor_si256(state[idx3], v3);
+        state[idx1] = mm256_xor_si256(state[idx1], v1);
+        state[idx2] = mm256_xor_si256(state[idx2], v2);
+        state[idx3] = mm256_xor_si256(state[idx3], v3);
     }
 
     let rem = RATE % 32; // has to be 8 or 16
@@ -125,23 +122,11 @@ pub(crate) fn store_block<const RATE: usize>(s: &[Vec256; 25], out: &mut [&mut [
         let idx2 = 5 * ((4 * i + 2) % 5) + ((4 * i + 2) / 5);
         let idx3 = 5 * ((4 * i + 3) % 5) + ((4 * i + 3) / 5);
 
-        let v0l = mm256_permute2x128_si256::<0x20>(
-            s[idx0],
-            s[idx2],
-        );
+        let v0l = mm256_permute2x128_si256::<0x20>(s[idx0], s[idx2]);
         // 0 0 2 2
-        let v1h = mm256_permute2x128_si256::<0x20>(
-            s[idx1],
-            s[idx3],
-        ); // 1 1 3 3
-        let v2l = mm256_permute2x128_si256::<0x31>(
-            s[idx0],
-            s[idx2],
-        ); // 0 0 2 2
-        let v3h = mm256_permute2x128_si256::<0x31>(
-            s[idx2],
-            s[idx3],
-        ); // 1 1 3 3
+        let v1h = mm256_permute2x128_si256::<0x20>(s[idx1], s[idx3]); // 1 1 3 3
+        let v2l = mm256_permute2x128_si256::<0x31>(s[idx0], s[idx2]); // 0 0 2 2
+        let v3h = mm256_permute2x128_si256::<0x31>(s[idx2], s[idx3]); // 1 1 3 3
 
         let v0 = mm256_unpacklo_epi64(v0l, v1h); // 0 1 2 3
         let v1 = mm256_unpackhi_epi64(v0l, v1h); // 0 1 2 3
@@ -175,10 +160,7 @@ pub(crate) fn store_block<const RATE: usize>(s: &[Vec256; 25], out: &mut [&mut [
 }
 
 #[inline(always)]
-pub(crate) fn store_block_full<const RATE: usize>(
-    state: &[Vec256; 25],
-    out: &mut [[u8; 200]; 4],
-) {
+pub(crate) fn store_block_full<const RATE: usize>(state: &[Vec256; 25], out: &mut [[u8; 200]; 4]) {
     let (out0, rest) = out.split_at_mut(1);
     let (out1, rest) = rest.split_at_mut(1);
     let (out2, out3) = rest.split_at_mut(1);
@@ -229,11 +211,7 @@ impl KeccakItem<4> for Vec256 {
         mm256_xor_si256(a, b)
     }
     #[inline(always)]
-    fn load_block<const RATE: usize>(
-        state: &mut [Self; 25],
-        blocks: &[&[u8]; 4],
-        start: usize,
-    ) {
+    fn load_block<const RATE: usize>(state: &mut [Self; 25], blocks: &[&[u8]; 4], start: usize) {
         load_block::<RATE>(state, blocks, start)
     }
     #[inline(always)]

--- a/libcrux-sha3/src/simd/avx2.rs
+++ b/libcrux-sha3/src/simd/avx2.rs
@@ -95,7 +95,7 @@ pub(crate) fn load_block<const RATE: usize>(
         u8s[24..32].copy_from_slice(&blocks[3][start + 8..start + 16]);
         let u = mm256_loadu_si256_u8(u8s.as_slice());
         let i = 5 * ((4 * (RATE / 32) + 1) % 5) + ((4 * (RATE / 32) + 1) / 5);
-        state[i][j] = mm256_xor_si256(state[i], u);
+        state[i] = mm256_xor_si256(state[i], u);
     }
 }
 

--- a/libcrux-sha3/src/traits.rs
+++ b/libcrux-sha3/src/traits.rs
@@ -5,11 +5,20 @@ pub trait KeccakStateItem<const N: usize>: internal::KeccakItem<N> {}
 // Implement the public trait for all items.
 impl<const N: usize, T: internal::KeccakItem<N>> KeccakStateItem<N> for T {}
 
-pub(crate) fn get_ij<const N: usize, T:KeccakStateItem<N>>(arr: &[T; 25], i: usize, j: usize) -> T {
+pub(crate) fn get_ij<const N: usize, T: KeccakStateItem<N>>(
+    arr: &[T; 25],
+    i: usize,
+    j: usize,
+) -> T {
     arr[5 * j + i]
 }
 
-pub(crate) fn set_ij<const N: usize, T:KeccakStateItem<N>>(arr: &mut [T; 25], i: usize, j: usize, v: T) {
+pub(crate) fn set_ij<const N: usize, T: KeccakStateItem<N>>(
+    arr: &mut [T; 25],
+    i: usize,
+    j: usize,
+    v: T,
+) {
     arr[5 * j + i] = v;
 }
 
@@ -23,11 +32,7 @@ pub(crate) mod internal {
         fn and_not_xor(a: Self, b: Self, c: Self) -> Self;
         fn xor_constant(a: Self, c: u64) -> Self;
         fn xor(a: Self, b: Self) -> Self;
-        fn load_block<const RATE: usize>(
-            state: &mut [Self; 25],
-            blocks: &[&[u8]; N],
-            start: usize,
-        );
+        fn load_block<const RATE: usize>(state: &mut [Self; 25], blocks: &[&[u8]; N], start: usize);
         fn store_block<const RATE: usize>(state: &[Self; 25], blocks: &mut [&mut [u8]; N]);
         fn load_block_full<const RATE: usize>(
             state: &mut [Self; 25],

--- a/libcrux-sha3/src/traits.rs
+++ b/libcrux-sha3/src/traits.rs
@@ -16,18 +16,18 @@ pub(crate) mod internal {
         fn xor_constant(a: Self, c: u64) -> Self;
         fn xor(a: Self, b: Self) -> Self;
         fn load_block<const RATE: usize>(
-            state: &mut [[Self; 5]; 5],
+            state: &mut [Self; 25],
             blocks: &[&[u8]; N],
             start: usize,
         );
-        fn store_block<const RATE: usize>(state: &[[Self; 5]; 5], blocks: &mut [&mut [u8]; N]);
+        fn store_block<const RATE: usize>(state: &[Self; 25], blocks: &mut [&mut [u8]; N]);
         fn load_block_full<const RATE: usize>(
-            state: &mut [[Self; 5]; 5],
+            state: &mut [Self; 25],
             blocks: &[[u8; 200]; N],
             start: usize,
         );
-        fn store_block_full<const RATE: usize>(a: &[[Self; 5]; 5], out: &mut [[u8; 200]; N]);
+        fn store_block_full<const RATE: usize>(a: &[Self; 25], out: &mut [[u8; 200]; N]);
         fn split_at_mut_n(a: [&mut [u8]; N], mid: usize) -> ([&mut [u8]; N], [&mut [u8]; N]);
-        fn store<const RATE: usize>(state: &[[Self; 5]; 5], out: [&mut [u8]; N]);
+        fn store<const RATE: usize>(state: &[Self; 25], out: [&mut [u8]; N]);
     }
 }

--- a/libcrux-sha3/src/traits.rs
+++ b/libcrux-sha3/src/traits.rs
@@ -5,6 +5,14 @@ pub trait KeccakStateItem<const N: usize>: internal::KeccakItem<N> {}
 // Implement the public trait for all items.
 impl<const N: usize, T: internal::KeccakItem<N>> KeccakStateItem<N> for T {}
 
+pub(crate) fn get_ij<const N: usize, T:KeccakStateItem<N>>(arr: &[T; 25], i: usize, j: usize) -> T {
+    arr[5 * j + i]
+}
+
+pub(crate) fn set_ij<const N: usize, T:KeccakStateItem<N>>(arr: &mut [T; 25], i: usize, j: usize, v: T) {
+    arr[5 * j + i] = v;
+}
+
 pub(crate) mod internal {
     /// A trait for multiplexing implementations.
     pub trait KeccakItem<const N: usize>: Clone + Copy {


### PR DESCRIPTION
This PR makes three main changes:
* switches the SHA-3 internal state to a flat array of 25 u64s
* generalizes access to this state using `get` and `set` functions.
* stores the state in column-major order (to try to get some locality for rho/theta)