### PR TITLE
Fixing proofs on CI

### DIFF
--- a/fstar-helpers/Makefile.generic
+++ b/fstar-helpers/Makefile.generic
@@ -120,23 +120,19 @@ endif
 
 .PHONY: all verify clean
 
-all:
-	$(Q)rm -f .depend
-	$(Q)$(MAKE) .depend hax.fst.config.json verify
-
-all-keep-going:
-	$(Q)rm -f .depend
-	$(Q)$(MAKE) --keep-going .depend hax.fst.config.json verify
-
 # Only run code extraction for build targets, not for 'clean'.
-all all-keep-going:
+all:
 ifeq "$(wildcard *.fst *fsti)" ""
 	$(shell cargo hax into fstar)
 endif
 	$(Q)rm -f .depend
-all:
 	$(Q)$(MAKE) .depend hax.fst.config.json verify
+
 all-keep-going:
+ifeq "$(wildcard *.fst *fsti)" ""
+	$(shell cargo hax into fstar)
+endif
+	$(Q)rm -f .depend
 	$(Q)$(MAKE) --keep-going .depend hax.fst.config.json verify
 
 # By default, we process all the files in the current directory

--- a/libcrux-ml-dsa/src/simd/portable/ntt.rs
+++ b/libcrux-ml-dsa/src/simd/portable/ntt.rs
@@ -323,18 +323,6 @@ fn ntt_at_layer_2(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(
-    r#"
-let layer_bound_factor (step_by:usize) : n:nat{n <= 4} =
-    match step_by with
-    | MkInt 1 -> 4
-    | MkInt 2 -> 3
-    | MkInt 4 -> 2
-    | MkInt 8 -> 1
-    | MkInt 16 -> 0
-    | _ -> 0
-"#
-)]
 #[hax_lib::fstar::options("--z3rlimit 600 --split_queries always")]
 #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
 #[hax_lib::requires(fstar!(r#"
@@ -357,6 +345,55 @@ let layer_bound_factor (step_by:usize) : n:nat{n <= 4} =
 fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
     re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT],
 ) {
+    #[inline(always)]
+    #[hax_lib::fstar::before(
+    r#"
+    let layer_bound_factor (step_by:usize) : n:nat{n <= 4} =
+        match step_by with
+        | MkInt 1 -> 4
+        | MkInt 2 -> 3
+        | MkInt 4 -> 2
+        | MkInt 8 -> 1
+        | MkInt 16 -> 0
+        | _ -> 0
+    "#
+    )]
+    #[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
+    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+    #[hax_lib::requires(fstar!(r#"
+        v $step_by > 0 /\
+        v $index + v $step_by < v $SIMD_UNITS_IN_RING_ELEMENT /\
+        Spec.Utils.is_i32b_array_opaque 
+                    (v $NTT_BASE_BOUND + ((layer_bound_factor $step_by) * v $FIELD_MAX)) 
+                    (Seq.index ${re} (v $index)).f_values /\
+        Spec.Utils.is_i32b_array_opaque 
+                    (v $NTT_BASE_BOUND + ((layer_bound_factor $step_by) * v $FIELD_MAX)) 
+                    (Seq.index ${re} (v $index + v $step_by)).f_values /\
+        Spec.Utils.is_i32b 4190208 $zeta
+    "#))]
+    #[hax_lib::ensures(|_| fstar!(r#"
+        Spec.Utils.modifies2_32 ${re} ${re}_future $index (${index + step_by}) /\
+        Spec.Utils.is_i32b_array_opaque 
+                    (v $NTT_BASE_BOUND + ((layer_bound_factor $step_by + 1) * v $FIELD_MAX)) 
+                    (Seq.index ${re}_future (v $index)).f_values /\
+        Spec.Utils.is_i32b_array_opaque 
+                    (v $NTT_BASE_BOUND + ((layer_bound_factor $step_by + 1) * v $FIELD_MAX)) 
+                    (Seq.index ${re}_future (v $index + v step_by)).f_values
+    "#))]
+    fn round(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT], index: usize, step_by:usize, zeta: i32) {
+        hax_lib::fstar!(
+            "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
+        );
+        let mut tmp = re[index+step_by];
+        montgomery_multiply_by_constant(&mut tmp, zeta);
+
+        re[index+step_by] = re[index];
+
+        arithmetic::subtract(&mut re[index+step_by], &tmp);
+        arithmetic::add(&mut re[index], &tmp);
+    }
+
+
     #[cfg(hax)]
     let orig_re = re.clone();
 
