### PR TITLE
Fix doc warnings in `libcrux-hacl-rs`

### DIFF
--- a/hacl-rs/src/bignum/bignum256.rs
+++ b/hacl-rs/src/bignum/bignum256.rs
@@ -13,7 +13,7 @@ Write `a + b mod 2^256` in `res`.
 
   This functions returns the carry.
 
-  The arguments a, b and res are meant to be 256-bit bignums, i.e. uint64_t[4]
+  The arguments a, b and res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`
 */
 pub fn add(a: &[u64], b: &[u64], res: &mut [u64]) -> u64 {
     let mut c: [u64; 1] = [0u64; 1usize];
@@ -45,7 +45,7 @@ Write `a - b mod 2^256` in `res`.
 
   This functions returns the carry.
 
-  The arguments a, b and res are meant to be 256-bit bignums, i.e. uint64_t[4]
+  The arguments a, b and res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`
 */
 pub fn sub(a: &[u64], b: &[u64], res: &mut [u64]) -> u64 {
     let mut c: [u64; 1] = [0u64; 1usize];
@@ -76,7 +76,7 @@ pub fn sub(a: &[u64], b: &[u64], res: &mut [u64]) -> u64 {
 /**
 Write `(a + b) mod n` in `res`.
 
-  The arguments a, b, n and the outparam res are meant to be 256-bit bignums, i.e. uint64_t[4].
+  The arguments a, b, n and the outparam res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -142,7 +142,7 @@ pub fn add_mod(n: &[u64], a: &[u64], b: &[u64], res: &mut [u64]) {
 /**
 Write `(a - b) mod n` in `res`.
 
-  The arguments a, b, n and the outparam res are meant to be 256-bit bignums, i.e. uint64_t[4].
+  The arguments a, b, n and the outparam res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -209,8 +209,8 @@ pub fn sub_mod(n: &[u64], a: &[u64], b: &[u64], res: &mut [u64]) {
 /**
 Write `a * b` in `res`.
 
-  The arguments a and b are meant to be 256-bit bignums, i.e. uint64_t[4].
-  The outparam res is meant to be a 512-bit bignum, i.e. uint64_t[8].
+  The arguments a and b are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
+  The outparam res is meant to be a 512-bit bignum, i.e. `uint64_t\[8\]`.
 */
 pub fn mul(a: &[u64], b: &[u64], res: &mut [u64]) {
     (res[0usize..8usize]).copy_from_slice(&[0u64; 8usize]);
@@ -245,8 +245,8 @@ pub fn mul(a: &[u64], b: &[u64], res: &mut [u64]) {
 /**
 Write `a * a` in `res`.
 
-  The argument a is meant to be a 256-bit bignum, i.e. uint64_t[4].
-  The outparam res is meant to be a 512-bit bignum, i.e. uint64_t[8].
+  The argument a is meant to be a 256-bit bignum, i.e. `uint64_t\[4\]`.
+  The outparam res is meant to be a 512-bit bignum, i.e. `uint64_t\[8\]`.
 */
 pub fn sqr(a: &[u64], res: &mut [u64]) {
     (res[0usize..8usize]).copy_from_slice(&[0u64; 8usize]);
@@ -476,8 +476,8 @@ fn bn_slow_precomp(n: &[u64], mu: u64, r2: &[u64], a: &[u64], res: &mut [u64]) {
 /**
 Write `a mod n` in `res`.
 
-  The argument a is meant to be a 512-bit bignum, i.e. uint64_t[8].
-  The argument n and the outparam res are meant to be 256-bit bignums, i.e. uint64_t[4].
+  The argument a is meant to be a 512-bit bignum, i.e. `uint64_t\[8\]`.
+  The argument n and the outparam res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
 
   The function returns false if any of the following preconditions are violated,
   true otherwise.
@@ -863,7 +863,7 @@ fn exp_consttime(nBits: u32, n: &[u64], a: &[u64], bBits: u32, b: &[u64], res: &
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. uint64_t[4].
+  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
   number of significant bits of b. A tighter bound results in faster execution
@@ -894,7 +894,7 @@ pub fn mod_exp_vartime(n: &[u64], a: &[u64], bBits: u32, b: &[u64], res: &mut [u
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. uint64_t[4].
+  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
   number of significant bits of b. A tighter bound results in faster execution
@@ -925,7 +925,7 @@ pub fn mod_exp_consttime(n: &[u64], a: &[u64], bBits: u32, b: &[u64], res: &mut 
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. uint64_t[4].
+  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -999,7 +999,7 @@ pub fn mod_inv_prime_vartime(n: &[u64], a: &[u64], res: &mut [u64]) -> bool {
 /**
 Heap-allocate and initialize a montgomery context.
 
-  The argument n is meant to be a 256-bit bignum, i.e. uint64_t[4].
+  The argument n is meant to be a 256-bit bignum, i.e. `uint64_t\[4\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -1031,8 +1031,8 @@ pub fn mont_ctx_init(n: &[u64]) -> Box<[super::base::bn_mont_ctx_u64]> {
 /**
 Write `a mod n` in `res`.
 
-  The argument a is meant to be a 512-bit bignum, i.e. uint64_t[8].
-  The outparam res is meant to be a 256-bit bignum, i.e. uint64_t[4].
+  The argument a is meant to be a 512-bit bignum, i.e. `uint64_t\[8\]`.
+  The outparam res is meant to be a 256-bit bignum, i.e. `uint64_t\[4\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum256_mont_ctx_init.
 */
 pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u64], a: &[u64], res: &mut [u64]) {
@@ -1045,7 +1045,7 @@ pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u64], a: &[u64], res: &mut [u64
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a and the outparam res are meant to be 256-bit bignums, i.e. uint64_t[4].
+  The arguments a and the outparam res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum256_mont_ctx_init.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
@@ -1077,7 +1077,7 @@ pub fn mod_exp_vartime_precomp(
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a and the outparam res are meant to be 256-bit bignums, i.e. uint64_t[4].
+  The arguments a and the outparam res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum256_mont_ctx_init.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
@@ -1109,7 +1109,7 @@ pub fn mod_exp_consttime_precomp(
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  The argument a and the outparam res are meant to be 256-bit bignums, i.e. uint64_t[4].
+  The argument a and the outparam res are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum256_mont_ctx_init.
 
   Before calling this function, the caller will need to ensure that the following
@@ -1267,7 +1267,7 @@ pub fn bn_to_bytes_le(b: &[u64], res: &mut [u8]) {
 /**
 Returns 2^64 - 1 if a < b, otherwise returns 0.
 
- The arguments a and b are meant to be 256-bit bignums, i.e. uint64_t[4].
+ The arguments a and b are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
 */
 pub fn lt_mask(a: &[u64], b: &[u64]) -> u64 {
     let mut acc: [u64; 1] = [0u64; 1usize];
@@ -1282,7 +1282,7 @@ pub fn lt_mask(a: &[u64], b: &[u64]) -> u64 {
 /**
 Returns 2^64 - 1 if a = b, otherwise returns 0.
 
- The arguments a and b are meant to be 256-bit bignums, i.e. uint64_t[4].
+ The arguments a and b are meant to be 256-bit bignums, i.e. `uint64_t\[4\]`.
 */
 pub fn eq_mask(a: &[u64], b: &[u64]) -> u64 {
     let mut mask: [u64; 1] = [0xFFFFFFFFFFFFFFFFu64; 1usize];

--- a/hacl-rs/src/bignum/bignum256_32.rs
+++ b/hacl-rs/src/bignum/bignum256_32.rs
@@ -13,7 +13,7 @@ Write `a + b mod 2^256` in `res`.
 
   This functions returns the carry.
 
-  The arguments a, b and res are meant to be 256-bit bignums, i.e. uint32_t[8]
+  The arguments a, b and res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`
 */
 pub fn add(a: &[u32], b: &[u32], res: &mut [u32]) -> u32 {
     let mut c: [u32; 1] = [0u32; 1usize];
@@ -45,7 +45,7 @@ Write `a - b mod 2^256` in `res`.
 
   This functions returns the carry.
 
-  The arguments a, b and res are meant to be 256-bit bignums, i.e. uint32_t[8]
+  The arguments a, b and res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`
 */
 pub fn sub(a: &[u32], b: &[u32], res: &mut [u32]) -> u32 {
     let mut c: [u32; 1] = [0u32; 1usize];
@@ -76,7 +76,7 @@ pub fn sub(a: &[u32], b: &[u32], res: &mut [u32]) -> u32 {
 /**
 Write `(a + b) mod n` in `res`.
 
-  The arguments a, b, n and the outparam res are meant to be 256-bit bignums, i.e. uint32_t[8].
+  The arguments a, b, n and the outparam res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -142,7 +142,7 @@ pub fn add_mod(n: &[u32], a: &[u32], b: &[u32], res: &mut [u32]) {
 /**
 Write `(a - b) mod n` in `res`.
 
-  The arguments a, b, n and the outparam res are meant to be 256-bit bignums, i.e. uint32_t[8].
+  The arguments a, b, n and the outparam res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -209,8 +209,8 @@ pub fn sub_mod(n: &[u32], a: &[u32], b: &[u32], res: &mut [u32]) {
 /**
 Write `a * b` in `res`.
 
-  The arguments a and b are meant to be 256-bit bignums, i.e. uint32_t[8].
-  The outparam res is meant to be a 512-bit bignum, i.e. uint32_t[16].
+  The arguments a and b are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
+  The outparam res is meant to be a 512-bit bignum, i.e. `uint32_t\[16\]`.
 */
 pub fn mul(a: &[u32], b: &[u32], res: &mut [u32]) {
     (res[0usize..16usize]).copy_from_slice(&[0u32; 16usize]);
@@ -245,8 +245,8 @@ pub fn mul(a: &[u32], b: &[u32], res: &mut [u32]) {
 /**
 Write `a * a` in `res`.
 
-  The argument a is meant to be a 256-bit bignum, i.e. uint32_t[8].
-  The outparam res is meant to be a 512-bit bignum, i.e. uint32_t[16].
+  The argument a is meant to be a 256-bit bignum, i.e. `uint32_t\[8\]`.
+  The outparam res is meant to be a 512-bit bignum, i.e. `uint32_t\[16\]`.
 */
 pub fn sqr(a: &[u32], res: &mut [u32]) {
     (res[0usize..16usize]).copy_from_slice(&[0u32; 16usize]);
@@ -476,8 +476,8 @@ fn bn_slow_precomp(n: &[u32], mu: u32, r2: &[u32], a: &[u32], res: &mut [u32]) {
 /**
 Write `a mod n` in `res`.
 
-  The argument a is meant to be a 512-bit bignum, i.e. uint32_t[16].
-  The argument n and the outparam res are meant to be 256-bit bignums, i.e. uint32_t[8].
+  The argument a is meant to be a 512-bit bignum, i.e. `uint32_t\[16\]`.
+  The argument n and the outparam res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
 
   The function returns false if any of the following preconditions are violated,
   true otherwise.
@@ -863,7 +863,7 @@ fn exp_consttime(nBits: u32, n: &[u32], a: &[u32], bBits: u32, b: &[u32], res: &
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. uint32_t[8].
+  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
   number of significant bits of b. A tighter bound results in faster execution
@@ -894,7 +894,7 @@ pub fn mod_exp_vartime(n: &[u32], a: &[u32], bBits: u32, b: &[u32], res: &mut [u
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. uint32_t[8].
+  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
   number of significant bits of b. A tighter bound results in faster execution
@@ -925,7 +925,7 @@ pub fn mod_exp_consttime(n: &[u32], a: &[u32], bBits: u32, b: &[u32], res: &mut 
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. uint32_t[8].
+  The arguments a, n and the outparam res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -1018,7 +1018,7 @@ pub fn mod_inv_prime_vartime(n: &[u32], a: &[u32], res: &mut [u32]) -> bool {
 /**
 Heap-allocate and initialize a montgomery context.
 
-  The argument n is meant to be a 256-bit bignum, i.e. uint32_t[8].
+  The argument n is meant to be a 256-bit bignum, i.e. `uint32_t\[8\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -1050,8 +1050,8 @@ pub fn mont_ctx_init(n: &[u32]) -> Box<[super::base::bn_mont_ctx_u32]> {
 /**
 Write `a mod n` in `res`.
 
-  The argument a is meant to be a 512-bit bignum, i.e. uint32_t[16].
-  The outparam res is meant to be a 256-bit bignum, i.e. uint32_t[8].
+  The argument a is meant to be a 512-bit bignum, i.e. `uint32_t\[16\]`.
+  The outparam res is meant to be a 256-bit bignum, i.e. `uint32_t\[8\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum256_mont_ctx_init.
 */
 pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u32], a: &[u32], res: &mut [u32]) {
@@ -1064,7 +1064,7 @@ pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u32], a: &[u32], res: &mut [u32
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a and the outparam res are meant to be 256-bit bignums, i.e. uint32_t[8].
+  The arguments a and the outparam res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum256_mont_ctx_init.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
@@ -1096,7 +1096,7 @@ pub fn mod_exp_vartime_precomp(
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a and the outparam res are meant to be 256-bit bignums, i.e. uint32_t[8].
+  The arguments a and the outparam res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum256_mont_ctx_init.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
@@ -1128,7 +1128,7 @@ pub fn mod_exp_consttime_precomp(
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  The argument a and the outparam res are meant to be 256-bit bignums, i.e. uint32_t[8].
+  The argument a and the outparam res are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum256_mont_ctx_init.
 
   Before calling this function, the caller will need to ensure that the following
@@ -1304,7 +1304,7 @@ pub fn bn_to_bytes_le(b: &[u32], res: &mut [u8]) {
 /**
 Returns 2^32 - 1 if a < b, otherwise returns 0.
 
- The arguments a and b are meant to be 256-bit bignums, i.e. uint32_t[8].
+ The arguments a and b are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
 */
 pub fn lt_mask(a: &[u32], b: &[u32]) -> u32 {
     let mut acc: [u32; 1] = [0u32; 1usize];
@@ -1319,7 +1319,7 @@ pub fn lt_mask(a: &[u32], b: &[u32]) -> u32 {
 /**
 Returns 2^32 - 1 if a = b, otherwise returns 0.
 
- The arguments a and b are meant to be 256-bit bignums, i.e. uint32_t[8].
+ The arguments a and b are meant to be 256-bit bignums, i.e. `uint32_t\[8\]`.
 */
 pub fn eq_mask(a: &[u32], b: &[u32]) -> u32 {
     let mut mask: [u32; 1] = [0xFFFFFFFFu32; 1usize];

--- a/hacl-rs/src/bignum/bignum32.rs
+++ b/hacl-rs/src/bignum/bignum32.rs
@@ -13,14 +13,14 @@ Write `a + b mod 2 ^ (32 * len)` in `res`.
 
   This function returns the carry.
 
-  @param[in] len Number of limbs.
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must not
+  - input `len`: Number of limbs.
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must not
     partially overlap the memory locations of `b` or `res`. May have exactly equal memory
     location to `b` or `res`.
-  @param[in] b Points to `len` number of limbs, i.e. `uint32_t[len]`. Must not
+  - input `b`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must not
     partially overlap the memory locations of `a` or `res`. May have exactly
     equal memory location to `a` or `res`.
-  @param[out] res Points to `len` number of limbs where the carry is written, i.e. `uint32_t[len]`.
+  - output `res`: Points to `len` number of limbs where the carry is written, i.e. ``uint32_t\[len\]``.
     Must not partially overlap the memory locations of `a` or `b`. May have
     exactly equal memory location to `a` or `b`.
 */
@@ -33,14 +33,14 @@ Write `a - b mod 2 ^ (32 * len)` in `res`.
 
   This functions returns the carry.
 
-  @param[in] len Number of limbs.
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must not
+  - input `len`: Number of limbs.
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must not
     partially overlap the memory locations of `b` or `res`. May have exactly
     equal memory location to `b` or `res`.
-  @param[in] b Points to `len` number of limbs, i.e. `uint32_t[len]`. Must not
+  - input `b`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must not
     partially overlap the memory locations of `a` or `res`. May have exactly
     equal memory location to `a` or `res`.
-  @param[out] res Points to `len` number of limbs where the carry is written, i.e. `uint32_t[len]`.
+  - output `res`: Points to `len` number of limbs where the carry is written, i.e. ``uint32_t\[len\]``.
     Must not partially overlap the memory locations of `a` or `b`. May have
     exactly equal memory location to `a` or `b`.
 */
@@ -51,16 +51,16 @@ pub fn sub(len: u32, a: &[u32], b: &[u32], res: &mut [u32]) -> u32 {
 /**
 Write `(a + b) mod n` in `res`.
 
-  @param[in] len Number of limbs.
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must not
+  - input `len`: Number of limbs.
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must not
     partially overlap the memory locations of `b` or `res`. May have exactly
     equal memory location to `b` or `res`.
-  @param[in] b Points to `len` number of limbs, i.e. `uint32_t[len]`. Must not
+  - input `b`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must not
     partially overlap the memory locations of `a` or `res`. May have exactly
     equal memory location to `a` or `res`.
-  @param[in] n Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `n`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `a`, `b`, and `res`.
-  @param[out] res Points to `len` number of limbs where the result is written, i.e. `uint32_t[len]`.
+  - output `res`: Points to `len` number of limbs where the result is written, i.e. ``uint32_t\[len\]``.
     Must not partially overlap the memory locations of `a` or `b`. May have
     exactly equal memory location to `a` or `b`.
 
@@ -80,16 +80,16 @@ pub fn add_mod(len: u32, n: &[u32], a: &[u32], b: &[u32], res: &mut [u32]) {
 /**
 Write `(a - b) mod n` in `res`.
 
-  @param[in] len Number of limbs.
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must not
+  - input `len`: Number of limbs.
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must not
     partially overlap the memory locations of `b` or `res`. May have exactly
     equal memory location to `b` or `res`.
-  @param[in] b Points to `len` number of limbs, i.e. `uint32_t[len]`. Must not
+  - input `b`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must not
     partially overlap the memory locations of `a` or `res`. May have exactly
     equal memory location to `a` or `res`.
-  @param[in] n Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `n`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `a`, `b`, and `res`.
-  @param[out] res Points to `len` number of limbs where the result is written, i.e. `uint32_t[len]`.
+  - output `res`: Points to `len` number of limbs where the result is written, i.e. ``uint32_t\[len\]``.
     Must not partially overlap the memory locations of `a` or `b`. May have
     exactly equal memory location to `a` or `b`.
 
@@ -105,12 +105,12 @@ pub fn sub_mod(len: u32, n: &[u32], a: &[u32], b: &[u32], res: &mut [u32]) {
 /**
 Write `a * b` in `res`.
 
-  @param[in] len Number of limbs.
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `len`: Number of limbs.
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory location of `b` and `res`.
-  @param[in] b Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `b`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory location of `a` and `res`.
-  @param[out] res Points to `2*len` number of limbs where the result is written, i.e. `uint32_t[2*len]`.
+  - output `res`: Points to `2*len` number of limbs where the result is written, i.e. ``uint32_t\[2*len\]``.
     Must be disjoint from the memory locations of `a` and `b`.
 */
 pub fn mul(len: u32, a: &[u32], b: &[u32], res: &mut [u32]) {
@@ -121,9 +121,9 @@ pub fn mul(len: u32, a: &[u32], b: &[u32], res: &mut [u32]) {
 /**
 Write `a * a` in `res`.
 
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory location of `res`.
-  @param[out] res Points to `2*len` number of limbs where the result is written, i.e. `uint32_t[2*len]`.
+  - output `res`: Points to `2*len` number of limbs where the result is written, i.e. ``uint32_t\[2*len\]``.
     Must be disjoint from the memory location of `a`.
 */
 pub fn sqr(len: u32, a: &[u32], res: &mut [u32]) {
@@ -144,11 +144,11 @@ fn bn_slow_precomp(len: u32, n: &[u32], mu: u32, r2: &[u32], a: &[u32], res: &mu
 /**
 Write `a mod n` in `res`.
 
-  @param[in] a Points to `2*len` number of limbs, i.e. `uint32_t[2*len]`. Must be
+  - input `a`: Points to `2*len` number of limbs, i.e. ``uint32_t\[2*len\]``. Must be
     disjoint from the memory location of `res`.
-  @param[in] n Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `n`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory location of `res`.
-  @param[out] res Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - output `res`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `a` and `n`.
 
   @return `false` if any precondition is violated, `true` otherwise.
@@ -191,17 +191,17 @@ Write `a ^ b mod n` in `res`.
   This function is *NOT* constant-time on the argument `b`. See the
   `mod_exp_consttime_*` functions for constant-time variants.
 
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `n` and `res`.
-  @param[in] n Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `n`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `a` and `res`.
-  @param[in] b Points to a bignum of any size, with an upper bound of `bBits` number of
+  - input `b`: Points to a bignum of any size, with an upper bound of `bBits` number of
     significant bits. Must be disjoint from the memory location of `res`.
-  @param[in] bBits An upper bound on the number of significant bits of `b`.
+  - input `bBits`: An upper bound on the number of significant bits of `b`.
     A tighter bound results in faster execution time. When in doubt, the number
     of bits for the bignum size is always a safe default, e.g. if `b` is a 4096-bit
     bignum, `bBits` should be `4096`.
-  @param[out] res Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - output `res`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `a`, `b`, and `n`.
 
   @return `false` if any preconditions are violated, `true` otherwise.
@@ -237,17 +237,17 @@ Write `a ^ b mod n` in `res`.
   This function is constant-time over its argument `b`, at the cost of a slower
   execution time than `mod_exp_vartime_*`.
 
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `n` and `res`.
-  @param[in] n Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `n`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `a` and `res`.
-  @param[in] b Points to a bignum of any size, with an upper bound of `bBits` number of
+  - input `b`: Points to a bignum of any size, with an upper bound of `bBits` number of
     significant bits. Must be disjoint from the memory location of `res`.
-  @param[in] bBits An upper bound on the number of significant bits of `b`.
+  - input `bBits`: An upper bound on the number of significant bits of `b`.
     A tighter bound results in faster execution time. When in doubt, the number
     of bits for the bignum size is always a safe default, e.g. if `b` is a 4096-bit
     bignum, `bBits` should be `4096`.
-  @param[out] res Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - output `res`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `a`, `b`, and `n`.
 
   @return `false` if any preconditions are violated, `true` otherwise.
@@ -280,11 +280,11 @@ pub fn mod_exp_consttime(
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `n` and `res`.
-  @param[in] n Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `n`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `a` and `res`.
-  @param[out] res Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - output `res`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory location of `a` and `n`.
 
   @return `false` if any preconditions (except the precondition: `n` is a prime)
@@ -386,7 +386,7 @@ pub fn mod_inv_prime_vartime(len: u32, n: &[u32], a: &[u32], res: &mut [u32]) ->
 /**
 Heap-allocate and initialize a montgomery context.
 
-  @param n Points to `len` number of limbs, i.e. `uint32_t[len]`.
+  @param n Points to `len` number of limbs, i.e. ``uint32_t\[len\]``.
 
   @return A pointer to an allocated and initialized Montgomery context is returned.
     Clients will need to call `Hacl_Bignum32_mont_ctx_free` on the return value to
@@ -419,10 +419,10 @@ pub fn mont_ctx_init(len: u32, n: &[u32]) -> Box<[super::base::bn_mont_ctx_u32]>
 /**
 Write `a mod n` in `res`.
 
-  @param[in] k Points to a Montgomery context obtained from `Hacl_Bignum32_mont_ctx_init`.
-  @param[in] a Points to `2*len` number of limbs, i.e. `uint32_t[2*len]`. Must be
+  - input `k`: Points to a Montgomery context obtained from `Hacl_Bignum32_mont_ctx_init`.
+  - input `a`: Points to `2*len` number of limbs, i.e. ``uint32_t\[2*len\]``. Must be
     disjoint from the memory location of `res`.
-  @param[out] res Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - output `res`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory location of `a`.
 */
 pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u32], a: &[u32], res: &mut [u32]) {
@@ -439,16 +439,16 @@ Write `a ^ b mod n` in `res`.
   This function is *NOT* constant-time on the argument `b`. See the
   `mod_exp_consttime_*` functions for constant-time variants.
 
-  @param[in] k Points to a Montgomery context obtained from `Hacl_Bignum32_mont_ctx_init`.
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `k`: Points to a Montgomery context obtained from `Hacl_Bignum32_mont_ctx_init`.
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory location of `res`.
-  @param[in] b Points to a bignum of any size, with an upper bound of `bBits` number of
+  - input `b`: Points to a bignum of any size, with an upper bound of `bBits` number of
     significant bits. Must be disjoint from the memory location of `res`.
-  @param[in] bBits An upper bound on the number of significant bits of `b`.
+  - input `bBits`: An upper bound on the number of significant bits of `b`.
     A tighter bound results in faster execution time. When in doubt, the number
     of bits for the bignum size is always a safe default, e.g. if `b` is a 4096-bit
     bignum, `bBits` should be `4096`.
-  @param[out] res Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - output `res`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `a` and `b`.
 
   @pre Before calling this function, the caller will need to ensure that the following
@@ -476,16 +476,16 @@ Write `a ^ b mod n` in `res`.
   This function is constant-time over its argument b, at the cost of a slower
   execution time than `mod_exp_vartime_*`.
 
-  @param[in] k Points to a Montgomery context obtained from `Hacl_Bignum32_mont_ctx_init`.
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `k`: Points to a Montgomery context obtained from `Hacl_Bignum32_mont_ctx_init`.
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory location of `res`.
-  @param[in] b Points to a bignum of any size, with an upper bound of `bBits` number of
+  - input `b`: Points to a bignum of any size, with an upper bound of `bBits` number of
     significant bits. Must be disjoint from the memory location of `res`.
-  @param[in] bBits An upper bound on the number of significant bits of `b`.
+  - input `bBits`: An upper bound on the number of significant bits of `b`.
     A tighter bound results in faster execution time. When in doubt, the number
     of bits for the bignum size is always a safe default, e.g. if `b` is a 4096-bit
     bignum, `bBits` should be `4096`.
-  @param[out] res Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - output `res`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory locations of `a` and `b`.
 
   @pre Before calling this function, the caller will need to ensure that the following
@@ -510,10 +510,10 @@ pub fn mod_exp_consttime_precomp(
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  @param[in] k Points to a Montgomery context obtained through `Hacl_Bignum32_mont_ctx_init`.
-  @param[in] a Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - input `k`: Points to a Montgomery context obtained through `Hacl_Bignum32_mont_ctx_init`.
+  - input `a`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory location of `res`.
-  @param[out] res Points to `len` number of limbs, i.e. `uint32_t[len]`. Must be
+  - output `res`: Points to `len` number of limbs, i.e. ``uint32_t\[len\]``. Must be
     disjoint from the memory location of `a`.
 
   @pre Before calling this function, the caller will need to ensure that the following
@@ -589,7 +589,7 @@ pub fn mod_inv_prime_vartime_precomp(
 Load a bid-endian bignum from memory.
 
   @param len Size of `b` as number of bytes.
-  @param b Points to `len` number of bytes, i.e. `uint8_t[len]`.
+  @param b Points to `len` number of bytes, i.e. ``uint8_t\[len\]``.
 
   @return A heap-allocated bignum of size sufficient to hold the result of
     loading `b`. Otherwise, `NULL`, if either the allocation failed, or the amount
@@ -631,7 +631,7 @@ pub fn new_bn_from_bytes_be(len: u32, b: &[u8]) -> Box<[u32]> {
 Load a little-endian bignum from memory.
 
   @param len Size of `b` as number of bytes.
-  @param b Points to `len` number of bytes, i.e. `uint8_t[len]`.
+  @param b Points to `len` number of bytes, i.e. ``uint8_t\[len\]``.
 
   @return A heap-allocated bignum of size sufficient to hold the result of
     loading `b`. Otherwise, `NULL`, if either the allocation failed, or the amount
@@ -670,10 +670,10 @@ pub fn new_bn_from_bytes_le(len: u32, b: &[u8]) -> Box<[u32]> {
 /**
 Serialize a bignum into big-endian memory.
 
-  @param[in] len Size of `b` as number of bytes.
-  @param[in] b Points to a bignum of `ceil(len/4)` size. Must be disjoint from
+  - input `len`: Size of `b` as number of bytes.
+  - input `b`: Points to a bignum of `ceil(len/4)` size. Must be disjoint from
     the memory location of `res`.
-  @param[out] res Points to `len` number of bytes, i.e. `uint8_t[len]`. Must be
+  - output `res`: Points to `len` number of bytes, i.e. ``uint8_t\[len\]``. Must be
     disjoint from the memory location of `b`.
 */
 pub fn bn_to_bytes_be(len: u32, b: &[u32], res: &mut [u8]) {
@@ -693,10 +693,10 @@ pub fn bn_to_bytes_be(len: u32, b: &[u32], res: &mut [u8]) {
 /**
 Serialize a bignum into little-endian memory.
 
-  @param[in] len Size of `b` as number of bytes.
-  @param[in] b Points to a bignum of `ceil(len/4)` size. Must be disjoint from
+  - input `len`: Size of `b` as number of bytes.
+  - input `b`: Points to a bignum of `ceil(len/4)` size. Must be disjoint from
     the memory location of `res`.
-  @param[out] res Points to `len` number of bytes, i.e. `uint8_t[len]`. Must be
+  - output `res`: Points to `len` number of bytes, i.e. ``uint8_t\[len\]``. Must be
     disjoint from the memory location of `b`.
 */
 pub fn bn_to_bytes_le(len: u32, b: &[u32], res: &mut [u8]) {
@@ -716,8 +716,8 @@ pub fn bn_to_bytes_le(len: u32, b: &[u32], res: &mut [u8]) {
 Returns 2^32 - 1 if a < b, otherwise returns 0.
 
   @param len Number of limbs.
-  @param a Points to `len` number of limbs, i.e. `uint32_t[len]`.
-  @param b Points to `len` number of limbs, i.e. `uint32_t[len]`.
+  @param a Points to `len` number of limbs, i.e. ``uint32_t\[len\]``.
+  @param b Points to `len` number of limbs, i.e. ``uint32_t\[len\]``.
 
   @return `2^32 - 1` if `a < b`, otherwise, `0`.
 */
@@ -735,8 +735,8 @@ pub fn lt_mask(len: u32, a: &[u32], b: &[u32]) -> u32 {
 Returns 2^32 - 1 if a = b, otherwise returns 0.
 
   @param len Number of limbs.
-  @param a Points to `len` number of limbs, i.e. `uint32_t[len]`.
-  @param b Points to `len` number of limbs, i.e. `uint32_t[len]`.
+  @param a Points to `len` number of limbs, i.e. ``uint32_t\[len\]``.
+  @param b Points to `len` number of limbs, i.e. ``uint32_t\[len\]``.
 
   @return `2^32 - 1` if a = b, otherwise, `0`.
 */

--- a/hacl-rs/src/bignum/bignum4096.rs
+++ b/hacl-rs/src/bignum/bignum4096.rs
@@ -13,7 +13,7 @@ Write `a + b mod 2^4096` in `res`.
 
   This functions returns the carry.
 
-  The arguments a, b and res are meant to be 4096-bit bignums, i.e. uint64_t[64]
+  The arguments a, b and res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`
 */
 pub fn add(a: &[u64], b: &[u64], res: &mut [u64]) -> u64 {
     let mut c: [u64; 1] = [0u64; 1usize];
@@ -45,7 +45,7 @@ Write `a - b mod 2^4096` in `res`.
 
   This functions returns the carry.
 
-  The arguments a, b and res are meant to be 4096-bit bignums, i.e. uint64_t[64]
+  The arguments a, b and res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`
 */
 pub fn sub(a: &[u64], b: &[u64], res: &mut [u64]) -> u64 {
     let mut c: [u64; 1] = [0u64; 1usize];
@@ -76,7 +76,7 @@ pub fn sub(a: &[u64], b: &[u64], res: &mut [u64]) -> u64 {
 /**
 Write `(a + b) mod n` in `res`.
 
-  The arguments a, b, n and the outparam res are meant to be 4096-bit bignums, i.e. uint64_t[64].
+  The arguments a, b, n and the outparam res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -142,7 +142,7 @@ pub fn add_mod(n: &[u64], a: &[u64], b: &[u64], res: &mut [u64]) {
 /**
 Write `(a - b) mod n` in `res`.
 
-  The arguments a, b, n and the outparam res are meant to be 4096-bit bignums, i.e. uint64_t[64].
+  The arguments a, b, n and the outparam res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -209,8 +209,8 @@ pub fn sub_mod(n: &[u64], a: &[u64], b: &[u64], res: &mut [u64]) {
 /**
 Write `a * b` in `res`.
 
-  The arguments a and b are meant to be 4096-bit bignums, i.e. uint64_t[64].
-  The outparam res is meant to be a 8192-bit bignum, i.e. uint64_t[128].
+  The arguments a and b are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
+  The outparam res is meant to be a 8192-bit bignum, i.e. `uint64_t\[128\]`.
 */
 pub fn mul(a: &[u64], b: &[u64], res: &mut [u64]) {
     let mut tmp: [u64; 256] = [0u64; 256usize];
@@ -220,8 +220,8 @@ pub fn mul(a: &[u64], b: &[u64], res: &mut [u64]) {
 /**
 Write `a * a` in `res`.
 
-  The argument a is meant to be a 4096-bit bignum, i.e. uint64_t[64].
-  The outparam res is meant to be a 8192-bit bignum, i.e. uint64_t[128].
+  The argument a is meant to be a 4096-bit bignum, i.e. `uint64_t\[64\]`.
+  The outparam res is meant to be a 8192-bit bignum, i.e. `uint64_t\[128\]`.
 */
 pub fn sqr(a: &[u64], res: &mut [u64]) {
     let mut tmp: [u64; 256] = [0u64; 256usize];
@@ -397,8 +397,8 @@ fn bn_slow_precomp(n: &[u64], mu: u64, r2: &[u64], a: &[u64], res: &mut [u64]) {
 /**
 Write `a mod n` in `res`.
 
-  The argument a is meant to be a 8192-bit bignum, i.e. uint64_t[128].
-  The argument n and the outparam res are meant to be 4096-bit bignums, i.e. uint64_t[64].
+  The argument a is meant to be a 8192-bit bignum, i.e. `uint64_t\[128\]`.
+  The argument n and the outparam res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
 
   The function returns false if any of the following preconditions are violated,
   true otherwise.
@@ -784,7 +784,7 @@ fn exp_consttime(nBits: u32, n: &[u64], a: &[u64], bBits: u32, b: &[u64], res: &
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. uint64_t[64].
+  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
   number of significant bits of b. A tighter bound results in faster execution
@@ -815,7 +815,7 @@ pub fn mod_exp_vartime(n: &[u64], a: &[u64], bBits: u32, b: &[u64], res: &mut [u
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. uint64_t[64].
+  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
   number of significant bits of b. A tighter bound results in faster execution
@@ -846,7 +846,7 @@ pub fn mod_exp_consttime(n: &[u64], a: &[u64], bBits: u32, b: &[u64], res: &mut 
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. uint64_t[64].
+  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -939,7 +939,7 @@ pub fn mod_inv_prime_vartime(n: &[u64], a: &[u64], res: &mut [u64]) -> bool {
 /**
 Heap-allocate and initialize a montgomery context.
 
-  The argument n is meant to be a 4096-bit bignum, i.e. uint64_t[64].
+  The argument n is meant to be a 4096-bit bignum, i.e. `uint64_t\[64\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -971,8 +971,8 @@ pub fn mont_ctx_init(n: &[u64]) -> Box<[super::base::bn_mont_ctx_u64]> {
 /**
 Write `a mod n` in `res`.
 
-  The argument a is meant to be a 8192-bit bignum, i.e. uint64_t[128].
-  The outparam res is meant to be a 4096-bit bignum, i.e. uint64_t[64].
+  The argument a is meant to be a 8192-bit bignum, i.e. `uint64_t\[128\]`.
+  The outparam res is meant to be a 4096-bit bignum, i.e. `uint64_t\[64\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum4096_mont_ctx_init.
 */
 pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u64], a: &[u64], res: &mut [u64]) {
@@ -985,7 +985,7 @@ pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u64], a: &[u64], res: &mut [u64
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a and the outparam res are meant to be 4096-bit bignums, i.e. uint64_t[64].
+  The arguments a and the outparam res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum4096_mont_ctx_init.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
@@ -1017,7 +1017,7 @@ pub fn mod_exp_vartime_precomp(
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a and the outparam res are meant to be 4096-bit bignums, i.e. uint64_t[64].
+  The arguments a and the outparam res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum4096_mont_ctx_init.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
@@ -1049,7 +1049,7 @@ pub fn mod_exp_consttime_precomp(
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  The argument a and the outparam res are meant to be 4096-bit bignums, i.e. uint64_t[64].
+  The argument a and the outparam res are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum4096_mont_ctx_init.
 
   Before calling this function, the caller will need to ensure that the following
@@ -1217,7 +1217,7 @@ pub fn bn_to_bytes_le(b: &[u64], res: &mut [u8]) {
 /**
 Returns 2^64 - 1 if a < b, otherwise returns 0.
 
- The arguments a and b are meant to be 4096-bit bignums, i.e. uint64_t[64].
+ The arguments a and b are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
 */
 pub fn lt_mask(a: &[u64], b: &[u64]) -> u64 {
     let mut acc: [u64; 1] = [0u64; 1usize];
@@ -1232,7 +1232,7 @@ pub fn lt_mask(a: &[u64], b: &[u64]) -> u64 {
 /**
 Returns 2^64 - 1 if a = b, otherwise returns 0.
 
- The arguments a and b are meant to be 4096-bit bignums, i.e. uint64_t[64].
+ The arguments a and b are meant to be 4096-bit bignums, i.e. `uint64_t\[64\]`.
 */
 pub fn eq_mask(a: &[u64], b: &[u64]) -> u64 {
     let mut mask: [u64; 1] = [0xFFFFFFFFFFFFFFFFu64; 1usize];

--- a/hacl-rs/src/bignum/bignum4096_32.rs
+++ b/hacl-rs/src/bignum/bignum4096_32.rs
@@ -13,7 +13,7 @@ Write `a + b mod 2^4096` in `res`.
 
   This functions returns the carry.
 
-  The arguments a, b and res are meant to be 4096-bit bignums, i.e. uint32_t[128]
+  The arguments a, b and res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`
 */
 pub fn add(a: &[u32], b: &[u32], res: &mut [u32]) -> u32 {
     let mut c: [u32; 1] = [0u32; 1usize];
@@ -45,7 +45,7 @@ Write `a - b mod 2^4096` in `res`.
 
   This functions returns the carry.
 
-  The arguments a, b and res are meant to be 4096-bit bignums, i.e. uint32_t[128]
+  The arguments a, b and res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`
 */
 pub fn sub(a: &[u32], b: &[u32], res: &mut [u32]) -> u32 {
     let mut c: [u32; 1] = [0u32; 1usize];
@@ -76,7 +76,7 @@ pub fn sub(a: &[u32], b: &[u32], res: &mut [u32]) -> u32 {
 /**
 Write `(a + b) mod n` in `res`.
 
-  The arguments a, b, n and the outparam res are meant to be 4096-bit bignums, i.e. uint32_t[128].
+  The arguments a, b, n and the outparam res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -142,7 +142,7 @@ pub fn add_mod(n: &[u32], a: &[u32], b: &[u32], res: &mut [u32]) {
 /**
 Write `(a - b) mod n` in `res`.
 
-  The arguments a, b, n and the outparam res are meant to be 4096-bit bignums, i.e. uint32_t[128].
+  The arguments a, b, n and the outparam res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -209,8 +209,8 @@ pub fn sub_mod(n: &[u32], a: &[u32], b: &[u32], res: &mut [u32]) {
 /**
 Write `a * b` in `res`.
 
-  The arguments a and b are meant to be 4096-bit bignums, i.e. uint32_t[128].
-  The outparam res is meant to be a 8192-bit bignum, i.e. uint32_t[256].
+  The arguments a and b are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
+  The outparam res is meant to be a 8192-bit bignum, i.e. `uint32_t\[256\]`.
 */
 pub fn mul(a: &[u32], b: &[u32], res: &mut [u32]) {
     let mut tmp: [u32; 512] = [0u32; 512usize];
@@ -220,8 +220,8 @@ pub fn mul(a: &[u32], b: &[u32], res: &mut [u32]) {
 /**
 Write `a * a` in `res`.
 
-  The argument a is meant to be a 4096-bit bignum, i.e. uint32_t[128].
-  The outparam res is meant to be a 8192-bit bignum, i.e. uint32_t[256].
+  The argument a is meant to be a 4096-bit bignum, i.e. `uint32_t\[128\]`.
+  The outparam res is meant to be a 8192-bit bignum, i.e. `uint32_t\[256\]`.
 */
 pub fn sqr(a: &[u32], res: &mut [u32]) {
     let mut tmp: [u32; 512] = [0u32; 512usize];
@@ -397,8 +397,8 @@ fn bn_slow_precomp(n: &[u32], mu: u32, r2: &[u32], a: &[u32], res: &mut [u32]) {
 /**
 Write `a mod n` in `res`.
 
-  The argument a is meant to be a 8192-bit bignum, i.e. uint32_t[256].
-  The argument n and the outparam res are meant to be 4096-bit bignums, i.e. uint32_t[128].
+  The argument a is meant to be a 8192-bit bignum, i.e. `uint32_t\[256\]`.
+  The argument n and the outparam res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
 
   The function returns false if any of the following preconditions are violated,
   true otherwise.
@@ -786,7 +786,7 @@ fn exp_consttime(nBits: u32, n: &[u32], a: &[u32], bBits: u32, b: &[u32], res: &
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. uint32_t[128].
+  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
   number of significant bits of b. A tighter bound results in faster execution
@@ -817,7 +817,7 @@ pub fn mod_exp_vartime(n: &[u32], a: &[u32], bBits: u32, b: &[u32], res: &mut [u
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. uint32_t[128].
+  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
   number of significant bits of b. A tighter bound results in faster execution
@@ -848,7 +848,7 @@ pub fn mod_exp_consttime(n: &[u32], a: &[u32], bBits: u32, b: &[u32], res: &mut 
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. uint32_t[128].
+  The arguments a, n and the outparam res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -941,7 +941,7 @@ pub fn mod_inv_prime_vartime(n: &[u32], a: &[u32], res: &mut [u32]) -> bool {
 /**
 Heap-allocate and initialize a montgomery context.
 
-  The argument n is meant to be a 4096-bit bignum, i.e. uint32_t[128].
+  The argument n is meant to be a 4096-bit bignum, i.e. `uint32_t\[128\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -973,8 +973,8 @@ pub fn mont_ctx_init(n: &[u32]) -> Box<[super::base::bn_mont_ctx_u32]> {
 /**
 Write `a mod n` in `res`.
 
-  The argument a is meant to be a 8192-bit bignum, i.e. uint32_t[256].
-  The outparam res is meant to be a 4096-bit bignum, i.e. uint32_t[128].
+  The argument a is meant to be a 8192-bit bignum, i.e. `uint32_t\[256\]`.
+  The outparam res is meant to be a 4096-bit bignum, i.e. `uint32_t\[128\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum4096_mont_ctx_init.
 */
 pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u32], a: &[u32], res: &mut [u32]) {
@@ -987,7 +987,7 @@ pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u32], a: &[u32], res: &mut [u32
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a and the outparam res are meant to be 4096-bit bignums, i.e. uint32_t[128].
+  The arguments a and the outparam res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum4096_mont_ctx_init.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
@@ -1019,7 +1019,7 @@ pub fn mod_exp_vartime_precomp(
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a and the outparam res are meant to be 4096-bit bignums, i.e. uint32_t[128].
+  The arguments a and the outparam res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum4096_mont_ctx_init.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
@@ -1051,7 +1051,7 @@ pub fn mod_exp_consttime_precomp(
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  The argument a and the outparam res are meant to be 4096-bit bignums, i.e. uint32_t[128].
+  The argument a and the outparam res are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum4096_mont_ctx_init.
 
   Before calling this function, the caller will need to ensure that the following
@@ -1219,7 +1219,7 @@ pub fn bn_to_bytes_le(b: &[u32], res: &mut [u8]) {
 /**
 Returns 2^32 - 1 if a < b, otherwise returns 0.
 
- The arguments a and b are meant to be 4096-bit bignums, i.e. uint32_t[128].
+ The arguments a and b are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
 */
 pub fn lt_mask(a: &[u32], b: &[u32]) -> u32 {
     let mut acc: [u32; 1] = [0u32; 1usize];
@@ -1234,7 +1234,7 @@ pub fn lt_mask(a: &[u32], b: &[u32]) -> u32 {
 /**
 Returns 2^32 - 1 if a = b, otherwise returns 0.
 
- The arguments a and b are meant to be 4096-bit bignums, i.e. uint32_t[128].
+ The arguments a and b are meant to be 4096-bit bignums, i.e. `uint32_t\[128\]`.
 */
 pub fn eq_mask(a: &[u32], b: &[u32]) -> u32 {
     let mut mask: [u32; 1] = [0xFFFFFFFFu32; 1usize];

--- a/hacl-rs/src/bignum/bignum64.rs
+++ b/hacl-rs/src/bignum/bignum64.rs
@@ -13,7 +13,7 @@ Write `a + b mod 2 ^ (64 * len)` in `res`.
 
   This functions returns the carry.
 
-  The arguments a, b and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len]
+  The arguments a, b and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`
 */
 pub fn add(len: u32, a: &[u64], b: &[u64], res: &mut [u64]) -> u64 {
     super::bignum_base::bn_add_eq_len_u64(len, a, b, res)
@@ -24,7 +24,7 @@ Write `a - b mod 2 ^ (64 * len)` in `res`.
 
   This functions returns the carry.
 
-  The arguments a, b and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len]
+  The arguments a, b and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`
 */
 pub fn sub(len: u32, a: &[u64], b: &[u64], res: &mut [u64]) -> u64 {
     super::bignum_base::bn_sub_eq_len_u64(len, a, b, res)
@@ -33,7 +33,7 @@ pub fn sub(len: u32, a: &[u64], b: &[u64], res: &mut [u64]) -> u64 {
 /**
 Write `(a + b) mod n` in `res`.
 
-  The arguments a, b, n and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len].
+  The arguments a, b, n and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -51,7 +51,7 @@ pub fn add_mod(len: u32, n: &[u64], a: &[u64], b: &[u64], res: &mut [u64]) {
 /**
 Write `(a - b) mod n` in `res`.
 
-  The arguments a, b, n and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len].
+  The arguments a, b, n and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -65,8 +65,8 @@ pub fn sub_mod(len: u32, n: &[u64], a: &[u64], b: &[u64], res: &mut [u64]) {
 /**
 Write `a * b` in `res`.
 
-  The arguments a and b are meant to be `len` limbs in size, i.e. uint64_t[len].
-  The outparam res is meant to be `2*len` limbs in size, i.e. uint64_t[2*len].
+  The arguments a and b are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
+  The outparam res is meant to be `2*len` limbs in size, i.e. `uint64_t\[2*len\]`.
 */
 pub fn mul(len: u32, a: &[u64], b: &[u64], res: &mut [u64]) {
     let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
@@ -76,8 +76,8 @@ pub fn mul(len: u32, a: &[u64], b: &[u64], res: &mut [u64]) {
 /**
 Write `a * a` in `res`.
 
-  The argument a is meant to be `len` limbs in size, i.e. uint64_t[len].
-  The outparam res is meant to be `2*len` limbs in size, i.e. uint64_t[2*len].
+  The argument a is meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
+  The outparam res is meant to be `2*len` limbs in size, i.e. `uint64_t\[2*len\]`.
 */
 pub fn sqr(len: u32, a: &[u64], res: &mut [u64]) {
     let mut tmp: Box<[u64]> = vec![0u64; 4u32.wrapping_mul(len) as usize].into_boxed_slice();
@@ -97,8 +97,8 @@ fn bn_slow_precomp(len: u32, n: &[u64], mu: u64, r2: &[u64], a: &[u64], res: &mu
 /**
 Write `a mod n` in `res`.
 
-  The argument a is meant to be `2*len` limbs in size, i.e. uint64_t[2*len].
-  The argument n and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len].
+  The argument a is meant to be `2*len` limbs in size, i.e. `uint64_t\[2*len\]`.
+  The argument n and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
 
   The function returns false if any of the following preconditions are violated,
   true otherwise.
@@ -135,7 +135,7 @@ pub fn r#mod(len: u32, n: &[u64], a: &[u64], res: &mut [u64]) -> bool {
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len].
+  The arguments a, n and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
   number of significant bits of b. A tighter bound results in faster execution
@@ -173,7 +173,7 @@ pub fn mod_exp_vartime(
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len].
+  The arguments a, n and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
   number of significant bits of b. A tighter bound results in faster execution
@@ -211,7 +211,7 @@ pub fn mod_exp_consttime(
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  The arguments a, n and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len].
+  The arguments a, n and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -312,7 +312,7 @@ pub fn mod_inv_prime_vartime(len: u32, n: &[u64], a: &[u64], res: &mut [u64]) ->
 /**
 Heap-allocate and initialize a montgomery context.
 
-  The argument n is meant to be `len` limbs in size, i.e. uint64_t[len].
+  The argument n is meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
 
   Before calling this function, the caller will need to ensure that the following
   preconditions are observed.
@@ -344,8 +344,8 @@ pub fn mont_ctx_init(len: u32, n: &[u64]) -> Box<[super::base::bn_mont_ctx_u64]>
 /**
 Write `a mod n` in `res`.
 
-  The argument a is meant to be `2*len` limbs in size, i.e. uint64_t[2*len].
-  The outparam res is meant to be `len` limbs in size, i.e. uint64_t[len].
+  The argument a is meant to be `2*len` limbs in size, i.e. `uint64_t\[2*len\]`.
+  The outparam res is meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum64_mont_ctx_init.
 */
 pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u64], a: &[u64], res: &mut [u64]) {
@@ -359,7 +359,7 @@ pub fn mod_precomp(k: &[super::base::bn_mont_ctx_u64], a: &[u64], res: &mut [u64
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len].
+  The arguments a and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum64_mont_ctx_init.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
@@ -392,7 +392,7 @@ pub fn mod_exp_vartime_precomp(
 /**
 Write `a ^ b mod n` in `res`.
 
-  The arguments a and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len].
+  The arguments a and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum64_mont_ctx_init.
 
   The argument b is a bignum of any size, and bBits is an upper bound on the
@@ -425,7 +425,7 @@ pub fn mod_exp_consttime_precomp(
 /**
 Write `a ^ (-1) mod n` in `res`.
 
-  The argument a and the outparam res are meant to be `len` limbs in size, i.e. uint64_t[len].
+  The argument a and the outparam res are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
   The argument k is a montgomery context obtained through Hacl_Bignum64_mont_ctx_init.
 
   Before calling this function, the caller will need to ensure that the following
@@ -621,7 +621,7 @@ pub fn bn_to_bytes_le(len: u32, b: &[u64], res: &mut [u8]) {
 /**
 Returns 2^64 - 1 if a < b, otherwise returns 0.
 
- The arguments a and b are meant to be `len` limbs in size, i.e. uint64_t[len].
+ The arguments a and b are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
 */
 pub fn lt_mask(len: u32, a: &[u64], b: &[u64]) -> u64 {
     let mut acc: [u64; 1] = [0u64; 1usize];
@@ -636,7 +636,7 @@ pub fn lt_mask(len: u32, a: &[u64], b: &[u64]) -> u64 {
 /**
 Returns 2^64 - 1 if a = b, otherwise returns 0.
 
- The arguments a and b are meant to be `len` limbs in size, i.e. uint64_t[len].
+ The arguments a and b are meant to be `len` limbs in size, i.e. `uint64_t\[len\]`.
 */
 pub fn eq_mask(len: u32, a: &[u64], b: &[u64]) -> u64 {
     let mut mask: [u64; 1] = [0xFFFFFFFFFFFFFFFFu64; 1usize];


### PR DESCRIPTION
First step towards #344.

This fixes a lot of warnings resulting from literal translation of HACL comments, which clutter up the doc output for the  other crates.
I did not change the content of the comments beyond what's needed to silence the warning, in particular, I did not e.g. change `uint64_t[8]` to an equivalent Rust type.