### PR TITLE
Minicore: add a integer vector interpretation for bitvecs and (some) avx2 intrinsics

### DIFF
--- a/fstar-helpers/minicore/src/abstractions/bitvec.rs
+++ b/fstar-helpers/minicore/src/abstractions/bitvec.rs
@@ -317,14 +317,14 @@ pub mod int_vec_interp {
 
 
                     #[doc = concat!("Lemma that asserts that applying ", stringify!(BitVec::<$n>::from)," and then ", stringify!($name::from), " is the identity.")]
-                    #[hax_lib::fstar::before("[@@$INTERPRETATION_LEMMA]")]
+                    #[hax_lib::fstar::before("[@@ $INTERPRETATION_LEMMA ]")]
                     #[hax_lib::opaque]
                     #[hax_lib::lemma]
                     pub fn lemma_cancel_iv(x: $name) -> Proof<{
                         hax_lib::eq($name::from(BitVec::<$n>::from(x)), x)
                     }> {}
                     #[doc = concat!("Lemma that asserts that applying ", stringify!($name::from)," and then ", stringify!(BitVec::<$n>::from), " is the identity.")]
-                    #[hax_lib::fstar::before("[@@$INTERPRETATION_LEMMA]")]
+                    #[hax_lib::fstar::before("[@@ $INTERPRETATION_LEMMA ]")]
                     #[hax_lib::opaque]
                     #[hax_lib::lemma]
                     pub fn lemma_cancel_bv(x: BitVec<$n>) -> Proof<{
@@ -349,7 +349,7 @@ pub mod int_vec_interp {
 
     /// Lemma stating that converting an `i64x4` vector to a `BitVec<256>` and then into an `i32x8`
     /// yields the same result as directly converting the `i64x4` into an `i32x8`.
-    #[hax_lib::fstar::before("[@@$INTERPRETATION_LEMMA]")]
+    #[hax_lib::fstar::before("[@@ $INTERPRETATION_LEMMA ]")]
     #[hax_lib::opaque]
     #[hax_lib::lemma]
     fn lemma_rewrite_i64x4_bv_i32x8(

--- a/fstar-helpers/minicore/src/abstractions/bitvec.rs
+++ b/fstar-helpers/minicore/src/abstractions/bitvec.rs
@@ -278,3 +278,82 @@ impl<const N: u64> BitVec<N> {
         chunked_shift::<N, CHUNK, SHIFTS>(self, shl)
     }
 }
+
+pub mod int_vec_interp {
+    //! This module defines interpretation for bit vectors as vectors of machine integers of various size and signedness.
+    use super::*;
+
+    /// An F* attribute that marks an item as being an interpretation lemma.
+    #[allow(dead_code)]
+    #[hax_lib::fstar::before("irreducible")]
+    const INTERPRETATION_LEMMA: () = ();
+
+    /// Derives interpretations functions, simplification lemmas and type
+    /// synonyms.
+    macro_rules! interpretations {
+        ($n:literal; $($name:ident [$ty:ty; $m:literal]),*) => {
+            $(
+                #[doc = concat!(stringify!($ty), " vectors of size ", stringify!($m))]
+                #[allow(non_camel_case_types)]
+                pub type $name = FunArray<$m, $ty>;
+                const _: ()  = {
+                    #[doc = concat!("Conversion from bit vectors of size ", stringify!($n), " to ", stringify!($ty), " vectors of size ", stringify!($m))]
+                    #[hax_lib::opaque]
+                    impl From<BitVec<$n>> for $name {
+                        fn from(bv: BitVec<$n>) -> Self {
+                            let vec: Vec<$ty> = bv.to_vec();
+                            Self::from_fn(|i| vec[i as usize])
+                        }
+                    }
+
+                    #[doc = concat!("Conversion from ", stringify!($ty), " vectors of size ", stringify!($m), "to  bit vectors of size ", stringify!($n))]
+                    #[hax_lib::opaque]
+                    impl From<$name> for BitVec<$n> {
+                        fn from(iv: $name) -> Self {
+                            let vec: Vec<$ty> = iv.as_vec();
+                            Self::from_slice(&vec[..], u64::MAX)
+                        }
+                    }
+
+
+                    #[doc = concat!("Lemma that asserts that applying ", stringify!(BitVec::<$n>::from)," and then ", stringify!($name::from), " is the identity.")]
+                    #[hax_lib::fstar::before("[@@$INTERPRETATION_LEMMA]")]
+                    #[hax_lib::opaque]
+                    #[hax_lib::lemma]
+                    pub fn lemma_cancel_iv(x: $name) -> Proof<{
+                        hax_lib::eq($name::from(BitVec::<$n>::from(x)), x)
+                    }> {}
+                    #[doc = concat!("Lemma that asserts that applying ", stringify!($name::from)," and then ", stringify!(BitVec::<$n>::from), " is the identity.")]
+                    #[hax_lib::fstar::before("[@@$INTERPRETATION_LEMMA]")]
+                    #[hax_lib::opaque]
+                    #[hax_lib::lemma]
+                    pub fn lemma_cancel_bv(x: BitVec<$n>) -> Proof<{
+                        hax_lib::eq(BitVec::<$n>::from($name::from(x)), x)
+                    }> {}
+                };
+            )*
+        };
+    }
+
+    // Defines the types `i32x8` and `i64x4`, and define intepretations function (`From` instances) from/to those types from/to bit vectors.
+    interpretations!(256; i32x8 [i32; 8], i64x4 [i64; 4]);
+
+    impl From<i64x4> for i32x8 {
+        fn from(vec: i64x4) -> Self {
+            Self::from_fn(|i| {
+                let value = *vec.get(i / 2);
+                (if i % 2 == 0 { value } else { value >> 32 }) as i32
+            })
+        }
+    }
+
+    /// Lemma stating that converting an `i64x4` vector to a `BitVec<256>` and then into an `i32x8`
+    /// yields the same result as directly converting the `i64x4` into an `i32x8`.
+    #[hax_lib::fstar::before("[@@$INTERPRETATION_LEMMA]")]
+    #[hax_lib::opaque]
+    #[hax_lib::lemma]
+    fn lemma_rewrite_i64x4_bv_i32x8(
+        bv: i64x4,
+    ) -> Proof<{ hax_lib::eq(i32x8::from(BitVec::<256>::from(bv)), i32x8::from(bv)) }> {
+    }
+}

--- a/fstar-helpers/minicore/src/core_arch/x86.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86.rs
@@ -122,6 +122,11 @@ pub mod avx {
     }
 
     #[hax_lib::opaque]
+    pub fn _mm256_set1_epi32(_: i32) -> __m256i {
+        unimplemented!()
+    }
+
+    #[hax_lib::opaque]
     pub fn _mm256_set_epi32(
         _e0: i32,
         _e1: i32,
@@ -198,6 +203,27 @@ pub mod avx {
 pub use avx2::*;
 pub mod avx2 {
     use super::*;
+
+    #[hax_lib::opaque]
+    pub fn _mm256_blend_epi32<const IMM8: i32>(_: __m256i, _: __m256i) -> __m256i {
+        unimplemented!()
+    }
+
+    #[hax_lib::opaque]
+    pub fn _mm256_shuffle_epi32<const MASK: i32>(_: __m256i) -> __m256i {
+        unimplemented!()
+    }
+
+    #[hax_lib::opaque]
+    pub fn _mm256_sub_epi32(_: __m256i, _: __m256i) -> __m256i {
+        unimplemented!()
+    }
+
+    #[hax_lib::opaque]
+    pub fn _mm256_mul_epi32(_: __m256i, _: __m256i) -> __m256i {
+        unimplemented!()
+    }
+
     #[hax_lib::exclude]
     pub fn _mm_storeu_si128(output: *mut __m128i, a: __m128i) {
         // This is equivalent to `*output = a`

--- a/fstar-helpers/minicore/src/core_arch/x86.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86.rs
@@ -4,6 +4,7 @@
 //! `core::arch::x86` and `core::arch::x86_64`.
 #![allow(clippy::too_many_arguments)]
 
+mod interpretations;
 use crate::abstractions::{bit::*, bitvec::*, funarr::*};
 
 pub(crate) mod upstream {

--- a/fstar-helpers/minicore/src/core_arch/x86/interpretations.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86/interpretations.rs
@@ -1,0 +1,125 @@
+pub mod int_vec {
+    //! Provides a machine integer vectors intepretation for AVX2 intrinsics.
+
+    use crate::abstractions::{bitvec::int_vec_interp::*, funarr::FunArray};
+    #[allow(unused)]
+    use crate::core_arch::x86;
+
+    pub fn _mm256_set1_epi32(x: i32) -> i32x8 {
+        i32x8::from_fn(|_| x)
+    }
+
+    pub fn _mm256_mul_epi32(x: i32x8, y: i32x8) -> i64x4 {
+        i64x4::from_fn(|i| (x[i * 2] as i64) * (y[i * 2] as i64))
+    }
+    pub fn _mm256_sub_epi32(x: i32x8, y: i32x8) -> i32x8 {
+        i32x8::from_fn(|i| x[i].wrapping_sub(y[i]))
+    }
+
+    pub fn _mm256_shuffle_epi32<const CONTROL: i32>(x: i32x8) -> i32x8 {
+        let indexes: FunArray<4, u64> = FunArray::from_fn(|i| ((CONTROL >> i * 2) % 4) as u64);
+        i32x8::from_fn(|i| {
+            if i < 4 {
+                x[indexes[i]]
+            } else {
+                x[4 + indexes[i - 4]]
+            }
+        })
+    }
+
+    pub fn _mm256_blend_epi32<const CONTROL: i32>(x: i32x8, y: i32x8) -> i32x8 {
+        FunArray::from_fn(|i| if (CONTROL >> i) % 2 == 0 { x[i] } else { y[i] })
+    }
+
+    mod lift_lemmas {
+        //! This module provides lemmas allowing to lift the intrinsics modeled in `super` from their version operating on AVX2 vectors to functions operating on machine integer vectors (e.g. on `i32x8`).
+
+        #[allow(unused)]
+        use crate::core_arch::x86 as upstream;
+        #[allow(unused)]
+        use crate::core_arch::x86::__m256i;
+
+        /// Derives automatically a lift lemma for a given function
+        macro_rules! mk {
+            (@into($x:expr) i32) => {$x};
+            (@into($x:expr) $any:ty) => {$x.into()};
+            ($name:ident$(<$(const $c:ident : $cty:ty),*>)?($($x:ident : $ty:ty),*)) => {
+                #[hax_lib::opaque]
+                #[hax_lib::lemma]
+                fn $name$(<$(const $c : $cty,)*>)?($($x : $ty,)*) -> Proof<{
+                    hax_lib::eq(
+                        unsafe {upstream::$name$(::<$($c,)*>)?($($x,)*)},
+                        super::$name$(::<$($c,)*>)?($(mk!(@into($x) $ty),)*),
+                    )
+                }> {}
+            }
+        }
+        mk!(_mm256_set1_epi32(x: i32));
+        mk!(_mm256_mul_epi32(x: __m256i, y: __m256i));
+        mk!(_mm256_sub_epi32(x: __m256i, y: __m256i));
+        mk!(_mm256_shuffle_epi32<const CONTROL: i32>(x: __m256i));
+        mk!(_mm256_blend_epi32<const CONTROL: i32>(x: __m256i, y: __m256i));
+    }
+
+    #[cfg(all(test, any(target_arch = "x86", target_arch = "x86_64")))]
+    mod tests {
+        use crate::abstractions::bitvec::BitVec;
+        use crate::core_arch::x86::upstream;
+
+        /// Helper trait to generate random values
+        pub trait HasRandom {
+            fn random() -> Self;
+        }
+
+        impl HasRandom for i32 {
+            fn random() -> Self {
+                use rand::prelude::*;
+                let mut rng = rand::rng();
+                rng.random()
+            }
+        }
+
+        impl<const N: u64> HasRandom for BitVec<N> {
+            fn random() -> Self {
+                BitVec::rand()
+            }
+        }
+
+        /// Derives tests for a given intrinsics. Test that a given intrisics and its model compute the same thing over random values (1000 by default).
+        macro_rules! mk {
+            ($([$N:literal])?$name:ident$({$(<$($c:literal),*>),*})?($($x:ident : $ty:ident),*)) => {
+                #[test]
+                fn $name() {
+                    #[allow(unused)]
+                    const N: usize = {
+                        let n: usize = 1000;
+                        $(let n: usize = $N;)?
+                        n
+                    };
+                    mk!(@[N]$name$($(<$($c),*>)*)?($($x : $ty),*));
+                }
+            };
+            (@[$N:ident]$name:ident$(<$($c:literal),*>)?($($x:ident : $ty:ident),*)) => {
+                for _ in 0..$N {
+                    $(let $x = $ty::random();)*
+                    assert_eq!(super::$name$(::<$($c,)*>)?($($x.into(),)*), unsafe {
+                        BitVec::from(upstream::$name$(::<$($c,)*>)?($($x.into(),)*)).into()
+                    });
+                }
+            };
+            (@[$N:ident]$name:ident<$($c1:literal),*>$(<$($c:literal),*>)*($($x:ident : $ty:ident),*)) => {
+                let one = || {
+                    mk!(@[$N]$name<$($c1),*>($($x : $ty),*));
+                };
+                one();
+                mk!(@[$N]$name$(<$($c),*>)*($($x : $ty),*));
+            }
+        }
+
+        mk!(_mm256_set1_epi32(x: i32));
+        mk!(_mm256_sub_epi32(x: BitVec, y: BitVec));
+        mk!(_mm256_mul_epi32(x: BitVec, y: BitVec));
+        mk!(_mm256_shuffle_epi32{<0b01_00_10_11>, <0b01_11_01_10>}(x: BitVec));
+        mk!([100]_mm256_blend_epi32{<0>,<1>,<2>,<3>,<4>,<5>,<6>,<7>,<8>,<9>,<10>,<11>,<12>,<13>,<14>,<15>,<16>,<17>,<18>,<19>,<20>,<21>,<22>,<23>,<24>,<25>,<26>,<27>,<28>,<29>,<30>,<31>,<32>,<33>,<34>,<35>,<36>,<37>,<38>,<39>,<40>,<41>,<42>,<43>,<44>,<45>,<46>,<47>,<48>,<49>,<50>,<51>,<52>,<53>,<54>,<55>,<56>,<57>,<58>,<59>,<60>,<61>,<62>,<63>,<64>,<65>,<66>,<67>,<68>,<69>,<70>,<71>,<72>,<73>,<74>,<75>,<76>,<77>,<78>,<79>,<80>,<81>,<82>,<83>,<84>,<85>,<86>,<87>,<88>,<89>,<90>,<91>,<92>,<93>,<94>,<95>,<96>,<97>,<98>,<99>,<100>,<101>,<102>,<103>,<104>,<105>,<106>,<107>,<108>,<109>,<110>,<111>,<112>,<113>,<114>,<115>,<116>,<117>,<118>,<119>,<120>,<121>,<122>,<123>,<124>,<125>,<126>,<127>,<128>,<129>,<130>,<131>,<132>,<133>,<134>,<135>,<136>,<137>,<138>,<139>,<140>,<141>,<142>,<143>,<144>,<145>,<146>,<147>,<148>,<149>,<150>,<151>,<152>,<153>,<154>,<155>,<156>,<157>,<158>,<159>,<160>,<161>,<162>,<163>,<164>,<165>,<166>,<167>,<168>,<169>,<170>,<171>,<172>,<173>,<174>,<175>,<176>,<177>,<178>,<179>,<180>,<181>,<182>,<183>,<184>,<185>,<186>,<187>,<188>,<189>,<190>,<191>,<192>,<193>,<194>,<195>,<196>,<197>,<198>,<199>,<200>,<201>,<202>,<203>,<204>,<205>,<206>,<207>,<208>,<209>,<210>,<211>,<212>,<213>,<214>,<215>,<216>,<217>,<218>,<219>,<220>,<221>,<222>,<223>,<224>,<225>,<226>,<227>,<228>,<229>,<230>,<231>,<232>,<233>,<234>,<235>,<236>,<237>,<238>,<239>,<240>,<241>,<242>,<243>,<244>,<245>,<246>,<247>,<248>,<249>,<250>,<251>,<252>,<253>,<254>,<255>}(x: BitVec, y: BitVec));
+    }
+}

--- a/fstar-helpers/minicore/src/lib.rs
+++ b/fstar-helpers/minicore/src/lib.rs
@@ -24,7 +24,7 @@
 //! `minicore` is designed as a reference model for formal verification and reasoning about Rust programs.
 //! By providing a readable, well-specified version of `core`'s behavior, it serves as a foundation for
 //! proof assistants and other verification tools.
-
+#![recursion_limit = "512"]
 pub mod abstractions;
 pub mod core_arch;
 

--- a/libcrux-ml-dsa/hax.sh
+++ b/libcrux-ml-dsa/hax.sh
@@ -42,9 +42,15 @@ function prove() {
     make -C proofs/fstar/extraction -j $JOBS "$@"
 }
 
-# This function replace every occurence of `Core<M>` by `Minicore<M>` if `Minicore<M>` is a module defined by `minicore`.
+# `fixup-minicore CRATE` adjusts the F* extraction output of `CRATE` to use modules from `minicore` instead of `core`.
+# This is necessary because our F* models of the Rust `core` library and the extracted code from `minicore` overlap,
+# particularly for `core::arch::*`. The `minicore` versions offer more accurate and specialized models.
+#
+# This function scans all modules defined in `minicore`, and for each one, replaces every occurrence of `Core<M>`
+# in the extracted code of `CRATE` with `Minicore<M>`, but only if that `Minicore<M>` module actually exists in `minicore`.
 function fixup-minicore() {
     go_to fstar-helpers/minicore/proofs/fstar/extraction
+    # List all modules provided by minicore
     minicore_modules=$(find . -type f -name '*Minicore*' -exec basename {} .fst ';')
 
     go_to "$1"/proofs/fstar/extraction/temp


### PR DESCRIPTION
This PR introduces an interpretation layer for SIMD-style machine integer vectors (`i32x8`, `i64x4`) over `BitVec<256>`, along with modeling support for selected AVX2 intrinsics.

## Additions
- **`int_vec_interp` module** (`bitvec.rs`):
  - Defines type aliases `i32x8` and `i64x4` as `FunArray`s over `i32` and `i64`.
  - Implements `From` conversions between `BitVec<256>` and these vector types.
  - Adds cancelation lemmas for round-trip conversions.

- **`core_arch::x86::interpretations` module**:
  - Models a subset of AVX2 intrinsics over `i32x8`/`i64x4`:
    - `_mm256_set1_epi32`
    - `_mm256_mul_epi32`
    - `_mm256_sub_epi32`
    - `_mm256_shuffle_epi32`
    - `_mm256_blend_epi32`
  - Defines lift lemmas that link the intrinsics with the interpreted model.
  - Provides randomized tests to validate the interpretations against upstream behavior.

## Motivation
This supports verification work in #744.