### PR TITLE
Revise ML-KEM benchmark naming convention

### DIFF
--- a/.github/workflows/mlkem-bench.yml
+++ b/.github/workflows/mlkem-bench.yml
@@ -88,10 +88,6 @@ jobs:
       - name: 🏃🏻‍♀️ Benchmarks
         run: cargo bench --verbose $RUST_TARGET_FLAG -- --output-format bencher | tee bench.txt 
 
-      - name: 🏃🏻‍♀️ Benchmarks Portable
-        run: |
-          cargo clean
-          LIBCRUX_DISABLE_SIMD128=1 LIBCRUX_DISABLE_SIMD256=1 cargo bench --verbose $RUST_TARGET_FLAG -- --output-format bencher | sed 's/^test \(.*\) \.\.\. bench/test portable \1 ... bench/' | tee -a bench.txt 
       - name: Store benchmarks
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/libcrux-ml-kem/benches/ml-kem.rs
+++ b/libcrux-ml-kem/benches/ml-kem.rs
@@ -106,7 +106,7 @@ pub fn pk_validation(c: &mut Criterion) {
     #[cfg(feature = "incremental")]
     macro_rules! fun_incremental {
         ($name:expr, $p:path, $group:expr) => {
-            $group.bench_function(format!("{} incremental", $name), |b| {
+            $group.bench_function(format!("{}/incremental", $name), |b| {
                 use $p::*;
 
                 b.iter_batched(
@@ -206,7 +206,7 @@ pub fn encapsulation(c: &mut Criterion) {
                 )
             });
 
-            $group.bench_function(format!("incremental {}", $name), |b| {
+            $group.bench_function(format!("{}/incremental", $name), |b| {
                 use $p::*;
 
                 b.iter_batched(
@@ -294,7 +294,7 @@ pub fn decapsulation(c: &mut Criterion) {
     #[cfg(feature = "incremental")]
     macro_rules! fun_incremental {
         ($name:expr, $p:path, $group:expr) => {
-            $group.bench_function(format!("incremental {}", $name), |b| {
+            $group.bench_function(format!("{}/incremental", $name), |b| {
                 use $p::*;
 
                 let mut seed1 = [0; 64];

--- a/libcrux-ml-kem/benches/ml-kem.rs
+++ b/libcrux-ml-kem/benches/ml-kem.rs
@@ -8,7 +8,11 @@ use libcrux_ml_kem::{mlkem1024, mlkem512, mlkem768};
 
 macro_rules! init {
     ($version:path, $bench:expr, $c:expr) => {{
-        let mut group = $c.benchmark_group(format!("ML-KEM {} {}", stringify!($version), $bench));
+        let version = stringify!($version);
+        let key_size = version
+            .strip_prefix("mlkem")
+            .expect("crate name does not begin with 'mlkem'");
+        let mut group = $c.benchmark_group(format!("ML-KEM/{}/{}", key_size, $bench));
         group.measurement_time(Duration::from_secs(10));
 
         use $version as version;
@@ -38,7 +42,7 @@ pub fn key_generation(c: &mut Criterion) {
 
     macro_rules! fun {
         ($name:expr, $p:path, $group:expr) => {
-            $group.bench_function(format!("{} (external random)", $name), |b| {
+            $group.bench_function(format!("{}/external random", $name), |b| {
                 use $p as p;
 
                 let mut seed = [0; 64];
@@ -52,7 +56,7 @@ pub fn key_generation(c: &mut Criterion) {
 
     macro_rules! fun_unpacked {
         ($name:expr, $p:path, $group:expr) => {
-            $group.bench_function(format!("unpacked {} (external random)", $name), |b| {
+            $group.bench_function(format!("{}/unpacked (external random)", $name), |b| {
                 use $p as p;
                 let mut seed = [0; 64];
                 rng.try_fill_bytes(&mut seed).unwrap();
@@ -127,7 +131,7 @@ pub fn pk_validation(c: &mut Criterion) {
 pub fn encapsulation(c: &mut Criterion) {
     macro_rules! fun {
         ($name:expr, $p:path, $group:expr) => {
-            $group.bench_function(format!("{} (external random)", $name), |b| {
+            $group.bench_function(format!("{}/external random", $name), |b| {
                 use $p as p;
                 let mut seed1 = [0; 64];
                 OsRng.try_fill_bytes(&mut seed1).unwrap();
@@ -147,7 +151,7 @@ pub fn encapsulation(c: &mut Criterion) {
 
     macro_rules! fun_unpacked {
         ($name:expr, $p:path, $group:expr) => {
-            $group.bench_function(format!("unpacked {} (external random)", $name), |b| {
+            $group.bench_function(format!("{}/unpacked (external random)", $name), |b| {
                 use $p as p;
 
                 let mut seed1 = [0; 64];
@@ -174,7 +178,7 @@ pub fn encapsulation(c: &mut Criterion) {
     #[cfg(feature = "incremental")]
     macro_rules! fun_incremental {
         ($name:expr, $p:path, $group:expr) => {
-            $group.bench_function(format!("incremental {} (external random)", $name), |b| {
+            $group.bench_function(format!("{}/incremental (external random)", $name), |b| {
                 use $p::*;
 
                 let mut seed1 = [0; 64];
@@ -264,7 +268,7 @@ pub fn decapsulation(c: &mut Criterion) {
 
     macro_rules! fun_unpacked {
         ($name:expr, $p:path, $group:expr) => {
-            $group.bench_function(format!("unpacked {}", $name), |b| {
+            $group.bench_function(format!("{}/unpacked", $name), |b| {
                 use $p as p;
                 let mut seed1 = [0; 64];
                 OsRng.try_fill_bytes(&mut seed1).unwrap();

--- a/libcrux-ml-kem/benches/ml-kem.rs
+++ b/libcrux-ml-kem/benches/ml-kem.rs
@@ -78,7 +78,7 @@ pub fn pk_validation(c: &mut Criterion) {
 
     macro_rules! fun {
         ($name:expr, $p:path, $group:expr) => {
-            $group.bench_function(format!("{}", $name), |b| {
+            $group.bench_function(format!("{}/", $name), |b| {
                 use $p as p;
 
                 let mut seed = [0; 64];
@@ -243,7 +243,7 @@ pub fn encapsulation(c: &mut Criterion) {
 pub fn decapsulation(c: &mut Criterion) {
     macro_rules! fun {
         ($name:expr, $p:path, $group:expr) => {
-            $group.bench_function(format!("{}", $name), |b| {
+            $group.bench_function(format!("{}/", $name), |b| {
                 use $p as p;
                 let mut seed1 = [0; 64];
                 OsRng.try_fill_bytes(&mut seed1).unwrap();


### PR DESCRIPTION
Implement new naming convention for benchmarks for ML-KEM, so that metadata can be more easily extracted for the name when creating charts.

Format: `category/key size/name/platform(neon, etc.)/api` 
- e.g. `ML-KEM/512/PK Validation/neon/unpacked`

This PR also removes the second `portable` step in the ML-KEM benchmarks workflow, which is no longer needed because `portable` benchmarks are run in the step that precedes it.