@@ -372,20 +409,15 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
                     (Seq.index ${re} i).f_values))
         "#
         ));
+        round(re, j, STEP_BY, ZETA);
+        // let mut tmp = re[j + STEP_BY];
+        // montgomery_multiply_by_constant(&mut tmp, ZETA);
 
-        let mut tmp = re[j + STEP_BY];
-        montgomery_multiply_by_constant(&mut tmp, ZETA);
+        // re[j + STEP_BY] = re[j];
 
-        re[j + STEP_BY] = re[j];
+        // arithmetic::subtract(&mut re[j + STEP_BY], &tmp);
+        // arithmetic::add(&mut re[j], &tmp);
 
-        arithmetic::subtract(&mut re[j + STEP_BY], &tmp);
-        arithmetic::add(&mut re[j], &tmp);
-
-        hax_lib::fstar!(
-            r#"
-        assert ((v ${NTT_BASE_BOUND} + ((layer_bound_factor v_STEP_BY) * v $FIELD_MAX)) + (v $FIELD_MAX) 
-                == (v ${NTT_BASE_BOUND} + ((layer_bound_factor v_STEP_BY + 1) * v $FIELD_MAX)))"#
-        );
     }
 }
 

--- a/libcrux-ml-dsa/src/simd/portable/ntt.rs
+++ b/libcrux-ml-dsa/src/simd/portable/ntt.rs
@@ -347,7 +347,7 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
 ) {
     #[inline(always)]
     #[hax_lib::fstar::before(
-    r#"
+        r#"
     let layer_bound_factor (step_by:usize) : n:nat{n <= 4} =
         match step_by with
         | MkInt 1 -> 4
@@ -380,19 +380,23 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
                     (v $NTT_BASE_BOUND + ((layer_bound_factor $step_by + 1) * v $FIELD_MAX)) 
                     (Seq.index ${re}_future (v $index + v step_by)).f_values
     "#))]
-    fn round(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT], index: usize, step_by:usize, zeta: i32) {
+    fn round(
+        re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT],
+        index: usize,
+        step_by: usize,
+        zeta: i32,
+    ) {
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
         );
-        let mut tmp = re[index+step_by];
+        let mut tmp = re[index + step_by];
         montgomery_multiply_by_constant(&mut tmp, zeta);
 
-        re[index+step_by] = re[index];
+        re[index + step_by] = re[index];
 
-        arithmetic::subtract(&mut re[index+step_by], &tmp);
+        arithmetic::subtract(&mut re[index + step_by], &tmp);
         arithmetic::add(&mut re[index], &tmp);
     }
-
 
     #[cfg(hax)]
     let orig_re = re.clone();
@@ -417,7 +421,6 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
 
         // arithmetic::subtract(&mut re[j + STEP_BY], &tmp);
         // arithmetic::add(&mut re[j], &tmp);
-
     }
 }
 

--- a/libcrux-ml-kem/proofs/fstar/spec/Spec.Utils.fsti
+++ b/libcrux-ml-kem/proofs/fstar/spec/Spec.Utils.fsti
@@ -621,6 +621,47 @@ let modifies2_8 #t
     ((v i <> 6 /\ v j <> 6)  ==> Seq.index a 6 == Seq.index b 6) /\
     ((v i <> 7 /\ v j <> 7)  ==> Seq.index a 7 == Seq.index b 7)
 
