### PR TITLE
[chacha20poly1305] Fix potential encryption panic on overlong ciphertext buffer

### DIFF
--- a/crates/algorithms/chacha20poly1305/CHANGELOG.md
+++ b/crates/algorithms/chacha20poly1305/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#1386](https://github.com/cryspen/libcrux/pull/1386): Fix potential panic in `libcrux_chacha20poly1305::encrypt (reported by @fg0x0)
+- [#1386](https://github.com/cryspen/libcrux/pull/1386): Fix potential panic in `libcrux_chacha20poly1305::encrypt` (reported by @fg0x0)
 
 ## [0.0.7] (2026-03-19)
 

--- a/crates/algorithms/chacha20poly1305/CHANGELOG.md
+++ b/crates/algorithms/chacha20poly1305/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [#1386](https://github.com/cryspen/libcrux/pull/1386): Fix potential panic in `libcrux_chacha20poly1305::encrypt (reported by @fg0x0)
+
 ## [0.0.7] (2026-03-19)
 
 ### Changed

--- a/crates/algorithms/chacha20poly1305/src/impl_hacl.rs
+++ b/crates/algorithms/chacha20poly1305/src/impl_hacl.rs
@@ -59,8 +59,9 @@ pub fn encrypt<'a>(
 ) -> Result<(&'a [u8], &'a [u8; TAG_LEN]), AeadError> {
     let (ptxt_len, aad_len) = encrypt_checks(ptxt, ctxt, aad, NOT_DETACHED)?;
 
-    // ensure destination slice has just the right length
-    let (ctxt_cpa, tag) = ctxt.split_at_mut(ptxt_len as usize);
+    let (ctxt_cpa, rest) = ctxt.split_at_mut(ptxt_len as usize);
+    // The ciphertext buffer may be longer than ptxt_len + TAG_LEN.
+    let (tag, _rest) = rest.split_at_mut(TAG_LEN);
     let tag: &mut [u8; TAG_LEN] = tag.try_into().unwrap();
 
     crate::hacl::aead_chacha20poly1305::encrypt(

--- a/crates/algorithms/chacha20poly1305/tests/chachapoly.rs
+++ b/crates/algorithms/chacha20poly1305/tests/chachapoly.rs
@@ -313,6 +313,13 @@ fn chachapoly_test_invalid_buffer_lengths() {
     let mut long_ctxt = [0; 30];
     libcrux_chacha20poly1305::encrypt(&key, msg, &mut long_ctxt, aad, &nonce).unwrap();
 
+    let mut decrypted = [0u8; 13];
+    assert!(
+        libcrux_chacha20poly1305::decrypt(&key, &mut decrypted, &long_ctxt[..29], aad, &nonce)
+            .is_ok()
+    );
+    assert_eq!(decrypted, *msg);
+
     // test that calling with incorrect-length buffers returns error: non-detached
     let err = libcrux_chacha20poly1305::decrypt(&key, &mut [], &ctxt, aad, &nonce).unwrap_err();
     assert!(matches!(

--- a/crates/algorithms/chacha20poly1305/tests/chachapoly.rs
+++ b/crates/algorithms/chacha20poly1305/tests/chachapoly.rs
@@ -309,6 +309,10 @@ fn chachapoly_test_invalid_buffer_lengths() {
     let mut ctxt = [0; 29];
     libcrux_chacha20poly1305::encrypt(&key, msg, &mut ctxt, aad, &nonce).unwrap();
 
+    // encrypt correctly on ciphertext buffer longer than `ptxt.len() + TAG_LEN`
+    let mut long_ctxt = [0; 30];
+    libcrux_chacha20poly1305::encrypt(&key, msg, &mut long_ctxt, aad, &nonce).unwrap();
+
     // test that calling with incorrect-length buffers returns error: non-detached
     let err = libcrux_chacha20poly1305::decrypt(&key, &mut [], &ctxt, aad, &nonce).unwrap_err();
     assert!(matches!(


### PR DESCRIPTION
This PR fixes an issue in `libcrux_chacha20poly1305::encrypt` where an application that passes in a ciphertext buffer of length greater than `ptxt.len() + TAG_LEN` would experience a panic.
The fix makes it so that `libcrux_chacha20poly1305::encrypt` no longer panics in this case, but instead writes out the ciphertext and tag into the first `ptxt.len() + TAG_LEN` bytes of the provided buffer.

The issue was reported by @fg0x0.