### PR TITLE
Update ML-KEM benchmarking workflow to use new benchmarking actions

### DIFF
--- a/.github/workflows/mlkem-bench.yml
+++ b/.github/workflows/mlkem-bench.yml
@@ -78,7 +78,8 @@ jobs:
       # Benchmarks ...
 
       - name: 🏃🏻‍♀️ Benchmarks
-        run: cargo bench --verbose $RUST_TARGET_FLAG -- --output-format bencher | tee bench.txt 
+        run: cargo bench --verbose $RUST_TARGET_FLAG -- --output-format bencher | tee bench.txt
+
       - name: Extract benchmarks
         uses: cryspen/benchmark-data-extract-transform@v1
         with:

--- a/.github/workflows/mlkem-bench.yml
+++ b/.github/workflows/mlkem-bench.yml
@@ -40,6 +40,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        # TODO: remove when migrating this workflow to libcrux
+        with:
+          repository: 'cryspen/libcrux'
 
       - name: Update dependencies
         run: cargo update
@@ -75,27 +78,27 @@ jobs:
           echo "RUST_TARGET_FLAG=--target=i686-unknown-linux-gnu" > $GITHUB_ENV
         if: ${{ matrix.bits == 32 && matrix.os == 'ubuntu-latest' }}
 
-      # - name: 🔨 Build
-      #   run: cargo build --benches
-
-      # - name: ⬆ Upload build
-      #   uses: ./.github/actions/upload_artifacts
-      #   with:
-      #     name: benchmarks_${{ matrix.os }}_${{ matrix.bits }}
-
       # Benchmarks ...
 
       - name: 🏃🏻‍♀️ Benchmarks
         run: cargo bench --verbose $RUST_TARGET_FLAG -- --output-format bencher | tee bench.txt 
-
-      - name: Store benchmarks
-        uses: benchmark-action/github-action-benchmark@v1
+      - name: Extract benchmarks
+        uses: cryspen/benchmark-data-extract-transform@v1
         with:
           name: ML-KEM Benchmark
           tool: 'cargo'
+          os: ${{ matrix.os }}_${{ matrix.bits }}
           output-file-path: libcrux-ml-kem/bench.txt
+          data-out-path: libcrux-ml-kem/bench-processed.txt
+      - name: Upload benchmarks
+        uses: cryspen/benchmark-upload-and-plot-action@v1
+        with:
+          name: ML-KEM Benchmark
+          input-data-path: libcrux-ml-kem/bench-processed.txt
           benchmark-data-dir-path: dev/bench/mlkem
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # NOTE: pushes to current repository
+          gh-repository: github.com/${{ github.repository }}
           auto-push: true
 
   mlkem-bench-status:

--- a/.github/workflows/mlkem-bench.yml
+++ b/.github/workflows/mlkem-bench.yml
@@ -40,9 +40,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        # TODO: remove when migrating this workflow to libcrux
-        with:
-          repository: 'cryspen/libcrux'
 
       - name: Update dependencies
         run: cargo update

--- a/.github/workflows/mlkem-bench.yml
+++ b/.github/workflows/mlkem-bench.yml
@@ -87,6 +87,7 @@ jobs:
           os: ${{ matrix.os }}_${{ matrix.bits }}
           output-file-path: libcrux-ml-kem/bench.txt
           data-out-path: libcrux-ml-kem/bench-processed.txt
+
       - name: Upload benchmarks
         uses: cryspen/benchmark-upload-and-plot-action@v1
         with:


### PR DESCRIPTION
This PR updates the ML-KEM benchmarks workflow to use the new benchmarking actions ([extract](https://github.com/cryspen/benchmark-data-extract-transform/) and  [upload](https://github.com/cryspen/benchmark-upload-and-plot-action)).

This is part of the CI cleanup in #544