### PR TITLE
blake2: make no_std optional using default std feature

### DIFF
--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -10,6 +10,10 @@ edition.workspace = true
 repository.workspace = true
 readme.workspace = true
 
+[features]
+std = []
+default = ["std"]
+
 [dependencies]
 libcrux-hacl-rs = { version = "=0.0.2", path = "../hacl-rs/" }
 libcrux-macros = { version = "=0.0.2", path = "../macros" }

--- a/blake2/src/impl_hacl/error.rs
+++ b/blake2/src/impl_hacl/error.rs
@@ -29,4 +29,8 @@ impl alloc::fmt::Display for Error {
     }
 }
 
+#[cfg(not(feature = "std"))]
 impl core::error::Error for Error {}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 mod hacl {
     //! This module contains generated hacl code.


### PR DESCRIPTION
This lets users that don't need `no_std` use an older version of Rust, because they don't need to use `error_in_core`. This was an issue for Rosenpass specifically.