### PR TITLE
Add `std` feature gate for `libcrux-ecdsa`

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -23,5 +23,6 @@ rand = ["dep:rand"]
 std = ["rand?/std"]
 
 [dev-dependencies]
+rand_core = { version = "0.9" , features = ["os_rng"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -15,11 +15,12 @@ libcrux-p256 = { version = "=0.0.3", path = "../p256", features = [
     "expose-hacl",
 ] }
 libcrux-sha2 = { version = "=0.0.3", path = "../sha2" }
-rand = { version = "0.9", optional = true }
+rand = { version = "0.9", optional = true, default-features = false }
 
 [features]
-default = ["rand"]
+default = ["rand", "std"]
 rand = ["dep:rand"]
+std = ["rand?/std"]
 
 [dev-dependencies]
 serde = { version = "1.0.217", features = ["derive"] }

--- a/ecdsa/tests/self.rs
+++ b/ecdsa/tests/self.rs
@@ -7,7 +7,7 @@ mod rand {
         p256::{Nonce, PrivateKey, PublicKey},
         *,
     };
-    use rand::rngs::OsRng;
+    use rand_core::OsRng;
 
     #[test]
     fn test_self() {


### PR DESCRIPTION
This PR adds an `std` feature to the `libcrux-ecdsa` crate. This places the dependencies of the `libcrux-ecdsa` crate that require `std` behind the `std` feature flag.

This PR also makes these related changes:
- include this new `std` feature in the `default` features list for this crate, so that, as before, `libcrux-ecdsa` depends by default on the `rand` crate, with `rand/std` enabled
- add `rand_core/os_rng` to the dev dependencies for this crate. This is the minimum dependency needed to run a test that uses `rand_core::OsRng` (or the version re-exported by the `rand` crate). 

Resolves #983