### PR TITLE
fix build warning on linux

### DIFF
--- a/sys/hacl/build.rs
+++ b/sys/hacl/build.rs
@@ -254,7 +254,6 @@ fn build(platform: &Platform, home_path: &Path) {
     }
     let hacl_target_arch = platform.hacl_target_arch.to_string();
     defines.push(("TARGET_ARCHITECTURE", hacl_target_arch.as_str()));
-    defines.push(("LINUX_NO_EXPLICIT_BZERO", "1")); // We disable this to avoid running into issues.
 
     // Platform detection
     if platform.simd128 {

--- a/sys/hacl/c/src/Lib_Memzero0.c
+++ b/sys/hacl/c/src/Lib_Memzero0.c
@@ -39,7 +39,9 @@ void Lib_Memzero0_memzero0(void *dst, uint64_t len) {
     SecureZeroMemory(dst, len);
   #elif defined(__APPLE__) && defined(__MACH__)
     memset_s(dst, len_, 0, len_);
-  #elif (defined(__linux__) && !defined(LINUX_NO_EXPLICIT_BZERO)) || defined(__FreeBSD__)
+  #elif defined(__linux__) && defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 25)
+    explicit_bzero(dst, len_);
+  #elif defined(__FreeBSD__)
     explicit_bzero(dst, len_);
   #elif defined(__NetBSD__)
     explicit_memset(dst, 0, len_);


### PR DESCRIPTION
This fixes #856. 

`explicit_bzero` has been in glibc since 2017