### PR TITLE
chore: extract anonymous implementations of `{Public,Private}Key` traits

### DIFF
--- a/libcrux-kem/src/kem.rs
+++ b/libcrux-kem/src/kem.rs
@@ -398,6 +398,7 @@ pub enum Ss {
     MlKem1024(MlKemSharedSecret),
 }
 
+#[hax_lib::include]
 impl PrivateKey {
     /// Encode a private key.
     pub fn encode(&self) -> Vec<u8> {
@@ -449,6 +450,7 @@ impl PrivateKey {
     }
 }
 
+#[hax_lib::include]
 impl PublicKey {
     /// Encapsulate a shared secret to the provided `pk` and return the `(Key, Enc)` tuple.
     pub fn encapsulate(&self, rng: &mut impl CryptoRng) -> Result<(Ss, Ct), Error> {


### PR DESCRIPTION
Marks these traits for extraction per <https://hax.cryspen.com/manual/faq/include-flags/#6-including-anonymous-items-using-hax_libinclude>.  But just let me know if there's a better way to make these available for extraction by crates that use them.  :-)