### PR TITLE
Reduce CI time

### DIFF
--- a/.github/workflows/aead-build_test.yml
+++ b/.github/workflows/aead-build_test.yml
@@ -2,9 +2,6 @@ name: AEAD - Build & Test
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
-    paths: ['crates/primitives/aead', 'chacha20poly1305', 'traits/src/aead']
   pull_request:
     branches: ["main", "dev", "*"]
     paths: ['crates/primitives/aead', 'chacha20poly1305', 'traits/src/aead']

--- a/.github/workflows/aead-build_test.yml
+++ b/.github/workflows/aead-build_test.yml
@@ -4,7 +4,17 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev", "*"]
-    paths: ['crates/primitives/aead', 'chacha20poly1305', 'traits/src/aead']
+    paths:
+        - 'crates/primitives/aead/**'
+        - 'crates/algorithms/aesgcm/**'
+        - 'crates/algorithms/chacha20poly1305/**'
+        - 'crates/algorithms/poly1305/**'
+        - 'crates/utils/hacl-rs/**'
+        - 'crates/utils/intrinsics/**'
+        - 'crates/utils/macros/**'
+        - 'crates/utils/secrets/**'
+        - 'crates/sys/platform/**'
+        - 'traits/**'
   workflow_dispatch:
 
 env:
@@ -128,6 +138,7 @@ jobs:
         run: |
           cargo clean
           LIBCRUX_DISABLE_SIMD128=1 LIBCRUX_DISABLE_SIMD256=1 cargo test --verbose --release $RUST_TARGET_FLAG
+          
   aead-build-test-status:
     if: ${{ always() }}
     needs: [build]

--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'merge_group' }}
     strategy:
       fail-fast: false
       matrix:
@@ -120,6 +121,7 @@ jobs:
           cargo hack test --each-feature $EXCLUDE_FEATURES --verbose $RUST_TARGET_FLAG
 
   build-intel-macos:
+    if: ${{ github.event_name != 'merge_group' }}
     runs-on: macos-15-intel
     defaults:
       run:
@@ -138,6 +140,7 @@ jobs:
           cargo build --lib --examples --benches --verbose
 
   fuzz:
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -167,3 +170,15 @@ jobs:
 
       - name: 🏃🏻‍♀️ Encrypt256
         run: CARGO_PROFILE_RELEASE_LTO=false cargo +nightly fuzz run encrypt256 -- -runs=100000
+        
+  aes-build-test-status:
+    if: ${{ always() }}
+    needs: [build, build-intel-macos, fuzz]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Successful
+        if: ${{ !(contains(needs.*.result, 'failure')) }} 
+        run: exit 0 
+      - name: Failing
+        if: ${{ (contains(needs.*.result, 'failure')) }} 
+        run: exit 1 

--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -5,7 +5,12 @@ on:
   pull_request:
     branches: ["main", "dev", "*"]
     paths:
-      - "crates/algorithms/aesgcm/**"
+      - 'cavp/**'
+      - 'crates/algorithms/aesgcm/**'
+      - 'crates/utils/intrinsics/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'traits/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ecdh-build-test.yml
+++ b/.github/workflows/ecdh-build-test.yml
@@ -108,6 +108,7 @@ jobs:
           LIBCRUX_DISABLE_SIMD128=1 LIBCRUX_DISABLE_SIMD256=1 cargo test --verbose --release $RUST_TARGET_FLAG
 
   build-no_std:
