### PR TITLE
[ML-KEM/ML-DSA] Remove `version` field from internal dev-dependency `libcrux-kats`

### DIFF
--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -28,7 +28,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 criterion = "0.7"
-libcrux-kats = { version = "0.0.3", path = "../crates/testing/kats", features = [
+libcrux-kats = { path = "../crates/testing/kats", features = [
     "mldsa"
 ] }
 

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -82,7 +82,7 @@ criterion = "0.7"
 libcrux-traits = { version = "0.0.4-pre.1", path = "../traits", features = [
     "generic-tests",
 ]}
-libcrux-kats = { version = "0.0.3", path = "../crates/testing/kats", features = [
+libcrux-kats = { path = "../crates/testing/kats", features = [
     "mlkem",
 ] }
 


### PR DESCRIPTION
[skip changelog]