### PR TITLE
Fix eurydice-glue.h for new eurydice

### DIFF
--- a/libcrux-ml-dsa/cg/eurydice_glue.h
+++ b/libcrux-ml-dsa/cg/eurydice_glue.h
@@ -248,7 +248,7 @@ static inline uint8_t core_num__u8_6__wrapping_sub(uint8_t x, uint8_t y) {
 
 // See note in karamel/lib/Inlining.ml if you change this
 #define Eurydice_into_iter(x, t, _ret_t, _) (x)
-#define core_iter_traits_collect___core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__1__into_iter \
+#define core_iter_traits_collect___core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I___into_iter \
   Eurydice_into_iter
 
 // Option


### PR DESCRIPTION
The update of the rustc pin (https://github.com/cryspen/hax/pull/1391, https://github.com/AeneasVerif/charon/pull/637, https://github.com/AeneasVerif/eurydice/pull/177) changed one name. This PR should be merged once https://github.com/AeneasVerif/eurydice/pull/177 is.