+    if: ${{ github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -119,7 +120,7 @@ jobs:
 
       - name: Add no_std target
         run: rustup target add thumbv6m-none-eabi
-        
+
       - name: Update dependencies
         run: cargo update
 
@@ -127,15 +128,15 @@ jobs:
         run: |
           rustc --print=cfg
           cargo check --lib --no-default-features --verbose --target thumbv6m-none-eabi
-  
+
   ecdh-build-test-status:
     if: ${{ always() }}
     needs: [build, build-no_std]
     runs-on: ubuntu-latest
     steps:
       - name: Successful
-        if: ${{ !(contains(needs.*.result, 'failure')) }} 
-        run: exit 0 
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
       - name: Failing
-        if: ${{ (contains(needs.*.result, 'failure')) }} 
-        run: exit 1 
+        if: ${{ (contains(needs.*.result, 'failure')) }}
+        run: exit 1

--- a/.github/workflows/ecdh-build-test.yml
+++ b/.github/workflows/ecdh-build-test.yml
@@ -2,8 +2,6 @@ name: ECDH - Build & Test
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev", "*"]
   workflow_dispatch:

--- a/.github/workflows/ecdh-build-test.yml
+++ b/.github/workflows/ecdh-build-test.yml
@@ -4,6 +4,16 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev", "*"]
+    paths:
+      - 'crates/algorithms/curve25519/**'
+      - 'libcrux-ecdh/**'
+      - 'crates/utils/hacl-rs/**'
+      - 'crates/utils/macros/**'
+      - 'crates/algorithms/p256/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha2/**'
+      - 'traits/**'
+
   workflow_dispatch:
 
 env:

--- a/.github/workflows/kem-build-test.yml
+++ b/.github/workflows/kem-build-test.yml
@@ -4,6 +4,20 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev", "*"]
+    paths:
+      - 'crates/algorithms/curve25519/**'
+      - 'libcrux-ecdh/**'
+      - 'crates/utils/hacl-rs/**'
+      - 'crates/utils/intrinsics/**'
+      - 'libcrux-kem/**'
+      - 'crates/utils/macros/**'
+      - 'libcrux-ml-kem/**'
+      - 'crates/algorithms/p256/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha2/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/kem-build-test.yml
+++ b/.github/workflows/kem-build-test.yml
@@ -2,8 +2,6 @@ name: KEM - Build & Test
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev", "*"]
   workflow_dispatch:

--- a/.github/workflows/libcrux-build-test.yml
+++ b/.github/workflows/libcrux-build-test.yml
@@ -2,8 +2,6 @@ name: Libcrux - Build & Test
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev"]
   workflow_dispatch:

--- a/.github/workflows/mldsa-bench.yml
+++ b/.github/workflows/mldsa-bench.yml
@@ -6,6 +6,15 @@ on:
   # run on PR but skip
   pull_request:
     branches: ["main", "dev"]
+    paths:
+      - 'crates/utils/intrinsics/**'
+      - 'crates/testing/kats/**'
+      - 'crates/utils/macros/**'
+      - 'libcrux-ml-dsa/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mldsa-bench.yml
+++ b/.github/workflows/mldsa-bench.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches: ["main", "dev"]
   workflow_dispatch:
-  # run benchmarks once merged and push data
-  push:
-    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/mldsa-build-test.yml
+++ b/.github/workflows/mldsa-build-test.yml
@@ -4,6 +4,15 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev", "*"]
+    paths:
+      - 'crates/utils/intrinsics/**'
+      - 'crates/testing/kats/**'
+      - 'crates/utils/macros/**'
+      - 'libcrux-ml-dsa/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mldsa-build-test.yml
+++ b/.github/workflows/mldsa-build-test.yml
@@ -2,8 +2,6 @@ name: ML-DSA - Build & Test
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev", "*"]
   workflow_dispatch:

--- a/.github/workflows/mldsa-c.yml
+++ b/.github/workflows/mldsa-c.yml
@@ -2,8 +2,6 @@ name: ML-DSA - Build & Test C
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev"]
   workflow_dispatch:

--- a/.github/workflows/mldsa-c.yml
+++ b/.github/workflows/mldsa-c.yml
@@ -4,6 +4,15 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev"]
+    paths:
+      - 'crates/utils/intrinsics/**'
+      - 'crates/testing/kats/**'
+      - 'crates/utils/macros/**'
+      - 'libcrux-ml-dsa/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mldsa-hax.yml
+++ b/.github/workflows/mldsa-hax.yml
@@ -4,7 +4,16 @@ on:
   merge_group:
   pull_request:
     branches: ["dev", "main"]
-
+    paths:
+      - 'crates/utils/intrinsics/**'
+      - 'crates/testing/kats/**'
+      - 'crates/utils/macros/**'
+      - 'libcrux-ml-dsa/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
+      
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/mldsa-hax.yml
+++ b/.github/workflows/mldsa-hax.yml
@@ -2,9 +2,6 @@ name: ML-DSA - hax
 
 on:
   merge_group:
-  push:
-    branches: ["dev", "main"]
-
   pull_request:
     branches: ["dev", "main"]
 

--- a/.github/workflows/mlkem-bench.yml
+++ b/.github/workflows/mlkem-bench.yml
@@ -7,9 +7,7 @@ on:
   pull_request:
     branches: ["main", "dev"]
   workflow_dispatch:
-  # run benchmarks once merged and push data
-  push:
-    branches: ["main"]
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/mlkem-bench.yml
+++ b/.github/workflows/mlkem-bench.yml
@@ -6,6 +6,14 @@ on:
   # run on PR but skip
   pull_request:
     branches: ["main", "dev"]
+    paths:
+      - 'crates/utils/intrinsics/**'
+      - 'crates/testing/kats/**'
+      - 'libcrux-ml-kem/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'    
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mlkem-build-test.yml
+++ b/.github/workflows/mlkem-build-test.yml
@@ -2,8 +2,6 @@ name: ML-KEM - Build & Test
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev", "*"]
   workflow_dispatch:

--- a/.github/workflows/mlkem-build-test.yml
+++ b/.github/workflows/mlkem-build-test.yml
@@ -4,6 +4,14 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev", "*"]
+    paths:
+      - 'crates/utils/intrinsics/**'
+      - 'crates/testing/kats/**'
+      - 'libcrux-ml-kem/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mlkem-c.yml
+++ b/.github/workflows/mlkem-c.yml
@@ -4,6 +4,14 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev"]
+    paths:
+      - 'crates/utils/intrinsics/**'
+      - 'crates/testing/kats/**'
+      - 'libcrux-ml-kem/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mlkem-hax.yml
+++ b/.github/workflows/mlkem-hax.yml
@@ -2,9 +2,6 @@ name: ML-KEM - hax
 
 on:
   merge_group:
-  push:
-    branches: ["dev", "main"]
-
   pull_request:
     branches: ["dev", "main"]
 

--- a/.github/workflows/mlkem-hax.yml
+++ b/.github/workflows/mlkem-hax.yml
@@ -4,7 +4,15 @@ on:
   merge_group:
   pull_request:
     branches: ["dev", "main"]
-
+    paths:
+      - 'crates/utils/intrinsics/**'
+      - 'crates/testing/kats/**'
+      - 'libcrux-ml-kem/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
+      
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/mlkem-s390x.yml
+++ b/.github/workflows/mlkem-s390x.yml
@@ -4,6 +4,14 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev"]
+    paths:
+      - 'crates/utils/intrinsics/**'
+      - 'crates/testing/kats/**'
+      - 'libcrux-ml-kem/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/platform-build-test.yml
+++ b/.github/workflows/platform-build-test.yml
@@ -2,8 +2,6 @@ name: Platform - Build & Test
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev", "*"]
   workflow_dispatch:

--- a/.github/workflows/platform-build-test.yml
+++ b/.github/workflows/platform-build-test.yml
@@ -4,6 +4,8 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev", "*"]
+    paths:
+      - 'crates/sys/platform/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/psq-build-test.yml
+++ b/.github/workflows/psq-build-test.yml
@@ -3,6 +3,28 @@ name: PSQ - Build & Test
 on:
   pull_request:
     branches: ["main", "dev", "*"]
+    paths:
+      - 'crates/algorithms/aesgcm/**'
+      - 'crates/algorithms/chacha20poly1305/**'
+      - 'crates/algorithms/curve25519/**'
+      - 'libcrux-ecdh/**'
+      - 'crates/algorithms/ed25519/**'
+      - 'crates/utils/hacl-rs/**'
+      - 'crates/algorithms/hkdf/**'
+      - 'crates/algorithms/hmac/**'
+      - 'crates/utils/intrinsics/**'
+      - 'libcrux-kem/**'
+      - 'crates/utils/macros/**'
+      - 'libcrux-ml-dsa/**'
+      - 'libcrux-ml-kem/**'
+      - 'crates/algorithms/p256/**'
+      - 'crates/sys/platform/**'
+      - 'crates/algorithms/poly1305/**'
+      - 'libcrux-psq/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha2/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/secrets-build-test.yml
+++ b/.github/workflows/secrets-build-test.yml
@@ -4,6 +4,8 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev", "*"]
+    paths:
+      - 'crates/utils/secrets/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/secrets-build-test.yml
+++ b/.github/workflows/secrets-build-test.yml
@@ -2,8 +2,6 @@ name: secrets - Build & Test
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev", "*"]
   workflow_dispatch:

--- a/.github/workflows/secrets-build-test.yml
+++ b/.github/workflows/secrets-build-test.yml
@@ -123,6 +123,7 @@ jobs:
           LIBCRUX_DISABLE_SIMD128=1 LIBCRUX_DISABLE_SIMD256=1 cargo test --verbose --release $RUST_TARGET_FLAG
 
   build-no_std:
+    if: ${{ github.event_name != 'merge_group' }}  
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/sha3-hax.yml
+++ b/.github/workflows/sha3-hax.yml
@@ -2,13 +2,15 @@ name: SHA3 - hax
 
 on:
   merge_group:
-    paths:
-      - "crates/algorithms/sha3/**"
   pull_request:
     branches: ["dev", "main"]
     paths:
-      - "crates/algorithms/sha3/**"
-
+      - 'cavp/**'
+      - 'crates/utils/intrinsics/**'
+      - 'crates/sys/platform/**'
+      - 'crates/utils/secrets/**'
+      - 'crates/algorithms/sha3/**'
+      - 'traits/**'
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/specs-build-test.yml
+++ b/.github/workflows/specs-build-test.yml
@@ -2,8 +2,6 @@ name: Specs - Build & Test
 
 on:
   merge_group:
-  push:
-    branches: [ "main", "dev" ]
   pull_request:
     branches: [ "main", "dev" ]
 

--- a/.github/workflows/traits-build.yml
+++ b/.github/workflows/traits-build.yml
@@ -84,6 +84,7 @@ jobs:
         run: RUSTDOCFLAGS=-Zsanitizer=address RUSTFLAGS=-Zsanitizer=address cargo +nightly test --release --target aarch64-apple-darwin
 
   build-no_std:
+    if: ${{ github.event_name != 'merge_group' }}  
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/traits-build.yml
+++ b/.github/workflows/traits-build.yml
@@ -2,8 +2,6 @@ name: Traits - Build
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev", "*"]
   workflow_dispatch:

--- a/.github/workflows/traits-build.yml
+++ b/.github/workflows/traits-build.yml
@@ -4,6 +4,9 @@ on:
   merge_group:
   pull_request:
     branches: ["main", "dev", "*"]
+    paths:
+      - 'crates/utils/secrets/**'
+      - 'traits/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/workspace-checks.yml
+++ b/.github/workflows/workspace-checks.yml
@@ -2,8 +2,6 @@ name: Workspace - Checks
 
 on:
   merge_group:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev"]
   workflow_dispatch:


### PR DESCRIPTION
This PR aims to reduce CI times by
- removing the `on.push` triggers for `main`, which cause workflows to be run on `main` after they've already been run on the merge queue.
- being more precise with `pull_request.path`, meaning a workflow for a given crate should only run if there were changes in its dependencies.

[skip changelog]