+let modifies1_16 #t
+    (a b: t_Array t (sz 16))
+    (i:usize{v i < 16}) = 
+//    normalize_term (forall8 (fun j -> (v i <> j) ==> Seq.index a j == Seq.index b j))
+    (v i <> 0  ==> Seq.index a 0 == Seq.index b 0) /\
+    (v i <> 1  ==> Seq.index a 1 == Seq.index b 1) /\
+    (v i <> 2  ==> Seq.index a 2 == Seq.index b 2) /\
+    (v i <> 3  ==> Seq.index a 3 == Seq.index b 3) /\
+    (v i <> 4  ==> Seq.index a 4 == Seq.index b 4) /\
+    (v i <> 5  ==> Seq.index a 5 == Seq.index b 5) /\
+    (v i <> 6  ==> Seq.index a 6 == Seq.index b 6) /\
+    (v i <> 7  ==> Seq.index a 7 == Seq.index b 7) /\
+    (v i <> 8  ==> Seq.index a 8 == Seq.index b 8) /\
+    (v i <> 9  ==> Seq.index a 9 == Seq.index b 9) /\
+    (v i <> 10 ==> Seq.index a 10 == Seq.index b 10) /\
+    (v i <> 11 ==> Seq.index a 11 == Seq.index b 11) /\
+    (v i <> 12 ==> Seq.index a 12 == Seq.index b 12) /\
+    (v i <> 13 ==> Seq.index a 13 == Seq.index b 13) /\
+    (v i <> 14 ==> Seq.index a 14 == Seq.index b 14) /\
+    (v i <> 15 ==> Seq.index a 15 == Seq.index b 15)
+
+let modifies2_16 #t
+    (a b: t_Array t (sz 16))
+    (i:usize{v i < 16}) (j:usize{v j < 16}) =
+    ((v i <> 0  /\ v j <> 0)  ==> Seq.index a 0 == Seq.index b 0) /\
+    ((v i <> 1  /\ v j <> 1)  ==> Seq.index a 1 == Seq.index b 1) /\
+    ((v i <> 2  /\ v j <> 2)  ==> Seq.index a 2 == Seq.index b 2) /\
+    ((v i <> 3  /\ v j <> 3)  ==> Seq.index a 3 == Seq.index b 3) /\
+    ((v i <> 4  /\ v j <> 4)  ==> Seq.index a 4 == Seq.index b 4) /\
+    ((v i <> 5  /\ v j <> 5)  ==> Seq.index a 5 == Seq.index b 5) /\
+    ((v i <> 6  /\ v j <> 6)  ==> Seq.index a 6 == Seq.index b 6) /\
+    ((v i <> 7  /\ v j <> 7)  ==> Seq.index a 7 == Seq.index b 7) /\
+    ((v i <> 8  /\ v j <> 8)  ==> Seq.index a 8 == Seq.index b 8) /\
+    ((v i <> 9  /\ v j <> 9)  ==> Seq.index a 9 == Seq.index b 9) /\
+    ((v i <> 10 /\ v j <> 10) ==> Seq.index a 10 == Seq.index b 10) /\
+    ((v i <> 11 /\ v j <> 11) ==> Seq.index a 11 == Seq.index b 11) /\
+    ((v i <> 12 /\ v j <> 12) ==> Seq.index a 12 == Seq.index b 12) /\
+    ((v i <> 13 /\ v j <> 13) ==> Seq.index a 13 == Seq.index b 13) /\
+    ((v i <> 14 /\ v j <> 14) ==> Seq.index a 14 == Seq.index b 14) /\
+    ((v i <> 15 /\ v j <> 15) ==> Seq.index a 15 == Seq.index b 15)
+
 let modifies1_32 #t
         (a b: t_Array t (mk_usize 32))
         (j:usize{v j < 32}) =

--- a/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux-ml-kem/src/ind_cca.rs
@@ -805,6 +805,7 @@ pub(crate) mod unpacked {
     }
 
     #[hax_lib::fstar::options("--z3rlimit 200")]
