### PR TITLE
[PSQ] Use TLSCodec for Serialization/Deserialization in PSQv1

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -17,6 +17,7 @@ libcrux-sha2 = { version = "=0.0.3", path = "../sha2", features = [
 ] }
 libcrux-macros = { version = "=0.0.3", path = "../macros" }
 rand_core = { version = "0.9", optional = true }
+tls_codec = { version = "0.4.2", features = ["derive"], optional = true }
 
 [dev-dependencies]
 rand = { version = "0.9" }
@@ -24,3 +25,4 @@ wycheproof = "0.6.0"
 
 [features]
 rand = ["dep:rand_core"]
+codec = ["tls_codec/std"]

--- a/ed25519/src/impl_hacl.rs
+++ b/ed25519/src/impl_hacl.rs
@@ -1,3 +1,12 @@
+#[cfg(feature = "codec")]
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+
+#[cfg(feature = "codec")]
+extern crate std;
+
+#[cfg(feature = "codec")]
+use std::format;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
     SigningError,
@@ -7,6 +16,7 @@ pub enum Error {
 
 /// An Ed25519 public, verification key
 #[derive(Default, Clone, Copy)]
+#[cfg_attr(feature = "codec", derive(TlsSerialize, TlsDeserialize, TlsSize))]
 pub struct VerificationKey {
     value: [u8; 32],
 }

--- a/libcrux-ecdh/Cargo.toml
+++ b/libcrux-ecdh/Cargo.toml
@@ -19,10 +19,14 @@ libcrux-curve25519 = { version = "=0.0.3", path = "../curve25519" }
 libcrux-p256 = { version = "=0.0.3", path = "../p256", features = [
     "expose-hacl",
 ] }
+tls_codec = { version = "0.4.2", features = [
+    "derive",
+], optional = true }
 
 [features]
 default = ["std"]
 std = ["rand/std"]
+codec = ["dep:tls_codec"]
 
 [dev-dependencies]
 rand_core = { version = "0.9", features = ["os_rng"] }

--- a/libcrux-ecdh/src/p256_internal.rs
+++ b/libcrux-ecdh/src/p256_internal.rs
@@ -8,7 +8,14 @@ use super::Error;
 
 pub struct PrivateKey(pub [u8; 32]);
 
+#[cfg(feature = "codec")]
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+
+#[cfg(feature = "codec")]
+extern crate std;
+
 #[derive(Debug)]
+#[cfg_attr(feature = "codec", derive(TlsSize, TlsSerialize, TlsDeserialize))]
 pub struct PublicKey(pub [u8; 64]);
 
 /// Output of a scalar multiplication between a public key and a secret key.
@@ -16,6 +23,7 @@ pub struct PublicKey(pub [u8; 64]);
 /// This value is NOT (!) safe for use as a key and needs to be processed in a round of key
 /// derivation, to ensure both that the output is uniformly random and that unkown key share
 /// attacks can not happen.
+#[cfg_attr(feature = "codec", derive(TlsSize, TlsSerialize, TlsDeserialize))]
 pub struct SharedSecret(pub [u8; 64]);
 
 impl From<&[u8; 64]> for PublicKey {

--- a/libcrux-ecdh/src/x25519.rs
+++ b/libcrux-ecdh/src/x25519.rs
@@ -7,7 +7,14 @@ use super::Error;
 
 pub struct PrivateKey(pub [u8; 32]);
 
+#[cfg(feature = "codec")]
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+
+#[cfg(feature = "codec")]
+extern crate std;
+
 #[derive(Debug)]
+#[cfg_attr(feature = "codec", derive(TlsSize, TlsSerialize, TlsDeserialize))]
 pub struct PublicKey(pub [u8; 32]);
 
 /// Output of a scalar multiplication between a public key and a secret key.
@@ -15,6 +22,7 @@ pub struct PublicKey(pub [u8; 32]);
 /// This value is NOT (!) safe for use as a key and needs to be processed in a round of key
 /// derivation, to ensure both that the output is uniformly random and that unkown key share
 /// attacks can not happen.
+#[cfg_attr(feature = "codec", derive(TlsSize, TlsSerialize, TlsDeserialize))]
 pub struct SharedSecret(pub [u8; 32]);
 
 impl From<&[u8; 32]> for PublicKey {

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -24,12 +24,17 @@ libcrux-curve25519 = { version = "=0.0.3", path = "../curve25519", default-featu
 libcrux-p256 = { version = "=0.0.3", path = "../p256", default-features = false }
 libcrux-traits = { version = "=0.0.3", path = "../traits" }
 rand = { version = "0.9", default-features = false }
+tls_codec = { version = "0.4.2", features = [
+    "derive",
+],  optional = true }
 
 [features]
 default = ["std"]
 std = ["rand/std", "libcrux-ecdh/std", "libcrux-ml-kem/std"]
 tests = []                                                   # Expose functions for testing.
 pre-verification = []
+# Encoding and decoding with TLSCodec
+codec = ["dep:tls_codec","libcrux-ml-kem/codec", "libcrux-ecdh/codec"]
 
 [dev-dependencies]
 libcrux-kem = { path = "./", features = ["tests"] }

--- a/libcrux-kem/src/kem.rs
+++ b/libcrux-kem/src/kem.rs
@@ -51,6 +51,14 @@ use libcrux_sha3 as sha3;
 
 use libcrux_ml_kem::{mlkem1024, mlkem512, mlkem768};
 
+#[cfg(feature = "codec")]
+use std::format;
+#[cfg(feature = "codec")]
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+
+#[cfg(feature = "codec")]
+extern crate std;
+
 // TODO: These functions are currently exposed simply in order to make NIST KAT
 // testing possible without an implementation of the NIST AES-CTR DRBG. Remove them
 // (and change the visibility of the exported functions to pub(crate)) the
@@ -198,6 +206,7 @@ pub enum PrivateKey {
 }
 
 /// An ML-KEM768-x25519 public key.
+#[cfg_attr(feature = "codec", derive(TlsSize, TlsSerialize, TlsDeserialize))]
 pub struct X25519MlKem768Draft00PublicKey {
     pub mlkem: MlKem768PublicKey,
     pub x25519: X25519PublicKey,
@@ -228,6 +237,7 @@ impl X25519MlKem768Draft00PublicKey {
 }
 
 /// An X-Wing public key.
+#[cfg_attr(feature = "codec", derive(TlsSize, TlsSerialize, TlsDeserialize))]
 pub struct XWingKemDraft06PublicKey {
     pub pk_m: MlKem768PublicKey,
     pub pk_x: X25519PublicKey,
@@ -258,6 +268,8 @@ impl XWingKemDraft06PublicKey {
 }
 
 /// A KEM public key.
+#[cfg_attr(feature = "codec", derive(TlsSize, TlsSerialize, TlsDeserialize))]
+#[repr(u8)]
 pub enum PublicKey {
     X25519(X25519PublicKey),
     P256(P256PublicKey),
@@ -269,6 +281,8 @@ pub enum PublicKey {
 }
 
 /// A KEM ciphertext
+#[cfg_attr(feature = "codec", derive(TlsSize, TlsSerialize, TlsDeserialize))]
+#[repr(u8)]
 pub enum Ct {
     X25519(X25519PublicKey),
     P256(P256PublicKey),
@@ -372,6 +386,8 @@ impl Ct {
 }
 
 /// A KEM shared secret
+#[cfg_attr(feature = "codec", derive(TlsSize, TlsSerialize, TlsDeserialize))]
+#[repr(u8)]
 pub enum Ss {
     X25519(X25519SharedSecret),
     P256(P256SharedSecret),
@@ -1018,6 +1034,7 @@ mod xwing {
 
     libcrux_traits::kem::slice::impl_trait!(XWing => EK_LEN, DK_LEN, CT_LEN, SS_LEN, RAND_KEYGEN_LEN, RAND_ENCAPS_LEN);
 
+    #[cfg_attr(feature = "codec", derive(TlsSize, TlsSerialize, TlsDeserialize))]
     pub struct XWingSharedSecret {
         pub(super) value: [u8; 32],
     }

--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -16,7 +16,7 @@ bench = false # so libtest doesn't eat the arguments to criterion
 
 [dependencies]
 libcrux-traits = { version = "0.0.3", path = "../traits" }
-libcrux-kem = { version = "=0.0.3", path = "../libcrux-kem" }
+libcrux-kem = { version = "=0.0.3", path = "../libcrux-kem", features = ["codec"]}
 libcrux-chacha20poly1305 = { version = "0.0.3", path = "../chacha20poly1305" }
 libcrux-hkdf = { version = "=0.0.3", path = "../libcrux-hkdf" }
 libcrux-hmac = { version = "=0.0.3", path = "../libcrux-hmac" }
@@ -34,6 +34,7 @@ libcrux-ml-kem = { version = "0.0.3", path = "../libcrux-ml-kem", features = [
 ] }
 libcrux-ed25519 = { version = "0.0.3", path = "../ed25519", features = [
     "rand",
+    "codec",
 ] }
 tls_codec = { version = "0.4.2", features = ["derive"] }
 

--- a/libcrux-psq/src/classic_mceliece.rs
+++ b/libcrux-psq/src/classic_mceliece.rs
@@ -11,6 +11,7 @@ use classic_mceliece_rust::{
 use libcrux_traits::kem::{KEMError, KeyPair, KEM};
 use tls_codec::{Deserialize, Serialize, Size, VLByteSlice, VLBytes};
 
+const MCELIECE460896F_CIPHERTEXT_LEN: usize = 156;
 use crate::traits::*;
 
 /// A wrapper around the `classic_mceliece_rust` type `Ciphertext`.
@@ -33,9 +34,9 @@ impl Deserialize for Ciphertext {
         // let array = GenericArray<u8, Ciphertext::EncappedKeySize>::from(bytes_deserialized);
         // let ciphertext =  Ciphertext::from_bytes(&array)?;
         // ```
-        Ok(Ciphertext(Ct::from(<[u8; 156]>::try_from(
-            bytes_deserialized.as_slice(),
-        )?)))
+        Ok(Ciphertext(Ct::from(
+            <[u8; MCELIECE460896F_CIPHERTEXT_LEN]>::try_from(bytes_deserialized.as_slice())?,
+        )))
     }
 }
 

--- a/libcrux-psq/src/classic_mceliece.rs
+++ b/libcrux-psq/src/classic_mceliece.rs
@@ -9,7 +9,7 @@ use classic_mceliece_rust::{
 };
 
 use libcrux_traits::kem::{KEMError, KeyPair, KEM};
-use tls_codec::{Deserialize, Serialize, Size};
+use tls_codec::{Deserialize, Serialize, Size, VLByteSlice, VLBytes};
 
 use crate::traits::*;
 
@@ -17,7 +17,7 @@ use crate::traits::*;
 pub struct Ciphertext(Ct);
 impl Serialize for Ciphertext {
     fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
-        todo!()
+        VLByteSlice(self.0.as_ref()).tls_serialize(writer)
     }
 }
 
@@ -26,13 +26,22 @@ impl Deserialize for Ciphertext {
     where
         Self: Sized,
     {
-        todo!()
+        let bytes_deserialized = VLBytes::tls_deserialize(bytes)?;
+        // XXX: This is the expected length of the ciphertext for mceliece460896f.
+        // If we didn't want to hardcode this, we'd have to pull in `generic-array` as a dependency and do something like
+        // ```
+        // let array = GenericArray<u8, Ciphertext::EncappedKeySize>::from(bytes_deserialized);
+        // let ciphertext =  Ciphertext::from_bytes(&array)?;
+        // ```
+        Ok(Ciphertext(Ct::from(<[u8; 156]>::try_from(
+            bytes_deserialized.as_slice(),
+        )?)))
     }
 }
 
 impl Size for Ciphertext {
     fn tls_serialized_len(&self) -> usize {
-        todo!()
+        VLByteSlice(self.0.as_ref()).tls_serialized_len()
     }
 }
 
@@ -41,12 +50,12 @@ pub struct PublicKey<'a>(Pk<'a>);
 
 impl<'a> Size for PublicKey<'a> {
     fn tls_serialized_len(&self) -> usize {
-        todo!()
+        VLByteSlice(self.0.as_ref()).tls_serialized_len()
     }
 }
 impl<'a> Serialize for PublicKey<'a> {
     fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
-        todo!()
+        VLByteSlice(self.0.as_ref()).tls_serialize(writer)
     }
 }
 
@@ -55,12 +64,12 @@ pub struct SharedSecret<'a>(Ss<'a>);
 
 impl<'a> Size for SharedSecret<'a> {
     fn tls_serialized_len(&self) -> usize {
-        todo!()
+        VLByteSlice(self.0.as_ref()).tls_serialized_len()
     }
 }
 impl<'a> Serialize for SharedSecret<'a> {
     fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
-        todo!()
+        VLByteSlice(self.0.as_ref()).tls_serialize(writer)
     }
 }
 

--- a/libcrux-psq/src/cred.rs
+++ b/libcrux-psq/src/cred.rs
@@ -41,12 +41,6 @@ pub trait Authenticator {
         signature: &Self::Signature,
         message: &[u8],
     ) -> Result<(), Error>;
-
-    // /// Deserialize a verification key.
-    // fn deserialize_credential(bytes: &[u8]) -> Result<Self::Credential, Error>;
-
-    // /// Deserialize a signature.
-    // fn deserialize_signature(bytes: &[u8]) -> Result<Self::Signature, Error>;
 }
 
 /// A no-op authenticator that does nothing.
@@ -73,14 +67,6 @@ impl Authenticator for NoAuth {
     ) -> Result<(), Error> {
         Ok(())
     }
-
-    // fn deserialize_credential(_bytes: &[u8]) -> Result<Self::VerificationKey, Error> {
-    //     Ok([0; 0])
-    // }
-
-    // fn deserialize_signature(_bytes: &[u8]) -> Result<Self::Signature, Error> {
-    //     Ok([0; 0])
-    // }
 
     fn validate_credential(
         _credential: Self::Credential,
@@ -123,15 +109,6 @@ impl Authenticator for Ed25519 {
         libcrux_ed25519::verify(message, verification_key.as_ref(), signature)
             .map_err(|_| Error::CredError)
     }
-
-    // /// CAUTION: This does not perform validation of the verification key.
-    // fn deserialize_credential(bytes: &[u8]) -> Result<Self::VerificationKey, Error> {
-    //     bytes.try_into().map_err(|_| Error::CredError)
-    // }
-
-    // fn deserialize_signature(bytes: &[u8]) -> Result<Self::Signature, Error> {
-    //     bytes.try_into().map_err(|_| Error::CredError)
-    // }
 
     fn validate_credential(
         credential: Self::Credential,

--- a/libcrux-psq/src/cred.rs
+++ b/libcrux-psq/src/cred.rs
@@ -1,4 +1,6 @@
 //! This module provides a trait for a generic authenticator.
+use tls_codec::{Deserialize, Serialize};
+
 use crate::Error;
 
 /// A generic authentication primitive.
@@ -10,13 +12,13 @@ use crate::Error;
 /// identity.
 pub trait Authenticator {
     /// The authenticator's signature objects.
-    type Signature: AsRef<[u8]>;
+    type Signature: Serialize + Deserialize;
     /// The authenticator's signing key objects.
     type SigningKey;
     /// The authenticator's verification key objects.
     type VerificationKey;
     /// The client's credential.
-    type Credential: AsRef<[u8]>;
+    type Credential: Serialize + Deserialize;
     /// Information necessary to validate the credential.
     type Certificate;
     /// Length (in bytes) of a serialized credential key.
@@ -40,11 +42,11 @@ pub trait Authenticator {
         message: &[u8],
     ) -> Result<(), Error>;
 
-    /// Deserialize a verification key.
-    fn deserialize_credential(bytes: &[u8]) -> Result<Self::Credential, Error>;
+    // /// Deserialize a verification key.
+    // fn deserialize_credential(bytes: &[u8]) -> Result<Self::Credential, Error>;
 
-    /// Deserialize a signature.
-    fn deserialize_signature(bytes: &[u8]) -> Result<Self::Signature, Error>;
+    // /// Deserialize a signature.
+    // fn deserialize_signature(bytes: &[u8]) -> Result<Self::Signature, Error>;
 }
 
 /// A no-op authenticator that does nothing.
@@ -72,13 +74,13 @@ impl Authenticator for NoAuth {
         Ok(())
     }
 
-    fn deserialize_credential(_bytes: &[u8]) -> Result<Self::VerificationKey, Error> {
-        Ok([0; 0])
-    }
+    // fn deserialize_credential(_bytes: &[u8]) -> Result<Self::VerificationKey, Error> {
+    //     Ok([0; 0])
+    // }
 
-    fn deserialize_signature(_bytes: &[u8]) -> Result<Self::Signature, Error> {
-        Ok([0; 0])
-    }
+    // fn deserialize_signature(_bytes: &[u8]) -> Result<Self::Signature, Error> {
+    //     Ok([0; 0])
+    // }
 
     fn validate_credential(
         _credential: Self::Credential,
@@ -99,7 +101,7 @@ impl Authenticator for Ed25519 {
 
     type SigningKey = [u8; 32];
 
-    type VerificationKey = [u8; 32];
+    type VerificationKey = libcrux_ed25519::VerificationKey;
 
     type Credential = Self::VerificationKey;
 
@@ -118,17 +120,18 @@ impl Authenticator for Ed25519 {
         signature: &Self::Signature,
         message: &[u8],
     ) -> Result<(), Error> {
-        libcrux_ed25519::verify(message, verification_key, signature).map_err(|_| Error::CredError)
+        libcrux_ed25519::verify(message, verification_key.as_ref(), signature)
+            .map_err(|_| Error::CredError)
     }
 
-    /// CAUTION: This does not perform validation of the verification key.
-    fn deserialize_credential(bytes: &[u8]) -> Result<Self::VerificationKey, Error> {
-        bytes.try_into().map_err(|_| Error::CredError)
-    }
+    // /// CAUTION: This does not perform validation of the verification key.
+    // fn deserialize_credential(bytes: &[u8]) -> Result<Self::VerificationKey, Error> {
+    //     bytes.try_into().map_err(|_| Error::CredError)
+    // }
 
-    fn deserialize_signature(bytes: &[u8]) -> Result<Self::Signature, Error> {
-        bytes.try_into().map_err(|_| Error::CredError)
-    }
+    // fn deserialize_signature(bytes: &[u8]) -> Result<Self::Signature, Error> {
+    //     bytes.try_into().map_err(|_| Error::CredError)
+    // }
 
     fn validate_credential(
         credential: Self::Credential,
@@ -136,7 +139,7 @@ impl Authenticator for Ed25519 {
     ) -> Result<Self::VerificationKey, Error> {
         // We only check that the out of band key is the same as the
         // key that is provided as the credential.
-        (credential == *cert)
+        (credential.as_ref() == cert.as_ref())
             .then_some(credential)
             .ok_or(Error::CredError)
     }

--- a/libcrux-psq/src/impls.rs
+++ b/libcrux-psq/src/impls.rs
@@ -73,24 +73,6 @@ libcrux_impl!(
     "A hybrid post-quantum KEM combining X25519 and ML-KEM 768"
 );
 
-// impl Encode for PublicKey {
-//     fn encode(&self) -> Vec<u8> {
-//         self.encode()
-//     }
-// }
-
-// impl Encode for Ct {
-//     fn encode(&self) -> Vec<u8> {
-//         self.encode()
-//     }
-// }
-
-// impl Encode for Ss {
-//     fn encode(&self) -> Vec<u8> {
-//         self.encode()
-//     }
-// }
-
 #[cfg(test)]
 mod tests {
     #![allow(non_snake_case)]

--- a/libcrux-psq/src/impls.rs
+++ b/libcrux-psq/src/impls.rs
@@ -8,8 +8,6 @@
 //!   KEM *does not provide post-quantum security*. We include it for
 //!   testing and benchmarking.
 
-#[allow(unused_imports)] // XXX: We do use it in the macro below.
-use crate::traits::PSQ;
 use libcrux_kem::{Ct, PrivateKey, PublicKey, Ss};
 use libcrux_traits::kem::{KEMError, KeyPair, KEM};
 
@@ -78,6 +76,7 @@ mod tests {
     #![allow(non_snake_case)]
     use super::*;
 
+    use crate::traits::PSQ;
     macro_rules! libcrux_test {
         ($alg:ident) => {
             #[test]

--- a/libcrux-psq/src/impls.rs
+++ b/libcrux-psq/src/impls.rs
@@ -8,7 +8,8 @@
 //!   KEM *does not provide post-quantum security*. We include it for
 //!   testing and benchmarking.
 
-use crate::traits::*;
+#[allow(unused_imports)] // XXX: We do use it in the macro below.
+use crate::traits::PSQ;
 use libcrux_kem::{Ct, PrivateKey, PublicKey, Ss};
 use libcrux_traits::kem::{KEMError, KeyPair, KEM};
 
@@ -72,23 +73,23 @@ libcrux_impl!(
     "A hybrid post-quantum KEM combining X25519 and ML-KEM 768"
 );
 
-impl Encode for PublicKey {
-    fn encode(&self) -> Vec<u8> {
-        self.encode()
-    }
-}
+// impl Encode for PublicKey {
+//     fn encode(&self) -> Vec<u8> {
+//         self.encode()
+//     }
+// }
 
-impl Encode for Ct {
-    fn encode(&self) -> Vec<u8> {
-        self.encode()
-    }
-}
+// impl Encode for Ct {
+//     fn encode(&self) -> Vec<u8> {
+//         self.encode()
+//     }
+// }
 
-impl Encode for Ss {
-    fn encode(&self) -> Vec<u8> {
-        self.encode()
-    }
-}
+// impl Encode for Ss {
+//     fn encode(&self) -> Vec<u8> {
+//         self.encode()
+//     }
+// }
 
 #[cfg(test)]
 mod tests {

--- a/libcrux-psq/src/psk_registration.rs
+++ b/libcrux-psq/src/psk_registration.rs
@@ -172,7 +172,12 @@ impl Initiator {
 
         let ts_ttl = serialize_ts_ttl(&ts, &psk_ttl);
 
-        let signature = C::sign(signing_key, &enc_pq.encode())?;
+        let mut enc_pq_serialized = vec![0u8; enc_pq.tls_serialized_len()];
+        enc_pq
+            .tls_serialize(&mut &mut enc_pq_serialized[..])
+            .map_err(|_| Error::Serialization)?;
+
+        let signature = C::sign(signing_key, &enc_pq_serialized)?;
 
         let mut message = Vec::new();
         message.extend_from_slice(&ts_ttl);

--- a/libcrux-psq/src/traits.rs
+++ b/libcrux-psq/src/traits.rs
@@ -22,27 +22,6 @@ type Mac = [u8; MAC_LENGTH];
 /// A post-quantum shared secret component.
 pub type PSQComponent = [u8; PSQ_COMPONENT_LENGTH];
 
-// /// A common trait for encoding structures into byte vectors.
-// pub trait Encode {
-//     // TODO: This can only become proper `no_std` once we get slices
-//     // of the backing datastructure from `libcrux_kem`.
-//     // See: https://github.com/cryspen/libcrux/issues/817
-//     /// Encodes self into a byte vector.
-//     ///
-//     /// This encoding needs to be unique.
-//     fn encode(&self) -> Vec<u8>;
-// }
-
-// /// Generic decode trait.
-// pub trait Decode {
-//     /// Decode bytes to Self
-//     ///
-//     /// Returns Self and the number of bytes consumed from `bytes`.
-//     fn decode(bytes: &[u8]) -> Result<(Self, usize), Error>
-//     where
-//         Self: Sized;
-// }
-
 pub(crate) mod private {
     pub trait Seal {}
 }
@@ -151,14 +130,6 @@ pub struct Ciphertext<
     pub(crate) inner_ctxt: T::Ciphertext,
     pub(crate) mac: Mac,
 }
-
-// impl<T: KEM<Ciphertext: Encode>> Encode for Ciphertext<T> {
-//     fn encode(&self) -> Vec<u8> {
-//         let mut serialized = self.inner_ctxt.encode();
-//         serialized.extend_from_slice(&self.mac);
-//         serialized
-//     }
-// }
 
 // TODO: Use functions from `secrets` crate instead once that's merged.
 // See:


### PR DESCRIPTION
This PR replaces almost all ad hoc serialization and deserialization in PSQv1 with TLSCodec (the exception being the timestamp included in the initiator message).

To this end, I've introduced `codec` features in `libcrux-ecdh`, `ed25519` & `libcrux-kem`.

Fixes #925