### PR TITLE
c: avoid warning C4003 in msvc in intrinsics macro

### DIFF
--- a/libcrux-ml-dsa/cg/intrinsics/libcrux_intrinsics_avx2.h
+++ b/libcrux-ml-dsa/cg/intrinsics/libcrux_intrinsics_avx2.h
@@ -32,8 +32,7 @@ typedef __m256i core_core_arch_x86___m256i;
 
 // Initialize, Load, Store
 
-#define libcrux_intrinsics_avx2_mm256_setzero_si256(void) \
-  (_mm256_setzero_si256())
+#define libcrux_intrinsics_avx2_mm256_setzero_si256() (_mm256_setzero_si256())
 
 #define libcrux_intrinsics_avx2_mm256_set1_epi16(a) (_mm256_set1_epi16(a))
 

--- a/libcrux-ml-kem/cg/intrinsics/libcrux_intrinsics_avx2.h
+++ b/libcrux-ml-kem/cg/intrinsics/libcrux_intrinsics_avx2.h
@@ -30,8 +30,7 @@ typedef __m256i core_core_arch_x86___m256i;
 
 // Initialize, Load, Store
 
-#define libcrux_intrinsics_avx2_mm256_setzero_si256(void) \
-  (_mm256_setzero_si256())
+#define libcrux_intrinsics_avx2_mm256_setzero_si256() (_mm256_setzero_si256())
 
 #define libcrux_intrinsics_avx2_mm256_set1_epi16(a) (_mm256_set1_epi16(a))
 


### PR DESCRIPTION
This has been fixed before but never upstreamed here.

```
C:\b\s\w\ir\cache\builder\boringssl\crypto\fipsmodule\mlkem\../../../third_party/libcrux/libcrux_mlkem768_avx2.h(45): error C2220: the following warning is treated as an error
C:\b\s\w\ir\cache\builder\boringssl\crypto\fipsmodule\mlkem\../../../third_party/libcrux/libcrux_mlkem768_avx2.h(45): warning C4003: not enough arguments for function-like macro invocation 'libcrux_intrinsics_avx2_mm256_setzero_si256'
C:\b\s\w\ir\cache\builder\boringssl\crypto\fipsmodule\mlkem\../../../third_party/libcrux/libcrux_mlkem768_avx2.h(314): warning C4003: not enough arguments for function-like macro invocation 'libcrux_intrinsics_avx2_mm256_setzero_si256'
```