### PR TITLE
Use the right F* for proofs

### DIFF
--- a/.github/workflows/mldsa-hax.yml
+++ b/.github/workflows/mldsa-hax.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           nix profile install ./hax
       - name: ⤵ Install FStar
-        run: nix profile install github:FStarLang/FStar/v2025.02.17
+        run: nix profile install github:FStarLang/FStar/v2025.12.15
 
       - uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
The CI is currently [failing](https://github.com/cryspen/libcrux/actions/runs/21379210181/job/61542465970#step:7:1) for ML-dsa F* proofs because the F* version is too old.