### PR TITLE
Improve Blake2 API using length trick and expose bounded types

### DIFF
--- a/blake2/benches/blake2.rs
+++ b/blake2/benches/blake2.rs
@@ -29,9 +29,7 @@ fn benchmarks(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("b", fmt(*payload_size)), |b| {
             b.iter(|| {
                 let mut digest = [0; 32];
-                let mut hasher = Blake2bBuilder::new_unkeyed()
-                    .build_const_digest_len()
-                    .unwrap();
+                let mut hasher = Blake2bBuilder::new_unkeyed().build_const_digest_len();
                 hasher.update(&payload).unwrap();
                 hasher.finalize(&mut digest);
             })
@@ -46,9 +44,7 @@ fn benchmarks(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("s", fmt(*payload_size)), |b| {
             b.iter(|| {
                 let mut digest = [0; 32];
-                let mut hasher = Blake2sBuilder::new_unkeyed()
-                    .build_const_digest_len()
-                    .unwrap();
+                let mut hasher = Blake2sBuilder::new_unkeyed().build_const_digest_len();
                 hasher.update(&payload).unwrap();
                 hasher.finalize(&mut digest);
             })

--- a/blake2/src/impl_digest_trait.rs
+++ b/blake2/src/impl_digest_trait.rs
@@ -3,139 +3,18 @@ use libcrux_traits::digest::{
     arrayref, slice, DigestIncrementalBase, Hasher, InitializeDigestState, UpdateError,
 };
 
-// Implements sets of allowed digest sizes
-mod digest_size_support {
-    pub(super) struct Blake2bOutSupport;
-    pub(super) struct Blake2sOutSupport;
-
-    // a marker trait indicating whether something is supported
-    pub(super) trait SupportsLen<const LEN: usize> {}
-
-    // this helps us implement SupportsLen for more than one number
-    macro_rules! support_out_lens {
-    ($ty:ty, $($supported:expr),*) => {
-        $( impl SupportsLen<$supported> for $ty {})*
-    };
-}
-    support_out_lens!(
-        Blake2bOutSupport,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23,
-        24,
-        25,
-        26,
-        27,
-        28,
-        29,
-        30,
-        31,
-        32,
-        33,
-        34,
-        35,
-        36,
-        37,
-        38,
-        39,
-        40,
-        41,
-        42,
-        43,
-        44,
-        45,
-        46,
-        47,
-        48,
-        49,
-        50,
-        51,
-        52,
-        53,
-        54,
-        55,
-        56,
-        57,
-        58,
-        59,
-        60,
-        61,
-        62,
-        63,
-        64
-    );
-    support_out_lens!(
-        Blake2sOutSupport,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23,
-        24,
-        25,
-        26,
-        27,
-        28,
-        29,
-        30,
-        31,
-        32
-    );
-}
-
-use digest_size_support::{Blake2bOutSupport, Blake2sOutSupport, SupportsLen};
+use crate::impl_hacl::SupportsOutLen;
 
 macro_rules! impl_digest_traits {
-    ($out_size:ident, $type:ty, $blake2:ty, $hasher:ty, $set:ident, $builder:ty) => {
+    ($out_size:ident, $type:ty, $blake2:ty, $hasher:ty, $set:ty, $builder:ty) => {
         // Digest state initialization
         impl<const $out_size: usize> InitializeDigestState for $blake2
         where
             // implement for supported digest lengths only
-            $set: SupportsLen<$out_size>,
+            $set: SupportsOutLen<$out_size>,
         {
             fn new() -> Self {
-                <$builder>::new_unkeyed()
-                    .build_const_digest_len()
-                    .expect("trait was implemented for invalid digest size")
-                    .into()
+                <$builder>::new_unkeyed().build_const_digest_len().into()
             }
         }
 
@@ -143,7 +22,7 @@ macro_rules! impl_digest_traits {
         impl<const $out_size: usize> arrayref::Hash<$out_size> for $type
         where
             // implement for supported digest lengths only
-            $set: SupportsLen<$out_size>,
+            $set: SupportsOutLen<$out_size>,
         {
             fn hash(
                 digest: &mut [u8; $out_size],
@@ -167,7 +46,7 @@ macro_rules! impl_digest_traits {
         impl<const $out_size: usize> slice::Hash for $type
         where
             // implement for supported digest lengths only
-            $set: SupportsLen<$out_size>,
+            $set: SupportsOutLen<$out_size>,
         {
             fn hash(digest: &mut [u8], payload: &[u8]) -> Result<usize, slice::HashError> {
                 let digest: &mut [u8; $out_size] = digest
@@ -184,7 +63,7 @@ macro_rules! impl_digest_traits {
         impl<const $out_size: usize> DigestIncrementalBase for $type
         where
             // implement for supported digest lengths only
-            $set: SupportsLen<$out_size>,
+            $set: SupportsOutLen<$out_size>,
         {
             type IncrementalState = $blake2;
 
@@ -205,7 +84,7 @@ macro_rules! impl_digest_traits {
         impl<const $out_size: usize> slice::DigestIncremental for $type
         where
             // implement for supported digest lengths only
-            $set: SupportsLen<$out_size>,
+            $set: SupportsOutLen<$out_size>,
         {
             fn finish(
                 state: &mut Self::IncrementalState,
@@ -224,7 +103,7 @@ macro_rules! impl_digest_traits {
         impl<const $out_size: usize> arrayref::DigestIncremental<$out_size> for $type
         where
             // implement for supported digest lengths only
-            $set: SupportsLen<$out_size>,
+            $set: SupportsOutLen<$out_size>,
         {
             fn finish(state: &mut Self::IncrementalState, dst: &mut [u8; $out_size]) {
                 state.finalize(dst)
@@ -235,7 +114,7 @@ macro_rules! impl_digest_traits {
         impl<const $out_size: usize> From<$blake2> for $hasher
         where
             // implement for supported digest lengths only
-            $set: SupportsLen<$out_size>,
+            $set: SupportsOutLen<$out_size>,
         {
             fn from(state: $blake2) -> Self {
                 Self { state }
@@ -254,7 +133,7 @@ impl_digest_traits!(
     Blake2bHash<OUT_SIZE>,
     Blake2b<ConstKeyLenConstDigestLen<0, OUT_SIZE>>,
     Blake2bHasher<OUT_SIZE>,
-    Blake2bOutSupport,
+    Blake2b<LengthBounds>,
     Blake2bBuilder<'_, &()>
 );
 
@@ -270,7 +149,7 @@ impl_digest_traits!(
     Blake2sHash<OUT_SIZE>,
     Blake2s<ConstKeyLenConstDigestLen<0, OUT_SIZE>>,
     Blake2sHasher<OUT_SIZE>,
-    Blake2sOutSupport,
+    Blake2s<LengthBounds>,
     Blake2sBuilder<'_, &()>
 );
 

--- a/blake2/src/impl_hacl/blake2b.rs
+++ b/blake2/src/impl_hacl/blake2b.rs
@@ -10,7 +10,10 @@ use crate::hacl::hash_blake2b::{
     update0,
 };
 
-use super::{ConstDigestLen, ConstKeyLen, ConstKeyLenConstDigestLen, Dynamic, Error};
+use super::{
+    ConstDigestLen, ConstKeyLen, ConstKeyLenConstDigestLen, Dynamic, Error, LengthBounds,
+    SupportsKeyLen, SupportsOutLen,
+};
 
 const PARAM_LEN: usize = 16;
 const MAX_LEN: usize = 64;
@@ -73,11 +76,10 @@ impl<'a> Blake2bBuilder<'a, &'a ()> {
     /// Constructs the [`Blake2b`] hasher for unkeyed hashes and constant digest length.
     pub fn build_const_digest_len<const OUT_LEN: usize>(
         self,
-    ) -> Result<Blake2b<ConstKeyLenConstDigestLen<0, OUT_LEN>>, Error> {
-        if OUT_LEN < 1 || OUT_LEN > MAX_LEN {
-            return Err(Error::InvalidDigestLength);
-        }
-
+    ) -> Blake2b<ConstKeyLenConstDigestLen<0, OUT_LEN>>
+    where
+        Blake2b<LengthBounds>: SupportsOutLen<OUT_LEN>,
+    {
         let digest_length = OUT_LEN as u8;
         let key_length = 0;
 
@@ -105,26 +107,25 @@ impl<'a> Blake2bBuilder<'a, &'a ()> {
             snd: &[],
         };
 
-        Ok(Blake2b {
+        Blake2b {
             state: malloc_raw(kk, key),
             _phantom: PhantomData,
-        })
+        }
     }
 }
 
-impl<'a, const KEY_LEN: usize> Blake2bBuilder<'a, &'a [u8; KEY_LEN]> {
+impl<'a, const KEY_LEN: usize> Blake2bBuilder<'a, &'a [u8; KEY_LEN]>
+where
+    Blake2b<LengthBounds>: SupportsKeyLen<KEY_LEN>,
+{
     /// Creates the builder for an keyed hasher for keys where the length is known at compile
     /// time.
-    pub fn new_keyed_const(key: &'a [u8; KEY_LEN]) -> Result<Self, Error> {
-        if KEY_LEN > MAX_LEN {
-            return Err(Error::InvalidKeyLength);
-        }
-
-        Ok(Self {
+    pub fn new_keyed_const(key: &'a [u8; KEY_LEN]) -> Self {
+        Self {
             key,
             personal: &[0; PARAM_LEN],
             salt: &[0; PARAM_LEN],
-        })
+        }
     }
 
     /// Constructs the [`Blake2b`] hasher for hashes with const key length and dynamic digest length.
@@ -172,11 +173,10 @@ impl<'a, const KEY_LEN: usize> Blake2bBuilder<'a, &'a [u8; KEY_LEN]> {
     /// Constructs the [`Blake2b`] hasher for hashes with const key length and constant digest length.
     pub fn build_const_digest_len<const OUT_LEN: usize>(
         self,
-    ) -> Result<Blake2b<ConstKeyLenConstDigestLen<KEY_LEN, OUT_LEN>>, Error> {
-        if OUT_LEN < 1 || OUT_LEN > MAX_LEN {
-            return Err(Error::InvalidDigestLength);
-        }
-
+    ) -> Blake2b<ConstKeyLenConstDigestLen<KEY_LEN, OUT_LEN>>
+    where
+        Blake2b<LengthBounds>: SupportsOutLen<OUT_LEN>,
+    {
         // These are safe because they both are at most 64, enforced either above or in the
         // constructor.
         let key_length = KEY_LEN as u8;
@@ -206,10 +206,10 @@ impl<'a, const KEY_LEN: usize> Blake2bBuilder<'a, &'a [u8; KEY_LEN]> {
             snd: self.key,
         };
 
-        Ok(Blake2b::<ConstKeyLenConstDigestLen<KEY_LEN, OUT_LEN>> {
+        Blake2b::<ConstKeyLenConstDigestLen<KEY_LEN, OUT_LEN>> {
             state: malloc_raw(kk, key),
             _phantom: PhantomData,
-        })
+        }
     }
 }
 
@@ -268,13 +268,10 @@ impl<'a> Blake2bBuilder<'a, &'a [u8]> {
     }
 
     /// Constructs the [`Blake2b`] hasher with dynamic key length and constant digest length.
-    pub fn build_const_digest_len<const OUT_LEN: usize>(
-        self,
-    ) -> Result<Blake2b<ConstDigestLen<OUT_LEN>>, Error> {
-        if OUT_LEN < 1 || OUT_LEN > MAX_LEN {
-            return Err(Error::InvalidDigestLength);
-        }
-
+    pub fn build_const_digest_len<const OUT_LEN: usize>(self) -> Blake2b<ConstDigestLen<OUT_LEN>>
+    where
+        Blake2b<LengthBounds>: SupportsOutLen<OUT_LEN>,
+    {
         // these are safe because they both are at most 64
         let key_length = self.key.len() as u8;
         let digest_length = OUT_LEN as u8;
@@ -303,10 +300,10 @@ impl<'a> Blake2bBuilder<'a, &'a [u8]> {
             snd: self.key,
         };
 
-        Ok(Blake2b {
+        Blake2b {
             state: malloc_raw(kk, key),
             _phantom: PhantomData,
-        })
+        }
     }
 }
 

--- a/blake2/src/impl_hacl/lengths.rs
+++ b/blake2/src/impl_hacl/lengths.rs
@@ -1,0 +1,82 @@
+use super::{Blake2b, Blake2s, LengthBounds};
+
+/// A marker trait indicating whether the hash supports keys of length LEN.
+/// This trait is sealed to protect the soundness of the compile time bounds checks.
+#[allow(private_bounds)]
+pub trait SupportsKeyLen<const LEN: usize>: SupportsKeyLenInternal<LEN> {}
+
+/// A marker trait indicating whether the hash supports outputs of length LEN.
+/// This trait is sealed to protect the soundness of the compile time bounds checks.
+#[allow(private_bounds)]
+pub trait SupportsOutLen<const LEN: usize>: SupportsOutLenInternal<LEN> {}
+
+/// A marker trait indicating whether the hash supports outputs of length LEN.
+/// This is internal to seal the actual trait.
+pub(super) trait SupportsOutLenInternal<const LEN: usize> {}
+
+/// A marker trait indicating whether the hash supports keys of length LEN.
+/// This is internal to seal the actual trait.
+pub(super) trait SupportsKeyLenInternal<const LEN: usize> {}
+
+// blanket impl the public part of the sealed trait
+#[allow(private_bounds)]
+impl<T, const LEN: usize> SupportsKeyLen<LEN> for T where T: SupportsKeyLenInternal<LEN> {}
+
+// blanket impl the public part of the sealed trait
+#[allow(private_bounds)]
+impl<T, const LEN: usize> SupportsOutLen<LEN> for T where T: SupportsOutLenInternal<LEN> {}
+
+/// this helps us implement SupportsLen for more than one number
+macro_rules! support_lens {
+    ($ty:ty, $trait:ident, $($supported:expr),*) => {
+        $( impl $trait<$supported> for $ty {})*
+    };
+}
+
+// implement the private parts of the sealed trait
+
+#[rustfmt::skip]
+support_lens!(
+    Blake2b<LengthBounds>, SupportsOutLenInternal,
+     1,  2,  3,  4,  5,  6,  7,  8,
+     9, 10, 11, 12, 13, 14, 15, 16,
+    17, 18, 19, 20, 21, 22, 23, 24,
+    25, 26, 27, 28, 29, 30, 31, 32,
+    33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48,
+    49, 50, 51, 52, 53, 54, 55, 56,
+    57, 58, 59, 60, 61, 62, 63, 64
+);
+
+#[rustfmt::skip]
+support_lens!(
+    Blake2s<LengthBounds>, SupportsOutLenInternal,
+     1,  2,  3,  4,  5,  6,  7,  8,
+     9, 10, 11, 12, 13, 14, 15, 16,
+    17, 18, 19, 20, 21, 22, 23, 24,
+    25, 26, 27, 28, 29, 30, 31, 32
+);
+
+#[rustfmt::skip]
+support_lens!(
+    Blake2b<LengthBounds>, SupportsKeyLenInternal,
+     0,
+     1,  2,  3,  4,  5,  6,  7,  8,
+     9, 10, 11, 12, 13, 14, 15, 16,
+    17, 18, 19, 20, 21, 22, 23, 24,
+    25, 26, 27, 28, 29, 30, 31, 32,
+    33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48,
+    49, 50, 51, 52, 53, 54, 55, 56,
+    57, 58, 59, 60, 61, 62, 63, 64
+);
+
+#[rustfmt::skip]
+support_lens!(
+    Blake2s<LengthBounds>, SupportsKeyLenInternal,
+     0,
+     1,  2,  3,  4,  5,  6,  7,  8,
+     9, 10, 11, 12, 13, 14, 15, 16,
+    17, 18, 19, 20, 21, 22, 23, 24,
+    25, 26, 27, 28, 29, 30, 31, 32
+);

--- a/blake2/src/impl_hacl/mod.rs
+++ b/blake2/src/impl_hacl/mod.rs
@@ -3,10 +3,12 @@ extern crate alloc;
 mod blake2b;
 mod blake2s;
 mod error;
+mod lengths;
 
 pub use blake2b::{Blake2b, Blake2bBuilder};
 pub use blake2s::{Blake2s, Blake2sBuilder};
 pub use error::Error;
+pub use lengths::{SupportsKeyLen, SupportsOutLen};
 
 /// Type that holds the constants in case both key length and digest length are known at compile
 /// time.
@@ -21,3 +23,35 @@ pub struct ConstDigestLen<const OUT_LEN: usize>;
 /// Type that holds the constant in case neither the key length nor the digest length is known at
 /// compile time.
 pub struct Dynamic;
+
+/// Type that is used to bound the implementations to valid key and output lengths.
+///
+/// We implement [`SupportsKeyLen`] and [`SupportsOutLen`] for [`Blake2s<LengthBounds>`] and
+/// [`Blake2b<LengthBounds>`] with the appropriate lengths. This can be used by callers to bound
+/// their own implementations to only accept valid lengths.
+///
+/// # Example
+///
+/// ```
+/// use libcrux_blake2::{Blake2b, Blake2bBuilder, LengthBounds, SupportsKeyLen, SupportsOutLen};
+///
+/// // A function that does a keyed Blake2b and only accepts valid key lengths
+/// fn keyed_hash<const KEY_LEN: usize>(key: &[u8; KEY_LEN], msg: &[u8]) -> [u8; 32]
+/// where
+///     Blake2b<LengthBounds>: SupportsKeyLen<KEY_LEN>,
+/// {
+///     let mut hasher = Blake2bBuilder::new_keyed_const(key)
+///         .build_const_digest_len::<32>();
+///     hasher.update(msg);
+///     let mut output = [0u8; 32];
+///     hasher.finalize(&mut output);
+///     output
+/// }
+///
+/// // This compiles because Blake2b supports 32 byte keys
+/// let key = [0; 32]; // this should actually be random
+/// let msg = b"a test message";
+/// let result = keyed_hash(&key, msg);
+///
+/// ```
+pub struct LengthBounds;

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -13,4 +13,7 @@ mod impl_hacl;
 mod impl_digest_trait;
 
 pub use impl_digest_trait::{Blake2bHash, Blake2bHasher, Blake2sHash, Blake2sHasher};
-pub use impl_hacl::{Blake2b, Blake2bBuilder, Blake2s, Blake2sBuilder, Error};
+pub use impl_hacl::{
+    Blake2b, Blake2bBuilder, Blake2s, Blake2sBuilder, Error, LengthBounds, SupportsKeyLen,
+    SupportsOutLen,
+};

--- a/blake2/tests/blake2.rs
+++ b/blake2/tests/blake2.rs
@@ -7,9 +7,7 @@ fn test_blake2b() {
 
     // test unkeyed, with const key and digest len
     let expected_hash = b"\xe9\xed\x14\x1d\xf1\xce\xbf\xc8\x9e\x46\x6c\xe0\x89\xee\xdd\x4f\x12\x5a\xa7\x57\x15\x01\xa0\xaf\x87\x1f\xab\x60\x59\x71\x17\xb7";
-    let mut hasher = Blake2bBuilder::new_unkeyed()
-        .build_const_digest_len()
-        .unwrap();
+    let mut hasher = Blake2bBuilder::new_unkeyed().build_const_digest_len();
     hasher.update(b"this is a test").unwrap();
     hasher.finalize(&mut got_hash);
 
@@ -38,10 +36,7 @@ fn test_blake2b() {
 
     // test keyed, with const key and digest len
     let expected_hash = b"\x2a\xbb\x86\x16\xc6\x99\xe5\x1d\xa3\x65\xca\xb7\xad\xe0\x53\x92\xaf\xa2\xc3\xc6\x13\x08\x7f\x84\xb0\xd1\x6e\x5a\x4f\xab\xa7\xb8";
-    let mut hasher = Blake2bBuilder::new_keyed_const(b"test")
-        .unwrap()
-        .build_const_digest_len()
-        .unwrap();
+    let mut hasher = Blake2bBuilder::new_keyed_const(b"test").build_const_digest_len();
     hasher.update(b"this is a test").unwrap();
     hasher.finalize(&mut got_hash);
 
@@ -55,7 +50,6 @@ fn test_blake2b() {
 
     // test keyed, with const key len and dynamic digest len
     let mut hasher = Blake2bBuilder::new_keyed_const(b"test")
-        .unwrap()
         .build_var_digest_len(32)
         .unwrap();
     hasher.update(b"this is a test").unwrap();
@@ -74,8 +68,7 @@ fn test_blake2b() {
     // test keyed, with dynamic key len and const digest len
     let mut hasher = Blake2bBuilder::new_keyed_dynamic(b"test")
         .unwrap()
-        .build_const_digest_len()
-        .unwrap();
+        .build_const_digest_len();
     hasher.update(b"this is a test").unwrap();
     hasher.finalize(&mut got_hash);
 
@@ -106,9 +99,7 @@ fn test_blake2b() {
     assert_eq!(len, 32);
 
     let mut got_hash = [0; 64];
-    let mut hasher = Blake2bBuilder::new_unkeyed()
-        .build_const_digest_len()
-        .unwrap();
+    let mut hasher = Blake2bBuilder::new_unkeyed().build_const_digest_len();
     hasher.update(b"this is a test").unwrap();
     hasher.finalize(&mut got_hash);
     let expected_hash = b"\x61\xa5\x48\xf2\xde\x1c\x31\x8b\xa9\x1d\x52\x07\x00\x78\x61\x01\x0f\x69\xa4\x3e\xc6\x63\xfe\x48\x7d\x84\x03\x28\x2c\x93\x4e\xa7\x25\xdc\x0b\xb1\x72\x25\x6a\xc9\x96\x25\xad\x64\xcc\xa6\xa2\xc4\xd6\x1c\x65\x0a\x35\xaf\xab\x47\x87\xdc\x67\x8e\x19\x07\x1e\xf9";
@@ -122,9 +113,7 @@ fn test_blake2s() {
 
     // test unkeyed, with const key and digest len
     let expected_hash = b"\xf2\x01\x46\xc0\x54\xf9\xdd\x6b\x67\x64\xb6\xc0\x93\x57\xf7\xcd\x75\x51\xdf\xbc\xba\x54\x59\x72\xa4\xc8\x16\x6d\xf8\xaf\xde\x60";
-    let mut hasher = Blake2sBuilder::new_unkeyed()
-        .build_const_digest_len()
-        .unwrap();
+    let mut hasher = Blake2sBuilder::new_unkeyed().build_const_digest_len();
     hasher.update(b"this is a test").unwrap();
     hasher.finalize(&mut got_hash);
 
@@ -154,10 +143,7 @@ fn test_blake2s() {
 
     // test keyed, with const key and digest len
     let expected_hash = b"\x98\xfb\xfa\x89\xb3\xee\x07\x51\x9e\xe6\x2c\x18\xfe\x9d\x85\xdc\xf0\x83\x7b\x12\xae\x4d\xe7\x29\xf0\x7b\x55\xa9\x1a\x94\x80\xe8";
-    let mut hasher = Blake2sBuilder::new_keyed_const(b"test")
-        .unwrap()
-        .build_const_digest_len()
-        .unwrap();
+    let mut hasher = Blake2sBuilder::new_keyed_const(b"test").build_const_digest_len();
     hasher.update(b"this is a test").unwrap();
     hasher.finalize(&mut got_hash);
 
@@ -171,7 +157,6 @@ fn test_blake2s() {
 
     // test keyed, with const key len and dynamic digest len
     let mut hasher = Blake2sBuilder::new_keyed_const(b"test")
-        .unwrap()
         .build_var_digest_len(32)
         .unwrap();
     hasher.update(b"this is a test").unwrap();
@@ -190,8 +175,7 @@ fn test_blake2s() {
     // test keyed, with dynamic key len and const digest len
     let mut hasher = Blake2sBuilder::new_keyed_dynamic(b"test")
         .unwrap()
-        .build_const_digest_len()
-        .unwrap();
+        .build_const_digest_len();
     hasher.update(b"this is a test").unwrap();
     hasher.finalize(&mut got_hash);
 


### PR DESCRIPTION
This PR

- introduces the length trick also for key lengths
- makes use of it in the "native" (i.e. non-trait) API
- makes it possible for consumers to reuse the length trick
- do that using sealed traits, to protect soundness (i.e. so others can't implement the traits for illegal values)