### PR TITLE
Fixes the flake to work with rust-rover IDE

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,58 @@
 {
   "nodes": {
+    "benchmark": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1716472966,
+        "narHash": "sha256-O+1ZHaNHSkKz3PlKDyI94LqiLtjyrKxjOIi8Q236/MI=",
+        "owner": "google",
+        "repo": "benchmark",
+        "rev": "a4cf155615c63e019ae549e31703bf367df5b471",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "ref": "v1.8.4",
+        "repo": "benchmark",
+        "type": "github"
+      }
+    },
     "charon": {
       "inputs": {
         "crane": "crane",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "eurydice",
-          "nixpkgs"
-        ],
-        "nixpkgs-ocaml": [
-          "eurydice",
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1743501557,
-        "narHash": "sha256-bZZfS0bwHRQh6p3svYqVBo65xdJgVejutU1oCd2QyKM=",
+        "lastModified": 1747923226,
+        "narHash": "sha256-ZjA1xrxEF823Ra9Ucco0oJNyCf2Sfkzpvs/lt13JUiI=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "99432e1474433e9eaed946539c12d45e72486e79",
+        "rev": "98ac30155a29c6067c8299cdc88bfbadf373d1b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aeneasverif",
+        "repo": "charon",
+        "type": "github"
+      }
+    },
+    "charon_2": {
+      "inputs": {
+        "crane": "crane_2",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1747150205,
+        "narHash": "sha256-j+0UPeTSmvnMJCcVNUDDdDvMZmC9hhuJ2hE9T16anSQ=",
+        "owner": "AeneasVerif",
+        "repo": "charon",
+        "rev": "cbbda54890d043c9ac454cfd7ee1dd38f98cd74a",
         "type": "github"
       },
       "original": {
@@ -29,13 +61,30 @@
         "type": "github"
       }
     },
+    "circus-green": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743124428,
+        "narHash": "sha256-XSRu3LH0RhZ+P8zCADl8e+yjghmol/Eb1oTsaI5JWr4=",
+        "owner": "Inria-Prosecco",
+        "repo": "circus-green",
+        "rev": "b18bf804c2a999a2f476e09608284561c964225c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Inria-Prosecco",
+        "repo": "circus-green",
+        "rev": "b18bf804c2a999a2f476e09608284561c964225c",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
-        "lastModified": 1727316705,
-        "narHash": "sha256-/mumx8AQ5xFuCJqxCIOFCHTVlxHkMT21idpbgbm/TIE=",
+        "lastModified": 1743700120,
+        "narHash": "sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "5b03654ce046b5167e7b0bccbd8244cb56c16f0e",
+        "rev": "e316f19ee058e6db50075115783be57ac549c389",
         "type": "github"
       },
       "original": {
@@ -45,6 +94,21 @@
       }
     },
     "crane_2": {
+      "locked": {
+        "lastModified": 1743700120,
+        "narHash": "sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "e316f19ee058e6db50075115783be57ac549c389",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_3": {
       "inputs": {
         "nixpkgs": [
           "hax",
@@ -67,21 +131,25 @@
     },
     "eurydice": {
       "inputs": {
-        "charon": "charon",
+        "charon": "charon_2",
         "flake-utils": [
           "eurydice",
           "karamel",
           "flake-utils"
         ],
         "karamel": "karamel",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "eurydice",
+          "charon",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1743586238,
-        "narHash": "sha256-BxJVtO2yu9gEgXiyEZk6/OPQg/6MRR5s/RU1QBaOWRQ=",
+        "lastModified": 1747839279,
+        "narHash": "sha256-N65WMNu4pJDpxY6u7bymjC2mZyEk4PbxvQlkN9XQ4g8=",
         "owner": "aeneasverif",
         "repo": "eurydice",
-        "rev": "9f45c5b6710ac03aa157299391233be90bc1565c",
+        "rev": "734efba70c4c3aa5c13309f71ec6edbd713ed7b2",
         "type": "github"
       },
       "original": {
@@ -91,6 +159,21 @@
       }
     },
     "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "locked": {
         "lastModified": 1733328505,
         "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
@@ -128,6 +211,24 @@
         "systems": "systems_2"
       },
       "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
         "lastModified": 1692799911,
         "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
@@ -140,9 +241,9 @@
         "type": "indirect"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_4": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -158,9 +259,9 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_5": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -178,15 +279,15 @@
     },
     "fstar": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs"
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1742959035,
-        "narHash": "sha256-PhjfThXF6fJlFHtNEURG4igCnM6VegWODypmRvnZPdA=",
+        "lastModified": 1746723992,
+        "narHash": "sha256-wIoTp1P21YI/vzdM4eFeoMaXAi1iCZ1pjESTcbEaIYA=",
         "owner": "fstarlang",
         "repo": "fstar",
-        "rev": "71d8221589d4d438af3706d89cb653cf53e18aab",
+        "rev": "5aa519babd519ab80bbbb662c83321c83ba259df",
         "type": "github"
       },
       "original": {
@@ -221,6 +322,23 @@
         "type": "github"
       }
     },
