### PR TITLE
F*: improve makefile, detect duplicates in `SLOW_MODULES`

### DIFF
--- a/fstar-helpers/Makefile.base
+++ b/fstar-helpers/Makefile.base
@@ -1,9 +1,25 @@
 # Base Makefile for F* in libcrux.
 # This inherits from Makefile.generic, and adds the `specs` folder from HACL.
 
+
+export ANSI_COLOR_RED=\033[31m
+export ANSI_COLOR_RESET=\033[0m
+
+# Check that no module from ADMIT_MODULES is also present in VERIFIED_MODULES or ADMIT_MODULES
+DUP_MODULES_SLOW := $(filter $(SLOW_MODULES), $(sort $(ADMIT_MODULES) $(VERIFIED_MODULES)))
+ifneq ($(strip $(DUP_MODULES_SLOW)),)
+K := $(info )
+ERROR := $(shell printf '  ${ANSI_COLOR_RED}The module(s) [${DUP_MODULES_SLOW}] are both in SLOW_MODULES and in VERIFIED_MODULES or ADMIT_MODULES. Please remove them from VERIFIED_MODULES or ADMIT_MODULES.${ANSI_COLOR_RESET}')
+K := $(info ${ERROR})
+K := $(info )
+K := $(error Fatal error: the intersection between variable ADMIT_MODULES and SLOW_MODULES is non-empty.)
+endif
+
 VERIFY_SLOW_MODULES ?= no
 ifeq (${VERIFY_SLOW_MODULES},no)
 	ADMIT_MODULES += ${SLOW_MODULES}
+else
+	VERIFIED_MODULES += ${SLOW_MODULES}
 endif
 
 EXTRA_HELPMESSAGE += printf "Libcrux specifics:\n";

--- a/fstar-helpers/Makefile.generic
+++ b/fstar-helpers/Makefile.generic
@@ -174,6 +174,7 @@ target "all" "Verify every F* files (stops whenever an F* fails first)"
 target "all-keep-going" "Verify every F* files (tries as many F* module as possible)"
 target "" ""
 target "run/${ANSI_COLOR_TONE}<MyModule.fst>  " 'Runs F* on `MyModule.fst` only'
+target "check/${ANSI_COLOR_TONE}<MyModule.fst>  " 'Typecheck up to `MyModule.fst`'
 target "" ""
 target "vscode" 'Generates a `hax.fst.config.json` file'
 target "${ANSI_COLOR_TONE}<MyModule.fst>${ANSI_COLOR_BLUE}-in   " 'Useful for Emacs, outputs the F* prefix command to be used'
@@ -215,6 +216,9 @@ HEADER = $(Q)printf '${ANSI_COLOR_BBLUE}[CHECK] %s ${ANSI_COLOR_RESET}\n' "$(bas
 run/%: | .depend $(HINT_DIR) $(CACHE_DIR)
 	${HEADER}
 	$(Q)$(FSTAR) $(OTHERFLAGS) $(@:run/%=%)
+
+check/%: | .depend $(HINT_DIR) $(CACHE_DIR) $(HACL_HOME)
+	$(Q)$(MAKE) "${CACHE_DIR}/$(@:check/%=%).checked"
 
 VERIFIED_CHECKED = $(addsuffix .checked, $(addprefix $(CACHE_DIR)/,$(ROOTS)))
 ADMIT_CHECKED = $(addsuffix .checked, $(addprefix $(CACHE_DIR)/,$(ADMIT_MODULES)))

--- a/libcrux-ml-dsa/proofs/fstar/extraction/Makefile
+++ b/libcrux-ml-dsa/proofs/fstar/extraction/Makefile
@@ -8,7 +8,8 @@ VERIFIED_MODULES = \
 	Libcrux_ml_dsa.Simd.Traits.fsti \
 	Libcrux_ml_dsa.Simd.Traits.fst \
 	end_of_verified_modules
-ADMIT_MODULES = $(filter-out ${VERIFIED_MODULES}, $(wildcard *.fst)) $(filter-out ${VERIFIED_MODULES}, $(wildcard *.fsti))
+VERIFIED_OR_SLOW_MODULES = $(sort $(SLOW_MODULES) $(VERIFIED_MODULES))
+ADMIT_MODULES = $(filter-out ${VERIFIED_OR_SLOW_MODULES}, $(wildcard *.fst)) $(filter-out ${VERIFIED_OR_SLOW_MODULES}, $(wildcard *.fsti))
 FSTAR_INCLUDE_DIRS_EXTRA += ../spec \
 	      $(shell git rev-parse --show-toplevel)/fstar-helpers/fstar-bitvec \
 	      $(shell git rev-parse --show-toplevel)/libcrux-ml-kem/proofs/fstar/spec \


### PR DESCRIPTION
This PR changes `fstar-helpers/Makefile.base` so that:
 - it detects when a module is present both in `SLOW_MODULES` and `VERIFIED_MODULES` or `ADMIT_MODULES`.
 - it adds `SLOW_MODULES` to `VERIFIED_MODULES` when `VERIFY_SLOW_MODULES` is `yes`.

This PR also fixes the makefile in mldsa: `ADMIT_MODULES` was populated with every module not in `VERIFIED_MODULES`. We need to filter out those present in `SLOW_MODULES` as well.

There was a duplicated make rule because of this, which was breaking emacs/vscode integration.

This PR also adds a `check/myfile.fst`, that checks up to `myfile.fst`. This is a shortcut for `make repo/.fstar-cache/checked/myfile.fst.checked`