### PR TITLE
Bump to release versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ libcrux-ml-kem = { version = "=0.0.6", path = "libcrux-ml-kem" }
 libcrux-sha3 = { version = "=0.0.6", path = "crates/algorithms/sha3" }
 libcrux-kem = { version = "=0.0.5", path = "libcrux-kem" }
 libcrux-secrets = { version = "=0.0.5", path = "crates/utils/secrets" }
-libcrux-aead = { version = "=0.0.5-pre.1", path = "crates/primitives/aead" }
-libcrux-blake2 = { version = "=0.0.5-pre.1", path = "crates/algorithms/blake2" }
+libcrux-aead = { version = "=0.0.5", path = "crates/primitives/aead" }
+libcrux-blake2 = { version = "=0.0.5", path = "crates/algorithms/blake2" }
 libcrux-p256 = { version = "=0.0.5", path = "crates/algorithms/p256" }
 
 [package]

--- a/crates/algorithms/blake2/CHANGELOG.md
+++ b/crates/algorithms/blake2/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5-pre.1] (2026-01-26)
+## [0.0.5] (2026-01-26)
 
 - [#1289](https://github.com/cryspen/libcrux/pull/1289): Update dependency `libcrux-traits`
 

--- a/crates/algorithms/blake2/Cargo.toml
+++ b/crates/algorithms/blake2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-blake2"
 description = "Formally verified blake2 hash library"
-version = "0.0.5-pre.1"
+version = "0.0.5"
 readme = "Readme.md"
 
 authors.workspace = true

--- a/crates/algorithms/ecdsa/CHANGELOG.md
+++ b/crates/algorithms/ecdsa/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5-pre.1] (2026-01-26)
+## [0.0.5] (2026-01-26)
 
 - [#1297](https://github.com/cryspen/libcrux/pull/1297): Update dependencies
 

--- a/crates/algorithms/ecdsa/Cargo.toml
+++ b/crates/algorithms/ecdsa/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcrux-ecdsa"
 description = "Formally verified ECDSA signature library"
 readme = "Readme.md"
-version = "0.0.5-pre.1"
+version = "0.0.5"
 
 authors.workspace = true
 license.workspace = true

--- a/crates/algorithms/rsa/CHANGELOG.md
+++ b/crates/algorithms/rsa/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5-pre.1] (2026-01-26)
+## [0.0.5] (2026-01-26)
 
 - [#1297](https://github.com/cryspen/libcrux/pull/1297): Update dependencies
 

--- a/crates/algorithms/rsa/Cargo.toml
+++ b/crates/algorithms/rsa/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-rsa"
 description = "Formally verified RSA signature library"
-version = "0.0.5-pre.1"
+version = "0.0.5"
 readme = "Readme.md"
 
 authors.workspace = true

--- a/crates/primitives/aead/CHANGELOG.md
+++ b/crates/primitives/aead/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5-pre.1] (2026-01-26)
+## [0.0.5] (2026-01-26)
 
 - [#1297](https://github.com/cryspen/libcrux/pull/1297): Update dependencies
 - [#1280](https://github.com/cryspen/libcrux/pull/1280): Update dependencies `libcrux-aesgcm`

--- a/crates/primitives/aead/Cargo.toml
+++ b/crates/primitives/aead/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Formally verified AEAD library"
 name = "libcrux-aead"
 readme = "Readme.md"
-version = "0.0.5-pre.1"
+version = "0.0.5"
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/primitives/digest/CHANGELOG.md
+++ b/crates/primitives/digest/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5-pre.1] (2026-01-26)
+## [0.0.5] (2026-01-26)
 
 - [#1297](https://github.com/cryspen/libcrux/pull/1297): Update dependencies
 - [#1280](https://github.com/cryspen/libcrux/pull/1280): Update dependency `libcrux-sha3`

--- a/crates/primitives/digest/Cargo.toml
+++ b/crates/primitives/digest/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Digest library"
 name = "libcrux-digest"
 readme = "Readme.md"
-version = "0.0.5-pre.1"
+version = "0.0.5"
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This will be the release for

- `libcrux-blake2 v0.0.5`
- `llibcrux-ecdsa v0.0.5`
- `llibcrux-rsa v0.0.5`
- `llibcrux-aead v0.0.5`
- `llibcrux-digest v0.0.5`