### PR TITLE
Fixes for `libcrux-ecdsa` with `--no-default-features`

### DIFF
--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -26,4 +26,5 @@ pub enum Error {
 pub type DigestAlgorithm = libcrux_sha2::Algorithm;
 
 /// The number of iteration for rejection sampling.
+#[cfg(feature = "rand")]
 pub(crate) const RAND_LIMIT: usize = 100;

--- a/ecdsa/src/p256.rs
+++ b/ecdsa/src/p256.rs
@@ -8,8 +8,6 @@ use libcrux_p256::{
 
 use crate::DigestAlgorithm;
 
-use ::rand::TryRngCore;
-
 use super::Error;
 
 /// A P-256 Signature
@@ -200,7 +198,7 @@ pub mod rand {
     use crate::RAND_LIMIT;
 
     use super::*;
-    use ::rand::{CryptoRng, RngCore};
+    use ::rand::{CryptoRng, RngCore, TryRngCore};
 
     /// Generate a random scalar for ECDSA.
     ///

--- a/ecdsa/tests/self.rs
+++ b/ecdsa/tests/self.rs
@@ -1,35 +1,38 @@
 mod util;
-use rand::rngs::OsRng;
-use util::*;
 
-use libcrux_ecdsa::{
-    p256::{Nonce, PrivateKey, PublicKey},
-    *,
-};
+#[cfg(feature = "rand")]
+mod rand {
+    use crate::util::*;
+    use libcrux_ecdsa::{
+        p256::{Nonce, PrivateKey, PublicKey},
+        *,
+    };
+    use rand::rngs::OsRng;
 
-#[test]
-fn test_self() {
-    // From https://tools.ietf.org/html/rfc6979#appendix-A.2.5
-    const PK_HEX: &str = "0460FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB67903FE1008B8BC99A41AE9E95628BC64F2F1B20C2D7E9F5177A3C294D4462299";
-    const SK_HEX: &str = "C9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721";
+    #[test]
+    fn test_self() {
+        // From https://tools.ietf.org/html/rfc6979#appendix-A.2.5
+        const PK_HEX: &str = "0460FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB67903FE1008B8BC99A41AE9E95628BC64F2F1B20C2D7E9F5177A3C294D4462299";
+        const SK_HEX: &str = "C9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721";
 
-    use rand::TryRngCore;
-    let mut os_rng = OsRng;
-    let mut rng = os_rng.unwrap_mut();
+        use rand::TryRngCore;
+        let mut os_rng = OsRng;
+        let mut rng = os_rng.unwrap_mut();
 
-    let pk = hex_str_to_bytes(PK_HEX);
-    let pk = PublicKey::try_from(pk.as_slice()).unwrap();
-    let sk: [u8; 32] = hex_str_to_array(SK_HEX);
-    let sk = PrivateKey::try_from(&sk).unwrap();
-    let nonce = Nonce::random(&mut rng).unwrap();
-    let msg = b"sample";
+        let pk = hex_str_to_bytes(PK_HEX);
+        let pk = PublicKey::try_from(pk.as_slice()).unwrap();
+        let sk: [u8; 32] = hex_str_to_array(SK_HEX);
+        let sk = PrivateKey::try_from(&sk).unwrap();
+        let nonce = Nonce::random(&mut rng).unwrap();
+        let msg = b"sample";
 
-    let sig = p256::sign(DigestAlgorithm::Sha256, &msg[..], &sk, &nonce).unwrap();
-    p256::verify(DigestAlgorithm::Sha256, &msg[..], &sig, &pk).unwrap();
+        let sig = p256::sign(DigestAlgorithm::Sha256, &msg[..], &sk, &nonce).unwrap();
+        p256::verify(DigestAlgorithm::Sha256, &msg[..], &sig, &pk).unwrap();
 
-    let new_msg = b"a different message";
-    let sig = p256::sign(DigestAlgorithm::Sha256, &new_msg[..], &sk, &nonce).unwrap();
-    let error = p256::verify(DigestAlgorithm::Sha256, &msg[..], &sig, &pk)
-        .expect_err("The message is wrong for the signature");
-    assert!(matches!(error, Error::InvalidSignature));
+        let new_msg = b"a different message";
+        let sig = p256::sign(DigestAlgorithm::Sha256, &new_msg[..], &sk, &nonce).unwrap();
+        let error = p256::verify(DigestAlgorithm::Sha256, &msg[..], &sig, &pk)
+            .expect_err("The message is wrong for the signature");
+        assert!(matches!(error, Error::InvalidSignature));
+    }
 }


### PR DESCRIPTION
This PR fixes a build error in `libcrux-ecdsa`, where the crate could not be built with the `--no-default-features` flag set, due to an import from the feature-gated `rand` dependency not being placed behind the correct feature flag.

This PR also makes these related changes:
- feature-gates a `libcrux-ecdsa` test that requires the `rand`  feature behind the `rand` feature flag
- feature-gates the crate's `RAND_LIMIT` constant  (which is only needed for the `rand` feature) behind the `rand` feature flag.

Resolves #1059