### PR TITLE
`libcrux_chacha20poly1305::encrypt_detached()`: add error handling for invalid ciphertext buffer length

### DIFF
--- a/chacha20poly1305/src/impl_hacl.rs
+++ b/chacha20poly1305/src/impl_hacl.rs
@@ -38,6 +38,10 @@ fn encrypt_checks(
         return Err(AeadError::CiphertextTooShort);
     }
 
+    if detached && (ctxt.len() as u64) < (ptxt.len() as u64) {
+        return Err(AeadError::CiphertextTooShort);
+    }
+
     Ok((ptxt_len, aad_len))
 }
 

--- a/chacha20poly1305/tests/chachapoly.rs
+++ b/chacha20poly1305/tests/chachapoly.rs
@@ -277,7 +277,7 @@ fn chachapoly_self_test_rand() {
 }
 
 #[test]
-fn chachapoly_test_incorrect_buffer_lengths() {
+fn chachapoly_test_invalid_buffer_lengths() {
     let msg = b"hacspec rulez";
     let aad = b"associated data" as &[u8];
 


### PR DESCRIPTION
This pull request adds error handling to the function `libcrux_chacha20poly1305::encrypt_detached()`, so that the function returns the error `AeadError::CiphertextTooShort` when the provided `ctxt` argument references a buffer that is too short.

This change aligns the approach to error handling used by this function with the approach used by the other encryption and decryption functions in this crate. It also prevents ths function from panicking when an invalid `ctxt` is provided.

Additionally, this pull request includes a test for this functionality. This test ensures that the public encryption/decryption functions in this crate return the correct error variants when their `ctxt` or `ptxt` arguments reference buffers that are too short:
- `encrypt_detached()` -> `AeadError::CiphertextTooShort`
- `encrypt()` -> `AeadError::CiphertextTooShort`
- `decrypt_detached()` -> `AeadError::PlaintextTooShort`
- `decrypt()` -> `AeadError::PlaintextTooShort`