### PR TITLE
[CI] Push ML-KEM and ML-DSA benchmark results to `gh-pages` branch in this repository

### DIFF
--- a/.github/workflows/mldsa-bench.yml
+++ b/.github/workflows/mldsa-bench.yml
@@ -93,7 +93,7 @@ jobs:
           input-data-path: libcrux-ml-dsa/bench-processed.json
           benchmark-data-dir-path: dev/bench/mldsa
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          gh-repository: github.com/cryspen/libcrux-benchmarks
+          gh-repository: github.com/${{ github.repository }}
           group-by: label,keySize,os
           schema: implementation,keySize,label,hardware,os
           auto-push: true

--- a/.github/workflows/mlkem-bench.yml
+++ b/.github/workflows/mlkem-bench.yml
@@ -96,7 +96,7 @@ jobs:
           input-data-path: libcrux-ml-kem/bench-processed.txt
           benchmark-data-dir-path: dev/bench/mlkem
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          gh-repository: github.com/cryspen/libcrux-benchmarks
+          gh-repository: github.com/${{ github.repository }}
           auto-push: true
 
   mlkem-bench-status:


### PR DESCRIPTION
Restores the original configuration of the benchmark chart action, so that benchmark results are written to the `gh-pages` branch in this repository.

Resolves #973 