### PR TITLE
Add API for initializing digest state

### DIFF
--- a/blake2/tests/blake2.rs
+++ b/blake2/tests/blake2.rs
@@ -1,5 +1,4 @@
 use libcrux_blake2::{Blake2bBuilder, Blake2bHasher, Blake2sBuilder, Blake2sHasher};
-
 #[test]
 fn test_blake2b() {
     let mut got_hash = [0; 32];
@@ -227,10 +226,7 @@ fn test_digest_traits_2s() {
 
     // test unkeyed, with const key and digest len
     let expected_hash = b"\xf2\x01\x46\xc0\x54\xf9\xdd\x6b\x67\x64\xb6\xc0\x93\x57\xf7\xcd\x75\x51\xdf\xbc\xba\x54\x59\x72\xa4\xc8\x16\x6d\xf8\xaf\xde\x60";
-    let mut hasher: Blake2sHasher<_> = Blake2sBuilder::new_unkeyed()
-        .build_const_digest_len()
-        .unwrap()
-        .into();
+    let mut hasher = Blake2sHasher::<32>::new();
     hasher.update(b"this is a test").unwrap();
     hasher.finish(&mut got_hash);
 
@@ -256,10 +252,7 @@ fn test_digest_traits_2b() {
 
     // test unkeyed, with const key and digest len
     let expected_hash = b"\xe9\xed\x14\x1d\xf1\xce\xbf\xc8\x9e\x46\x6c\xe0\x89\xee\xdd\x4f\x12\x5a\xa7\x57\x15\x01\xa0\xaf\x87\x1f\xab\x60\x59\x71\x17\xb7";
-    let mut hasher: Blake2bHasher<_> = Blake2bBuilder::new_unkeyed()
-        .build_const_digest_len()
-        .unwrap()
-        .into();
+    let mut hasher = Blake2bHasher::<32>::new();
     hasher.update(b"this is a test").unwrap();
     hasher.finish(&mut got_hash);
 

--- a/sha2/src/impl_digest_trait.rs
+++ b/sha2/src/impl_digest_trait.rs
@@ -2,7 +2,9 @@ use crate::impl_hacl::*;
 
 use libcrux_traits::Digest;
 
-use libcrux_traits::digest::{arrayref, slice, DigestIncrementalBase, UpdateError};
+use libcrux_traits::digest::{
+    arrayref, slice, DigestIncrementalBase, InitializeDigestState, UpdateError,
+};
 
 // Streaming API - This is the recommended one.
 // For implementations based on hacl_rs (over hacl-c)
@@ -37,6 +39,13 @@ macro_rules! impl_hash {
 
 
         }
+
+        impl InitializeDigestState for $state_name {
+            fn new() -> Self {
+                Self::default()
+            }
+        }
+
         impl DigestIncrementalBase for $name {
             type IncrementalState = $state_name;
             /// Add the `payload` to the digest.

--- a/sha2/tests/sha2.rs
+++ b/sha2/tests/sha2.rs
@@ -77,3 +77,17 @@ fn shaclone() {
     assert_eq!(digest, digest_2);
     assert_eq!(digest, libcrux_sha2::sha512(b"test 512more 512"));
 }
+
+// test the incremental digest functionality provided by the `libcrux_traits` crate
+#[test]
+fn test_digest_traits() {
+    let expected = "8683520e19e5b33db33c8fb90918c0c96fcdfd9a17c695ce0f0ea2eaa0c95956";
+
+    // incremental API
+    let mut hasher = libcrux_sha2::Sha256Hasher::new();
+    hasher.update(b"libcrux sha2 256 tests").unwrap();
+    let mut d = [0u8; 32];
+    hasher.finish(&mut d);
+
+    assert_eq!(hex::encode(d), expected);
+}

--- a/traits/src/digest.rs
+++ b/traits/src/digest.rs
@@ -44,11 +44,17 @@ mod error_in_core {
 /// - [`owned::DigestIncremental`]
 pub trait DigestIncrementalBase {
     /// The digest state.
-    type IncrementalState;
+    type IncrementalState: InitializeDigestState;
     /// Reset the digest state.
     fn reset(state: &mut Self::IncrementalState);
     /// Update the digest state with the `payload`.
     fn update(state: &mut Self::IncrementalState, payload: &[u8]) -> Result<(), UpdateError>;
+}
+
+/// Base trait for digest state initialization.
+pub trait InitializeDigestState {
+    /// Initialize a new incremental digest state.
+    fn new() -> Self;
 }
 
 #[derive(Clone)]
@@ -91,6 +97,13 @@ impl<const N: usize, D: DigestIncrementalBase> Hasher<N, D> {
     /// Reset the digest state.
     pub fn reset(&mut self) {
         D::reset(&mut self.state)
+    }
+
+    /// Initialize a hasher.
+    pub fn new() -> Self {
+        Self {
+            state: D::IncrementalState::new(),
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds more convenient APIs for initializing the digest state associated with an implementor `D` of `DigestIncrementalBase`. A `D::IncrementalState` can now be initialized by calling the `new()` method.

A new API is also added to `libcrux_traits::digest::Hasher`, that builds on this API:
```rust
/// Initialize a hasher.
pub fn new() -> Self {
    Self {
        state: D::IncrementalState::new(),
    }
}
``` 
Using `Hasher::new()` to initialize hashers:
```rust
// type aliases for `libcrux_traits::digest::Hasher<_,_>`
let mut hasher = libcrux_sha2::Sha256Hasher::new();
let mut hasher = libcrux_blake2::Blake2sHasher::<32>::new();
```
Additionally, the tests in the `blake2` and `sha2` crates are updated to include tests for this API.

This PR is based on the branch in:
- https://github.com/cryspen/libcrux/pull/1154

This PR addresses #1156 