### PR TITLE
[PSQ] Allow derivation of an Unregistered PSK.

### DIFF
--- a/libcrux-psq/src/psk_registration.rs
+++ b/libcrux-psq/src/psk_registration.rs
@@ -156,8 +156,8 @@ impl Initiator {
 
     /// Returns the unregisterd PSK.
     /// This is computed while generating the inital message.
-    pub fn unregistered_psk(&self) -> Psk {
-        self.unregistered_psk
+    pub fn unregistered_psk(&self) -> &Psk {
+        &self.unregistered_psk
     }
 }
 


### PR DESCRIPTION
Hello :-)

I added a simple function which enables a PSQ initiator to extract the PSK before the PSQ Responder sends their message.
This is very helpful for nym.

Thanks for taking a look, I'm happy to answer any questions.