### PR TITLE
Migrate macOS runners to `macos-15-intel`

### DIFF
--- a/.github/workflows/aead-build_test.yml
+++ b/.github/workflows/aead-build_test.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build-intel-mac:
     if: ${{ github.event_name != 'merge_group' }}
-    runs-on: macos-13
+    runs-on: macos-15-intel
     defaults:
       run:
         shell: bash

--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -120,7 +120,7 @@ jobs:
           cargo hack test --each-feature $EXCLUDE_FEATURES --verbose $RUST_TARGET_FLAG
 
   build-intel-macos:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ecdh-build-test.yml
+++ b/.github/workflows/ecdh-build-test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         bits: [32, 64]
         os:
-          - macos-13 # Intel mac
+          - macos-15-intel # Intel mac
           - macos-latest # macos-15 on apple silicon
           - ubuntu-latest
           - windows-latest
@@ -31,7 +31,7 @@ jobs:
           - bits: 32
             os: "macos-latest"
           - bits: 32
-            os: "macos-13"
+            os: "macos-15-intel"
           - bits: 32 # FIXME: Linking isn't working here yet for hacl #42
             os: "windows-latest"
 

--- a/.github/workflows/github-skip-benches-in-prs.yml.disabled
+++ b/.github/workflows/github-skip-benches-in-prs.yml.disabled
@@ -9,7 +9,7 @@ jobs:
       matrix:
         bits: [32, 64]
         os:
-          - macos-13
+          - macos-15-intel
           - macos-latest
           - ubuntu-latest
           - windows-latest
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-15-intel
           - macos-latest
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/kem-build-test.yml
+++ b/.github/workflows/kem-build-test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         bits: [32, 64]
         os:
-          - macos-13 # Intel mac
+          - macos-15-intel # Intel mac
           - macos-latest # macos-15 on apple silicon
           - ubuntu-latest
           - windows-latest
@@ -31,7 +31,7 @@ jobs:
           - bits: 32
             os: "macos-latest"
           - bits: 32
-            os: "macos-13"
+            os: "macos-15-intel"
           - bits: 32 # FIXME: Linking isn't working here yet for hacl #42
             os: "windows-latest"
 

--- a/.github/workflows/mldsa-bench.yml
+++ b/.github/workflows/mldsa-bench.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         bits: [32, 64]
         os:
-          - macos-13
+          - macos-15-intel
           - macos-latest
           - ubuntu-latest
           - windows-latest
@@ -35,7 +35,7 @@ jobs:
           - bits: 32
             os: "macos-latest"
           - bits: 32
-            os: "macos-13"
+            os: "macos-15-intel"
 
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/mldsa-build-test.yml
+++ b/.github/workflows/mldsa-build-test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         bits: [32, 64]
         os:
-          - macos-13 # Intel mac
+          - macos-15-intel # Intel mac
           - macos-latest # macos-15 on apple silicon
           - ubuntu-latest
           - ubuntu-24.04-arm
@@ -32,7 +32,7 @@ jobs:
           - bits: 32
             os: "macos-latest"
           - bits: 32
-            os: "macos-13"
+            os: "macos-15-intel"
 
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/mlkem-bench.yml
+++ b/.github/workflows/mlkem-bench.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         bits: [32, 64]
         os:
-          - macos-13
+          - macos-15-intel
           - macos-latest
           - ubuntu-latest
           - windows-latest
@@ -34,7 +34,7 @@ jobs:
           - bits: 32
             os: "macos-latest"
           - bits: 32
-            os: "macos-13"
+            os: "macos-15-intel"
 
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/mlkem-build-test.yml
+++ b/.github/workflows/mlkem-build-test.yml
@@ -166,7 +166,7 @@ jobs:
   build-intel-macos:
     if: ${{ github.event_name != 'merge_group' }}
 
-    runs-on: macos-13
+    runs-on: macos-15-intel
     defaults:
       run:
         shell: bash

--- a/.github/workflows/platform-build-test.yml
+++ b/.github/workflows/platform-build-test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         bits: [32, 64]
         os:
-          - macos-13 # Intel mac
+          - macos-15-intel # Intel mac
           - macos-latest # macos-15 on apple silicon
           - ubuntu-latest
           - windows-latest
@@ -31,7 +31,7 @@ jobs:
           - bits: 32
             os: "macos-latest"
           - bits: 32
-            os: "macos-13"
+            os: "macos-15-intel"
 
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/psq-build-test.yml
+++ b/.github/workflows/psq-build-test.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         bits: [32, 64]
         os:
-          - macos-13 # Intel mac
+          - macos-15-intel # Intel mac
           - macos-latest # macos-15 on apple silicon
           - ubuntu-latest
           - windows-latest
@@ -28,7 +28,7 @@ jobs:
           - bits: 32
             os: "macos-latest"
           - bits: 32
-            os: "macos-13"
+            os: "macos-15-intel"
 
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/secrets-build-test.yml
+++ b/.github/workflows/secrets-build-test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         bits: [32, 64]
         os:
-          - macos-13 # Intel mac
+          - macos-15-intel # Intel mac
           - macos-latest # macos-14 m1
           - ubuntu-latest
           - windows-latest
@@ -31,7 +31,7 @@ jobs:
           - bits: 32
             os: "macos-latest"
           - bits: 32
-            os: "macos-13"
+            os: "macos-15-intel"
           - bits: 32 # FIXME: Linking isn't working here yet for hacl #42
             os: "windows-latest"
 

--- a/.github/workflows/traits-build.yml
+++ b/.github/workflows/traits-build.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         bits: [32, 64]
         os:
-          - macos-13 # Intel mac
+          - macos-15-intel # Intel mac
           - macos-latest # macos-15 on apple silicon
           - ubuntu-latest
           - windows-latest
@@ -31,7 +31,7 @@ jobs:
           - bits: 32
             os: "macos-latest"
           - bits: 32
-            os: "macos-13"
+            os: "macos-15-intel"
           - bits: 32 # FIXME: Linking isn't working here yet for hacl #42
             os: "windows-latest"
 


### PR DESCRIPTION
The `macos-13` runners run out of support *tomorrow*.

[skip changelog]

Fixes #1245 