+    #[hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#)]
     #[hax_lib::ensures(|result|
         fstar!(r#"forall (i: nat). i < v $K ==>
             (forall (j: nat). j < v $K ==>
@@ -852,7 +853,7 @@ pub(crate) mod unpacked {
 
     /// Generate Unpacked Keys
     #[inline(always)]
-    #[hax_lib::fstar::options("--z3rlimit 1500 --ext context_pruning --z3refresh")]
+    #[hax_lib::fstar::options("--z3rlimit 300 --ext context_pruning --split_queries always")]
     #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
@@ -1012,7 +1013,7 @@ pub(crate) mod unpacked {
 
     // Decapsulate with Unpacked Private Key
     #[inline(always)]
-    #[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning --z3refresh")]
+    #[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
     #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\

--- a/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux-ml-kem/src/ind_cpa.rs
@@ -127,7 +127,7 @@ pub(crate) fn serialize_public_key_mut<
 
 /// Call [`serialize_uncompressed_ring_element`] for each ring element.
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 1000 --ext context_pruning --z3refresh")]
+#[hax_lib::fstar::options("--z3rlimit 1000 --ext context_pruning")]
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     ${out.len()} == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
     (forall (i:nat). i < v $K ==>
@@ -183,7 +183,7 @@ pub(crate) fn serialize_vector<const K: usize, Vector: Operations>(
 /// Sample a vector of ring elements from a centered binomial distribution.
 #[inline(always)]
 #[hax_lib::fstar::options(
-    "--max_fuel 15 --z3rlimit 1500 --ext context_pruning --z3refresh --split_queries always"
+    "--max_fuel 15 --z3rlimit 1500 --ext context_pruning --split_queries always"
 )]
 #[cfg_attr(
     hax,
@@ -301,7 +301,7 @@ fn sample_ring_element_cbd<
 /// convert them into their NTT representations.
 #[inline(always)]
 #[hax_lib::fstar::options(
-    "--max_fuel 25 --z3rlimit 2500 --ext context_pruning --z3refresh --split_queries always"
+    "--max_fuel 25 --z3rlimit 2500 --ext context_pruning --split_queries always"
 )]
 #[cfg_attr(hax, hax_lib::fstar::before(r#"let sample_vector_cbd_then_ntt_helper_2
       (v_K v_ETA v_ETA_RANDOMNESS_SIZE: usize)
@@ -450,7 +450,8 @@ fn sample_vector_cbd_then_ntt<
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
-#[hax_lib::fstar::options("--z3rlimit 500 --ext context_pruning --z3refresh")]
+#[hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#)]
+#[hax_lib::fstar::options("--z3rlimit 500 --ext context_pruning")]
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
@@ -602,7 +603,7 @@ pub(crate) fn serialize_unpacked_secret_key<
 }
 
 /// Call [`compress_then_serialize_ring_element_u`] on each ring element.
-#[hax_lib::fstar::options("--z3rlimit 1500 --ext context_pruning --z3refresh")]
+#[hax_lib::fstar::options("--z3rlimit 1500 --ext context_pruning")]
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $OUT_LEN == Spec.MLKEM.v_C1_SIZE $K /\
     $COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K /\
@@ -706,7 +707,7 @@ fn compress_then_serialize_u<
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
-#[hax_lib::fstar::options("--z3rlimit 800 --ext context_pruning --z3refresh")]
+#[hax_lib::fstar::options("--z3rlimit 800 --ext context_pruning")]
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
       $ETA1 == Spec.MLKEM.v_ETA1 $K /\
       $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\

--- a/libcrux-ml-kem/src/vector/portable/compress.rs
+++ b/libcrux-ml-kem/src/vector/portable/compress.rs
@@ -212,7 +212,8 @@ pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> Po
                       v (cast (${a}.f_elements.[ sz j ]) <: u16) < v (cast ($FIELD_MODULUS) <: u16))) /\
                     (forall (j:nat). j < v $i ==> v (${a}.f_elements.[ sz j ] <: i16) >= 0 /\
                      v (${a}.f_elements.[ sz j ] <: i16) < pow2 (v $COEFFICIENT_BITS)))"#