+    "googletest": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1623433346,
+        "narHash": "sha256-SjlJxushfry13RGA7BCjYC9oZqV4z6x8dOiHfl/wpF0=",
+        "owner": "google",
+        "repo": "googletest",
+        "rev": "e2239ee6043f73722e7aa812a459f54a28552929",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "ref": "release-1.11.0",
+        "repo": "googletest",
+        "type": "github"
+      }
+    },
     "hacl-star": {
       "flake": false,
       "locked": {
@@ -239,25 +357,42 @@
     },
     "hax": {
       "inputs": {
-        "crane": "crane_2",
-        "flake-utils": "flake-utils_4",
+        "crane": "crane_3",
+        "flake-utils": "flake-utils_5",
         "fstar": "fstar_2",
         "hacl-star": "hacl-star",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "rust-by-examples": "rust-by-examples",
-        "rust-overlay": "rust-overlay_2"
+        "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1743519862,
-        "narHash": "sha256-sImnpixyAP1ZnetCxEyHLL1uh9vJc4950Vp6komag0E=",
+        "lastModified": 1747918141,
+        "narHash": "sha256-CKgTZGv/POPMIgUw6Evhj9CpP7whnzmDo9NaDDZadHM=",
         "owner": "hacspec",
         "repo": "hax",
-        "rev": "a647a0dade25ab655dc3d4e7ad85ebe992fe2c47",
+        "rev": "7260084bc7d0b744cc242445e2791139ae372bf8",
         "type": "github"
       },
       "original": {
         "owner": "hacspec",
         "repo": "hax",
+        "type": "github"
+      }
+    },
+    "json": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633696761,
+        "narHash": "sha256-EBzwaHyDWF8h/z3Zfq4p/n5Vpz7Ozlc3eoWDKXWv2YY=",
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "aa0e847e5b57a00696bdcb6a834b927231b81613",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlohmann",
+        "ref": "v3.10.3",
+        "repo": "json",
         "type": "github"
       }
     },
@@ -276,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742380878,
-        "narHash": "sha256-Xgx1EpmP7aVLmiEY5pNc1Uoao1v0nBeTlEC3Sfodapk=",
+        "lastModified": 1747253824,
+        "narHash": "sha256-xj6u9pNcJ1c4QWg17TIQEVtDmSM/JKd+zTh3doF9/PU=",
         "owner": "FStarLang",
         "repo": "karamel",
-        "rev": "25027047c3f0f0cfc473827e5451c8e064d59869",
+        "rev": "f1837bde2a25b0be80c850340674aa0fb8ff72d7",
         "type": "github"
       },
       "original": {
@@ -291,11 +426,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693158576,
-        "narHash": "sha256-aRTTXkYvhXosGx535iAFUaoFboUrZSYb1Ooih/auGp0=",
+        "lastModified": 1743588408,
+        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a999c1cc0c9eb2095729d5aa03e0d8f7ed256780",
+        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
         "type": "github"
       },
       "original": {
@@ -306,21 +441,35 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743441817,
-        "narHash": "sha256-+OE03P3u0FRwhS+Ah6EYiwxdS1rcIYlXheuXGM3wP3Q=",
+        "lastModified": 1743588408,
+        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3eeaa42ef4c19447b48d1c676fe59077dfd0846e",
+        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
       }
     },
     "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1743588408,
+        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1717402443,
         "narHash": "sha256-KlFiT8xFAVy29iYJU9nBwvkC7WTfUC/jak5jNFz5wHM=",
