### PR TITLE
Fix warning. Unused Import.

### DIFF
--- a/secrets/src/int/classify_public.rs
+++ b/secrets/src/int/classify_public.rs
@@ -2,6 +2,7 @@
 //! We give definitions for all conversions so that they can be tested.
 //! We define no-ops here and force inlining, to ensure that these are free.
 
+#[cfg(not(hax))]
 use crate::traits::*;
 
 // TODO: Remove hax exemptions once this is supported.


### PR DESCRIPTION
Fixes warning when extracting libcrux-sha3

```rust
warning: unused import: `crate::traits::*`
 --> secrets/src/int/classify_public.rs:5:5
  |
5 | use crate::traits::*;
  |     ^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```