### PR TITLE
Release: Bump versions from `0.0.3/5.-pre.1` -> `0.0.3/5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,18 +55,18 @@ allow-branch = ["main"]
 [workspace.dependencies]
 hax-lib = { version = "=0.3.5" }
 libcrux-intrinsics = { version = "=0.0.4", path = "crates/utils/intrinsics" }
-libcrux-aesgcm = { version = "=0.0.5-pre.1", path = "crates/algorithms/aesgcm" }
+libcrux-aesgcm = { version = "=0.0.5", path = "crates/algorithms/aesgcm" }
 libcrux-chacha20poly1305 = { version = "=0.0.4", path = "crates/algorithms/chacha20poly1305" }
 libcrux-traits = { version = "=0.0.4", path = "traits" }
 libcrux-hacl-rs = { version = "=0.0.4", path = "crates/utils/hacl-rs" }
 libcrux-hacl = { version = "=0.0.2", path = "crates/sys/hacl" }
-libcrux-platform = { version = "=0.0.3-pre.1", path = "crates/sys/platform" }
+libcrux-platform = { version = "=0.0.3", path = "crates/sys/platform" }
 libcrux-hkdf = { version = "=0.0.4", path = "crates/algorithms/hkdf" }
 libcrux-hmac = { version = "=0.0.4", path = "crates/algorithms/hmac" }
 libcrux-sha2 = { version = "=0.0.4", path = "crates/algorithms/sha2" }
 libcrux-ed25519 = { version = "=0.0.4", path = "crates/algorithms/ed25519" }
 libcrux-ecdh = { version = "=0.0.4", path = "libcrux-ecdh" }
-libcrux-ml-kem = { version = "=0.0.5-pre.1", path = "libcrux-ml-kem" }
+libcrux-ml-kem = { version = "=0.0.5", path = "libcrux-ml-kem" }
 libcrux-kem = { version = "=0.0.4", path = "libcrux-kem" }
 libcrux-secrets = { version = "=0.0.4", path = "crates/utils/secrets" }
 
@@ -98,7 +98,7 @@ crate-type = ["staticlib", "cdylib", "lib"]
 bench = false                               # so libtest doesn't eat the arguments for criterion
 
 [build-dependencies]
-libcrux-platform = { version = "=0.0.3-pre.1", path = "crates/sys/platform" }
+libcrux-platform = { version = "=0.0.3", path = "crates/sys/platform" }
 
 [dependencies]
 libcrux-hacl-rs.workspace = true

--- a/crates/algorithms/aesgcm/CHANGELOG.md
+++ b/crates/algorithms/aesgcm/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5-pre.1] (2026-01-12)
+## [0.0.5] (2026-01-12)
 
 - [#1280](https://github.com/cryspen/libcrux/pull/1280): Update dependency `libcrux-platform`
 

--- a/crates/algorithms/aesgcm/Cargo.toml
+++ b/crates/algorithms/aesgcm/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 name = "libcrux-aesgcm"
 readme = "README.md"
 repository.workspace = true
-version = "0.0.5-pre.1"
+version = "0.0.5"
 
 [lib]
 bench = false # so libtest doesn't eat the arguments to criterion

--- a/crates/algorithms/sha3/CHANGELOG.md
+++ b/crates/algorithms/sha3/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5-pre.1] (2026-01-12)
+## [0.0.5] (2026-01-12)
 
 - [#1280](https://github.com/cryspen/libcrux/pull/1280): Update dependency `libcrux-platform`
 - [#1238](https://github.com/cryspen/libcrux/pull/1237): Remove digest type aliases

--- a/crates/algorithms/sha3/Cargo.toml
+++ b/crates/algorithms/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-sha3"
-version = "0.0.5-pre.1"
+version = "0.0.5"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -14,7 +14,7 @@ exclude = ["/proofs", "/c.sh", "/c.yaml", "/tests/tv", "tests/cavp.rs", "hax.py"
 bench = false # so libtest doesn't eat the arguments to criterion
 
 [dependencies]
-libcrux-platform = { version = "0.0.3-pre.1", path = "../../sys/platform" }
+libcrux-platform = { version = "0.0.3", path = "../../sys/platform" }
 libcrux-intrinsics = { version = "0.0.4", path = "../../utils/intrinsics" }
 libcrux-traits = { version = "=0.0.4", path = "../../../traits/" }
 hax-lib.workspace = true

--- a/crates/primitives/aead/Cargo.toml
+++ b/crates/primitives/aead/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 
 [dependencies]
 libcrux-chacha20poly1305 = { version = "0.0.4", path = "../../algorithms/chacha20poly1305", optional = true }
-libcrux-aesgcm = { version = "0.0.5-pre.1", path = "../../algorithms/aesgcm", optional = true }
+libcrux-aesgcm = { version = "0.0.5", path = "../../algorithms/aesgcm", optional = true }
 libcrux-secrets = { version = "0.0.4", path = "../../utils/secrets" }
 libcrux-traits = { version = "0.0.4", path = "../../../traits", optional = true }
 

--- a/crates/primitives/digest/Cargo.toml
+++ b/crates/primitives/digest/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [dependencies]
 libcrux-blake2 = { version = "0.0.4", path = "../../algorithms/blake2", optional = true }
 libcrux-sha2 = { version = "0.0.4", path = "../../algorithms/sha2", optional = true }
-libcrux-sha3 = { version = "0.0.5-pre.1", path = "../../algorithms/sha3", optional = true }
+libcrux-sha3 = { version = "0.0.5", path = "../../algorithms/sha3", optional = true }
 libcrux-traits = { version = "0.0.4", path = "../../../traits", optional = true }
 
 [features]

--- a/crates/sys/hacl/Cargo.toml
+++ b/crates/sys/hacl/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [build-dependencies]
 cc = { version = "1.1", features = ["parallel"] }
-libcrux-platform = { version = "=0.0.3-pre.1", path = "../platform" }
+libcrux-platform = { version = "=0.0.3", path = "../platform" }
 bindgen = { version = "0.72", optional = true }
 
 [features]

--- a/crates/sys/libjade/Cargo.toml
+++ b/crates/sys/libjade/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 
 [build-dependencies]
 cc = { version = "1.1", features = ["parallel"] }
-libcrux-platform = { version = "=0.0.3-pre.1", path = "../platform" }
+libcrux-platform = { version = "=0.0.3", path = "../platform" }
 
 [target.'cfg(not(windows))'.build-dependencies]
 bindgen = { version = "0.72", optional = true }

--- a/crates/sys/platform/CHANGELOG.md
+++ b/crates/sys/platform/CHANGELOG.md
@@ -5,6 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.3-pre.1] (2026-01-12)
+## [0.0.3] (2026-01-12)
 
 - [#1265](https://github.com/cryspen/libcrux/pull/1265): Simplify AArch64 feature checks, use atomics instead of static mut (@jrose-signal)

--- a/crates/sys/platform/Cargo.toml
+++ b/crates/sys/platform/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 readme.workspace = true
 description = "Platform detection crate for libcrux."
 
-version = "0.0.3-pre.1"
+version = "0.0.3"
 
 [dependencies]
 libc = "0.2.153"

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -15,10 +15,10 @@ exclude = ["/tests"]
 path = "src/kem.rs"
 
 [dependencies]
-libcrux-ml-kem = { version = "=0.0.5-pre.1", path = "../libcrux-ml-kem", default-features = false, features = [
+libcrux-ml-kem = { version = "=0.0.5", path = "../libcrux-ml-kem", default-features = false, features = [
     "default-no-std",
 ] }
-libcrux-sha3 = { version = "=0.0.5-pre.1", path = "../crates/algorithms/sha3" }
+libcrux-sha3 = { version = "=0.0.5", path = "../crates/algorithms/sha3" }
 libcrux-ecdh = { version = "=0.0.4", path = "../libcrux-ecdh", default-features = false }
 libcrux-curve25519 = { version = "=0.0.4", path = "../crates/algorithms/curve25519", default-features = false }
 libcrux-p256 = { version = "=0.0.4", path = "../crates/algorithms/p256", default-features = false }

--- a/libcrux-ml-dsa/CHANGELOG.md
+++ b/libcrux-ml-dsa/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5-pre.1] (2026-01-12)
+## [0.0.5] (2026-01-12)
 
 - [#1280](https://github.com/cryspen/libcrux/pull/1280): Update dependencies `libcrux-platform`, `libcrux-sha3`
 - [#1248](https://github.com/cryspen/libcrux/pull/1248): Add serialization of generic structs using `tls_codec` (feature `codec`).

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-ml-dsa"
 description = "Libcrux ML-DSA implementation"
-version = "0.0.5-pre.1"
+version = "0.0.5"
 readme = "README.md"
 
 authors.workspace = true
@@ -18,9 +18,9 @@ bench = false # so libtest doesn't eat the arguments to criterion
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libcrux-sha3 = { version = "0.0.5-pre.1", path = "../crates/algorithms/sha3" }
+libcrux-sha3 = { version = "0.0.5", path = "../crates/algorithms/sha3" }
 libcrux-intrinsics = { version = "0.0.4", path = "../crates/utils/intrinsics" }
-libcrux-platform = { version = "0.0.3-pre.1", path = "../crates/sys/platform" }
+libcrux-platform = { version = "0.0.3", path = "../crates/sys/platform" }
 libcrux-macros = { version = "=0.0.3",  path = "../crates/utils/macros" }
 hax-lib.workspace = true
 tls_codec = { version = "0.4.2", features = [

--- a/libcrux-ml-kem/CHANGELOG.md
+++ b/libcrux-ml-kem/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5-pre.1] (2026-01-12)
+## [0.0.5] (2026-01-12)
 
 - [#1280](https://github.com/cryspen/libcrux/pull/1280): Update dependencies `libcrux-platform`, `libcrux-sha3`
 - [#1276](https://github.com/cryspen/libcrux/pull/1276): (Breaking) Fix incorrect portable state serialization in incremental API (@GuuJiang)

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-ml-kem"
-version = "0.0.5-pre.1"
+version = "0.0.5"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -23,8 +23,8 @@ bench = false # so libtest doesn't eat the arguments to criterion
 
 [dependencies]
 rand = { version = "0.9", optional = true, default-features = false }
-libcrux-platform = { version = "0.0.3-pre.1", path = "../crates/sys/platform" }
-libcrux-sha3 = { version = "0.0.5-pre.1", path = "../crates/algorithms/sha3" }
+libcrux-platform = { version = "0.0.3", path = "../crates/sys/platform" }
+libcrux-sha3 = { version = "0.0.5", path = "../crates/algorithms/sha3" }
 libcrux-intrinsics = { version = "0.0.4", path = "../crates/utils/intrinsics" }
 libcrux-secrets = { version = "0.0.4", path = "../crates/utils/secrets" }
 libcrux-traits = { version = "0.0.4", path = "../traits" }

--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -30,7 +30,7 @@ classic-mceliece-rust = { version = "3.1.0", features = [
 rand = { version = "0.9" }
 rand_old = { version = "0.8", package = "rand", optional = true }
 libcrux-ecdh = { version = "0.0.4", path = "../libcrux-ecdh" }
-libcrux-ml-kem = { version = "0.0.5-pre.1", path = "../libcrux-ml-kem", features = [
+libcrux-ml-kem = { version = "0.0.5", path = "../libcrux-ml-kem", features = [
     "codec",
     "rand",
 ] }
@@ -39,8 +39,8 @@ libcrux-ed25519 = { version = "0.0.4", path = "../crates/algorithms/ed25519", fe
     "codec",
 ] }
 tls_codec = { version = "0.4.2", features = ["derive"] }
-libcrux-ml-dsa = { version = "0.0.5-pre.1", path = "../libcrux-ml-dsa", features = ["codec"] }
-libcrux-aesgcm = { version = "0.0.5-pre.1", path = "../crates/algorithms/aesgcm"}
+libcrux-ml-dsa = { version = "0.0.5", path = "../libcrux-ml-dsa", features = ["codec"] }
+libcrux-aesgcm = { version = "0.0.5", path = "../crates/algorithms/aesgcm"}
 
 [dev-dependencies]
 libcrux-psq = { path = ".", features = ["test-utils"] }


### PR DESCRIPTION
This is for releasing

- `libcrux-platform 0.0.3`
- `libcrux-sha3 0.0.5`
- `libcrux-ml-kem 0.0.5`
- `libcrux-ml-dsa 0.0.5`
- `libcrux-aesgcm 0.0.5`