### PR TITLE
ML-DSA: proofs: `montgomery_multiply`: flatten circuit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ readme = "Readme.md"
 allow-branch = ["main"]
 
 [workspace.dependencies]
-hax-lib = { version = "0.2", git = "https://github.com/cryspen/hax/" }
+hax-lib = { version = "0.2", git = "https://github.com/cryspen/hax/", branch = "add-postprocess-with" }
 
 [package]
 name = "libcrux"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ readme = "Readme.md"
 allow-branch = ["main"]
 
 [workspace.dependencies]
-hax-lib = { version = "0.2", git = "https://github.com/cryspen/hax/", branch = "add-postprocess-with" }
+hax-lib = { version = "0.2", git = "https://github.com/cryspen/hax/" }
 
 [package]
 name = "libcrux"

--- a/fstar-helpers/minicore/src/core_arch/x86.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86.rs
@@ -363,60 +363,48 @@ const _: () = {
     > {
     }
 
-    #[hax_lib::fstar::before("[@@ $REWRITE_RULE ]")]
-    #[hax_lib::lemma]
-    #[hax_lib::opaque]
-    pub fn _rw_mm256_mullo_epi16_shifts(
-        vector: __m256i,
-        s15: u8,
-        s14: u8,
-        s13: u8,
-        s12: u8,
-        s11: u8,
-        s10: u8,
-        s9: u8,
-        s8: u8,
-        s7: u8,
-        s6: u8,
-        s5: u8,
-        s4: u8,
-        s3: u8,
-        s2: u8,
-        s1: u8,
-        s0: u8,
-    ) -> Proof<
-        {
-            hax_lib::prop::eq(
-                _mm256_mullo_epi16(
-                    vector,
-                    _mm256_set_epi16(
-                        1i16 << s15,
-                        1i16 << s14,
-                        1i16 << s13,
-                        1i16 << s12,
-                        1i16 << s11,
-                        1i16 << s10,
-                        1i16 << s9,
-                        1i16 << s8,
-                        1i16 << s7,
-                        1i16 << s6,
-                        1i16 << s5,
-                        1i16 << s4,
-                        1i16 << s3,
-                        1i16 << s2,
-                        1i16 << s1,
-                        1i16 << s0,
-                    ),
-                ),
-                extra::mm256_mullo_epi16_shifts(
-                    vector, s15, s14, s13, s12, s11, s10, s9, s8, s7, s6, s5, s4, s3, s2, s1, s0,
-                ),
-            )
-        },
-    > {
-    }
+    #[hax_lib::fstar::replace(
+        r#"
+[@@ Minicore.Abstractions.Bitvec.v_REWRITE_RULE ]
 
-    // mm256_mullo_epi16_shifts
+assume
+val e___e_rw_mm256_mullo_epi16_shifts':
+    vector: $:{__m256i} ->
+    s15: (n: $:{u8} {v n < 16}) ->
+    s14: (n: $:{u8} {v n < 16}) ->
+    s13: (n: $:{u8} {v n < 16}) ->
+    s12: (n: $:{u8} {v n < 16}) ->
+    s11: (n: $:{u8} {v n < 16}) ->
+    s10: (n: $:{u8} {v n < 16}) ->
+    s9: (n: $:{u8} {v n < 16}) ->
+    s8: (n: $:{u8} {v n < 16}) ->
+    s7: (n: $:{u8} {v n < 16}) ->
+    s6: (n: $:{u8} {v n < 16}) ->
+    s5: (n: $:{u8} {v n < 16}) ->
+    s4: (n: $:{u8} {v n < 16}) ->
+    s3: (n: $:{u8} {v n < 16}) ->
+    s2: (n: $:{u8} {v n < 16}) ->
+    s1: (n: $:{u8} {v n < 16}) ->
+    s0: (n: $:{u8} {v n < 16})
+  -> Lemma
+    (ensures
+      ($_mm256_mullo_epi16 vector
+          ($_mm256_set_epi16 (${1i16} <<! s15 <: i16)
+              (${1i16} <<! s14 <: i16) (${1i16} <<! s13 <: i16) (${1i16} <<! s12 <: i16)
+              (${1i16} <<! s11 <: i16) (${1i16} <<! s10 <: i16) (${1i16} <<! s9 <: i16)
+              (${1i16} <<! s8 <: i16) (${1i16} <<! s7 <: i16) (${1i16} <<! s6 <: i16)
+              (${1i16} <<! s5 <: i16) (${1i16} <<! s4 <: i16) (${1i16} <<! s3 <: i16)
+              (${1i16} <<! s2 <: i16) (${1i16} <<! s1 <: i16) (${1i16} <<! s0 <: i16)
+            )
+        ) ==
+      (${extra::mm256_mullo_epi16_shifts} vector s15 s14 s13 s12 s11 s10 s9 s8 s7
+          s6 s5 s4 s3 s2 s1 s0))
+
+let ${_rw_mm256_mullo_epi16_shifts} = e___e_rw_mm256_mullo_epi16_shifts'
+    "#
+    )]
+    // Note: this is replace with F* code because we need to refine the input of the lemma.
+    pub fn _rw_mm256_mullo_epi16_shifts() {}
 
     #[hax_lib::fstar::before("[@@ $REWRITE_RULE ]")]
     #[hax_lib::lemma]