@@ -335,13 +484,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
-        "lastModified": 1743448293,
-        "narHash": "sha256-bmEPmSjJakAp/JojZRrUvNcDX2R5/nuX6bm+seVaGhs=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "77b584d61ff80b4cef9245829a6f1dfad5afdfa3",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {
@@ -353,10 +502,15 @@
     },
     "root": {
       "inputs": {
+        "benchmark": "benchmark",
+        "charon": "charon",
+        "circus-green": "circus-green",
         "eurydice": "eurydice",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
+        "googletest": "googletest",
         "hax": "hax",
-        "nixpkgs": "nixpkgs_4"
+        "json": "json",
+        "nixpkgs": "nixpkgs_5"
       }
     },
     "rust-by-examples": {
@@ -378,27 +532,49 @@
     "rust-overlay": {
       "inputs": {
         "nixpkgs": [
+          "charon",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743475035,
+        "narHash": "sha256-uLjVsb4Rxnp1zmFdPCDmdODd4RY6ETOeRj0IkC0ij/4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "bee11c51c2cda3ac57c9e0149d94b86cc1b00d13",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "bee11c51c2cda3ac57c9e0149d94b86cc1b00d13",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
           "eurydice",
           "charon",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1737340068,
-        "narHash": "sha256-5UciRckNV+YOZ6y6ASBIb01cySB12whDxgFUK+EqT8g=",
+        "lastModified": 1743475035,
+        "narHash": "sha256-uLjVsb4Rxnp1zmFdPCDmdODd4RY6ETOeRj0IkC0ij/4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "275c824ed9e90e7fd4f96d187bde3670062e721f",
+        "rev": "bee11c51c2cda3ac57c9e0149d94b86cc1b00d13",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "275c824ed9e90e7fd4f96d187bde3670062e721f",
+        "rev": "bee11c51c2cda3ac57c9e0149d94b86cc1b00d13",
         "type": "github"
       }
     },
-    "rust-overlay_2": {
+    "rust-overlay_3": {
       "inputs": {
         "nixpkgs": [
           "hax",
@@ -406,11 +582,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736735482,
-        "narHash": "sha256-QOA4jCDyyUM9Y2Vba+HSZ/5LdtCMGaTE/7NkkUzBr50=",
+        "lastModified": 1743388531,
+        "narHash": "sha256-OBcNE+2/TD1AMgq8HKMotSQF8ZPJEFGZdRoBJ7t/HIc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "cf960a1938ee91200fe0d2f7b2582fde2429d562",
+        "rev": "011de3c895927300651d9c2cb8e062adf17aa665",
         "type": "github"
       },
       "original": {
@@ -465,6 +641,21 @@
       }
     },
     "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -28,31 +28,9 @@
       "locked": {
         "lastModified": 1747923226,
         "narHash": "sha256-ZjA1xrxEF823Ra9Ucco0oJNyCf2Sfkzpvs/lt13JUiI=",
-        "owner": "aeneasverif",
-        "repo": "charon",
-        "rev": "98ac30155a29c6067c8299cdc88bfbadf373d1b4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "aeneasverif",
-        "repo": "charon",
-        "type": "github"
-      }
-    },
-    "charon_2": {
-      "inputs": {
-        "crane": "crane_2",
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay_2"
-      },
-      "locked": {
-        "lastModified": 1747150205,
-        "narHash": "sha256-j+0UPeTSmvnMJCcVNUDDdDvMZmC9hhuJ2hE9T16anSQ=",
         "owner": "AeneasVerif",
         "repo": "charon",
-        "rev": "cbbda54890d043c9ac454cfd7ee1dd38f98cd74a",
+        "rev": "98ac30155a29c6067c8299cdc88bfbadf373d1b4",
         "type": "github"
       },
       "original": {
@@ -94,21 +72,6 @@
       }
     },
     "crane_2": {
-      "locked": {
-        "lastModified": 1743700120,
-        "narHash": "sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "e316f19ee058e6db50075115783be57ac549c389",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_3": {
       "inputs": {
         "nixpkgs": [
           "hax",
@@ -131,7 +94,7 @@
     },
     "eurydice": {
       "inputs": {
-        "charon": "charon_2",
+        "charon": "charon",
         "flake-utils": [
           "eurydice",
           "karamel",
@@ -145,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747839279,
-        "narHash": "sha256-N65WMNu4pJDpxY6u7bymjC2mZyEk4PbxvQlkN9XQ4g8=",
+        "lastModified": 1747931994,
+        "narHash": "sha256-k+mrCg25e/57WczRCiSKjppU5pyWpEu8VsFTb1gAQ5k=",
         "owner": "aeneasverif",
         "repo": "eurydice",
-        "rev": "734efba70c4c3aa5c13309f71ec6edbd713ed7b2",
+        "rev": "c91b0d409b125844b3dfb134223c8fd0bb4f5ce5",
         "type": "github"
       },
       "original": {
@@ -159,21 +122,6 @@
       }
     },
     "flake-compat": {
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
       "locked": {
         "lastModified": 1733328505,
         "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
@@ -211,24 +159,6 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
         "lastModified": 1692799911,
         "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
@@ -241,9 +171,9 @@
         "type": "indirect"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_3": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -259,9 +189,9 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
+    "flake-utils_4": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -279,8 +209,8 @@
     },
     "fstar": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1746723992,
@@ -357,13 +287,13 @@
     },
     "hax": {
       "inputs": {
-        "crane": "crane_3",
-        "flake-utils": "flake-utils_5",
+        "crane": "crane_2",
+        "flake-utils": "flake-utils_4",
         "fstar": "fstar_2",
         "hacl-star": "hacl-star",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "rust-by-examples": "rust-by-examples",
-        "rust-overlay": "rust-overlay_3"
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
         "lastModified": 1747918141,
@@ -456,21 +386,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1743588408,
-        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1717402443,
         "narHash": "sha256-KlFiT8xFAVy29iYJU9nBwvkC7WTfUC/jak5jNFz5wHM=",
         "owner": "nixos",
@@ -484,7 +399,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1747744144,
         "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
@@ -503,14 +418,13 @@
     "root": {
       "inputs": {
         "benchmark": "benchmark",
-        "charon": "charon",
         "circus-green": "circus-green",
         "eurydice": "eurydice",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "googletest": "googletest",
         "hax": "hax",
         "json": "json",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       }
     },
     "rust-by-examples": {
@@ -530,28 +444,6 @@
       }
     },
     "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "charon",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1743475035,
-        "narHash": "sha256-uLjVsb4Rxnp1zmFdPCDmdODd4RY6ETOeRj0IkC0ij/4=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "bee11c51c2cda3ac57c9e0149d94b86cc1b00d13",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "bee11c51c2cda3ac57c9e0149d94b86cc1b00d13",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "eurydice",
@@ -574,7 +466,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_3": {
+    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "hax",
@@ -641,21 +533,6 @@
       }
     },
     "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_5": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     eurydice.url = "github:aeneasverif/eurydice";
-    charon.url = "github:aeneasverif/charon"; 
     hax.url = "github:hacspec/hax";
     googletest = {
       url = "github:google/googletest/release-1.11.0";
@@ -24,11 +23,12 @@
   };
 
   outputs =
-    { self, nixpkgs, flake-utils, eurydice, hax, charon, googletest, benchmark, json, circus-green, ... } @ inputs:
+    { self, nixpkgs, flake-utils, eurydice, hax, googletest, benchmark, json, circus-green, ... } @ inputs:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = import nixpkgs { inherit system; };
+        charon = eurydice.inputs.charon;
         crane = charon.inputs.crane;
         # Use the overridden package exported by the eurydice flake.
         karamel = eurydice.packages.${system}.karamel;
@@ -53,6 +53,9 @@
 
         rustToolchain = charon.packages.${system}.rustToolchain;
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+        # libcrux doesn't want to commit a Cargo.lock but flakes can only take
+        # local inputs if they're committed. The circus-green CI maintains a
+        # working Cargo.lock file for this repo, so we use it here.
         defaultCargoLock = "${circus-green}/libcrux-Cargo.lock";
 
         # Construct a copy of the current directory with the given `Cargo.lock` added.

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,8 @@
+#
+#       Disclaimer: This nix environment is provided as-is.
+#       None of this is officially supported and use is at your own risk.
+#       We do not maintain or support nix environments.
+#
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";


### PR DESCRIPTION
- Move flake dependencies into inputs
- Add missing openssl and pkg-config dependency
- Add direct import of charon
- Update all inputs

Uses [this](https://github.com/AeneasVerif/charon/commit/98ac30155a29c6067c8299cdc88bfbadf373d1b4) update from charon to have access to rust src. 