### PR TITLE
Blake2: implement `libcrux_traits::digest` traits for supported digest sizes only

### DIFF
--- a/blake2/src/impl_digest_trait.rs
+++ b/blake2/src/impl_digest_trait.rs
@@ -1,9 +1,134 @@
 use crate::impl_hacl::*;
 use libcrux_traits::digest::{arrayref, slice, DigestIncrementalBase, Hasher, UpdateError};
 
+// Implements sets of allowed digest sizes
+mod digest_size_support {
+    pub(super) struct Blake2bOutSupport;
+    pub(super) struct Blake2sOutSupport;
+
+    // a marker trait indicating whether something is supported
+    pub(super) trait SupportsLen<const LEN: usize> {}
+
+    // this helps us implement SupportsLen for more than one number with little code
+
+    macro_rules! support_out_lens {
+    ($ty:ty, $($supported:expr),*) => {
+        $( impl SupportsLen<$supported> for $ty {})*
+    };
+}
+    support_out_lens!(
+        Blake2bOutSupport,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        45,
+        46,
+        47,
+        48,
+        49,
+        50,
+        51,
+        52,
+        53,
+        54,
+        55,
+        56,
+        57,
+        58,
+        59,
+        60,
+        61,
+        62,
+        63,
+        64
+    );
+    support_out_lens!(
+        Blake2sOutSupport,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32
+    );
+}
+
+use digest_size_support::{Blake2bOutSupport, Blake2sOutSupport, SupportsLen};
+
 macro_rules! impl_digest_traits {
-    ($out_size:ident, $type:ty, $blake2:ty, $hasher:ty) => {
-        impl<const $out_size: usize> DigestIncrementalBase for $type {
+    ($out_size:ident, $type:ty, $blake2:ty, $hasher:ty, $set:ident) => {
+        impl<const $out_size: usize> DigestIncrementalBase for $type
+        where
+            // implement for supported digest lengths only
+            $set: SupportsLen<$out_size>,
+        {
             type IncrementalState = $blake2;
 
             fn update(state: &mut Self::IncrementalState, chunk: &[u8]) -> Result<(), UpdateError> {
@@ -19,7 +144,11 @@ macro_rules! impl_digest_traits {
             }
         }
 
-        impl<const $out_size: usize> slice::DigestIncremental for $type {
+        impl<const $out_size: usize> slice::DigestIncremental for $type
+        where
+            // implement for supported digest lengths only
+            $set: SupportsLen<$out_size>,
+        {
             fn finish(
                 state: &mut Self::IncrementalState,
                 digest: &mut [u8],
@@ -33,13 +162,21 @@ macro_rules! impl_digest_traits {
             }
         }
 
-        impl<const $out_size: usize> arrayref::DigestIncremental<$out_size> for $type {
+        impl<const $out_size: usize> arrayref::DigestIncremental<$out_size> for $type
+        where
+            // implement for supported digest lengths only
+            $set: SupportsLen<$out_size>,
+        {
             fn finish(state: &mut Self::IncrementalState, dst: &mut [u8; $out_size]) {
                 state.finalize(dst)
             }
         }
 
-        impl<const $out_size: usize> From<$blake2> for $hasher {
+        impl<const $out_size: usize> From<$blake2> for $hasher
+        where
+            // implement for supported digest lengths only
+            $set: SupportsLen<$out_size>,
+        {
             fn from(state: $blake2) -> Self {
                 Self { state }
             }
@@ -56,7 +193,8 @@ impl_digest_traits!(
     OUT_SIZE,
     Blake2bHash<OUT_SIZE>,
     Blake2b<ConstKeyLenConstDigestLen<0, OUT_SIZE>>,
-    Blake2bHasher<OUT_SIZE>
+    Blake2bHasher<OUT_SIZE>,
+    Blake2bOutSupport
 );
 
 /// A hasher for [`Blake2bHash`].
@@ -70,7 +208,8 @@ impl_digest_traits!(
     OUT_SIZE,
     Blake2sHash<OUT_SIZE>,
     Blake2s<ConstKeyLenConstDigestLen<0, OUT_SIZE>>,
-    Blake2sHasher<OUT_SIZE>
+    Blake2sHasher<OUT_SIZE>,
+    Blake2sOutSupport
 );
 
 /// A hasher for [`Blake2sHash`].

--- a/blake2/src/impl_digest_trait.rs
+++ b/blake2/src/impl_digest_trait.rs
@@ -9,8 +9,7 @@ mod digest_size_support {
     // a marker trait indicating whether something is supported
     pub(super) trait SupportsLen<const LEN: usize> {}
 
-    // this helps us implement SupportsLen for more than one number with little code
-
+    // this helps us implement SupportsLen for more than one number
     macro_rules! support_out_lens {
     ($ty:ty, $($supported:expr),*) => {
         $( impl SupportsLen<$supported> for $ty {})*


### PR DESCRIPTION
This PR implements the incremental digest traits (introduced in #1078) for only valid digest sizes, for each of the two algorithm structs `Blake2bHash<N>` and `Blake2sHash<N>`, to only allow valid hashers to be constructed.

One issue currently is that, when initializing the `Hasher` types that are based on these algorithms, the digest size needs to be checked at runtime for validity. The changes in this PR mean that, for these hasher types, code that initializes hashers with invalid digest sizes will not compile.

```rust
// This will not compile, because the provided digest sizes are not valid
// let hasher: Blake2bHasher<0> = todo!();
// let hasher: Blake2bHasher<65> = todo!();

// This will compile, because the digest size 32 is valid
let hasher: Blake2bHasher<32> = todo!();
```

These changes will also be helpful later on when implementing a `Hasher::new()` API that does not require a runtime check for digest size validity:
```rust
let hasher = Blake2bHasher::<32>::new();

// This will not compile, because the digest size 0 is invalid
let hasher = Blake2bHasher::<0>::new();
```