--- a/libcrux-intrinsics/src/avx2.rs
+++ b/libcrux-intrinsics/src/avx2.rs
@@ -13,6 +13,7 @@ pub type Vec256Float = __m256;
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_storeu_si256_u8(output: &mut [u8], vector: Vec256) {
+    #[cfg(not(hax))]
     debug_assert_eq!(output.len(), 32);
     unsafe {
         _mm256_storeu_si256(output.as_mut_ptr() as *mut Vec256, vector);
@@ -22,6 +23,7 @@ pub fn mm256_storeu_si256_u8(output: &mut [u8], vector: Vec256) {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_storeu_si256_i16(output: &mut [i16], vector: Vec256) {
+    #[cfg(not(hax))]
     debug_assert_eq!(output.len(), 16);
     unsafe {
         _mm256_storeu_si256(output.as_mut_ptr() as *mut Vec256, vector);
@@ -31,6 +33,7 @@ pub fn mm256_storeu_si256_i16(output: &mut [i16], vector: Vec256) {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_storeu_si256_i32(output: &mut [i32], vector: Vec256) {
+    #[cfg(not(hax))]
     debug_assert_eq!(output.len(), 8);
     unsafe {
         _mm256_storeu_si256(output.as_mut_ptr() as *mut Vec256, vector);
@@ -40,6 +43,7 @@ pub fn mm256_storeu_si256_i32(output: &mut [i32], vector: Vec256) {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm_storeu_si128(output: &mut [i16], vector: Vec128) {
+    #[cfg(not(hax))]
     debug_assert!(output.len() >= 8);
     unsafe {
         _mm_storeu_si128(output.as_mut_ptr() as *mut Vec128, vector);
@@ -49,6 +53,7 @@ pub fn mm_storeu_si128(output: &mut [i16], vector: Vec128) {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm_storeu_si128_i32(output: &mut [i32], vector: Vec128) {
+    #[cfg(not(hax))]
     debug_assert_eq!(output.len(), 4);
     unsafe {
         _mm_storeu_si128(output.as_mut_ptr() as *mut Vec128, vector);
@@ -59,6 +64,7 @@ pub fn mm_storeu_si128_i32(output: &mut [i32], vector: Vec128) {
 #[hax_lib::ensures(|_r| future(output).len() == output.len())]
 #[inline(always)]
 pub fn mm_storeu_bytes_si128(output: &mut [u8], vector: Vec128) {
+    #[cfg(not(hax))]
     debug_assert_eq!(output.len(), 16);
     unsafe {
         _mm_storeu_si128(output.as_mut_ptr() as *mut Vec128, vector);
@@ -68,6 +74,7 @@ pub fn mm_storeu_bytes_si128(output: &mut [u8], vector: Vec128) {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm_loadu_si128(input: &[u8]) -> Vec128 {
+    #[cfg(not(hax))]
     debug_assert_eq!(input.len(), 16);
     unsafe { _mm_loadu_si128(input.as_ptr() as *const Vec128) }
 }
@@ -75,6 +82,7 @@ pub fn mm_loadu_si128(input: &[u8]) -> Vec128 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_loadu_si256_u8(input: &[u8]) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert_eq!(input.len(), 32);
     unsafe { _mm256_loadu_si256(input.as_ptr() as *const Vec256) }
 }
@@ -82,6 +90,7 @@ pub fn mm256_loadu_si256_u8(input: &[u8]) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_loadu_si256_i16(input: &[i16]) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert_eq!(input.len(), 16);
     unsafe { _mm256_loadu_si256(input.as_ptr() as *const Vec256) }
 }
@@ -89,6 +98,7 @@ pub fn mm256_loadu_si256_i16(input: &[i16]) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_loadu_si256_i32(input: &[i32]) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert_eq!(input.len(), 8);
     unsafe { _mm256_loadu_si256(input.as_ptr() as *const Vec256) }
 }
@@ -229,7 +239,6 @@ pub fn mm_set1_epi16(constant: i16) -> Vec128 {
     unsafe { _mm_set1_epi16(constant) }
 }
 
-#[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_set1_epi32(constant: i32) -> Vec256 {
     unsafe { _mm256_set1_epi32(constant) }
@@ -301,7 +310,6 @@ pub fn mm256_sub_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_sub_epi16(lhs, rhs) }
 }
 
-#[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_sub_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_sub_epi32(lhs, rhs) }
@@ -390,7 +398,6 @@ pub fn mm256_mul_epu32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mul_epu32(lhs, rhs) }
 }
 
-#[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_mul_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mul_epi32(lhs, rhs) }
@@ -436,6 +443,7 @@ pub fn mm256_xor_si256(lhs: Vec256, rhs: Vec256) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_srai_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
     unsafe { _mm256_srai_epi16::<SHIFT_BY>(vector) }
 }
@@ -443,6 +451,7 @@ pub fn mm256_srai_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_srai_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 32);
     unsafe { _mm256_srai_epi32::<SHIFT_BY>(vector) }
 }
@@ -450,6 +459,7 @@ pub fn mm256_srai_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_srli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
     unsafe { _mm256_srli_epi16::<SHIFT_BY>(vector) }
 }
@@ -457,6 +467,7 @@ pub fn mm256_srli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_srli_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 32);
     unsafe { _mm256_srli_epi32::<SHIFT_BY>(vector) }
 }
@@ -464,12 +475,15 @@ pub fn mm256_srli_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm_srli_epi64<const SHIFT_BY: i32>(vector: Vec128) -> Vec128 {
+    #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 64);
     unsafe { _mm_srli_epi64::<SHIFT_BY>(vector) }
 }
 
 #[inline(always)]
+#[hax_lib::requires(SHIFT_BY > 0 && SHIFT_BY < 64)]
 pub fn mm256_srli_epi64<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 64);
     unsafe { _mm256_srli_epi64::<SHIFT_BY>(vector) }
 }
@@ -477,6 +491,7 @@ pub fn mm256_srli_epi64<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_slli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
     unsafe { _mm256_slli_epi16::<SHIFT_BY>(vector) }
 }
@@ -484,6 +499,7 @@ pub fn mm256_slli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_slli_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 32);
     unsafe { _mm256_slli_epi32::<SHIFT_BY>(vector) }
 }
