### PR TITLE
Add `no_std` support to additional libcrux crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,16 +79,16 @@ bench = false                               # so libtest doesn't eat the argumen
 libcrux-platform = { version = "=0.0.2", path = "sys/platform" }
 
 [dependencies]
-libcrux-traits = { version = "=0.0.2", path = "traits" }
+libcrux-traits = { version = "=0.0.3-alpha.1", path = "traits" }
 libcrux-hacl-rs = { version = "=0.0.2", path = "hacl-rs" }
 libcrux-hacl = { version = "=0.0.2", path = "sys/hacl" }
 libcrux-platform = { version = "=0.0.2", path = "sys/platform" }
-libcrux-hkdf = { version = "=0.0.2", path = "libcrux-hkdf" }
-libcrux-hmac = { version = "=0.0.2", path = "libcrux-hmac" }
-libcrux-sha2 = { version = "=0.0.2", path = "sha2" }
-libcrux-ed25519 = { version = "=0.0.2", path = "ed25519" }
+libcrux-hkdf = { version = "=0.0.3-alpha.1", path = "libcrux-hkdf" }
+libcrux-hmac = { version = "=0.0.3-alpha.1", path = "libcrux-hmac" }
+libcrux-sha2 = { version = "=0.0.3-alpha.1", path = "sha2" }
+libcrux-ed25519 = { version = "=0.0.3-alpha.1", path = "ed25519" }
 libcrux-ecdh = { version = "=0.0.3-alpha.1", path = "libcrux-ecdh" }
-libcrux-ml-kem = { version = "=0.0.2", path = "libcrux-ml-kem" }
+libcrux-ml-kem = { version = "=0.0.3-alpha.1", path = "libcrux-ml-kem" }
 libcrux-kem = { version = "=0.0.3-alpha.1", path = "libcrux-kem" }
 rand = { version = "0.9" }
 log = { version = "0.4", optional = true }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcrux-ecdsa"
 description = "Formally verified ECDSA signature library"
 
-version.workspace = true
+version = "0.0.3-alpha.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -11,10 +11,10 @@ repository.workspace = true
 readme.workspace = true
 
 [dependencies]
