### PR TITLE
fix Readme references in more Cargo.tomls

### DIFF
--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -2,13 +2,13 @@
 name = "libcrux-blake2"
 description = "Formally verified blake2 hash library"
 version = "0.0.3-alpha.1"
+readme = "Readme.md"
 
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 edition.workspace = true
 repository.workspace = true
-readme.workspace = true
 
 [features]
 std = []

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -2,13 +2,13 @@
 name = "libcrux-chacha20poly1305"
 description = "Formally verified ChaCha20-Poly1305 AEAD library"
 version = "0.0.3-alpha.1"
+readme = "Readme.md"
 
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 edition.workspace = true
 repository.workspace = true
-readme.workspace = true
 
 [dependencies]
 libcrux-poly1305 = { version = "=0.0.3-alpha.1", path = "../poly1305/", features = [

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "libcrux-ecdsa"
 description = "Formally verified ECDSA signature library"
-
+readme = "Readme.md"
 version = "0.0.3-alpha.1"
+
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 edition.workspace = true
 repository.workspace = true
-readme.workspace = true
 
 [dependencies]
 libcrux-p256 = { version = "=0.0.3-alpha.1", path = "../p256", features = [

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "libcrux-ed25519"
 description = "Formally verified ed25519 signature library"
-
 version = "0.0.3-alpha.1"
+readme = "Readme.md"
+
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 edition.workspace = true
 repository.workspace = true
-readme.workspace = true
 
 [dependencies]
 libcrux-hacl-rs = { version = "=0.0.3-alpha.1", path = "../hacl-rs/" }

--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "libcrux-psq"
+description = "Libcrux Pre-Shared post-Quantum key establishement protocol"
 version = "0.0.3-alpha.1"
+readme = "Readme.md"
+
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 edition.workspace = true
 repository.workspace = true
-readme.workspace = true
-description = "Libcrux Pre-Shared post-Quantum key establishement protocol"
 publish = true
 
 [lib]


### PR DESCRIPTION
These used to point to the readme in the repo root, not the one in the crate directory