@@ -498,9 +514,9 @@ pub fn mm256_shuffle_epi8(vector: Vec256, control: Vec256) -> Vec256 {
     unsafe { _mm256_shuffle_epi8(vector, control) }
 }
 
-#[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_shuffle_epi32<const CONTROL: i32>(vector: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
     unsafe { _mm256_shuffle_epi32::<CONTROL>(vector) }
 }
@@ -508,6 +524,7 @@ pub fn mm256_shuffle_epi32<const CONTROL: i32>(vector: Vec256) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_permute4x64_epi64<const CONTROL: i32>(vector: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
     unsafe { _mm256_permute4x64_epi64::<CONTROL>(vector) }
 }
@@ -561,6 +578,7 @@ pub fn mm256_packs_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
 
 #[inline(always)]
 pub fn mm256_extracti128_si256<const CONTROL: i32>(vector: Vec256) -> Vec128 {
+    #[cfg(not(hax))]
     debug_assert!(CONTROL == 0 || CONTROL == 1);
     unsafe { _mm256_extracti128_si256::<CONTROL>(vector) }
 }
@@ -568,6 +586,7 @@ pub fn mm256_extracti128_si256<const CONTROL: i32>(vector: Vec256) -> Vec128 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_inserti128_si256<const CONTROL: i32>(vector: Vec256, vector_i128: Vec128) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(CONTROL == 0 || CONTROL == 1);
     unsafe { _mm256_inserti128_si256::<CONTROL>(vector, vector_i128) }
 }
