### PR TITLE
Fix warning. Remove unused lemma.

### DIFF
--- a/fstar-helpers/core-models/src/abstractions/bitvec.rs
+++ b/fstar-helpers/core-models/src/abstractions/bitvec.rs
@@ -337,23 +337,6 @@ pub mod int_vec_interp {
                                 BitVec::[< from_ $name >](iv)
                             }
                         }
-
-                        #[doc = concat!("Lemma that asserts that applying ", stringify!(BitVec::<$n>::from)," and then ", stringify!($name::from), " is the identity.")]
-                        #[hax_lib::fstar::before("[@@ $SIMPLIFICATION_LEMMA ]")]
-                        #[hax_lib::opaque]
-                        #[hax_lib::lemma]
-                        #[hax_lib::fstar::smt_pat(BitVec::[< to_ $name >](BitVec::[<from_ $name>](x)))]
-                        pub fn lemma_cancel_iv(x: $name) -> Proof<{
-                            hax_lib::eq(BitVec::[< to_ $name >](BitVec::[<from_ $name>](x)), x)
-                        }> {}
-                        #[doc = concat!("Lemma that asserts that applying ", stringify!($name::from)," and then ", stringify!(BitVec::<$n>::from), " is the identity.")]
-                        #[hax_lib::fstar::before("[@@ $SIMPLIFICATION_LEMMA ]")]
-                        #[hax_lib::opaque]
-                        #[hax_lib::lemma]
-                        #[hax_lib::fstar::smt_pat(BitVec::[< from_ $name >](BitVec::[<to_ $name>](x)))]
-                        pub fn lemma_cancel_bv(x: BitVec<$n>) -> Proof<{
-                            hax_lib::eq(BitVec::[< from_ $name >](BitVec::[<to_ $name>](x)), x)
-                        }> {}
                     };
                 }
             )*


### PR DESCRIPTION
Fixes the following warnings: 

```rust
warning: function `lemma_cancel_iv` is never used
   --> fstar-helpers/core-models/src/abstractions/bitvec.rs:346:32
    |
346 |                           pub fn lemma_cancel_iv(x: $name) -> Proof<{
    |                                  ^^^^^^^^^^^^^^^
...
369 | /     interpretations!(256; i32x8 [i32; 8], i64x4 [i64; 4], i16x16 [i16; 16], i128x2 [i128; 2], i8x32 [i8; 32],
370 | |              u32x8 [u32; 8], u64x4 [u64; 4], u16x16 [u16; 16]);
    | |______________________________________________________________- in this macro invocation
    |
    = note: `#[warn(dead_code)]` on by default
    = note: this warning originates in the macro `interpretations` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: function `lemma_cancel_bv` is never used
   --> fstar-helpers/core-models/src/abstractions/bitvec.rs:354:32
    |
354 |                           pub fn lemma_cancel_bv(x: BitVec<$n>) -> Proof<{
    |                                  ^^^^^^^^^^^^^^^
...
369 | /     interpretations!(256; i32x8 [i32; 8], i64x4 [i64; 4], i16x16 [i16; 16], i128x2 [i128; 2], i8x32 [i8; 32],
370 | |              u32x8 [u32; 8], u64x4 [u64; 4], u16x16 [u16; 16]);
    | |______________________________________________________________- in this macro invocation
    |
    = note: this warning originates in the macro `interpretations` (in Nightly builds, run with -Z macro-backtrace for more info)```