-libcrux-p256 = { version = "=0.0.2", path = "../p256", features = [
+libcrux-p256 = { version = "=0.0.3-alpha.1", path = "../p256", features = [
     "expose-hacl",
 ] }
-libcrux-sha2 = { version = "=0.0.2", path = "../sha2" }
+libcrux-sha2 = { version = "=0.0.3-alpha.1", path = "../sha2" }
 rand = { version = "0.9", optional = true }
 
 [features]

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcrux-ed25519"
 description = "Formally verified ed25519 signature library"
 
-version.workspace = true
+version = "0.0.3-alpha.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -12,7 +12,7 @@ readme.workspace = true
 
 [dependencies]
 libcrux-hacl-rs = { version = "=0.0.2", path = "../hacl-rs/" }
-libcrux-sha2 = { version = "=0.0.2", path = "../sha2", features = [
+libcrux-sha2 = { version = "=0.0.3-alpha.1", path = "../sha2", features = [
     "expose-hacl",
 ] }
 libcrux-macros = { version = "=0.0.2", path = "../macros" }

--- a/libcrux-ecdh/Cargo.toml
+++ b/libcrux-ecdh/Cargo.toml
@@ -13,11 +13,15 @@ description = "Libcrux ECDH implementation"
 path = "src/ecdh.rs"
 
 [dependencies]
-rand = { version = "0.9" }
+rand = { version = "0.9", default-features = false }
 libcrux-curve25519 = { version = "=0.0.2", path = "../curve25519" }
-libcrux-p256 = { version = "=0.0.2", path = "../p256", features = [
+libcrux-p256 = { version = "=0.0.3-alpha.1", path = "../p256", features = [
     "expose-hacl",
 ] }
+
+[features]
+default = ["std"]
+std = ["rand/std"]
 
 [dev-dependencies]
 rand_core = { version = "0.9" }

--- a/libcrux-ecdh/Cargo.toml
+++ b/libcrux-ecdh/Cargo.toml
@@ -24,7 +24,7 @@ default = ["std"]
 std = ["rand/std"]
 
 [dev-dependencies]
-rand_core = { version = "0.9" }
+rand_core = { version = "0.9" , features = ["os_rng"]}
 hex = { version = "0.4.3", features = ["serde"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/libcrux-hkdf/Cargo.toml
+++ b/libcrux-hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-hkdf"
-version.workspace = true
+version = "0.0.3-alpha.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -14,7 +14,7 @@ path = "src/hkdf.rs"
 
 [features]
 [dependencies]
-libcrux-hmac = { version = "=0.0.2", path = "../libcrux-hmac", features = [
+libcrux-hmac = { version = "=0.0.3-alpha.1", path = "../libcrux-hmac", features = [
     "expose-hacl",
 ] }
 libcrux-hacl-rs = { version = "=0.0.2", path = "../hacl-rs/" }

--- a/libcrux-hmac/Cargo.toml
+++ b/libcrux-hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-hmac"
-version.workspace = true
+version = "0.0.3-alpha.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -17,7 +17,7 @@ expose-hacl = []
 
 [dependencies]
 libcrux-hacl-rs = { version = "=0.0.2", path = "../hacl-rs/" }
-libcrux-sha2 = { version = "=0.0.2", path = "../sha2", features = [
+libcrux-sha2 = { version = "=0.0.3-alpha.1", path = "../sha2", features = [
     "expose-hacl",
 ] }
 libcrux-macros = { version = "=0.0.2", path = "../macros" }

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -28,4 +28,5 @@ pre-verification = []
 
 [dev-dependencies]
 libcrux-kem = { path = "./", features = ["tests"] }
+rand = { version = "0.9", features = ["os_rng"] }
 hex = { version = "0.4.3", features = ["serde"] }

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -14,13 +14,15 @@ exclude = ["/tests"]
 path = "src/kem.rs"
 
 [dependencies]
-libcrux-ml-kem = { version = "=0.0.2", path = "../libcrux-ml-kem" }
+libcrux-ml-kem = { version = "=0.0.3-alpha.1", path = "../libcrux-ml-kem", default-features = false, features = ["default-no-std"] }
 libcrux-sha3 = { version = "=0.0.2", path = "../libcrux-sha3" }
-libcrux-ecdh = { version = "=0.0.3-alpha.1", path = "../libcrux-ecdh" }
-libcrux-traits = { version = "=0.0.2", path = "../traits" }
-rand = { version = "0.9" }
+libcrux-ecdh = { version = "=0.0.3-alpha.1", path = "../libcrux-ecdh", default-features = false }
+libcrux-traits = { version = "=0.0.3-alpha.1", path = "../traits" }
+rand = { version = "0.9", default-features = false }
 
 [features]
+default = ["std"]
+std = ["rand/std", "libcrux-ecdh/std", "libcrux-ml-kem/std"]
 tests = []                       # Expose functions for testing.
 pre-verification = []
 

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -34,7 +34,7 @@ hax-lib.workspace = true
 
 [features]
 # By default all variants and std are enabled.
-default = ["std", "rand/std", "default-no-std"]
+default = ["default-no-std", "std"]
 default-no-std = ["mlkem512", "mlkem768", "mlkem1024", "rand"]
 
 # Hardware features can be force enabled.

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-ml-kem"
-version.workspace = true
+version = "0.0.3-alpha.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -26,7 +26,7 @@ exclude = [
 bench = false # so libtest doesn't eat the arguments to criterion
 
 [dependencies]
-rand = { version = "0.9", optional = true }
+rand = { version = "0.9", optional = true, default-features = false }
 libcrux-platform = { version = "0.0.2", path = "../sys/platform" }
 libcrux-sha3 = { version = "0.0.2", path = "../libcrux-sha3" }
 libcrux-intrinsics = { version = "0.0.2", path = "../libcrux-intrinsics" }
@@ -34,7 +34,8 @@ hax-lib.workspace = true
 
 [features]
 # By default all variants and std are enabled.
-default = ["std", "mlkem512", "mlkem768", "mlkem1024", "rand"]
+default = ["std", "rand/std", "default-no-std"]
+default-no-std = ["mlkem512", "mlkem768", "mlkem1024", "rand"]
 
 # Hardware features can be force enabled.
 # It is not recommended to use these. This crate performs CPU feature detection
@@ -54,7 +55,7 @@ kyber = []
 rand = ["dep:rand"]
 
 # std support
-std = ["alloc"]
+std = ["alloc", "rand/std"]
 alloc = []
 
 # Incremental encapsulation API

--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -14,11 +14,11 @@ publish = true
 bench = false # so libtest doesn't eat the arguments to criterion
 
 [dependencies]
-libcrux-traits = { version = "0.0.2", path = "../traits" }
+libcrux-traits = { version = "0.0.3-alpha.1", path = "../traits" }
 libcrux-kem = { version = "=0.0.3-alpha.1", path = "../libcrux-kem" }
 libcrux-chacha20poly1305 = { version = "0.0.2", path = "../chacha20poly1305" }
-libcrux-hkdf = { version = "=0.0.2", path = "../libcrux-hkdf" }
-libcrux-hmac = { version = "=0.0.2", path = "../libcrux-hmac" }
+libcrux-hkdf = { version = "=0.0.3-alpha.1", path = "../libcrux-hkdf" }
+libcrux-hmac = { version = "=0.0.3-alpha.1", path = "../libcrux-hmac" }
 classic-mceliece-rust = { version = "3.1.0", features = [
     "mceliece460896f",
     "zeroize",
@@ -26,7 +26,7 @@ classic-mceliece-rust = { version = "3.1.0", features = [
 rand = { version = "0.9" }
 rand_old = { version = "0.8", package = "rand", optional = true }
 libcrux-ecdh = { version = "0.0.3-alpha.1", path = "../libcrux-ecdh", optional = true }
-libcrux-ed25519 = { version = "0.0.2", path = "../ed25519", features = [
+libcrux-ed25519 = { version = "0.0.3-alpha.1", path = "../ed25519", features = [
     "rand",
 ] }
 

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcrux-p256"
 description = "Formally verified P-256 implementation"
 
-version.workspace = true
+version = "0.0.3-alpha.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 [dependencies]
 libcrux-macros = { version = "=0.0.2", path = "../macros" }
 libcrux-hacl-rs = { version = "=0.0.2", path = "../hacl-rs" }
-libcrux-sha2 = { version = "=0.0.2", path = "../sha2", features = [
+libcrux-sha2 = { version = "=0.0.3-alpha.1", path = "../sha2", features = [
     "expose-hacl",
 ] }
 

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This crate should not be used directly and is internal to libcrux.
 //! By default this crate is empty.
+#![no_std]
 
 // HACL* generated code
 mod p256;

--- a/rsa/Cargo.toml
+++ b/rsa/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcrux-rsa"
 description = "Formally verified RSA signature library"
 
-version.workspace = true
+version = "0.0.3-alpha.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -15,9 +15,9 @@ expose-hacl = []
 
 [dependencies]
 libcrux-hacl-rs = { version = "=0.0.2", path = "../hacl-rs" }
-libcrux-traits = { version = "=0.0.2", path = "../traits/" }
+libcrux-traits = { version = "=0.0.3-alpha.1", path = "../traits/" }
 libcrux-macros = { version = "=0.0.2", path = "../macros" }
-libcrux-sha2 = { version = "=0.0.2", path = "../sha2", features = [
+libcrux-sha2 = { version = "=0.0.3-alpha.1", path = "../sha2", features = [
     "expose-hacl",
 ] }
 

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcrux-sha2"
 description = "Formally verified SHA2 hash library"
 
-version.workspace = true
+version = "0.0.3-alpha.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -15,7 +15,7 @@ expose-hacl = []
 
 [dependencies]
 libcrux-hacl-rs = { version = "=0.0.2", path = "../hacl-rs" }
-libcrux-traits = { version = "=0.0.2", path = "../traits/" }
+libcrux-traits = { version = "=0.0.3-alpha.1", path = "../traits/" }
 libcrux-macros = { version = "=0.0.2", path = "../macros" }
 
 [dev-dependencies]

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcrux-traits"
 description = "Traits for cryptographic algorithms"
 
-version.workspace = true
+version = "0.0.3-alpha.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -11,4 +11,4 @@ repository.workspace = true
 readme.workspace = true
 
 [dependencies]
-rand = { version = "0.9" }
+rand = { version = "0.9", default-features = false }


### PR DESCRIPTION
This PR makes the following crates `no_std`-compatible by default:
- `libcrux-traits`
- `libcrux-sha2`
- `libcrux-p256`

It also adds `no_std` support for the following crates (which can be activated with `default-features = false`):
- `libcrux-ml-kem`
- `libcrux-kem`
- `libcrux-ecdh`

Version numbers are also updated where needed.