### PR TITLE
[ML-KEM] Fix test path for s390x CI

### DIFF
--- a/.github/workflows/mlkem-s390x.yml
+++ b/.github/workflows/mlkem-s390x.yml
@@ -50,4 +50,4 @@ jobs:
             cd libcrux-ml-kem/extracts/cpp_header_only/generated
             cmake -B build -G"Ninja Multi-Config"
             cmake --build build
-            ./build/Debug/ml_kem_test
+            ./build/Debug/ml_kem_test768


### PR DESCRIPTION
This was failing on the merge queue, e.g. https://github.com/cryspen/libcrux/actions/runs/20921824969/job/60109102091.

[skip changelog]