@@ -575,13 +594,14 @@ pub fn mm256_inserti128_si256<const CONTROL: i32>(vector: Vec256, vector_i128: V
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_blend_epi16<const CONTROL: i32>(lhs: Vec256, rhs: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
     unsafe { _mm256_blend_epi16::<CONTROL>(lhs, rhs) }
 }
 
-#[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_blend_epi32<const CONTROL: i32>(lhs: Vec256, rhs: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
     unsafe { _mm256_blend_epi32::<CONTROL>(lhs, rhs) }
 }
@@ -642,6 +662,7 @@ pub fn mm256_slli_epi64<const LEFT: i32>(x: Vec256) -> Vec256 {
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_bsrli_epi128<const SHIFT_BY: i32>(x: Vec256) -> Vec256 {
+    #[cfg(not(hax))]
     debug_assert!(SHIFT_BY > 0 && SHIFT_BY < 16);
     unsafe { _mm256_bsrli_epi128::<SHIFT_BY>(x) }
 }

--- a/libcrux-intrinsics/src/avx2.rs
+++ b/libcrux-intrinsics/src/avx2.rs
@@ -13,6 +13,11 @@ pub type Vec256Float = __m256;
 #[hax_lib::opaque]
 #[inline(always)]
 pub fn mm256_storeu_si256_u8(output: &mut [u8], vector: Vec256) {
+    // Note: in this module the `debug_assert_eq!` are essentially sanity
+    // checks. In the context of hax, those are counterproductive. Our models
+    // are total: for example, `mm256_extracti128_si256` asserts CONTROL is
+    // either zero or one, but the intel spec allows any value, so our model
+    // does. Thus, we guard those debug asserts so that they don't appear in F*.
     #[cfg(not(hax))]
     debug_assert_eq!(output.len(), 32);
     unsafe {

--- a/libcrux-ml-dsa/proofs/fstar/extraction/Libcrux_ml_dsa.Simd.Avx2.Arithmetic.Expanded.fst
+++ b/libcrux-ml-dsa/proofs/fstar/extraction/Libcrux_ml_dsa.Simd.Avx2.Arithmetic.Expanded.fst
@@ -1,4 +1,4 @@
-module Libcrux_ml_dsa.Simd.Avx2.Arithmetic.Hello
+module Libcrux_ml_dsa.Simd.Avx2.Arithmetic.Expanded
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 80"
 open Core
 open FStar.Mul

--- a/libcrux-ml-dsa/proofs/fstar/extraction/Libcrux_ml_dsa.Simd.Avx2.Arithmetic.Expanded.fst
+++ b/libcrux-ml-dsa/proofs/fstar/extraction/Libcrux_ml_dsa.Simd.Avx2.Arithmetic.Expanded.fst
@@ -1,0 +1,250 @@
+module Libcrux_ml_dsa.Simd.Avx2.Arithmetic.Hello
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 80"
+open Core
+open FStar.Mul
+
+unfold let i32_to_i64 (x: i32): i64 = Rust_primitives.cast x
+unfold let i64_to_i32 (x: i64): i32 = Rust_primitives.cast x
+
+unfold type i32x8 = Minicore.Abstractions.Funarr.t_FunArray (mk_u64 8) i32
+
+unfold let i32x8_of_bv (bv: Minicore.Abstractions.Bitvec.t_BitVec (mk_u64 256)): i32x8 =
+  Core.Convert.f_from bv
+unfold let bv_of_i32x8 (bv: i32x8): Minicore.Abstractions.Bitvec.t_BitVec (mk_u64 256) =
+  Core.Convert.f_from bv
+
+let cast_lemma1 x: Lemma (Rust_primitives.cast x == i32_to_i64 x) = ()
+let cast_lemma2 x: Lemma (Rust_primitives.cast x == i64_to_i32 x) = ()
+let cast_lemma3 x n: Lemma ((Core.Convert.f_from x <: i32x8) n == i32x8_of_bv x n) = ()
+let cast_lemma4 x: Lemma (Core.Convert.f_from x == bv_of_i32x8 x) = ()
+
+let expanded (lhs rhs: Minicore.Abstractions.Bitvec.t_BitVec (mk_u64 256))
+    : Minicore.Abstractions.Bitvec.t_BitVec (mk_u64 256) = 
+        bv_of_i32x8 (FStar.FunctionalExtensionality.on_domain
+              (i:
+                Rust_primitives.Integers.u64
+                  { Rust_primitives.Integers.v i <
+                    Rust_primitives.Integers.v (Rust_primitives.Integers.mk_u64 8) })
+              (fun i ->
+                  match i with
+                  | Rust_primitives.Integers.MkInt 0 ->
+                    Core.Num.impl_i32__wrapping_sub (i64_to_i32
+                          (i32_to_i64 (i32x8_of_bv
+                                  lhs
+                                  (Rust_primitives.Integers.mk_u64 0)) *!
+                            i32_to_i64 (i32x8_of_bv
+                                  rhs
+                                  (Rust_primitives.Integers.mk_u64 0)) >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                      (i64_to_i32 (i32_to_i64
+                              (i64_to_i32 (i32_to_i64
+                                      (i64_to_i32 (i32_to_i64
+                                              (i32x8_of_bv
+                                                  lhs
+                                                  (Rust_primitives.Integers.mk_u64 0)) *!
+                                            i32_to_i64 (i32x8_of_bv
+                                                  rhs
+                                                  (Rust_primitives.Integers.mk_u64 0)))) *!
+                                    i32_to_i64 (Rust_primitives.cast
+                                          Libcrux_ml_dsa.Simd.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R
+                                        ))) *!
+                            i32_to_i64 Libcrux_ml_dsa.Simd.Traits.v_FIELD_MODULUS
+                             >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                  | Rust_primitives.Integers.MkInt 1 ->
+                    Core.Num.impl_i32__wrapping_sub (i64_to_i32
+                          (i32_to_i64 (i32x8_of_bv
+                                  lhs
+                                  (Rust_primitives.Integers.mk_u64 1)) *!
+                            i32_to_i64 (i32x8_of_bv
+                                  rhs
+                                  (Rust_primitives.Integers.mk_u64 1)) >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                      (i64_to_i32 (i32_to_i64
+                              (i64_to_i32 (i32_to_i64
+                                      (i64_to_i32 (i32_to_i64
+                                              (i32x8_of_bv
+                                                  lhs
+                                                  (Rust_primitives.Integers.mk_u64 1)) *!
+                                            i32_to_i64 (i32x8_of_bv
+                                                  rhs
+                                                  (Rust_primitives.Integers.mk_u64 1)))) *!
+                                    i32_to_i64 (Rust_primitives.cast
+                                          Libcrux_ml_dsa.Simd.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R
+                                        ))) *!
+                            i32_to_i64 Libcrux_ml_dsa.Simd.Traits.v_FIELD_MODULUS
+                             >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                  | Rust_primitives.Integers.MkInt 2 ->
+                    Core.Num.impl_i32__wrapping_sub (i64_to_i32
+                          (i32_to_i64 (i32x8_of_bv
+                                  lhs
+                                  (Rust_primitives.Integers.mk_u64 2)) *!
+                            i32_to_i64 (i32x8_of_bv
+                                  rhs
+                                  (Rust_primitives.Integers.mk_u64 2)) >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                      (i64_to_i32 (i32_to_i64
+                              (i64_to_i32 (i32_to_i64
+                                      (i64_to_i32 (i32_to_i64
+                                              (i32x8_of_bv
+                                                  lhs
+                                                  (Rust_primitives.Integers.mk_u64 2)) *!
+                                            i32_to_i64 (i32x8_of_bv
+                                                  rhs
+                                                  (Rust_primitives.Integers.mk_u64 2)))) *!
+                                    i32_to_i64 (Rust_primitives.cast
+                                          Libcrux_ml_dsa.Simd.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R
+                                        ))) *!
+                            i32_to_i64 Libcrux_ml_dsa.Simd.Traits.v_FIELD_MODULUS
+                             >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                  | Rust_primitives.Integers.MkInt 3 ->
+                    Core.Num.impl_i32__wrapping_sub (i64_to_i32
+                          (i32_to_i64 (i32x8_of_bv
+                                  lhs
+                                  (Rust_primitives.Integers.mk_u64 3)) *!
+                            i32_to_i64 (i32x8_of_bv
+                                  rhs
+                                  (Rust_primitives.Integers.mk_u64 3)) >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                      (i64_to_i32 (i32_to_i64
+                              (i64_to_i32 (i32_to_i64
+                                      (i64_to_i32 (i32_to_i64
+                                              (i32x8_of_bv
+                                                  lhs
+                                                  (Rust_primitives.Integers.mk_u64 3)) *!
+                                            i32_to_i64 (i32x8_of_bv
+                                                  rhs
+                                                  (Rust_primitives.Integers.mk_u64 3)))) *!
+                                    i32_to_i64 (Rust_primitives.cast
+                                          Libcrux_ml_dsa.Simd.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R
+                                        ))) *!
+                            i32_to_i64 Libcrux_ml_dsa.Simd.Traits.v_FIELD_MODULUS
+                             >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                  | Rust_primitives.Integers.MkInt 4 ->
+                    Core.Num.impl_i32__wrapping_sub (i64_to_i32
+                          (i32_to_i64 (i32x8_of_bv
+                                  lhs
+                                  (Rust_primitives.Integers.mk_u64 4)) *!
+                            i32_to_i64 (i32x8_of_bv
+                                  rhs
+                                  (Rust_primitives.Integers.mk_u64 4)) >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                      (i64_to_i32 (i32_to_i64
+                              (i64_to_i32 (i32_to_i64
+                                      (i64_to_i32 (i32_to_i64
+                                              (i32x8_of_bv
+                                                  lhs
+                                                  (Rust_primitives.Integers.mk_u64 4)) *!
+                                            i32_to_i64 (i32x8_of_bv
+                                                  rhs
+                                                  (Rust_primitives.Integers.mk_u64 4)))) *!
+                                    i32_to_i64 (Rust_primitives.cast
+                                          Libcrux_ml_dsa.Simd.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R
+                                        ))) *!
+                            i32_to_i64 Libcrux_ml_dsa.Simd.Traits.v_FIELD_MODULUS
+                             >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                  | Rust_primitives.Integers.MkInt 5 ->
+                    Core.Num.impl_i32__wrapping_sub (i64_to_i32
+                          (i32_to_i64 (i32x8_of_bv
+                                  lhs
+                                  (Rust_primitives.Integers.mk_u64 5)) *!
+                            i32_to_i64 (i32x8_of_bv
+                                  rhs
+                                  (Rust_primitives.Integers.mk_u64 5)) >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                      (i64_to_i32 (i32_to_i64
+                              (i64_to_i32 (i32_to_i64
+                                      (i64_to_i32 (i32_to_i64
+                                              (i32x8_of_bv
+                                                  lhs
+                                                  (Rust_primitives.Integers.mk_u64 5)) *!
+                                            i32_to_i64 (i32x8_of_bv
+                                                  rhs
+                                                  (Rust_primitives.Integers.mk_u64 5)))) *!
+                                    i32_to_i64 (Rust_primitives.cast
+                                          Libcrux_ml_dsa.Simd.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R
+                                        ))) *!
+                            i32_to_i64 Libcrux_ml_dsa.Simd.Traits.v_FIELD_MODULUS
+                             >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                  | Rust_primitives.Integers.MkInt 6 ->
+                    Core.Num.impl_i32__wrapping_sub (i64_to_i32
+                          (i32_to_i64 (i32x8_of_bv
+                                  lhs
+                                  (Rust_primitives.Integers.mk_u64 6)) *!
+                            i32_to_i64 (i32x8_of_bv
+                                  rhs
+                                  (Rust_primitives.Integers.mk_u64 6)) >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                      (i64_to_i32 (i32_to_i64
+                              (i64_to_i32 (i32_to_i64
+                                      (i64_to_i32 (i32_to_i64
+                                              (i32x8_of_bv
+                                                  lhs
+                                                  (Rust_primitives.Integers.mk_u64 6)) *!
+                                            i32_to_i64 (i32x8_of_bv
+                                                  rhs
+                                                  (Rust_primitives.Integers.mk_u64 6)))) *!
+                                    i32_to_i64 (Rust_primitives.cast
+                                          Libcrux_ml_dsa.Simd.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R
+                                        ))) *!
+                            i32_to_i64 Libcrux_ml_dsa.Simd.Traits.v_FIELD_MODULUS
+                             >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                  | Rust_primitives.Integers.MkInt 7 ->
+                    Core.Num.impl_i32__wrapping_sub (i64_to_i32
+                          (i32_to_i64 (i32x8_of_bv
+                                  lhs
+                                  (Rust_primitives.Integers.mk_u64 7)) *!
+                            i32_to_i64 (i32x8_of_bv
+                                  rhs
+                                  (Rust_primitives.Integers.mk_u64 7)) >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                      (i64_to_i32 (i32_to_i64
+                              (i64_to_i32 (i32_to_i64
+                                      (i64_to_i32 (i32_to_i64
+                                              (i32x8_of_bv
+                                                  lhs
+                                                  (Rust_primitives.Integers.mk_u64 7)) *!
+                                            i32_to_i64 (i32x8_of_bv
+                                                  rhs
+                                                  (Rust_primitives.Integers.mk_u64 7)))) *!
+                                    i32_to_i64 (Rust_primitives.cast
+                                          Libcrux_ml_dsa.Simd.Traits.v_INVERSE_OF_MODULUS_MOD_MONTGOMERY_R
+                                        ))) *!
+                            i32_to_i64 Libcrux_ml_dsa.Simd.Traits.v_FIELD_MODULUS
+                             >>!
+                            Rust_primitives.Integers.mk_i32 32))
+                  | _ ->
+                    Rust_primitives.Hax.never_to_any (Core.Panicking.panic "internal error: entered unreachable code"
+                        )))
+
+open FStar.Tactics
+
+let expanded_lemma (lhs rhs: Minicore.Abstractions.Bitvec.t_BitVec (mk_u64 256))
+    : Lemma (expanded lhs rhs == Libcrux_ml_dsa.Simd.Avx2.Arithmetic.montgomery_multiply lhs rhs) = 
+    assert (expanded lhs rhs == Libcrux_ml_dsa.Simd.Avx2.Arithmetic.montgomery_multiply lhs rhs) by (
+      compute ();
+      trefl ()
+    )
+
+
+
+// [@@FStar.Tactics.postprocess_with (fun _ -> 
+//         let open FStar.Tactics in
+//         norm [iota; primops; delta_only [`% Libcrux_ml_dsa.Simd.Avx2.Arithmetic.montgomery_multiply ]; zeta];
+//         l_to_r [`cast_lemma1;`cast_lemma2;`cast_lemma3;`cast_lemma4];
+//         dump "show";
+//         trefl ()
+//     )]
+
+// let f (lhs rhs: Minicore.Abstractions.Bitvec.t_BitVec (mk_u64 256))
+//     : Minicore.Abstractions.Bitvec.t_BitVec (mk_u64 256) =
+//   let lhs:Minicore.Abstractions.Bitvec.t_BitVec (mk_u64 256) =
+//     Libcrux_ml_dsa.Simd.Avx2.Arithmetic.montgomery_multiply lhs rhs
+//   in
+//   lhs

--- a/libcrux-ml-dsa/proofs/fstar/extraction/Makefile
+++ b/libcrux-ml-dsa/proofs/fstar/extraction/Makefile
@@ -4,6 +4,8 @@ VERIFIED_MODULES = \
 	Libcrux_ml_dsa.Simd.Portable.Encoding.Commitment.fst \
 	Libcrux_ml_dsa.Simd.Portable.Arithmetic.fsti \
 	Libcrux_ml_dsa.Simd.Portable.Arithmetic.fst \
+	Libcrux_ml_dsa.Simd.Avx2.Encoding.Commitment.fst \
+	Libcrux_ml_dsa.Simd.Avx2.Arithmetic.fst \
 	Libcrux_ml_dsa.Simd.Traits.fsti \
 	Libcrux_ml_dsa.Simd.Traits.fst \
 	end_of_verified_modules

--- a/libcrux-ml-dsa/src/simd/avx2/arithmetic.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/arithmetic.rs
@@ -56,11 +56,7 @@ pub(super) fn montgomery_multiply_by_constant(lhs: Vec256, constant: i32) -> Vec
     res
 }
 
-#[hax_lib::fstar::before(
-    r#"
-[@@FStar.Tactics.postprocess_with ${minicore::arch::x86::interpretations::int_vec::flatten_circuit}]
-"#
-)]
+#[hax_lib::fstar::postprocess_with(minicore::arch::x86::interpretations::int_vec::flatten_circuit)]
 #[inline(always)]
 pub(super) fn montgomery_multiply(lhs: &mut Vec256, rhs: &Vec256) {
     let field_modulus = mm256_set1_epi32(FIELD_MODULUS);

--- a/libcrux-ml-dsa/src/simd/avx2/arithmetic.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/arithmetic.rs
@@ -56,6 +56,11 @@ pub(super) fn montgomery_multiply_by_constant(lhs: Vec256, constant: i32) -> Vec
     res
 }
 
+#[hax_lib::fstar::before(
+    r#"
+[@@FStar.Tactics.postprocess_with ${minicore::arch::x86::interpretations::int_vec::flatten_circuit}]
+"#
+)]
 #[inline(always)]
 pub(super) fn montgomery_multiply(lhs: &mut Vec256, rhs: &Vec256) {
     let field_modulus = mm256_set1_epi32(FIELD_MODULUS);
@@ -95,6 +100,7 @@ pub(super) fn shift_left_then_reduce<const SHIFT_BY: i32>(simd_unit: &mut Vec256
 // TODO: Revisit this function when doing the range analysis and testing
 // additional KATs.
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 pub(super) fn infinity_norm_exceeds(simd_unit: &Vec256, bound: i32) -> bool {
     let absolute_values = mm256_abs_epi32(*simd_unit);
 
@@ -111,6 +117,7 @@ pub(super) fn infinity_norm_exceeds(simd_unit: &Vec256, bound: i32) -> bool {
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 pub(super) fn power2round(r0: &mut Vec256, r1: &mut Vec256) {
     to_unsigned_representatives(r0);
 
@@ -125,6 +132,7 @@ pub(super) fn power2round(r0: &mut Vec256, r1: &mut Vec256) {
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 pub(super) fn decompose(gamma2: Gamma2, r: &Vec256, r0: &mut Vec256, r1: &mut Vec256) {
     let r = to_unsigned_representatives_ret(r);
 
@@ -180,6 +188,7 @@ pub(super) fn decompose(gamma2: Gamma2, r: &Vec256, r0: &mut Vec256, r1: &mut Ve
 }
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 pub(super) fn compute_hint(low: &Vec256, high: &Vec256, gamma2: i32, hint: &mut Vec256) -> usize {
     let minus_gamma2 = mm256_set1_epi32(-gamma2);
     let gamma2 = mm256_set1_epi32(gamma2);
@@ -203,6 +212,7 @@ pub(super) fn compute_hint(low: &Vec256, high: &Vec256, gamma2: i32, hint: &mut 
     hints_mask.count_ones() as usize
 }
 
+#[hax_lib::fstar::verification_status(lax)]
 #[inline(always)]
 pub(super) fn use_hint(gamma2: Gamma2, r: &Vec256, hint: &mut Vec256) {
     let (mut r0, mut r1) = (mm256_setzero_si256(), mm256_setzero_si256());


### PR DESCRIPTION
This PR makes F* normalize `montgomery_mulitply` so that it becomes a flat circuit.

This PR also adds a file `Libcrux_mld_dsa.Simd.Avx2.Arithmetic.fst`, which contains the fully expanded version of `montgomery_mulitply`, and a proof of equivalence.

Fixes https://github.com/cryspen/libcrux/issues/942.