-        )});
+            )
+        });
 
         a.elements[i] =
             compress_ciphertext_coefficient(COEFFICIENT_BITS as u8, a.elements[i].as_u16())

--- a/libcrux-ml-kem/src/vector/portable/compress.rs
+++ b/libcrux-ml-kem/src/vector/portable/compress.rs
@@ -25,6 +25,7 @@ use libcrux_secrets::*;
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
+#[hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#)]
 #[cfg_attr(hax, hax_lib::requires(fe < (FIELD_MODULUS as u16)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"((833 <= v fe && v fe <= 2496) ==> v result == 1) /\
 						    (~(833 <=  v fe && v fe <= 2496) ==> v result == 0)"#)))]
@@ -93,6 +94,7 @@ pub(crate) fn compress_message_coefficient(fe: U16) -> U8 {
 }
 
 #[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
+#[hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#)]
 #[cfg_attr(hax,
     hax_lib::requires(
         (coefficient_bits == 4 ||
@@ -102,7 +104,7 @@ pub(crate) fn compress_message_coefficient(fe: U16) -> U8 {
          fe < (FIELD_MODULUS as u16)))]
 #[cfg_attr(hax,
      hax_lib::ensures(
-     |result| result >= 0 && result < 2i16.pow(coefficient_bits as u32)))]
+     |result| fstar!(r#"v result >= 0 && v result < pow2 (v $coefficient_bits)"#)))]
 pub(crate) fn compress_ciphertext_coefficient(coefficient_bits: u8, fe: U16) -> FieldElement {
     // hax_debug_assert!(
     //     coefficient_bits == 4
@@ -137,7 +139,7 @@ let compress_message_coefficient_range_helper (fe: u16) : Lemma
 "#
     )
 )]
-#[hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 2000")]
+#[hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 200")]
 #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index ${a}.f_elements i) >= 0 /\
     v (Seq.index ${a}.f_elements i) < 3329"#))]
 #[hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> 
@@ -180,16 +182,17 @@ pub(crate) fn compress_1(mut a: PortableVector) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 2000")]
+#[hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 500")]
 #[hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
         v $COEFFICIENT_BITS == 5 \/
         v $COEFFICIENT_BITS == 10 \/
         v $COEFFICIENT_BITS == 11) /\
-    (forall (i:nat). i < 16 ==> v (Seq.index ${a}.f_elements i) >= 0 /\
-        v (Seq.index ${a}.f_elements i) < 3329)"#))]
+    (forall (i:nat). i < 16 ==> 
+        (v (Seq.index ${a}.f_elements i) >= 0 /\
+         v (Seq.index ${a}.f_elements i) < 3329))"#))]
 #[hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> 
-    v (${result}.f_elements.[ sz i ] <: i16) >= 0 /\
-    v (${result}.f_elements.[ sz i ] <: i16) < pow2 (v $COEFFICIENT_BITS))"#))]
+    (v (${result}.f_elements.[ sz i ] <: i16) >= 0 /\
+     v (${result}.f_elements.[ sz i ] <: i16) < pow2 (v $COEFFICIENT_BITS)))"#))]
 pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> PortableVector {
     hax_lib::fstar!(
         "assert (v (cast ($COEFFICIENT_BITS) <: u8) == v $COEFFICIENT_BITS);
@@ -197,19 +200,19 @@ pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> Po
         assert (v (cast ($FIELD_MODULUS) <: u16) == 3329)"
     );
     hax_lib::fstar!(
-        "assert (forall (i:nat). i < 16 ==> (cast (${a}.f_elements.[ sz i ]) <: u16) <.
-        (cast ($FIELD_MODULUS) <: u16))"
+        "assert (forall (i:nat). i < 16 ==> 
+            (cast (${a}.f_elements.[ sz i ]) <: u16) <.
+            (cast ($FIELD_MODULUS) <: u16))"
     );
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
-                r#"(v $i < 16 ==> (forall (j:nat). (j >= v $i /\ j < 16) ==>
-            v (cast (${a}.f_elements.[ sz j ]) <: u16) < v (cast ($FIELD_MODULUS) <: u16))) /\
-            (forall (j:nat). j < v $i ==> v (${a}.f_elements.[ sz j ] <: i16) >= 0 /\
-                v (${a}.f_elements.[ sz j ] <: i16) < pow2 (v (cast ($COEFFICIENT_BITS) <: u32)))"#
-            )
-        });
+                r#"((forall (j:nat). (j >= v $i /\ j < 16) ==>
+                      v (cast (${a}.f_elements.[ sz j ]) <: u16) < v (cast ($FIELD_MODULUS) <: u16))) /\
+                    (forall (j:nat). j < v $i ==> v (${a}.f_elements.[ sz j ] <: i16) >= 0 /\
+                     v (${a}.f_elements.[ sz j ] <: i16) < pow2 (v $COEFFICIENT_BITS)))"#
+        )});
 
         a.elements[i] =
             compress_ciphertext_coefficient(COEFFICIENT_BITS as u8, a.elements[i].as_u16())
