### PR TITLE
Blake2: Implement `Hash` traits on top of `DigestIncremental` API

### DIFF
--- a/traits/src/digest/arrayref.rs
+++ b/traits/src/digest/arrayref.rs
@@ -7,12 +7,15 @@
 pub enum HashError {
     /// The length of the provided payload is invalid.
     InvalidPayloadLength,
+    /// Indicates an unknown error.
+    Unknown,
 }
 
 impl core::fmt::Display for HashError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let text = match self {
             HashError::InvalidPayloadLength => "the length of the provided payload is invalid",
+            HashError::Unknown => "indicates an unknown error",
         };
 
         f.write_str(text)

--- a/traits/src/digest/slice.rs
+++ b/traits/src/digest/slice.rs
@@ -46,6 +46,8 @@ pub enum HashError {
     InvalidDigestLength,
     /// The length of the provided payload is invalid.
     InvalidPayloadLength,
+    /// Indicates an unknown error.
+    Unknown,
 }
 
 impl core::fmt::Display for HashError {
@@ -53,6 +55,7 @@ impl core::fmt::Display for HashError {
         let text = match self {
             HashError::InvalidDigestLength => "the length of the provided digest buffer is invalid",
             HashError::InvalidPayloadLength => "the length of the provided payload is invalid",
+            HashError::Unknown => "indicates an unknown error",
         };
 
         f.write_str(text)
@@ -70,6 +73,7 @@ impl From<arrayref::HashError> for HashError {
     fn from(e: arrayref::HashError) -> Self {
         match e {
             arrayref::HashError::InvalidPayloadLength => Self::InvalidPayloadLength,
+            arrayref::HashError::Unknown => Self::Unknown,
         }
     }
 }


### PR DESCRIPTION
This pull request implements `arrayref::Hash` and `slice::Hash` on top of the `DigestIncremental` API for Blake2.

This PR addresses #1156