### PR TITLE
Add provided method `generate_pair` to ECDH traits

### DIFF
--- a/traits/src/ecdh/arrayref.rs
+++ b/traits/src/ecdh/arrayref.rs
@@ -21,6 +21,17 @@ pub trait EcdhArrayref<const RAND_LEN: usize, const SECRET_LEN: usize, const PUB
         secret: &[U8; SECRET_LEN],
     ) -> Result<(), SecretToPublicError>;
 
+    /// Generate a Diffie-Hellman secret value and derive the
+    /// corresponding public value in one step.
+    fn generate_pair(
+        public: &mut [u8; PUBLIC_LEN],
+        secret: &mut [U8; SECRET_LEN],
+        rand: &[U8; RAND_LEN],
+    ) -> Result<(), GenerateSecretError> {
+        Self::generate_secret(secret, rand)?;
+        Self::secret_to_public(public, secret).map_err(|_| GenerateSecretError::Unknown)
+    }
+
     /// Derive a Diffie-Hellman shared secret from a public and a
     /// secret value.
     ///

--- a/traits/src/ecdh/owned.rs
+++ b/traits/src/ecdh/owned.rs
@@ -18,6 +18,16 @@ pub trait EcdhOwned<const RAND_LEN: usize, const SECRET_LEN: usize, const PUBLIC
     fn secret_to_public(secret: &[U8; SECRET_LEN])
         -> Result<[u8; PUBLIC_LEN], SecretToPublicError>;
 
+    /// Generate a Diffie-Hellman secret value and derive the
+    /// corresponding public value in one step.
+    fn generate_pair(
+        rand: &[U8; RAND_LEN],
+    ) -> Result<([u8; PUBLIC_LEN], [U8; SECRET_LEN]), GenerateSecretError> {
+        let secret = Self::generate_secret(rand)?;
+        let public = Self::secret_to_public(&secret).map_err(|_| GenerateSecretError::Unknown)?;
+        Ok((public, secret))
+    }
+
     /// Derive a Diffie-Hellman shared secret from a public and a
     /// secret value.
     ///

--- a/traits/src/ecdh/slice.rs
+++ b/traits/src/ecdh/slice.rs
@@ -14,6 +14,17 @@ pub trait EcdhSlice {
     /// Derive a Diffie-Hellman public value from a secret value.
     fn secret_to_public(public: &mut [u8], secret: &[U8]) -> Result<(), SecretToPublicError>;
 
+    /// Generate a Diffie-Hellman secret value and derive the
+    /// corresponding public value in one step.
+    fn generate_pair(
+        public: &mut [u8],
+        secret: &mut [U8],
+        rand: &[U8],
+    ) -> Result<(), GenerateSecretError> {
+        Self::generate_secret(secret, rand)?;
+        Self::secret_to_public(public, secret).map_err(|_| GenerateSecretError::Unknown)
+    }
+
     /// Derive a Diffie-Hellman shared secret from a public and a
     /// secret value.
     ///


### PR DESCRIPTION
This is just a convenience that saves you from doing the same manually.