### PR TITLE
Remove unsafe expression on safe AVX2 instructions

### DIFF
--- a/libcrux-intrinsics/src/avx2.rs
+++ b/libcrux-intrinsics/src/avx2.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(hax, allow(unused_unsafe))]
+
 #[cfg(all(target_arch = "x86", not(hax)))]
 pub use core::arch::x86::*;
 #[cfg(all(target_arch = "x86_64", not(hax)))]


### PR DESCRIPTION
The changed AVX2 simd instructions in this PR are no longer unsafe. The Compiler gives a warning when using them in an unsafe block.