### PR TITLE
Minicore: add a integer vector interpretation for bitvecs and (some) avx2 intrinsics

### DIFF
--- a/fstar-helpers/minicore/src/abstractions/bitvec.rs
+++ b/fstar-helpers/minicore/src/abstractions/bitvec.rs
@@ -341,7 +341,12 @@ pub mod int_vec_interp {
         };
     }
 
-    // Defines the types `i32x8` and `i64x4`, and define intepretations function (`From` instances) from/to those types from/to bit vectors.
+    // Defines the types `i32x8` and `i64x4`, and define intepretations function
+    // (`From` instances) from/to those types from/to bit vectors.
+    //
+    // We will need more such interpreations in the future to handle more avx2
+    // intrinsics (e.g. `_mm256_add_epi16` works on 16 bits integers, not on i32
+    // or i64).
     interpretations!(256; i32x8 [i32; 8], i64x4 [i64; 4]);
 
     impl i64x4 {

--- a/fstar-helpers/minicore/src/abstractions/bitvec.rs
+++ b/fstar-helpers/minicore/src/abstractions/bitvec.rs
@@ -344,12 +344,18 @@ pub mod int_vec_interp {
     // Defines the types `i32x8` and `i64x4`, and define intepretations function (`From` instances) from/to those types from/to bit vectors.
     interpretations!(256; i32x8 [i32; 8], i64x4 [i64; 4]);
 
-    impl From<i64x4> for i32x8 {
-        fn from(vec: i64x4) -> Self {
-            Self::from_fn(|i| {
-                let value = *vec.get(i / 2);
+    impl i64x4 {
+        pub fn into_i32x8(self) -> i32x8 {
+            i32x8::from_fn(|i| {
+                let value = *self.get(i / 2);
                 (if i % 2 == 0 { value } else { value >> 32 }) as i32
             })
+        }
+    }
+
+    impl From<i64x4> for i32x8 {
+        fn from(vec: i64x4) -> Self {
+            vec.into_i32x8()
         }
     }
 
@@ -360,6 +366,6 @@ pub mod int_vec_interp {
     #[hax_lib::lemma]
     fn lemma_rewrite_i64x4_bv_i32x8(
         bv: i64x4,
-    ) -> Proof<{ hax_lib::eq(i32x8::from(BitVec::<256>::from(bv)), i32x8::from(bv)) }> {
+    ) -> Proof<{ hax_lib::eq(i32x8::from(BitVec::<256>::from(bv)), bv.into_i32x8()) }> {
     }
 }

--- a/fstar-helpers/minicore/src/abstractions/funarr.rs
+++ b/fstar-helpers/minicore/src/abstractions/funarr.rs
@@ -84,6 +84,23 @@ impl<const N: u64, T> FunArray<N, T> {
     }
 }
 
+macro_rules! impl_pointwise {
+    ($n:literal, $($i:literal)*) => {
+        impl<T: Copy> FunArray<$n, T> {
+            pub fn pointwise(self) -> Self {
+                Self::from_fn(|i| match i {
+                    $($i => self[$i],)*
+                    _ => unreachable!(),
+                })
+            }
+        }
+    };
+}
+
+impl_pointwise!(4, 0 1 2 3);
+impl_pointwise!(8, 0 1 2 3 4 5 6 7);
+impl_pointwise!(16, 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15);
+
 #[hax_lib::exclude]
 impl<const N: u64, T: Clone> TryFrom<Vec<T>> for FunArray<N, T> {
     type Error = ();

--- a/fstar-helpers/minicore/src/core_arch/x86.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86.rs
@@ -2,6 +2,78 @@
 //!
 //! This module provides a purely Rust implementation of selected operations from
 //! `core::arch::x86` and `core::arch::x86_64`.
+//!
+//! # Guide — Adding a New Intrinsic to the `core_arch::x86` Model
+//!
+//! ## Introduction — Why & How We Model SIMD
+//!
+//! In order to verify code that uses SIMD, every intrinsic has to be modeled.  
+//! Your crate already provides the scaffolding:
+//!
+//! * **`src/core_arch/x86/opaque.rs`** — list of **empty** intrinsics (stubs).  
+//! * **`src/core_arch/x86/{sse2,avx,avx2,…}.rs`** — where *real* models belong.
+//!
+//! This guide shows an end‑to‑end path:
+//!
+//! 1. **Locate** the intrinsic in upstream docs.  
+//! 2. **Pick a representation** (bit‑vector, integer vector, or both).  
+//! 3. **Move** the item out of `opaque.rs` (if it is defined here).  
+//! 4. **Implement** the model and (optionally) an interpretation with a lift lemma.  
+//! 5. **Test**.  
+//!
+//! ## Choosing Your Semantic Representation
+//!
+//! | Representation | Good for | Extra work |
+//! |----------------|----------|------------|
+//! | **Bit‑vector** (`BitVec<256>`) | Bit-wise proofs, shuffles, masking | None |
+//! | **Integer vector** (`i32x8`, `i64x4`, …) | Lane‑wise integer reasoning | Add lift lemma |
+//!
+//! ## Driving Example – `_mm256_mul_epi32`
+//!
+//! We add the AVX2 "multiply packed 32‑bit integers" intrinsic.
+//!
+//!  1. *Locate* in <https://doc.rust-lang.org/stable/core/arch/x86/> → click **Source**. Path shows `core_arch/src/x86/avx2.rs`: this intrinsics needs to be added to the  `avx2` sub module of `x86.rs`.
+//!  2. **Delete the stub** from `opaque.rs`
+//!  3. **Implement** the bit‑vector spec. (file `x86.rs`, module `avx2`)
+//!  4. *(Optional)* add an `i32x8` interpretation + lift lemma. (file `x86/interpretations.rs`)
+//!  5. **Unit‑test** equivalence.
+//!
+//! ### (step 3) Bit‑Vector Model (if needed)
+//! In the case of `_mm256_mul_epi32` you probably don't want to have a bit vec model. You would have to write a bit vec addition primitive first.
+//! In this case, we just declare an opaque `_mm256_mul_epi32` in `x86::avx2`.
+//!
+//! ```rust
+//! #[hax_lib::opaque]
+//! pub fn _mm256_mul_epi32(_: __m256i, _: __m256i) -> __m256i {
+//!     unimplemented!()
+//! }
+//! ```
+//!
+//! ### (step 4) Integer‑Vector Interpretation & Lift Lemma (if needed)
+//! In `minicore::core_arch::x86::interpretations::int_vec`, we add the following model:
+//!
+//! ```rust
+//! pub fn _mm256_mul_epi32(x: i32x8, y: i32x8) -> i64x4 {
+//!     i64x4::from_fn(|i| (x[i * 2] as i64) * (y[i * 2] as i64))
+//! }
+//! ```
+//!
+//! And a lift lemma in `minicore::core_arch::x86::interpretations::int_vec::lemmas`:
+//! ```rust
+//! mk_lift_lemma!(
+//!     _mm256_mul_epi32(x: __m256i, y: __m256i) ==
+//!     __m256i::from(super::_mm256_mul_epi32(super::i32x8::from(x), super::i32x8::from(y)))
+//! );
+//! ```
+//!
+//! ### (step 5) Unit Test
+//! In `minicore::core_arch::x86::interpretations::int_vec::tests`:
+//! ```rust
+//! mk!(_mm256_mul_epi32(x: BitVec, y: BitVec));
+//! ```
+//!
+//! `mk!` will create a test function that tests that our model of `_mm256_mul_epi32` and its original definition are equivalent for 1000 random values of `x` and `y`.
+//!
 #![allow(clippy::too_many_arguments)]
 
 pub mod interpretations;

--- a/fstar-helpers/minicore/src/core_arch/x86.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86.rs
@@ -126,6 +126,11 @@ pub mod avx {
     }
 
     #[hax_lib::opaque]
+    pub fn _mm256_set1_epi32(_: i32) -> __m256i {
+        unimplemented!()
+    }
+
+    #[hax_lib::opaque]
     pub fn _mm256_set_epi32(
         _e0: i32,
         _e1: i32,
@@ -202,6 +207,27 @@ pub mod avx {
 pub use avx2::*;
 pub mod avx2 {
     use super::*;
+
+    #[hax_lib::opaque]
+    pub fn _mm256_blend_epi32<const IMM8: i32>(_: __m256i, _: __m256i) -> __m256i {
+        unimplemented!()
+    }
+
+    #[hax_lib::opaque]
+    pub fn _mm256_shuffle_epi32<const MASK: i32>(_: __m256i) -> __m256i {
+        unimplemented!()
+    }
+
+    #[hax_lib::opaque]
+    pub fn _mm256_sub_epi32(_: __m256i, _: __m256i) -> __m256i {
+        unimplemented!()
+    }
+
+    #[hax_lib::opaque]
+    pub fn _mm256_mul_epi32(_: __m256i, _: __m256i) -> __m256i {
+        unimplemented!()
+    }
+
     #[hax_lib::exclude]
     pub fn _mm_storeu_si128(output: *mut __m128i, a: __m128i) {
         // This is equivalent to `*output = a`

--- a/fstar-helpers/minicore/src/core_arch/x86.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86.rs
@@ -126,11 +126,15 @@ pub mod avx {
         BitVec::from_fn(|i| vector[i])
     }
 
+    /// This is opaque to Hax: it is defined only via the integer
+    /// interpretation. See `interpretations::int_vec::_mm256_set1_epi32`.
     #[hax_lib::opaque]
     pub fn _mm256_set1_epi32(_: i32) -> __m256i {
         unimplemented!()
     }
 
+    /// This is opaque to Hax: we have lemmas about this intrinsics
+    /// composed with others. See e.g. `_rw_mm256_sllv_epi32`.
     #[hax_lib::opaque]
     pub fn _mm256_set_epi32(
         _e0: i32,
@@ -145,6 +149,8 @@ pub mod avx {
         todo!()
     }
 
+    /// This is opaque to Hax: we have lemmas about this intrinsics
+    /// composed with others. See e.g. `_rw_mm256_mullo_epi16_shifts`.
     #[hax_lib::opaque]
     pub fn _mm256_set_epi16(
         _e00: i16,
@@ -167,6 +173,8 @@ pub mod avx {
         todo!()
     }
 
+    /// This is opaque to Hax: we have lemmas about this intrinsics
+    /// composed with others. See e.g. `_rw_mm256_shuffle_epi8`.
     #[hax_lib::opaque]
     pub fn _mm256_set_epi8(
         _e00: i8,

--- a/fstar-helpers/minicore/src/core_arch/x86.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86.rs
@@ -4,6 +4,7 @@
 //! `core::arch::x86` and `core::arch::x86_64`.
 #![allow(clippy::too_many_arguments)]
 
+pub mod interpretations;
 use crate::abstractions::{bit::*, bitvec::*, funarr::*};
 
 pub(crate) mod upstream {

--- a/fstar-helpers/minicore/src/core_arch/x86/interpretations.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86/interpretations.rs
@@ -97,9 +97,6 @@ pub mod int_vec {
 
         #[hax_lib::fstar::replace(
             r#"
-        // irreducible let cast (t:inttype) (t':inttype) (x:int_t t): int_t t' = magic ()
-        // let hey (#t:inttype) (#t':inttype) (x:int_t t): Lemma (Rust_primitives.cast x == cast t t' x) = admit ()
-
         let ${flatten_circuit} (): FStar.Tactics.Tac unit =
             let open Tactics.Circuits in
             flatten_circuit
@@ -111,8 +108,7 @@ pub mod int_vec {
                 ]
                 (top_levels_of_attr (` $LIFT_LEMMA ))
                 (top_levels_of_attr (` $SIMPLIFICATION_LEMMA ))
-                (top_levels_of_attr (` $ETA_MATCH_EXPAND ));
-            ()
+                (top_levels_of_attr (` $ETA_MATCH_EXPAND ))
         "#
         )]
         /// F* tactic: specialization of `Tactics.Circuits.flatten_circuit`.

--- a/fstar-helpers/minicore/src/core_arch/x86/interpretations.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86/interpretations.rs
@@ -1,0 +1,183 @@
+pub mod int_vec {
+    //! Provides a machine integer vectors intepretation for AVX2 intrinsics.
+
+    use crate::abstractions::{bitvec::int_vec_interp::*, funarr::FunArray};
+    #[allow(unused)]
+    use crate::core_arch::x86;
+
+    pub fn _mm256_set1_epi32(x: i32) -> i32x8 {
+        i32x8::from_fn(|_| x)
+    }
+
+    pub fn _mm256_mul_epi32(x: i32x8, y: i32x8) -> i64x4 {
+        i64x4::from_fn(|i| (x[i * 2] as i64) * (y[i * 2] as i64))
+    }
+    pub fn _mm256_sub_epi32(x: i32x8, y: i32x8) -> i32x8 {
+        i32x8::from_fn(|i| x[i].wrapping_sub(y[i]))
+    }
+
+    pub fn _mm256_shuffle_epi32<const CONTROL: i32>(x: i32x8) -> i32x8 {
+        let indexes: FunArray<4, u64> = FunArray::from_fn(|i| ((CONTROL >> i * 2) % 4) as u64);
+        i32x8::from_fn(|i| {
+            if i < 4 {
+                x[indexes[i]]
+            } else {
+                x[4 + indexes[i - 4]]
+            }
+        })
+    }
+
+    pub fn _mm256_blend_epi32<const CONTROL: i32>(x: i32x8, y: i32x8) -> i32x8 {
+        FunArray::from_fn(|i| if (CONTROL >> i) % 2 == 0 { x[i] } else { y[i] })
+    }
+
+    pub use lemmas::flatten_circuit;
+    // ! This module provides lemmas allowing to lift the intrinsics modeled in `super` from their version operating on AVX2 vectors to functions operating on machine integer vectors (e.g. on `i32x8`).
+    pub mod lemmas {
+        use super::*;
+
+        #[allow(unused)]
+        use crate::core_arch::x86 as upstream;
+        #[allow(unused)]
+        use crate::core_arch::x86::__m256i;
+
+        /// An F* attribute that marks an item as being an lifting lemma.
+        #[allow(dead_code)]
+        #[hax_lib::fstar::before("irreducible")]
+        pub const ETA_MATCH_EXPAND: () = ();
+
+        #[hax_lib::fstar::before("[@@ $ETA_MATCH_EXPAND ]")]
+        #[hax_lib::lemma]
+        #[hax_lib::opaque]
+        pub fn pointwise_i32x8(x: i32x8) -> Proof<{ hax_lib::eq(x, x.pointwise()) }> {}
+
+        #[hax_lib::fstar::before("[@@ $ETA_MATCH_EXPAND ]")]
+        #[hax_lib::lemma]
+        #[hax_lib::opaque]
+        pub fn pointwise_i64x4(x: i64x4) -> Proof<{ hax_lib::eq(x, x.pointwise()) }> {}
+
+        /// An F* attribute that marks an item as being an lifting lemma.
+        #[allow(dead_code)]
+        #[hax_lib::fstar::before("irreducible")]
+        pub const LIFT_LEMMA: () = ();
+
+        /// Derives automatically a lift lemma for a given function
+        macro_rules! mk_lift_lemma {
+            ($name:ident$(<$(const $c:ident : $cty:ty),*>)?($($x:ident : $ty:ty),*) == $lhs:expr) => {
+                #[hax_lib::opaque]
+                #[hax_lib::lemma]
+                #[hax_lib::fstar::before("[@@ $LIFT_LEMMA ]")]
+                fn $name$(<$(const $c : $cty,)*>)?($($x : $ty,)*) -> Proof<{
+                    hax_lib::eq(
+                        unsafe {upstream::$name$(::<$($c,)*>)?($($x,)*)},
+                        $lhs
+                    )
+                }> {}
+            }
+        }
+        mk_lift_lemma!(
+            _mm256_set1_epi32(x: i32) ==
+            __m256i::from(super::_mm256_set1_epi32(x))
+        );
+        mk_lift_lemma!(
+            _mm256_mul_epi32(x: __m256i, y: __m256i) ==
+            __m256i::from(super::_mm256_mul_epi32(super::i32x8::from(x), super::i32x8::from(y)))
+        );
+        mk_lift_lemma!(
+            _mm256_sub_epi32(x: __m256i, y: __m256i) ==
+            __m256i::from(super::_mm256_sub_epi32(super::i32x8::from(x), super::i32x8::from(y)))
+        );
+        mk_lift_lemma!(
+            _mm256_shuffle_epi32<const CONTROL: i32>(x: __m256i) ==
+            __m256i::from(super::_mm256_shuffle_epi32::<CONTROL>(super::i32x8::from(x)))
+        );
+        mk_lift_lemma!(_mm256_blend_epi32<const CONTROL: i32>(x: __m256i, y: __m256i) ==
+            __m256i::from(super::_mm256_blend_epi32::<CONTROL>(super::i32x8::from(x), super::i32x8::from(y)))
+        );
+
+        #[hax_lib::fstar::replace(
+            r#"
+        // irreducible let cast (t:inttype) (t':inttype) (x:int_t t): int_t t' = magic ()
+        // let hey (#t:inttype) (#t':inttype) (x:int_t t): Lemma (Rust_primitives.cast x == cast t t' x) = admit ()
+
+        let ${flatten_circuit} (): FStar.Tactics.Tac unit =
+            let open Tactics.Circuits in
+            flatten_circuit
+                [
+                    "Minicore";
+                    "FStar.FunctionalExtensionality";
+                    `%Rust_primitives.cast_tc; `%Rust_primitives.unsize_tc;
+                    "Core.Ops"; `%(.[]);
+                ]
+                (top_levels_of_attr (` $LIFT_LEMMA ))
+                (top_levels_of_attr (` $SIMPLIFICATION_LEMMA ))
+                (top_levels_of_attr (` $ETA_MATCH_EXPAND ));
+            ()
+        "#
+        )]
+        /// F* tactic: specialization of `Tactics.Circuits.flatten_circuit`.
+        pub fn flatten_circuit() {}
+    }
+
+    #[cfg(all(test, any(target_arch = "x86", target_arch = "x86_64")))]
+    mod tests {
+        use crate::abstractions::bitvec::BitVec;
+        use crate::core_arch::x86::upstream;
+
+        /// Helper trait to generate random values
+        pub trait HasRandom {
+            fn random() -> Self;
+        }
+
+        impl HasRandom for i32 {
+            fn random() -> Self {
+                use rand::prelude::*;
+                let mut rng = rand::rng();
+                rng.random()
+            }
+        }
+
+        impl<const N: u64> HasRandom for BitVec<N> {
+            fn random() -> Self {
+                BitVec::rand()
+            }
+        }
+
+        /// Derives tests for a given intrinsics. Test that a given intrisics and its model compute the same thing over random values (1000 by default).
+        macro_rules! mk {
+            ($([$N:literal])?$name:ident$({$(<$($c:literal),*>),*})?($($x:ident : $ty:ident),*)) => {
+                #[test]
+                fn $name() {
+                    #[allow(unused)]
+                    const N: usize = {
+                        let n: usize = 1000;
+                        $(let n: usize = $N;)?
+                        n
+                    };
+                    mk!(@[N]$name$($(<$($c),*>)*)?($($x : $ty),*));
+                }
+            };
+            (@[$N:ident]$name:ident$(<$($c:literal),*>)?($($x:ident : $ty:ident),*)) => {
+                for _ in 0..$N {
+                    $(let $x = $ty::random();)*
+                    assert_eq!(super::$name$(::<$($c,)*>)?($($x.into(),)*), unsafe {
+                        BitVec::from(upstream::$name$(::<$($c,)*>)?($($x.into(),)*)).into()
+                    });
+                }
+            };
+            (@[$N:ident]$name:ident<$($c1:literal),*>$(<$($c:literal),*>)*($($x:ident : $ty:ident),*)) => {
+                let one = || {
+                    mk!(@[$N]$name<$($c1),*>($($x : $ty),*));
+                };
+                one();
+                mk!(@[$N]$name$(<$($c),*>)*($($x : $ty),*));
+            }
+        }
+
+        mk!(_mm256_set1_epi32(x: i32));
+        mk!(_mm256_sub_epi32(x: BitVec, y: BitVec));
+        mk!(_mm256_mul_epi32(x: BitVec, y: BitVec));
+        mk!(_mm256_shuffle_epi32{<0b01_00_10_11>, <0b01_11_01_10>}(x: BitVec));
+        mk!([100]_mm256_blend_epi32{<0>,<1>,<2>,<3>,<4>,<5>,<6>,<7>,<8>,<9>,<10>,<11>,<12>,<13>,<14>,<15>,<16>,<17>,<18>,<19>,<20>,<21>,<22>,<23>,<24>,<25>,<26>,<27>,<28>,<29>,<30>,<31>,<32>,<33>,<34>,<35>,<36>,<37>,<38>,<39>,<40>,<41>,<42>,<43>,<44>,<45>,<46>,<47>,<48>,<49>,<50>,<51>,<52>,<53>,<54>,<55>,<56>,<57>,<58>,<59>,<60>,<61>,<62>,<63>,<64>,<65>,<66>,<67>,<68>,<69>,<70>,<71>,<72>,<73>,<74>,<75>,<76>,<77>,<78>,<79>,<80>,<81>,<82>,<83>,<84>,<85>,<86>,<87>,<88>,<89>,<90>,<91>,<92>,<93>,<94>,<95>,<96>,<97>,<98>,<99>,<100>,<101>,<102>,<103>,<104>,<105>,<106>,<107>,<108>,<109>,<110>,<111>,<112>,<113>,<114>,<115>,<116>,<117>,<118>,<119>,<120>,<121>,<122>,<123>,<124>,<125>,<126>,<127>,<128>,<129>,<130>,<131>,<132>,<133>,<134>,<135>,<136>,<137>,<138>,<139>,<140>,<141>,<142>,<143>,<144>,<145>,<146>,<147>,<148>,<149>,<150>,<151>,<152>,<153>,<154>,<155>,<156>,<157>,<158>,<159>,<160>,<161>,<162>,<163>,<164>,<165>,<166>,<167>,<168>,<169>,<170>,<171>,<172>,<173>,<174>,<175>,<176>,<177>,<178>,<179>,<180>,<181>,<182>,<183>,<184>,<185>,<186>,<187>,<188>,<189>,<190>,<191>,<192>,<193>,<194>,<195>,<196>,<197>,<198>,<199>,<200>,<201>,<202>,<203>,<204>,<205>,<206>,<207>,<208>,<209>,<210>,<211>,<212>,<213>,<214>,<215>,<216>,<217>,<218>,<219>,<220>,<221>,<222>,<223>,<224>,<225>,<226>,<227>,<228>,<229>,<230>,<231>,<232>,<233>,<234>,<235>,<236>,<237>,<238>,<239>,<240>,<241>,<242>,<243>,<244>,<245>,<246>,<247>,<248>,<249>,<250>,<251>,<252>,<253>,<254>,<255>}(x: BitVec, y: BitVec));
+    }
+}

--- a/fstar-helpers/minicore/src/core_arch/x86/opaque.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86/opaque.rs
@@ -26,10 +26,6 @@ pub unsafe fn _mm_set1_epi16(a: i16) -> __m128i {
     unimplemented!()
 }
 #[hax_lib::opaque]
-pub unsafe fn _mm256_set1_epi32(a: i32) -> __m256i {
-    unimplemented!()
-}
-#[hax_lib::opaque]
 pub unsafe fn _mm_set_epi32(e3: i32, e2: i32, e1: i32, e0: i32) -> __m128i {
     unimplemented!()
 }

--- a/fstar-helpers/minicore/src/core_arch/x86/opaque.rs
+++ b/fstar-helpers/minicore/src/core_arch/x86/opaque.rs
@@ -58,10 +58,6 @@ pub unsafe fn _mm256_sub_epi16(a: __m256i, b: __m256i) -> __m256i {
     unimplemented!()
 }
 #[hax_lib::opaque]
-pub unsafe fn _mm256_sub_epi32(a: __m256i, b: __m256i) -> __m256i {
-    unimplemented!()
-}
-#[hax_lib::opaque]
 pub unsafe fn _mm_sub_epi16(a: __m128i, b: __m128i) -> __m128i {
     unimplemented!()
 }
@@ -114,10 +110,6 @@ pub unsafe fn _mm256_mul_epu32(a: __m256i, b: __m256i) -> __m256i {
     unimplemented!()
 }
 #[hax_lib::opaque]
-pub unsafe fn _mm256_mul_epi32(a: __m256i, b: __m256i) -> __m256i {
-    unimplemented!()
-}
-#[hax_lib::opaque]
 pub unsafe fn _mm256_and_si256(a: __m256i, b: __m256i) -> __m256i {
     unimplemented!()
 }
@@ -158,10 +150,6 @@ pub unsafe fn _mm256_slli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
     unimplemented!()
 }
 #[hax_lib::opaque]
-pub unsafe fn _mm256_shuffle_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
-    unimplemented!()
-}
-#[hax_lib::opaque]
 pub unsafe fn _mm256_permute4x64_epi64<const IMM8: i32>(a: __m256i) -> __m256i {
     unimplemented!()
 }
@@ -199,10 +187,6 @@ pub unsafe fn _mm256_inserti128_si256<const IMM8: i32>(a: __m256i, b: __m128i) -
 }
 #[hax_lib::opaque]
 pub unsafe fn _mm256_blend_epi16<const IMM8: i32>(a: __m256i, b: __m256i) -> __m256i {
-    unimplemented!()
-}
-#[hax_lib::opaque]
-pub unsafe fn _mm256_blend_epi32<const IMM8: i32>(a: __m256i, b: __m256i) -> __m256i {
     unimplemented!()
 }
 #[hax_lib::opaque]

--- a/fstar-helpers/minicore/src/lib.rs
+++ b/fstar-helpers/minicore/src/lib.rs
@@ -24,7 +24,7 @@
 //! `minicore` is designed as a reference model for formal verification and reasoning about Rust programs.
 //! By providing a readable, well-specified version of `core`'s behavior, it serves as a foundation for
 //! proof assistants and other verification tools.
-
+#![recursion_limit = "512"]
 pub mod abstractions;
 pub mod core_arch;
 

--- a/fstar-helpers/minicore/src/lib.rs
+++ b/fstar-helpers/minicore/src/lib.rs
@@ -24,6 +24,9 @@
 //! `minicore` is designed as a reference model for formal verification and reasoning about Rust programs.
 //! By providing a readable, well-specified version of `core`'s behavior, it serves as a foundation for
 //! proof assistants and other verification tools.
+
+// This recursion limit is necessary for macro `minicore::core_arch::x86::interpretations::int_vec::tests::mk!`.
+// We test functions with const generics, the macro generate a test per possible (const generic) control value.
 #![recursion_limit = "512"]
 pub mod abstractions;
 pub mod core_arch;


### PR DESCRIPTION
> Note: this is a remake of https://github.com/cryspen/libcrux/pull/923

This PR introduces an interpretation layer for SIMD-style machine integer vectors (`i32x8`, `i64x4`) over `BitVec<256>`, along with modeling support for selected AVX2 intrinsics.

## Additions
- **`int_vec_interp` module** (`bitvec.rs`):
  - Defines type aliases `i32x8` and `i64x4` as `FunArray`s over `i32` and `i64`.
  - Implements `From` conversions between `BitVec<256>` and these vector types.
  - Adds cancelation lemmas for round-trip conversions.

- **`core_arch::x86::interpretations` module**:
  - Models a subset of AVX2 intrinsics over `i32x8`/`i64x4`:
    - `_mm256_set1_epi32`
    - `_mm256_mul_epi32`
    - `_mm256_sub_epi32`
    - `_mm256_shuffle_epi32`
    - `_mm256_blend_epi32`
  - Defines lift lemmas that link the intrinsics with the interpreted model.
  - Provides randomized tests to validate the interpretations against upstream behavior.

## Motivation
This supports verification work in #744.