@@ -217,12 +220,13 @@ pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> Po
 
         hax_lib::fstar!(
             r#"assert (v (${a}.f_elements.[ $i ] <: i16) >= 0 /\
-            v (${a}.f_elements.[ $i ] <: i16) < pow2 (v (cast ($COEFFICIENT_BITS) <: u32)))"#
+            v (${a}.f_elements.[ $i ] <: i16) < pow2 (v $COEFFICIENT_BITS))"#
         );
     }
     hax_lib::fstar!(
-        r#"assert (forall (i:nat). i < 16 ==> v (${a}.f_elements.[ sz i ] <: i16) >= 0 /\
-        v (${a}.f_elements.[ sz i ] <: i16) < pow2 (v $COEFFICIENT_BITS))"#
+        r#"assert (forall (i:nat). i < 16 ==> 
+                    (v (${a}.f_elements.[ sz i ] <: i16) >= 0 /\
+                     v (${a}.f_elements.[ sz i ] <: i16) < pow2 (v $COEFFICIENT_BITS)))"#
     );
 
     a

--- a/libcrux-ml-kem/src/vector/portable/ntt.rs
+++ b/libcrux-ml-kem/src/vector/portable/ntt.rs
@@ -267,7 +267,9 @@ pub(crate) fn inv_ntt_layer_3_step(mut vec: PortableVector, zeta: i16) -> Portab
 #[hax_lib::fstar::options(
     "--z3rlimit 250 --split_queries always --query_stats --ext context_prune"
 )]
-#[hax_lib::fstar::before(interface, r#"
+#[hax_lib::fstar::before(
+    interface,
+    r#"
     let ntt_multiply_binomials_post
       (a b: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
       (zeta: i16)
@@ -281,7 +283,8 @@ pub(crate) fn inv_ntt_layer_3_step(mut vec: PortableVector, zeta: i16) -> Portab
             let oj = Seq.index out_future.f_elements (2 * v i + 1) in
             ((v oi % 3329) == (((v ai * v bi + (v aj * v bj * v zeta * 169)) * 169) % 3329)) /\
             ((v oj % 3329) == (((v ai * v bj + v aj * v bi) * 169) % 3329))
-"#)]
+"#
+)]
 #[hax_lib::fstar::before("[@@ \"opaque_to_smt\"]")]
 #[hax_lib::requires(fstar!(r#"v i < 8 /\ Spec.Utils.is_i16b 1664 $zeta /\
         Spec.Utils.is_i16b_array 3328 ${a}.f_elements /\


### PR DESCRIPTION
This PR improves the performance of some ML-KEM and ML-DSA proofs to help them pass on the CI machine.
There is still some work to be done here.

To measure the worst-performing functions, I use the following command on the logs generated:
```
cat log | sed -n 's/^[^(]*(\([^)]*)\)).*in \([0-9]*\) milliseconds .*/\2 \1/p' | sort -r -n -k1
```
I then addressed the top few failing queries by rewriting their proofs.

