### PR TITLE
Add explicit `no_std` support to the `libcrux-secrets` crate

### DIFF
--- a/secrets/src/int/secret_integers.rs
+++ b/secrets/src/int/secret_integers.rs
@@ -2,7 +2,7 @@
 //! These implementations are meant to be used when feature `check-secret-independence` is set
 use super::classify::*;
 use crate::traits::*;
-use std::ops::*;
+use core::ops::*;
 
 pub type I8 = Secret<i8>;
 pub type U8 = Secret<u8>;

--- a/secrets/src/lib.rs
+++ b/secrets/src/lib.rs
@@ -23,6 +23,8 @@
 //! However, note that every use of `.declassify()` is at the responsibility of the
 //! programmer and represents a potential side-channel leak
 //!
+#![no_std]
+
 mod traits;
 pub use traits::*;
 mod int;


### PR DESCRIPTION
This PR adds explicit `no_std` support to the `libcrux-secrets` crate by adding the `no_std` crate-level attribute, and replacing `std::ops` with `core::ops`.

Closes #978 