### PR TITLE
[kats / chacha20poly1305]: Add wycheproof chacha20poly1305 tests

### DIFF
--- a/crates/algorithms/chacha20poly1305/Cargo.toml
+++ b/crates/algorithms/chacha20poly1305/Cargo.toml
@@ -20,11 +20,10 @@ libcrux-traits.workspace = true
 libcrux-secrets.workspace = true
 
 [dev-dependencies]
-hex = { version = "0.4.3", features = ["serde"] }
-serde = { version = "1.0.216", features = ["derive"] }
-serde_json = "1.0.133"
 rand_core = { version = "0.10" }
 rand = { version = "0.10", features = ["sys_rng"] }
+libcrux-kats = { workspace = true, features = ["chacha20poly1305"] }
+hex = "0.4.3"
 
 [features]
 check-secret-independence = ["libcrux-secrets/check-secret-independence"]

--- a/crates/algorithms/chacha20poly1305/tests/chachapoly.rs
+++ b/crates/algorithms/chacha20poly1305/tests/chachapoly.rs
@@ -1,8 +1,6 @@
-use std::{fs::File, io::BufReader};
-
+use libcrux_chacha20poly1305::{AeadError, KEY_LEN, TAG_LEN};
+use libcrux_kats::wycheproof::{aead, TestResult};
 use rand_core::UnwrapErr;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
 
 fn randbuf<const N: usize>(rng: &mut impl rand_core::Rng) -> [u8; N] {
     let mut buf = [0; N];
@@ -10,227 +8,134 @@ fn randbuf<const N: usize>(rng: &mut impl rand_core::Rng) -> [u8; N] {
     buf
 }
 
-pub(crate) trait ReadFromFile {
-    fn from_file<T: DeserializeOwned>(file_str: &'static str) -> T {
-        let file = match File::open(file_str) {
-            Ok(f) => f,
-            Err(_) => panic!("Couldn't open file {file_str}."),
-        };
-        let reader = BufReader::new(file);
-        match serde_json::from_reader(reader) {
-            Ok(r) => r,
-            Err(e) => {
-                println!("{:?}", e);
-                panic!("Error reading file {file_str}.")
-            }
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[allow(non_snake_case)]
-struct AeadTestVector {
-    algorithm: String,
-    numberOfTests: usize,
-    notes: Option<Value>, // text notes (might not be present), keys correspond to flags
-    header: Vec<Value>,   // not used
-    testGroups: Vec<TestGroup>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[allow(non_snake_case)]
-struct TestGroup {
-    ivSize: usize,
-    keySize: usize,
-    tagSize: usize,
-    r#type: String,
-    tests: Vec<Test>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[allow(non_snake_case)]
-struct Test {
-    tcId: usize,
-    comment: String,
-    #[serde(with = "hex::serde")]
-    key: Vec<u8>,
-    #[serde(with = "hex::serde")]
-    iv: Vec<u8>,
-    #[serde(with = "hex::serde")]
-    aad: Vec<u8>,
-    #[serde(with = "hex::serde")]
-    msg: Vec<u8>,
-    #[serde(with = "hex::serde")]
-    ct: Vec<u8>,
-    #[serde(with = "hex::serde")]
-    tag: Vec<u8>,
-    result: String,
-    flags: Vec<String>,
-}
-
-impl ReadFromFile for AeadTestVector {}
-
-#[allow(non_snake_case)]
-#[test]
-fn wycheproof() {
-    let chacha_poly_tests: AeadTestVector =
-        AeadTestVector::from_file("../tests/wycheproof/chacha20_poly1305_test.json");
-
-    let num_tests = chacha_poly_tests.numberOfTests;
-    let mut skipped_tests = 0;
+/// Generic function to instantiate wycheproof tests for either
+/// chacha20poly1305 or xchacha20poly1305
+fn wycheproof_test<EncF, DecF, const NONCE_LEN: usize>(
+    test_set: aead::TestSet,
+    encrypt: EncF,
+    decrypt: DecF,
+) where
+    EncF: for<'a> Fn(
+        &[u8; KEY_LEN],
+        &[u8],
+        &'a mut [u8],
+        &[u8],
+        &[u8; NONCE_LEN],
+    ) -> Result<(&'a [u8], &'a [u8; TAG_LEN]), AeadError>,
+    DecF: for<'a> Fn(
+        &[u8; KEY_LEN],
+        &'a mut [u8],
+        &[u8],
+        &[u8],
+        &[u8; NONCE_LEN],
+    ) -> Result<&'a [u8], AeadError>,
+{
     let mut tests_run = 0;
-    assert_eq!(chacha_poly_tests.algorithm, "CHACHA20-POLY1305");
 
-    test_group(chacha_poly_tests, &mut skipped_tests, &mut tests_run);
+    for test_group in test_set.test_groups {
+        for test in &test_group.tests {
+            let Ok(nonce) = <&[u8; NONCE_LEN]>::try_from(test.nonce.as_slice()) else {
+                assert_eq!(TestResult::Invalid, test.result, "tc_id {}", test.tc_id);
+                assert!(
+                    test.flags.contains(&"InvalidNonceSize".to_owned()),
+                    "tc_id: {}",
+                    test.tc_id
+                );
+                tests_run += 1;
+                continue;
+            };
+            let Ok(key) = <&[u8; 32]>::try_from(test.key.as_slice()) else {
+                panic!("tc_id: {} has invalid key size", test.tc_id)
+            };
 
-    fn test_group(test_vec: AeadTestVector, skipped_tests: &mut usize, tests_run: &mut usize) {
-        for testGroup in test_vec.testGroups.iter() {
-            assert_eq!(testGroup.r#type, "AeadTest");
-            assert_eq!(testGroup.keySize, 256);
+            match test.result {
+                TestResult::Valid => {
+                    let mut ctxt_tag = vec![0; test.ct.len() + TAG_LEN];
+                    // check that we encrypt to the expected ciphertext
+                    let (ctxt, tag) = match encrypt(key, &test.pt, &mut ctxt_tag, &test.aad, nonce)
+                    {
+                        Ok((c, t)) => (c, t),
+                        Err(err) => {
+                            panic!(
+                                "Unexpected encryption failure in tc_id {}: {err}",
+                                test.tc_id
+                            );
+                        }
+                    };
+                    assert_eq!(
+                        test.ct, ctxt,
+                        "ciphertext mismatch tc_id {}: {}",
+                        test.tc_id, test.comment
+                    );
+                    assert_eq!(
+                        test.tag, tag,
+                        "tag mismatch tc_id {}: {}",
+                        test.tc_id, test.comment
+                    );
 
-            let invalid_iv = testGroup.ivSize != 96;
-
-            for test in testGroup.tests.iter() {
-                let valid = test.result.eq("valid");
-                if invalid_iv {
-                    // AEAD requires input of a 12-byte nonce.
-                    let nonce = &test.iv;
-                    assert!(nonce.len() != 12);
-                    *skipped_tests += 1;
-                    continue;
+                    // check that we can decrypt to the original plaintext
+                    let mut decrypted = vec![0; test.pt.len()];
+                    match decrypt(key, &mut decrypted, &ctxt_tag, &test.aad, nonce) {
+                        Ok(ptxt) => {
+                            assert_eq!(test.pt, ptxt);
+                            assert_eq!(test.pt, decrypted);
+                        }
+                        Err(err) => {
+                            panic!(
+                                "Unexpected decryption failure in tc_id {}: {err}",
+                                test.tc_id
+                            );
+                        }
+                    };
                 }
-                println!("Test {:?}: {:?}", test.tcId, test.comment);
-                let nonce = <&[u8; 12]>::try_from(&test.iv[..]).unwrap();
-                let msg = &test.msg;
-                let aad = &test.aad;
-                let exp_cipher = &test.ct;
-                let exp_tag = &test.tag;
-                let key = <&[u8; 32]>::try_from(&test.key[..]).unwrap();
-
-                let mut ctxt = msg.clone();
-                let tag = match libcrux_chacha20poly1305::encrypt(key, msg, &mut ctxt, aad, nonce) {
-                    Ok((_v, t)) => t,
-                    Err(_) => {
-                        *tests_run += 1;
-                        continue;
-                    }
-                };
-                if valid {
-                    assert_eq!(tag, exp_tag.as_slice());
-                } else {
-                    assert_ne!(tag, exp_tag.as_slice());
+                TestResult::Invalid => {
+                    // Invalid test cases have either wrong Nonce sizes (caught above),
+                    // or an invalid ciphertext+tag
+                    let mut decrypted = vec![0; test.pt.len()];
+                    let invalid_ct_and_tag = [&test.ct[..], &test.tag[..]].concat();
+                    match decrypt(key, &mut decrypted, &invalid_ct_and_tag, &test.aad, nonce) {
+                        Ok(ptxt) => {
+                            panic!(
+                                "Unexpected decryption success in tc_id {}: {}. Decrypted plaintext: {:?}",
+                                test.tc_id, test.comment, ptxt
+                            );
+                        }
+                        Err(err) => {
+                            assert!(
+                                matches!(err, AeadError::InvalidCiphertext),
+                                "decryption failed with wrong error"
+                            );
+                        }
+                    };
                 }
-                assert_eq!(ctxt, exp_cipher.as_slice());
-
-                let mut decrypted = vec![0; msg.len()];
-                match libcrux_chacha20poly1305::decrypt(key, &mut decrypted, &ctxt, aad, nonce) {
-                    Ok(m) => {
-                        assert_eq!(m, msg);
-                        assert_eq!(&decrypted, msg);
-                    }
-                    Err(_) => {
-                        assert!(!valid);
-                    }
-                };
-
-                *tests_run += 1;
+                TestResult::Acceptable => unreachable!("not present in chacha test vectors"),
             }
+            tests_run += 1;
         }
     }
-    // Check that we ran all tests.
-    println!(
-        "Ran {} out of {} tests and skipped {}.",
-        tests_run, num_tests, skipped_tests
-    );
-    assert_eq!(num_tests - skipped_tests, tests_run);
+
+    assert_eq!(test_set.number_of_tests, tests_run);
+    println!("Ran {tests_run} ChaCha20-Poly1305 tests");
 }
 
-#[allow(non_snake_case)]
 #[test]
-fn wycheproof_xchacha() {
-    let chacha_poly_tests: AeadTestVector =
-        AeadTestVector::from_file("../tests/wycheproof/xchacha20_poly1305_test.json");
-
-    let num_tests = chacha_poly_tests.numberOfTests;
-    let mut skipped_tests = 0;
-    let mut tests_run = 0;
-    assert_eq!(chacha_poly_tests.algorithm, "XCHACHA20-POLY1305");
-
-    test_group(chacha_poly_tests, &mut skipped_tests, &mut tests_run);
-
-    fn test_group(test_vec: AeadTestVector, skipped_tests: &mut usize, tests_run: &mut usize) {
-        for testGroup in test_vec.testGroups.iter() {
-            assert_eq!(testGroup.r#type, "AeadTest");
-            assert_eq!(testGroup.keySize, 256);
-
-            let invalid_iv = testGroup.ivSize != 96;
-
-            for test in testGroup.tests.iter() {
-                let valid = test.result.eq("valid");
-                if invalid_iv {
-                    // AEAD requires input of a 12-byte nonce.
-                    let nonce = &test.iv;
-                    assert!(nonce.len() != 12);
-                    *skipped_tests += 1;
-                    continue;
-                }
-                println!("Test {:?}: {:?}", test.tcId, test.comment);
-                // Don't attempt to read nonces less than 24 bytes long.
-                if test.iv.len() != 24 {
-                    *tests_run += 1;
-                    continue;
-                }
-                let nonce = <&[u8; 24]>::try_from(&test.iv[..]).unwrap();
-                let msg = &test.msg;
-                let aad = &test.aad;
-                let exp_cipher = &test.ct;
-                let exp_tag = &test.tag;
-                let key = <&[u8; 32]>::try_from(&test.key[..]).unwrap();
-
-                let mut ctxt = msg.clone();
-                let tag = match libcrux_chacha20poly1305::xchacha20_poly1305::encrypt(
-                    key, msg, &mut ctxt, aad, nonce,
-                ) {
-                    Ok((_v, t)) => t,
-                    Err(_) => {
-                        *tests_run += 1;
-                        continue;
-                    }
-                };
-                if valid {
-                    assert_eq!(tag, exp_tag.as_slice());
-                } else {
-                    assert_ne!(tag, exp_tag.as_slice());
-                }
-                assert_eq!(ctxt, exp_cipher.as_slice());
-
-                let mut decrypted = vec![0; msg.len()];
-                match libcrux_chacha20poly1305::xchacha20_poly1305::decrypt(
-                    key,
-                    &mut decrypted,
-                    &ctxt,
-                    aad,
-                    nonce,
-                ) {
-                    Ok(m) => {
-                        assert_eq!(m, msg);
-                        assert_eq!(&decrypted, msg);
-                    }
-                    Err(_) => {
-                        assert!(!valid);
-                    }
-                };
-
-                *tests_run += 1;
-            }
-        }
-    }
-    // Check that we ran all tests.
-    println!(
-        "Ran {} out of {} tests and skipped {}.",
-        tests_run, num_tests, skipped_tests
+fn wycheproof_chacha20_poly1305() {
+    let test_set = aead::TestSet::load_chacha20_poly1305();
+    wycheproof_test(
+        test_set,
+        libcrux_chacha20poly1305::encrypt,
+        libcrux_chacha20poly1305::decrypt,
     );
-    assert_eq!(num_tests - skipped_tests, tests_run);
+}
+
+#[test]
+fn wycheproof_xchacha20_poly1305() {
+    let test_set = aead::TestSet::load_xchacha20_poly1305();
+    wycheproof_test(
+        test_set,
+        libcrux_chacha20poly1305::xchacha20_poly1305::encrypt,
+        libcrux_chacha20poly1305::xchacha20_poly1305::decrypt,
+    );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/testing/kats/Cargo.toml
+++ b/crates/testing/kats/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 
 [features]
+chacha20poly1305 = []
 mldsa = []
 mlkem = []
 sha2 = ["dep:cavp"]

--- a/crates/testing/kats/src/wycheproof.rs
+++ b/crates/testing/kats/src/wycheproof.rs
@@ -1,5 +1,8 @@
 //! Wycheproof Known Answer Tests
 
+#[cfg(feature = "chacha20poly1305")]
+pub mod aead;
+
 #[cfg(feature = "mldsa")]
 pub mod mldsa;
 
@@ -7,3 +10,4 @@ pub mod mldsa;
 pub mod mlkem;
 
 pub mod schema_common;
+pub use schema_common::TestResult;

--- a/crates/testing/kats/src/wycheproof/aead.rs
+++ b/crates/testing/kats/src/wycheproof/aead.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+
+use super::schema_common::TestResult;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestSet {
+    pub number_of_tests: usize,
+    pub test_groups: Vec<TestGroup>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestGroup {
+    pub iv_size: usize,
+    pub key_size: usize,
+    pub tag_size: usize,
+    pub tests: Vec<Test>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Test {
+    pub tc_id: usize,
+    pub flags: Vec<String>,
+    #[serde(with = "hex::serde")]
+    pub key: Vec<u8>,
+    #[serde(rename = "iv", with = "hex::serde")]
+    pub nonce: Vec<u8>,
+    #[serde(with = "hex::serde")]
+    pub aad: Vec<u8>,
+    #[serde(rename = "msg", with = "hex::serde")]
+    pub pt: Vec<u8>,
+    #[serde(with = "hex::serde")]
+    pub ct: Vec<u8>,
+    #[serde(with = "hex::serde")]
+    pub tag: Vec<u8>,
+    pub result: TestResult,
+}
+
+impl TestSet {
+    pub fn load_chacha20_poly1305() -> Self {
+        let data = include_str!("../../wycheproof/chacha20_poly1305_test.json");
+        serde_json::from_str(data).expect("could not deserialize chacha20_poly1305 KAT file")
+    }
+
+    pub fn load_xchacha20_poly1305() -> Self {
+        let data = include_str!("../../wycheproof/xchacha20_poly1305_test.json");
+        serde_json::from_str(data).expect("could not deserialize xchacha20_poly1305 KAT file")
+    }
+}

--- a/crates/testing/kats/src/wycheproof/aead.rs
+++ b/crates/testing/kats/src/wycheproof/aead.rs
@@ -23,6 +23,7 @@ pub struct TestGroup {
 pub struct Test {
     pub tc_id: usize,
     pub flags: Vec<String>,
+    pub comment: String,
     #[serde(with = "hex::serde")]
     pub key: Vec<u8>,
     #[serde(rename = "iv", with = "hex::serde")]

--- a/crates/testing/kats/src/wycheproof/mldsa/sign_common.rs
+++ b/crates/testing/kats/src/wycheproof/mldsa/sign_common.rs
@@ -26,7 +26,7 @@ pub struct Test {
     pub sig: Vec<u8>,
 
     /// Test result
-    pub result: SignResult,
+    pub result: TestResult,
 
     /// A list of flags
     pub flags: Vec<Flag>,
@@ -40,12 +40,4 @@ pub enum Flag {
     InvalidContext,
     ManySteps,
     ValidSignature,
-}
-
-#[derive(PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SignResult {
-    Invalid,
-
-    Valid,
 }

--- a/crates/testing/kats/src/wycheproof/mldsa/verify_schema.rs
+++ b/crates/testing/kats/src/wycheproof/mldsa/verify_schema.rs
@@ -73,7 +73,7 @@ pub struct Test {
     pub sig: Vec<u8>,
 
     /// Test result
-    pub result: VerifyResult,
+    pub result: TestResult,
 
     /// A list of flags
     pub flags: Vec<Flag>,
@@ -93,12 +93,4 @@ pub enum Flag {
     ZeroPublicKey,
     InfinityNormViolation,
     InvalidSignature,
-}
-
-#[derive(PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum VerifyResult {
-    Invalid,
-
-    Valid,
 }

--- a/crates/testing/kats/src/wycheproof/mlkem/schema.rs
+++ b/crates/testing/kats/src/wycheproof/mlkem/schema.rs
@@ -101,7 +101,7 @@ pub struct MlKemTest {
     pub shared_secret: Vec<u8>,
 
     /// Test result
-    pub result: MlKemResult,
+    pub result: TestResult,
 }
 
 #[derive(PartialEq, Serialize, Deserialize)]
@@ -132,20 +132,11 @@ pub struct MlKemEncapsTest {
     pub shared_secret: Vec<u8>,
 
     /// Test result
-    pub result: MlKemResult,
+    pub result: TestResult,
 }
 
 #[derive(Hash, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum Flag {
     ModulusOverflow,
     Strcmp,
-}
-
-#[derive(PartialEq, Serialize, Deserialize, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum MlKemResult {
-    Invalid,
-
-    Valid,
-    Acceptable,
 }

--- a/crates/testing/kats/src/wycheproof/schema_common.rs
+++ b/crates/testing/kats/src/wycheproof/schema_common.rs
@@ -3,6 +3,14 @@
 
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TestResult {
+    Valid,
+    Invalid,
+    Acceptable,
+}
+
 #[derive(PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Source {

--- a/crates/testing/kats/src/wycheproof/schema_common.rs
+++ b/crates/testing/kats/src/wycheproof/schema_common.rs
@@ -3,7 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TestResult {
     Valid,

--- a/crates/testing/kats/wycheproof/chacha20_poly1305_test.json
+++ b/crates/testing/kats/wycheproof/chacha20_poly1305_test.json
@@ -1,0 +1,4721 @@
+{
+  "algorithm": "CHACHA20-POLY1305",
+  "schema": "aead_test_schema_v1.json",
+  "numberOfTests": 325,
+  "header": [
+    "Test vectors of type AeadTest test authenticated encryption with additional data.",
+    "The test vectors are intended for testing both encryption and decryption.",
+    "Test vectors with \"result\" : \"valid\" are valid encryptions.",
+    "Test vectors with \"result\" : \"invalid\" are using invalid parameters",
+    "or contain an invalid ciphertext or tag."
+  ],
+  "notes": {
+    "EdgeCaseCiphertext": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains values where the ciphertext is a special case. The purpose of the test vector is to detect incorrect poly1305 computations."
+    },
+    "EdgeCasePoly1305": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains an edge case for the integer arithmetic used to compute Poly1305. I.e., the goal of the test vector is to catch integer overflows."
+    },
+    "EdgeCasePolyKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains values where the key for Poly1305 has edge case values. E.g. the nonces have been constructed such that the Poly1305 key contains limbs with values such as 0. The goal of the test vector is to detect incorrect integer arithmetic in the Poly1305 computation."
+    },
+    "EdgeCaseTag": {
+      "bugType": "EDGE_CASE",
+      "description": "The tag contains an edge case. The goal of the test vector is to check for arithmetic errors in the final modular addition of CHACHA-POLY-1305."
+    },
+    "InvalidNonceSize": {
+      "bugType": "MODIFIED_PARAMETER",
+      "description": "RFC 7539 restricts the size of the nonce of CHACHA-POLY1305 to 12 bytes and XCHACHA-POLY1305 to 24 bytes. Other sizes are invalid."
+    },
+    "Ktv": {
+      "bugType": "BASIC",
+      "description": "Known test vector.",
+      "links": [
+        "RFC 7539"
+      ]
+    },
+    "ModifiedTag": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The test vector contains a ciphertext where the tag has been modified. The goal of the test vector is to detect implementations with partial or incorrect tag verification."
+    },
+    "Pseudorandom": {
+      "bugType": "FUNCTIONALITY",
+      "description": "The test vector contains pseudorandomly generated inputs. The goal of the test vector is to check the implementation for different input sizes."
+    }
+  },
+  "testGroups": [
+    {
+      "ivSize": 96,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "RFC 7539",
+          "flags": [
+            "Ktv"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "070000004041424344454647",
+          "aad": "50515253c0c1c2c3c4c5c6c7",
+          "msg": "4c616469657320616e642047656e746c656d656e206f662074686520636c617373206f66202739393a204966204920636f756c64206f6666657220796f75206f6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73637265656e20776f756c642062652069742e",
+          "ct": "d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d63dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b3692ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc3ff4def08e4b7a9de576d26586cec64b6116",
+          "tag": "1ae10b594f09e26a7e902ecbd0600691",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "80ba3192c803ce965ea371d5ff073cf0f43b6a2ab576b208426e11409c09b9b0",
+          "iv": "4da5bf8dfd5852c1ea12379d",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "76acb342cf3166a5b63c0c0ea1383c8d",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7a4cd759172e02eb204db2c3f5c746227df584fc1345196391dbb9577a250742",
+          "iv": "a92ef0ac991dd516a3c6f689",
+          "aad": "bd506764f2d2c410",
+          "msg": "",
+          "ct": "",
+          "tag": "906fa6284b52f87b7359cbaa7563c709",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "cc56b680552eb75008f5484b4cb803fa5063ebd6eab91f6ab6aef4916a766273",
+          "iv": "99e23ec48985bccdeeab60f1",
+          "aad": "",
+          "msg": "2a",
+          "ct": "3a",
+          "tag": "cac27dec0968801e9f6eded69d807522",
+          "result": "valid"
+        },
+        {
+          "tcId": 5,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "46f0254965f769d52bdb4a70b443199f8ef207520d1220c55e4b70f0fda620ee",
+          "iv": "ab0dca716ee051d2782f4403",
+          "aad": "91ca6c592cbcca53",
+          "msg": "51",
+          "ct": "c4",
+          "tag": "168310ca45b1f7c66cad4e99e43f72b9",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2f7f7e4f592bb389194989743507bf3ee9cbde1786b6695fe6c025fd9ba4c100",
+          "iv": "461af122e9f2e0347e03f2db",
+          "aad": "",
+          "msg": "5c60",
+          "ct": "4d13",
+          "tag": "91e8b61efb39c122195453077b22e5e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 7,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "c8833dce5ea9f248aa2030eacfe72bffe69a620caf793344e5718fe0d7ab1a58",
+          "iv": "61546ba5f1720590b6040ac6",
+          "aad": "88364fc8060518bf",
+          "msg": "ddf2",
+          "ct": "b60d",
+          "tag": "ead0fd4697ec2e5558237719d02437a2",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "bd8ed7fb0d607522f04d0b12d42c92570bccc5ba2486953d70ba2e8193f6225a",
+          "iv": "d2ab0abb50a8e9fba25429e1",
+          "aad": "",
+          "msg": "201221",
+          "ct": "3cf470",
+          "tag": "a27a69c9d7ee84586f11388c6884e63a",
+          "result": "valid"
+        },
+        {
+          "tcId": 9,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "1c8b59b17a5ceced31bde97d4cefd9aaaa63362e096e863ec1c89580bca79b7a",
+          "iv": "94f32a6dff588f2b5a2ead45",
+          "aad": "6c8cf2ab3820b695",
+          "msg": "453f95",
+          "ct": "610925",
+          "tag": "a8a7883eb7e40bc40e2e5922ae95ddc3",
+          "result": "valid"
+        },
+        {
+          "tcId": 10,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e4912cb75a1174345f1a457366f18885fe8460b06478e04be2f7fb4ec9c113e5",
+          "iv": "7aa5ad8bf5254762171ec869",
+          "aad": "",
+          "msg": "9e4c1d03",
+          "ct": "fe6849aa",
+          "tag": "99ad07871b25c27defc31a541bd5c418",
+          "result": "valid"
+        },
+        {
+          "tcId": 11,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e05777ef3d989ace7d2abfba452bfded54801dbd5c66e91c0c2ef00479d85572",
+          "iv": "b7f526e3fd71cf5720961aec",
+          "aad": "15d93a96d0e6c5a9",
+          "msg": "17bfda03",
+          "ct": "f4710e51",
+          "tag": "b957c6a37b6a4c94996c002186d63b2b",
+          "result": "valid"
+        },
+        {
+          "tcId": 12,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "1a4c4f39abe890e62345c947bcf7de7c2e33bd5ceeda0a0abf0e7ef935ddf3ee",
+          "iv": "9447bf85d5b97d8aee0f8e51",
+          "aad": "",
+          "msg": "c15a593bd0",
+          "ct": "f711647ff1",
+          "tag": "22b12dc38cb79629f84cdbdc2425c09d",
+          "result": "valid"
+        },
+        {
+          "tcId": 13,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "800e9a24791700c9609736695ba2a8b99b2d57f1c3bfb61ed49db1c6c5219583",
+          "iv": "3dbe876bd880ec8ea2017043",
+          "aad": "96224835610b782b",
+          "msg": "a7bfd041e3",
+          "ct": "d171f046ea",
+          "tag": "d179b1b9c4184378df009019dbb8c249",
+          "result": "valid"
+        },
+        {
+          "tcId": 14,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "208c2c376c9430433db20e1a6b7ba817f8ffbfa6827f26759ccede42e591d3ec",
+          "iv": "27fb58ec6a21e84696cb8830",
+          "aad": "",
+          "msg": "af104b5ccd0e",
+          "ct": "9351b1b1b082",
+          "tag": "560785509f60f26b681933d9cdbfd29f",
+          "result": "valid"
+        },
+        {
+          "tcId": 15,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2eb168e53b07ab04355ea792fe11a6be2ce9c39cfe15a997076b1e38c17ad620",
+          "iv": "b5965470c383fd29fe7eaee7",
+          "aad": "6d52feb2509f7fbf",
+          "msg": "6fdf2927e169",
+          "ct": "41abff7b71cc",
+          "tag": "9b5174297c03cf8902d1f706fd008902",
+          "result": "valid"
+        },
+        {
+          "tcId": 16,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "55568158d3a6483f1f7021eab69b703f614251cadc1af5d34a374fdbfc5adac7",
+          "iv": "3c4e654d663fa4596dc55bb7",
+          "aad": "",
+          "msg": "ab85e9c1571731",
+          "ct": "5dfe3440dbb3c3",
+          "tag": "ed7a434e2602d394281e0afa9fb7aa42",
+          "result": "valid"
+        },
+        {
+          "tcId": 17,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e3c09e7fab1aefb516da6a33022a1dd4eb272c80d540c5da52a730f34d840d7f",
+          "iv": "58389375c69ee398de948396",
+          "aad": "84e46be8c0919053",
+          "msg": "4ee5cda20d4290",
+          "ct": "4bd47212941ce3",
+          "tag": "185f1408ee7fbf18f5abad6e2253a1ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 18,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "51e4bf2bad92b7aff1a4bc05550ba81df4b96fabf41c12c7b00e60e48db7e152",
+          "iv": "4f07afedfdc3b6c2361823d3",
+          "aad": "",
+          "msg": "be3308f72a2c6aed",
+          "ct": "8e9439a56eeec817",
+          "tag": "fbe8a6ed8fabb1937539dd6c00e90021",
+          "result": "valid"
+        },
+        {
+          "tcId": 19,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "1131c1418577a054de7a4ac551950f1a053f9ae46e5b75fe4abd5608d7cddadd",
+          "iv": "b4ea666ee119563366484a78",
+          "aad": "66c0ae70076cb14d",
+          "msg": "a4c9c2801b71f7df",
+          "ct": "b9b910433af052b0",
+          "tag": "4530f51aeee024e0a445a6328fa67a18",
+          "result": "valid"
+        },
+        {
+          "tcId": 20,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e1094967f86d893cdfe2e2e6d5c7ee4dfef67da3c9c5d64e6ad7c1577dcb38c5",
+          "iv": "8092fc245b3326cddbd1424c",
+          "aad": "",
+          "msg": "c37aa791ddd6accf91",
+          "ct": "d9d897a9c1c5bb9f01",
+          "tag": "085a430373058f1a12a0d589fd5be68b",
+          "result": "valid"
+        },
+        {
+          "tcId": 21,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "236f9baee4f9da15beeca40ff4af7c760f254a64bc3a3d7f4fad557e61b68586",
+          "iv": "f1ca81338629587acf9372bf",
+          "aad": "8c32f47a386152ec",
+          "msg": "d7f26d5252e1765f5b",
+          "ct": "8fdb429d47761cbf8e",
+          "tag": "8ef647ed334fdebbc2bef80be02884e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 22,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "4de207a3b70c51e5f23048eed5a5da9bb65e917a69aa93e7c8b4a815cd9724de",
+          "iv": "4c15a71dc6791a8c005ad502",
+          "aad": "",
+          "msg": "f2c54b6b5e490da18659",
+          "ct": "700d35adf5100a22a1de",
+          "tag": "102d992ffaff599b5bddddeb2dfb399b",
+          "result": "valid"
+        },
+        {
+          "tcId": 23,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "6d667fd79e5fb725f50343dccc4863227c75ee3f7a578476e3e9f32598d81559",
+          "iv": "6220527aba88e27f766658b2",
+          "aad": "e1e27ccddb3cb407",
+          "msg": "0c8c5a252681f2b5b4c0",
+          "ct": "04aad66c60e0bf8ebba9",
+          "tag": "c15f69a4d2aef97d7748756ff49d894b",
+          "result": "valid"
+        },
+        {
+          "tcId": 24,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "8f4bd94ef73e75d1e068c30b37ead576c5344e093ece1330e9101c82f793cf05",
+          "iv": "ec1e2967f0f6979e5f5b07fb",
+          "aad": "",
+          "msg": "b89812b34d9bced4a0ba07",
+          "ct": "1c3d53baaa36eaa1d8ec4d",
+          "tag": "4d94ebf960f12433bec43aa86d7e6e6d",
+          "result": "valid"
+        },
+        {
+          "tcId": 25,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2aa3bc7033351cac51364cdaf6ffac2c20f64046e1550a7b1c65f41800599019",
+          "iv": "28cce57a5db2cd206321e340",
+          "aad": "a9bc350eaf2e6e3d",
+          "msg": "83016823123484b56095b0",
+          "ct": "1c8578f8e75203d0336a52",
+          "tag": "5910f7a9d5e4df05d7248bd7a8d65e63",
+          "result": "valid"
+        },
+        {
+          "tcId": 26,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "99b62bd5afbe3fb015bde93f0abf483957a1c3eb3ca59cb50b39f7f8a9cc51be",
+          "iv": "9a59fce26df0005e07538656",
+          "aad": "",
+          "msg": "42baae5978feaf5c368d14e0",
+          "ct": "ff7dc203b26c467a6b50db33",
+          "tag": "578c0f2758c2e14e36d4fc106dcb29b4",
+          "result": "valid"
+        },
+        {
+          "tcId": 27,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "85f35b6282cff440bc1020c8136ff27031110fa63ec16f1e825118b006b91257",
+          "iv": "58dbd4ad2c4ad35dd906e9ce",
+          "aad": "a506e1a5c69093f9",
+          "msg": "fdc85b94a4b2a6b759b1a0da",
+          "ct": "9f8816de0994e938d9e53f95",
+          "tag": "d086fc6c9d8fa915fd8423a7cf05072f",
+          "result": "valid"
+        },
+        {
+          "tcId": 28,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "faf4bfe8019a891c74901b17f4f48cee5cd065d55fdea60118aaf6c4319a0ea5",
+          "iv": "b776c3fddba7c81362ce6e1b",
+          "aad": "",
+          "msg": "8dadff8d60c8e88f604f274833",
+          "ct": "e6b33a74a4ac443bd93f9c1b94",
+          "tag": "0c115172bdb02bbad3130fff22790d60",
+          "result": "valid"
+        },
+        {
+          "tcId": 29,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "841020d1606edcfc536abfb1a638a7b958e21efc10c386ac45a18493450afd5f",
+          "iv": "6d62f159731b140eb18ce074",
+          "aad": "5a8e1c7aa39810d5",
+          "msg": "d6af138f701b801e60c85ffd5c",
+          "ct": "b0a7500aca45bb15f01ece4389",
+          "tag": "0160e83adbec7f6a2ee2ff0215f9ef00",
+          "result": "valid"
+        },
+        {
+          "tcId": 30,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "470f9ce3d2250bd60cbbefdb2e6a1178c012299b5590639c7797b6024fa703d8",
+          "iv": "a9ea4d619fe405d04cba7d7a",
+          "aad": "",
+          "msg": "6ca67dd023fba6507b9f9a1f667e",
+          "ct": "d3017e0bb1705b380b34cc333450",
+          "tag": "5708e72ca2bd354f487f82f67fbc3acb",
+          "result": "valid"
+        },
+        {
+          "tcId": 31,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e4b97e91e4c8e85eb7ce0a7f30bf8a0abf4468251e4c6386c0e7aacb8e879aa8",
+          "iv": "0e23c942a0c9fb526586eead",
+          "aad": "eaaaeab26957f9a1",
+          "msg": "b84b3f74cd23064bb426fe2ced2b",
+          "ct": "52e9672b416d84d97033796072d0",
+          "tag": "e83839dc1fd9b8b9d1444c40e488d493",
+          "result": "valid"
+        },
+        {
+          "tcId": 32,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "67119627bd988eda906219e08c0d0d779a07d208ce8a4fe0709af755eeec6dcb",
+          "iv": "68ab7fdbf61901dad461d23c",
+          "aad": "",
+          "msg": "51f8c1f731ea14acdb210a6d973e07",
+          "ct": "0b29638e1fbdd6df53970be2210042",
+          "tag": "2a9134087d67a46e79178d0a93f5e1d2",
+          "result": "valid"
+        },
+        {
+          "tcId": 33,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e6f1118d41e4b43fb58221b7ed79673834e0d8ac5c4fa60bbc8bc4893a58894d",
+          "iv": "d95b3243afaef714c5035b6a",
+          "aad": "6453a53384632212",
+          "msg": "97469da667d6110f9cbda1d1a20673",
+          "ct": "32db66c4a3819d81557455e5980fed",
+          "tag": "feae30dec94e6ad3a9eea06a0d703917",
+          "result": "valid"
+        },
+        {
+          "tcId": 34,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "59d4eafb4de0cfc7d3db99a8f54b15d7b39f0acc8da69763b019c1699f87674a",
+          "iv": "2fcb1b38a99e71b84740ad9b",
+          "aad": "",
+          "msg": "549b365af913f3b081131ccb6b825588",
+          "ct": "e9110e9f56ab3ca483500ceabab67a13",
+          "tag": "836ccabf15a6a22a51c1071cfa68fa0c",
+          "result": "valid"
+        },
+        {
+          "tcId": 35,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "b907a45075513fe8a8019edee3f2591487b2a030b03c6e1d771c862571d2ea1e",
+          "iv": "118a6964c2d3e380071f5266",
+          "aad": "034585621af8d7ff",
+          "msg": "55a465644f5b650928cbee7c063214d6",
+          "ct": "e4b113cb775945f3d3a8ae9ec141c00c",
+          "tag": "7c43f16ce096d0dc27c95849dc383b7d",
+          "result": "valid"
+        },
+        {
+          "tcId": 36,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "3b2458d8176e1621c0cc24c0c0e24c1e80d72f7ee9149a4b166176629616d011",
+          "iv": "45aaa3e5d16d2d42dc03445d",
+          "aad": "",
+          "msg": "3ff1514b1c503915918f0c0c31094a6e1f",
+          "ct": "02cc3acb5ee1fcdd12a03bb857976474d3",
+          "tag": "d83b7463a2c3800fe958c28eaa290813",
+          "result": "valid"
+        },
+        {
+          "tcId": 37,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "f60c6a1b625725f76c7037b48fe3577fa7f7b87b1bd5a982176d182306ffb870",
+          "iv": "f0384fb876121410633d993d",
+          "aad": "9aaf299eeea78f79",
+          "msg": "63858ca3e2ce69887b578a3c167b421c9c",
+          "ct": "35766488d2bc7c2b8d17cbbb9abfad9e6d",
+          "tag": "1f391e657b2738dda08448cba2811ceb",
+          "result": "valid"
+        },
+        {
+          "tcId": 38,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "37ceb574ccb0b701dd11369388ca27101732339f49d8d908ace4b23af0b7ce89",
+          "iv": "37270b368f6b1e3e2ca51744",
+          "aad": "",
+          "msg": "f26991537257378151f4776aad28ae8bd16b",
+          "ct": "b621d76a8dacff00b3f840cdf26c894cc5d1",
+          "tag": "e0a21716ed94c0382fa9b0903d15bb68",
+          "result": "valid"
+        },
+        {
+          "tcId": 39,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "68888361919bc10622f45df168e5f6a03bd8e884c0611bea2f34c1882ed9832b",
+          "iv": "bfd6ff40f2df8ca7845980cc",
+          "aad": "b8373438ddb2d6c3",
+          "msg": "ff97f2eefb3401ac31fc8dc1590d1a92cbc1",
+          "ct": "e0a745186c1a7b147f74faff2a715df5c19d",
+          "tag": "917baf703e355d4d950e6c05fe8f349f",
+          "result": "valid"
+        },
+        {
+          "tcId": 40,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "1b35b856b5a86d3403d28fc2103a631d42deca5175cdb0669a5e5d90b2caafc5",
+          "iv": "2343de88be6c7196d33b8694",
+          "aad": "",
+          "msg": "21ef185c3ae9a96fa5eb473878f4d0b242781d",
+          "ct": "d6e0ed54fccef30bd605d72da3320e249a9cb5",
+          "tag": "c68bc6724ec803c43984ce42f6bd09ff",
+          "result": "valid"
+        },
+        {
+          "tcId": 41,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d6484e3973f6be8c83ed3208d5be5cfa06fda72fbfdc5b19d09be3f4e4eba29d",
+          "iv": "1af1d90e877e11a496efa3df",
+          "aad": "cc4efd8364fb114a",
+          "msg": "7335ab04b03e706109ec3ee835db9a246ea0ad",
+          "ct": "29e54d608237c3c3609dba16e6edf43842d72f",
+          "tag": "d3365fdcd506aaaa5368661e80e9d99b",
+          "result": "valid"
+        },
+        {
+          "tcId": 42,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "422add37849d6e4c3dfd8020dc6a07e8a249788f3d6a83b9cb4d802362c97542",
+          "iv": "1e7e67be948de7352ffdb727",
+          "aad": "",
+          "msg": "d7f5e611dd3a2750fb843fc1b6b93087310dc87d",
+          "ct": "7fe606652d858f595ec2e706754fa3d933fcc834",
+          "tag": "78d59235aa5d03a4c32590e590c04d22",
+          "result": "valid"
+        },
+        {
+          "tcId": 43,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "cdccfe3f46d782ef47df4e72f0c02d9c7f774def970d23486f11a57f54247f17",
+          "iv": "376187894605a8d45e30de51",
+          "aad": "956846a209e087ed",
+          "msg": "e28e0e9f9d22463ac0e42639b530f42102fded75",
+          "ct": "14f707c446988a4903775ec7acec6da114d43112",
+          "tag": "987d4b147c490d43d376a198cab383f0",
+          "result": "valid"
+        },
+        {
+          "tcId": 44,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e79dfc6d2fc465b8439e1c5baccb5d8ef2853899fc19753b397e6c25b35e977e",
+          "iv": "f9d6320d7ce51d8ed0677d3a",
+          "aad": "",
+          "msg": "4f543e7938d1b878dacaeec81dce4899974816813b",
+          "ct": "1003f13ea1329cbb187316f64c3ff3a87cf5b96661",
+          "tag": "d2323ad625094bec84790d7958d5583f",
+          "result": "valid"
+        },
+        {
+          "tcId": 45,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "1d7b8f1d96a1424923aef8a984869d4a777a110990ba465627acf80396c7f376",
+          "iv": "50ba1962cdc32a5a2d36e640",
+          "aad": "093053e20261daab",
+          "msg": "5d3efd5767f3c12efd08af9a44e028ae68c9eff843",
+          "ct": "2d48b0834e9ffe3046103ef7a214f02e8e4d33360e",
+          "tag": "d533ad089be229ea606ec0f3fa22eb33",
+          "result": "valid"
+        },
+        {
+          "tcId": 46,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "dd433e28cfbcb5de4ab36a02bf38686d83208771a0e63dcd08b4df1a07ac47a1",
+          "iv": "c9cc0a1afc38ec6c30c38c68",
+          "aad": "",
+          "msg": "8a3e17aba9606dd49e3b1a4d9e5e42f1742373632489",
+          "ct": "e9917ff3e64bbe1783579375e75ea823976b35539949",
+          "tag": "074a890669b25105434c75beed3248db",
+          "result": "valid"
+        },
+        {
+          "tcId": 47,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "a60924101b42ac24154a88de42142b2334cf599176caf4d1226f712dd9172930",
+          "iv": "8ba77644b08d65d5e9f31942",
+          "aad": "b2a4e12a19a61c75",
+          "msg": "c949957e66439deee4b2ac1d4a6c98a6c527b90f52ab",
+          "ct": "db4c700513818972b0dc0e531b1c281ca03e40c60dea",
+          "tag": "63f4478bba2af469a7a4dc3b4f141360",
+          "result": "valid"
+        },
+        {
+          "tcId": 48,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "1aa42027836965b1e6086fa137f9cf7f1ff48676696829bd281ff81c8ea0a4a9",
+          "iv": "4b3dca84ecc407f424f281a9",
+          "aad": "",
+          "msg": "37252a3eb5c8960f0567e503a9035783b3d0a19a4b9a47",
+          "ct": "b5f14617491fc923b683e2cc9562d043dd5986b97dbdbd",
+          "tag": "972ce54713c05c4bb4d088c0a30cacd3",
+          "result": "valid"
+        },
+        {
+          "tcId": 49,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "5d40db0cc18ef2e42815d3b6245a466a0b30a0f93e318ac10edde3bf8ad98160",
+          "iv": "acad618039b317470d21621b",
+          "aad": "413036411af75745",
+          "msg": "959dde1ef3129b27702c558849e466f2baca1a45bdf4b2",
+          "ct": "b7ca3879f95140bf6a97b3212218b7bf864a51e5bb0b3e",
+          "tag": "fe558fb570145470ea693eb76eb73171",
+          "result": "valid"
+        },
+        {
+          "tcId": 50,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "0212a8de5007ed87b33f1a7090b6114f9e08cefd9607f2c276bdcfdbc5ce9cd7",
+          "iv": "e6b1adf2fd58a8762c65f31b",
+          "aad": "",
+          "msg": "10f1ecf9c60584665d9ae5efe279e7f7377eea6916d2b111",
+          "ct": "42f26c56cb4be21d9d8d0c80fc99dde00d75f38074bfe764",
+          "tag": "54aa7e13d48fff7d7557039457040a3a",
+          "result": "valid"
+        },
+        {
+          "tcId": 51,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "c5bc09565646e7edda954f1f739223dada20b95c44ab033d0fae4b0283d18be3",
+          "iv": "6b282ebecc541bcd7834ed55",
+          "aad": "3e8bc5ade182ff08",
+          "msg": "9222f9018e54fd6de1200806a9ee8e4cc904d29f25cba193",
+          "ct": "123032437b4bfd6920e8f7e7e0087ae4889ebe7a0ad0e900",
+          "tag": "3cf68f179550da63d3b96c2d55411865",
+          "result": "valid"
+        },
+        {
+          "tcId": 52,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "9460b3c44ed86e70f3bda66385e1ca10b0c1677ef4f1360532830d17535f996f",
+          "iv": "abfaf42e0dba884efcf07823",
+          "aad": "",
+          "msg": "5c5cce881b93fb7a1b7939af1ffc5f84d3280ada778cca0953",
+          "ct": "1d218c9f1f9f02f248a6f976a7557057f37d9393d9f213c1f3",
+          "tag": "bc88344c6fdc898feed394fb28511316",
+          "result": "valid"
+        },
+        {
+          "tcId": 53,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "c111d6d5d78a071b15ab37cc8c3819199387ab7c1933aa97b1489f6584ba8e2a",
+          "iv": "85f18ad8ff72cafee2452ab8",
+          "aad": "84cdff939391c022",
+          "msg": "6989c646a10b7c76f4d9f7d574da40e152013cf0dd78f5aa8a",
+          "ct": "9715d344e8d3f3a3eaa98a9cea57c0cd717c6ef5076027c9ec",
+          "tag": "3056ff5ee0aa8636bb639984edb5236b",
+          "result": "valid"
+        },
+        {
+          "tcId": 54,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "8a1b1e699a0c4a3e610b10902daedab1bf1ea0d505c47d7842cbcee0d3b1b6e6",
+          "iv": "a6f9a8d335fa84c3b27dcd2a",
+          "aad": "",
+          "msg": "ee6a15fc183108f0877e7f2b8a9615f4b3fc36e1c83440f66aad",
+          "ct": "9089bbdb8bcfd124e227bf75c4bfe1cba2004a274fc31aa32358",
+          "tag": "fd2e21c64a019621c68594826cd7b1cd",
+          "result": "valid"
+        },
+        {
+          "tcId": 55,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "74b384e6e013ec4172ed7a28a10fb9bb79b4be2a24f6999e3d3caa28e64a8656",
+          "iv": "ebc19fc9ecb2339908ea3836",
+          "aad": "85073f2edc13d3a1",
+          "msg": "3aa9f7372f056e5a0729752d9a37132d6dd07c56792e1c7582a9",
+          "ct": "796ffb70ab43e7fa79f95583e384524727bb3e47fc45b969f714",
+          "tag": "c3322b4445de5f3c9f18dcc847cc94c3",
+          "result": "valid"
+        },
+        {
+          "tcId": 56,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "77d824795d2029f0eb0e0baab5cfeb32f7e93474913a7f95c737a667a3c33314",
+          "iv": "f3307430f492d2b8a72d3a81",
+          "aad": "",
+          "msg": "0c4179a497d8fdd72796fb725692b805d63b7c718359cf10518aee",
+          "ct": "49c81d17d67d7ba9954f497d0b0ddc21f3f839c9d2cc198d30bc2c",
+          "tag": "50009899e5b2a9726c8f3556cadfbe84",
+          "result": "valid"
+        },
+        {
+          "tcId": 57,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "bec5eac68f893951cbd7d1ecd3ee6611130dd9c3f80cddf95111d07d5edd76d1",
+          "iv": "342ada4f0c115124b222df80",
+          "aad": "73365f6d80edb1d8",
+          "msg": "481433d8b1cd38af4a750e13a64b7a4e8507682b3517595938a20e",
+          "ct": "4c129fc13cbdd9d3fe81ac755bf4fbea2fdd7e0aca0505a6ee9637",
+          "tag": "9cede1d30a03db5d55265d3648bc40d4",
+          "result": "valid"
+        },
+        {
+          "tcId": 58,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "a59c1e13064df8f2b8df77a492b0ca2eae921b52a84b305a3a9a51408a9ecb69",
+          "iv": "9544d41ece0c92ef01cfac2d",
+          "aad": "",
+          "msg": "1c35b898821ba55c2617c25df9e6df2a8002b384902186cd69dfd20e",
+          "ct": "a6fa8f57ddc81d6099f667dd62402b6a5d5b7d05a329298029113169",
+          "tag": "bb24e38b31dbbc3e575b9e3ee076af2a",
+          "result": "valid"
+        },
+        {
+          "tcId": 59,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "084b5d7365f1a8fec6365939ed741e6ea5893e0318d82ab47500a97d77aaa041",
+          "iv": "829f005e980f0a6e2f983eaa",
+          "aad": "770f6e6e89a3fe8e",
+          "msg": "7510016efadc385a71ed689ceb590c8ea9cc1e81b793338bddf5f10c",
+          "ct": "fd42cb5cf894f879e3cf751662aaa58a2288cc53548802becaf42359",
+          "tag": "188329438afe1cd7225d0478aa90c773",
+          "result": "valid"
+        },
+        {
+          "tcId": 60,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "5a7f850a1d9aafa77d59ae1b731965e8aaec6352280fc76a7b5e23ef3610cfe4",
+          "iv": "4946a0d6adea93b82d4332e5",
+          "aad": "",
+          "msg": "3c161d791f624fb0388e808f0f69ed790dbe4cbd089ebac46627bcf01d",
+          "ct": "402302b56140c4dcc39774732c55883de124ce4bf0a0261cfa1569e2cf",
+          "tag": "e830bfe933a96786cff2dd72b82c4bd5",
+          "result": "valid"
+        },
+        {
+          "tcId": 61,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e6d5a4246f6f05618b59c8f9ec3ac8068cc0d3f351c571aa52b09cb251f9c2f6",
+          "iv": "2f90a65e9e48725de6ffc727",
+          "aad": "f2415377ad283fd8",
+          "msg": "964fc9e0e8355947aa1c2caadd7b3dbef82a1024e623606fac436ef573",
+          "ct": "d052932bad6e6c4f835f02019e52d7ff807dc2a5aac2040883c79dd3d5",
+          "tag": "655f93396b4d755dc4475721665fed91",
+          "result": "valid"
+        },
+        {
+          "tcId": 62,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "09e822123adbb1ed89b79a58619c64853992f8371d46338712f6c91ab11a68bb",
+          "iv": "a797205a6cacdd7e47a4789d",
+          "aad": "",
+          "msg": "80b71bbe833629841bd3aeaeb9db6123e51d367b436fe9d2d3454b62cfad",
+          "ct": "83f5c77396cabd28dfcc002cba0756d4ea5455e0261d847d5708aac21e8d",
+          "tag": "705a05820a21f381d244d40e58d2f16b",
+          "result": "valid"
+        },
+        {
+          "tcId": 63,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "625735fe7f8fc81b0c1edc3d08a78b41268f87a3c68488b674222630c1d587a5",
+          "iv": "9d8cdf289dddd09afdc1b02f",
+          "aad": "200a9c95946ff05c",
+          "msg": "67ae1882d0b1c1b2485bec98115ecf53b9b438deb1d0400531705038873a",
+          "ct": "209b7539385c8b19ecd0fd8b5011b2996e316f1942064e68edfa363acbcd",
+          "tag": "fa2f454b9fa2608f780f7c6f9b780fe1",
+          "result": "valid"
+        },
+        {
+          "tcId": 64,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2eb51c469aa8eb9e6c54a8349bae50a20f0e382711bba1152c424f03b6671d71",
+          "iv": "04a9be03508a5f31371a6fd2",
+          "aad": "",
+          "msg": "b053999286a2824f42cc8c203ab24e2c97a685adcc2ad32662558e55a5c729",
+          "ct": "45c7d6b53acad4abb68876a6e96a48fb59524d2c92c9d8a189c9fd2db91746",
+          "tag": "566d3ca10e311b695f3eae1551652493",
+          "result": "valid"
+        },
+        {
+          "tcId": 65,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7f5b74c07ed1b40fd14358fe2ff2a740c116c7706510e6a437f19ea49911cec4",
+          "iv": "470a339ecb3219b8b81a1f8b",
+          "aad": "374618a06ea98a48",
+          "msg": "f45206abc25552b2abc9ab7fa243035fedaaddc3b2293956f1ea6e7156e7eb",
+          "ct": "46a80c4187024720084627580080dde5a3f4a11093a7076ed6f3d326bc7b70",
+          "tag": "534d4aa2835a52e72d14df0e4f47f25f",
+          "result": "valid"
+        },
+        {
+          "tcId": 66,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e1731d5854e1b70cb3ffe8b786a2b3ebf0994370954757b9dc8c7bc5354634a3",
+          "iv": "72cfd90ef3026ca22b7e6e6a",
+          "aad": "",
+          "msg": "b9c554cbc36ac18ae897df7beecac1dbeb4eafa156bb60ce2e5d48f05715e678",
+          "ct": "ea29afa49d36e8760f5fe19723b9811ed5d519934a440f5081ac430b953b0e21",
+          "tag": "222541af46b86533c6b68d2ff108a7ea",
+          "result": "valid"
+        },
+        {
+          "tcId": 67,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "27d860631b0485a410702fea61bc873f3442260caded4abde25b786a2d97f145",
+          "iv": "262880d475f3dac5340dd1b8",
+          "aad": "2333e5ce0f93b059",
+          "msg": "6b2604996cd30c14a13a5257ed6cffd3bc5e29d6b97eb1799eb335e281ea451e",
+          "ct": "6dad637897544d8bf6be9507ed4d1bb2e954bc427e5de729daf50762846ff2f4",
+          "tag": "7b997d93c982189d7095dc794c746232",
+          "result": "valid"
+        },
+        {
+          "tcId": 68,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "5155dee9aade1cc61ee7e3f92660f7590f5e5ba82f1b59b850e3fa453d2fa6b3",
+          "iv": "c26c4b3bfdb97ee6b0f63ca1",
+          "aad": "",
+          "msg": "2734e08eff8f5c4f84fa0c207f49c7fd78af1ad5123ff81f83f500edf4eda09edf",
+          "ct": "f5982b601c7a18fc72a65b218c44974dc564d8314cbe6f87fcf6c6cfbe618b34b1",
+          "tag": "c43632f55760b5d1ed37556a94d049b5",
+          "result": "valid"
+        },
+        {
+          "tcId": 69,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "573f08ebbe0cce4ac9618e8c3b224bea0a32f055c6996838a32f527ca3c3b695",
+          "iv": "ad8050dc6d122dce3e5639ed",
+          "aad": "e99698241c599b5f",
+          "msg": "668d5e3f95fe030daf432a5fc5837af3a79c81e94b28d8204c5ee262ab3c9908a7",
+          "ct": "eaf6810e6ec1cb7a2918856257d1aa3d51a827879146c6337ecf535e9c89b149c5",
+          "tag": "a2950c2f394a3466c345f796323c1aa7",
+          "result": "valid"
+        },
+        {
+          "tcId": 70,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "cf0d40a4644e5f51815165d5301b22631f4544c49a1878e3a0a5e8e1aae0f264",
+          "iv": "e74a515e7e2102b90bef55d2",
+          "aad": "",
+          "msg": "973d0c753826bae466cf9abb3493152e9de7819e2bd0c71171346b4d2cebf8041aa3cedc0dfd7b467e26228bc86c9a",
+          "ct": "fba78ae4f9d808a62e3da40be2cb7700c3613d9eb2c529c652e76a432c658d27095f0eb8f940c324981ea935e507f9",
+          "tag": "8f046956db3a512908bd7afc8f2ab0a9",
+          "result": "valid"
+        },
+        {
+          "tcId": 71,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "6cbfd71c645d184cf5d23c402bdb0d25ec54898c8a0273d42eb5be109fdcb2ac",
+          "iv": "d4d807341683825b31cd4d95",
+          "aad": "b3e4064683b02d84",
+          "msg": "a98995504df16f748bfb7785ff91eeb3b660ea9ed3450c3d5e7b0e79ef653659a9978d75542ef91c456762215640b9",
+          "ct": "a1ffed80761829ecce242e0e88b138049016bca018da2b6e19986b3e318cae8d806198fb4c527cc39350ebddeac573",
+          "tag": "c4cbf0befda0b70242c640d7cd02d7a3",
+          "result": "valid"
+        },
+        {
+          "tcId": 72,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "5b1d1035c0b17ee0b0444767f80a25b8c1b741f4b50a4d3052226baa1c6fb701",
+          "iv": "d61040a313ed492823cc065b",
+          "aad": "",
+          "msg": "d096803181beef9e008ff85d5ddc38ddacf0f09ee5f7e07f1e4079cb64d0dc8f5e6711cd4921a7887de76e2678fdc67618f1185586bfea9d4c685d50e4bb9a82",
+          "ct": "9a4ef22b181677b5755c08f747c0f8d8e8d4c18a9cc2405c12bb51bb1872c8e8b877678bec442cfcbb0ff464a64b74332cf072898c7e0eddf6232ea6e27efe50",
+          "tag": "9ff3427a0f32fa566d9ca0a78aefc013",
+          "result": "valid"
+        },
+        {
+          "tcId": 73,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "97d635c4f47574d9998a90875da1d3a284b755b2d39297a5725235190e10a97e",
+          "iv": "d31c21aba175b70de4ebb19c",
+          "aad": "7193f623663321a2",
+          "msg": "94ee166d6d6ecf8832437136b4ae805d428864359586d9193a25016293edba443c58e07e7b7195ec5bd84582a9d56c8d4a108c7d7ce34e6c6f8ea1bec0567317",
+          "ct": "5fbbdecc34be201614f636031eeb42f1cace3c79a12cffd871ee8e73820c829749f1abb4294367849fb6c2aa56bda8a3078f723d7c1c852024b017b58973fb1e",
+          "tag": "09263da7b4cb921452f97dca40f580ec",
+          "result": "valid"
+        },
+        {
+          "tcId": 74,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "fe6e55bdaed1f7284ca5fc0f8c5f2b8df56dc0f49e8ca66a41995e783351f901",
+          "iv": "17c86a8abbb7e003acde2799",
+          "aad": "",
+          "msg": "b429eb80fb8fe8baeda0c85b9c333458e7c2992e558475069d12d45c22217564121588032297eff56783742a5fc22d7410ffb29d66098661d76f126c3c27689e43b37267cac5a3a6d3ab49e391da29cd3054a5692e2807e4c3ea46c8761d50f592",
+          "ct": "d0102f6c258bf49742cec34cf2d0fedf23d105fb4c84cf98515e1bc9a64f8ad5be8f0721bde50645d00083c3a263a31053b760245f52ae2866a5ec83b19f61be1d30d5c5d9fecc4cbbe08fd385813a2aa39a00ff9c10f7f23702add1e4b2ffa31c",
+          "tag": "41865fc71de12b19612127ce49993bb0",
+          "result": "valid"
+        },
+        {
+          "tcId": 75,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "aabc063474e65c4c3e9bdc480dea97b45110c8618846ff6b15bdd2a4a5682c4e",
+          "iv": "46362f45d6379e63e5229460",
+          "aad": "a11c40b603767330",
+          "msg": "ceb534ce50dc23ff638ace3ef63ab2cc2973eeada80785fc165d06c2f5100ff5e8ab2882c475afcd05ccd49f2e7d8f55ef3a72e3dc51d6852b8e6b9e7aece57be6556b0b6d9413e33fc5fc24a9a205ad59574bb39d944a92dc47970d84a6ad3176",
+          "ct": "7545391b51de01d5c53dfaca777909063e58edee4bb1227e7110ac4d2620c2aec2f848f56deeb037a8dced75afa8a6c890e2dee42f950bb33d9e2424d08a505d899563973ed38870f3de6ee2adc7fe072c366c14e2cf7ca62fb3d36bee11685461",
+          "tag": "b70d44ef8c66c5c7bbf10dcadd7facf6",
+          "result": "valid"
+        },
+        {
+          "tcId": 76,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "ea1d436f6359caec010789fa94fe08b167c3e497d8917282f47ad2a8f95fd0f1",
+          "iv": "73fe022202767af834e32126",
+          "aad": "",
+          "msg": "adf9b6df5c5cc9473e0bb579f9a6aad396f93d28bf83e98136f978cfb9d501d09ef778c122b43c876c22e40d74a48d908978465a06be9e80891710c8c2690a762bc9eb8bcb2aa2707db149abafb9c17c1f0b68c7adcea98aebf4c6a39e5a8f693133eaaa5bb0b3708720d7b86424101bad56aa190c67d25fe35a4a34e1f4fd",
+          "ct": "ace9d080f1ae875c559fb3f0830e042a3a21ed7cbe6c5de366a3b0d7511b31425fd43a0af3ba7bb0a299c0f122ac5c677babcd1e1af24f284ead5fbb42aadc3665d2c28c818aac133c851efe01dad7d7321b197390e707df69b2a386de1d4cea60c203324b53102f4a760644cda341fdbdc3b5ca0aae74b7411c63a958e742",
+          "tag": "aadbe96afff09960024a0be5e94425c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 77,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "ce758567bb0bf3a692333e4fa7b6a52e02c6afb4ca04beadb94a4aff207e9bc2",
+          "iv": "d1cc1ab3d7d31e478cb4a589",
+          "aad": "884fe40045a1893f",
+          "msg": "03f9bcc27aef21ad1c9f22ca275f294ab582cf9a4878b2a6abec983723621c8b2d4cc97d91f1e96a946a8d25206a9ff0f4f04c5784dc64af5978b7371f12eac6bb47111eede49be44d23355bf0e477d701f3fefb26b67aa95354230f6cee09699252421ab2c3f2e89ecddecc405acd8c177a2aa5b6b2ff2ebff301ee59b5b5",
+          "ct": "ebdbb8a9613cd78b62ae915f355fdaf50b6967688d25e0757d8988e6145aa557593f0476e70c0c307f0c3878da9d0454e652771ea89fcfa29ac89737ce53942654488dc9311fd6430da3ae7c390ee4f11db6b7a775e4c3759603de64ebc55c755f46476d2289f3f468e60b12cd615137ebbec389b58db53a20c8b708b445ec",
+          "tag": "3d49d49da114603a70034b6437aa565b",
+          "result": "valid"
+        },
+        {
+          "tcId": 78,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d7addd3889fadf8c893eee14ba2b7ea5bf56b449904869615bd05d5f114cf377",
+          "iv": "8a3ad26b28cd13ba6504e260",
+          "aad": "",
+          "msg": "c877a76bf595560772167c6e3bcc705305db9c6fcbeb90f4fea85116038bc53c3fa5b4b4ea0de5cc534fbe1cf9ae44824c6c2c0a5c885bd8c3cdc906f12675737e434b983e1e231a52a275db5fb1a0cac6a07b3b7dcb19482a5d3b06a9317a54826cea6b36fce452fa9b5475e2aaf25499499d8a8932a19eb987c903bd8502fe",
+          "ct": "294a764c03353f5f4f6e93cd7e977480d6c343071db0b7c1f0db1e95b85e6053f0423168a9c7533268db9a194e7665359d14489bc47172a9f21370e89b0bd0e5ef9661738de282572bcc3e541247626e57e75dec0f91ac5c530bd1a53271842996dcd04d865321b1ecb6e7630114fe780291b8dc3e5d0abc8e65b1c5493e9af0",
+          "tag": "f2b974ca0f14fb9f92014bff18573cff",
+          "result": "valid"
+        },
+        {
+          "tcId": 79,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "80be86fb6fc49bc73428cab576f6ad72ff6aca04001b8b1c57a7128be73900aa",
+          "iv": "903188433c1ce8971aa19b9d",
+          "aad": "0587af8530ad0547",
+          "msg": "67ce499cd8ed68bd717dfe61c60f27d260b1c163a72e8cc8597253d3d987c2dbe1bff2e44d9bd4765d3e53d9c3f8eb3b90e751f47c7157bdc1142bc33f5833ac1cd1262cbb239066b334a4ed99ae82c74f2b49540f1a614bc239d8fc5add8c178184e41281f6e66c5c3117fd953547f7c829425b5082aa69686847eaf5784692",
+          "ct": "2b90b4f3de280c44913d1984bdd5dfa0566c6a14a058659a9b623277b0bb6e82101e79395d12e643f62d9a822bae497907493e4f8213fcf99da8a78fdf867af36bc8b0931c1886b4f0ae5729986494dbd59737e956cd8f226c7c522689d082f023894d54acab0c4d609f3746a67369bb8876008f7fd3dc6681c5fb9d728c5911",
+          "tag": "f005ebe1c1ada75a9cee8d630881d5b8",
+          "result": "valid"
+        },
+        {
+          "tcId": 80,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "01e75ae803d3045e6b28b7f67937eee2d8d98f77b4892d48ab1f15f57fa88bbe",
+          "iv": "6902e8f0ef1e9ec60a3e46f0",
+          "aad": "",
+          "msg": "32dde3b9bc671fad1265b26cad3d8dd0f099134f6755f98613024e1bd10da9a62bad01a997f973101e855ee1c7e60e6b6aa1df9d80fa567d0ccca0f956680be76ed37c71fdedef560e2523e8c5fdb9516250017304f8ff416b9b8e5d17c1f062ded4616ea9d462ed6ca0dfddb9f5295b7a127c0825ffab56ea4983c01eec867f93e24a18be48ceb540986c530104fd466318eb812eb42fd04355615f92503e53799742cdc71830eaa44aeec914b6ff1cbb4f6f81ab595078331d645c8d083b469731174a706b1666e5e450cb62671067032a566f597b9866b71514a409e38fcabe844964581b3ab5152696b76e49ace66581d21f512e28e077c44948a65260",
+          "ct": "6bc2433f8ab0712b59c5fbc6915bc5b971002b1689d36ee49089ff0c54fa359acf9a2a22823b0f9705f702891999f0685cb5f043c5b70d7581c18332144afe7eb3e43a843efdb7ae608f23267088a180d9620aa278129b0dc7af85901815c91b9b26b1007bb394ae1586426c58b5f34f403d311a98aa5a552f7b02491aab1e358e1c06efff292cfd4f28f0ddb25fb13365850992650a8a2f551e7abecd9995bb4219e69ab32ce1b7e73a68a72d66f84f6ba8af34f4673c43e9f8b298016647b878c786ac04145759bc758342c82a71e2590da936d85fa3f0d3ccc3c26265bf5aa1ceb68b572528e3e6d261d537f72345b5ca2b807e5c5d61ca198caeb848a5",
+          "tag": "6e646aa9606b65092b3c5714b0a06eec",
+          "result": "valid"
+        },
+        {
+          "tcId": 81,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "09e85f871440c5e49fb7364fcd0627c0623c4240af18afb446c0051c04948e28",
+          "iv": "dfff8398e35a2e760dc5884a",
+          "aad": "f7bd1b5ce93343df",
+          "msg": "028f4d6686248655364389d9f5ecaebb69fc78dac06d7b7811ca1d0b00e529fa8497f3633cf33c9488d039eed3e58becedd6897f1cd285c0624b822789d8f5a392f21feee6fd8973e217bc3113bc669fd3f99585b9ef82e66ee60ee1ee8af75e2a0149001610a980ec9dfec09249514360f24016ad861e56366a402d68c624f4f56dacfc6a6043abe7c06a00e10d68838f86a2569f652ce5fb1f8345cd81ab73adefe859bbe10226de32f16d6dfaddcf6f3af160e134500d2896e3dd148b9d8c4df663c9f65bd417e0f3cfb979c06d88f749451f4d82c6f7e35b9e0ba382a0551593edccb3b3b4d620cea2705255246184f0ee9236443c8e3b4867604add56",
+          "ct": "1227bc0e129faf1f3ef849e0a091b53a4f1b94c989a0f6975765a6f98f5738e2e3253aec99ce1e1943d21efd21313db6e61904921a5a981f910171e9faa0e7ee57cb1f63876733a023391f9f70adefb9d61630b7adb1e2a3f57a8cea23975c073e128d8c8fac29d7f1a30082966e03e5e38560dd2527757f3f1d31a722f5840271803e2aab34443e7d793a0743532cb7de6d45664696107ac41da5a860420b0f15754c077f6e6df2f7f1f3854fccd6c701ad0c790499bdbead35f9192ff537ab2180b2beed6578de7f732d5f913ece1eb5a022adb57933606998ff3c00c560e8f89c3d8417b5f85f06cc9eed1a7678510bab47c6f06f9dfa6bccb0e9b605fd",
+          "tag": "2b63fa33cc020819b33c1ca9108986ec",
+          "result": "valid"
+        },
+        {
+          "tcId": 82,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "dc4dbf811f9509e33a45a8a0743e9391de333f69c56ee4f0fe90ce21c238ee59",
+          "iv": "1859d3ba4710cdd300baa029",
+          "aad": "",
+          "msg": "df91c48591f4cae8c4d659d024dfd0a3535981487764bf19b012713e6ac6d578aa0b3a51d7ac97cd503fdc8682cabdb6a5256e9890458356f39b9749f6ab158112fbe4f91acd333477998b9f0d7cc0be2d40acfa5103adc1b0d0a5cc94733d703e0d8c26e09e9d079fa6a65cf35240a16280826ab7c0d8ac5882c89e58444233c2f60aaae0cbd1a7ed850065242a9378c340232fd86f1fd52a92c960a9a86f529f431acf3aa94133785803f4ac1a22378332daa22dea3d34d2fdb7c308fa44ab93b3fb02f428be22fad6c0b10c138af97b92a199296dd947c93fbc40674c34c5623d26d9c90dc6b3357018b9f9250fb4dd5c11518191a236745a2bd42f863766",
+          "ct": "c155b08f248b9a1ec7cd3b3a7a1fe37964de2effb752342d8c2804558c36be935bcd900dac4a0120f1ca7b8d1d1bc886ad5660e29af36523fb53fd5993f106fccf6b4e8448bf4f3f331133767d6a961e1bf756ab676485755852deec520d97fd4f97c945389768777ea01c4f03cb8d4ad9c3badd09724a5a542b2223b50b1b0f0b311e7321b5e1c4b7e1fc1a8cac613ef91187166147ce84321ce1bb10e82e401e4f5b5009a590937e4e0be98d4d1f3a3c809fe8546255e77c756f809b273ddd18ac2098e315a4ab6e6e8f7749a72b50ae449878153c12f63e62c9e453790c74b7ae09f6c2d9331b532127c29b36a8fd87552f189ef67a66f204d0813e2547ea",
+          "tag": "a0aafb534e72d5d0291ce28de457714b",
+          "result": "valid"
+        },
+        {
+          "tcId": 83,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "851d60f903fee79704ef4a5e64d6ea9bbdbbc2bbce54a08ffd810a7d966dd2d6",
+          "iv": "aa9434bf91cd9e494314e68e",
+          "aad": "6fd57103d966e810",
+          "msg": "d0197218ffe58d1bff3a3e0b4d246495a2198eece00185095f0bff1bb2eb78ee83b86c232444e2bac93c05f5be3ae1913077c24f8a753362729ea8f947a82a0a5c0ab56762cbc78f94992396e3f252a38591fe1de6d0e71b5dc01d3f146d3050de55d15f64e11bc5510df4dca985e4ebdd232b972615e749914cf26ceb4e66802eb8324a5aa54b515b3386e1305f0efbade636f2e0f0a8b365783a1f02a1462002ff444bd8ce05397037bd96a910eba07bd606a8599202cf1ec70bda6b3346ff7060bf2837ba3f000fb63d31451de7fbc4544e920fba343ce7e49b71aab3a3e7bdc23e1ebfeaf00ee980368e0e6c13ca0ba195333d610fe826ab2f15e2a26e82",
+          "ct": "6fe7d827a25e8028ba3a228894bb4d0c05a3e9d0b18273126669f90f8b46764252e9197d748178d4386472b286262f9d322f327e50e998e3928d3d201600e3c6431c697f848c91fa1cd1f8d282c3778662ee4e4cb2a225a5f1e362703011703ec1ffba91febe291f3d49cfe40a8fe34fba48686974f0957dd1351c7ed05795de157dac2e8be7c15cb33acc322bf8f5d9fbdebb84744e2a69d44ec1efe2a34ce97afc6fc46311885c96c481747ab86fe9c1c60832dc5625dbb9f48e34dc7a6f0fc439ecd76729f6b7b9cbade2703efdf352d3421aa715e3dd954cbf0fbdf74d31f980c4c0a1867b430f20f35127eef3a996ab46667ee3709afcf6490383efb394",
+          "tag": "02dc33981da69c02be2c7e383a4001c4",
+          "result": "valid"
+        },
+        {
+          "tcId": 84,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "317ba331307f3a3d3d82ee1fdab70f62a155af14daf631307a61b187d413e533",
+          "iv": "a6687cf508356b174625deaa",
+          "aad": "",
+          "msg": "32c1d09107c599d3cce4e782179c966c6ef963689d45351dbe0f6f881db273e54db76fc48fdc5d30f089da838301a5f924bba3c044e19b3ed5aa6be87118554004ca30e0324337d987839412bf8f8bbdd537205d4b0e2120e965373235d6cbd2fb3776ba0a384ec1d9b7c631a0379ff997c3f974a6f7bbf4fd23016211f5fc10acadb5e400d2ff0fdfd193f5c6fc6d4f7271dfd1349ed80fbedaebb155b9b02fb3074495d55f9a2455f59bf6f113191a029c6b0ba75d97cdc0c84f131836337f29f9d96ca448eec0cc46d1ca8b3735661979d83302fec08fffcf5e58f12b1e7050657b1b97c64a4e07e317f554f8310b6ccb49f36d48c57816d24952aada711d4f",
+          "ct": "2152f1edb34c35b43f7176809ecf6db0a0a2afaa18392744f7bb1d4a4c026c374bc28fb560987d0259da7b59a1920528a192211244f8b9446f3e680a54e4c0c66d4c60449ccb2e9244cec83622cdce99f5aafb8cb37d70bc866a045202cff331c783ff953ba053bd2db6086ac351878f0deaf49d92d0dded0a39182da35dac8c47e14cfe258aa4c85903c4ec1739261221a75e918b5ef24ca1ef1beb7a32e1890548d34cab34b4bcefad5d5d110cf6fd4e42ff4e35c24e8b6295130c5dd914e96b1f89838018914adf2e17426ff36965a738892007a74111c977a6d78250b912a539909d6ac350f37a67ec0fb0aafba26f2df1814691987145bcb3d80a815daba2",
+          "tag": "a17ed683b37ce537184298103ad6a8c3",
+          "result": "valid"
+        },
+        {
+          "tcId": 85,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "a0e4170759650755c454888ab1e44913ad801fb6c4035c2d6aaf537a4fbb21c5",
+          "iv": "b10abdcc32cfb8523c6449f0",
+          "aad": "9d3abb5f1b4791fa",
+          "msg": "654a874abb7a13ea1d43140ae49f6e4ac8bfb8a8e979ce4b21320e69af4ea44bad0f3166db17017cedaad64719917e58c05bc4646a8c4c34931043cd6136202ec65487a1713ce144248d8ff8199763a3c37943e4c0a9de87d1079ed2a19cdb322cbe8131c1b04f7770ea23f8603076073b4a5bbdba96a3ea09197cfb61f7411a75e1855b076f5f57f6a3611ba821047f8880d82795397aaf900b335a458990622ba91fa5758e996d55209e44879c6d068e7cc0d5abed0d9470d8198ddbae92a28f98c62a158316dea8092ca7ffcf8b81adcb0f918f296e9a655439a186190b41cc9b4580627da94ebfe1d621bcca787de5f970006b7de87a6645827afc4ebf7ffa",
+          "ct": "91d5e36eade5744e02e1cd1368258eb15dd4b3bbc92aa030a947c274328a26fa326ad8ea814db7beee7e6d991a27bc95045853c6b434fa64810623152a35ca79dca26d1742b2b3cdfbcebdcde47c087bbbc4e9ed4fe2d67e51d5cb16326ebb17e949ba3415f8fbd235276f2f90e3a233271ea7ddf88c3f9105685bcf3295f94505e2bdfa8f6fd18498ea945e7b47fb016feef608327dca93ccf54cccb3825cdb7ee61ed5d47f33b175ec0f6393136b0b17fa640d3d3e6f7f06990b80035e0297caab819dcdbb60b877b5ae2d09b4708d5e27c656c5c28e29ad85b32e84802efe315d90da7eb07575971dc39c2a7f44db5c0fbf47d8700e70103a0669462425453c",
+          "tag": "737254b4bf0485fccde0392be1a3c858",
+          "result": "valid"
+        },
+        {
+          "tcId": 86,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "4f62e56f7b15035f427849714beb97e6acf88371e1f69b388129bb447273d6b8",
+          "iv": "137d5c98a92f6dcee4f29d7c",
+          "aad": "",
+          "msg": "a147b716b86ac8dac7447d5ba60ee8a4191d2c64a3aa04276aee7bf7dc824962c09ace20a7e614cc9e177b5b11819b8f17008a9408e8cd8bb34b401be35368f492c17629b6467299bfd2ec4d9a7f17dea6f9ca084e871fb7fc78c2bf299b810522062726c5cae14b839722ecff499a2b3f082b6d1bfedb752f84a4e77459c9268d63199315363e9aaa39bea7fbbcc60a5eedc8a1a982ad6fa67c295b932eb3999047e0a99b3823032b6b3b7c4c553970afca50cb4e5ce859c25c598eb682005f17aec5526e26493208483679a23ccef6f7403a3f3055affd531a1cb7d183892dd577d526e8da8aa8b8b980a36e176b8d9293e785ac01bdd4dac8cf8dbdd82926f1e31408284fb3aa01f4414ac7aa7832d2ec02dd2db9b6b4b61d8c1cbb31dac7b6afa8d08b6877e439600c4a6fc07511877df2e9ce3a9538a726002a46c083d98124b185730f3b2aea2a01cb626be809f87b2ac100511c5b8fa0e9d40c9c999ea0aa87aad08cfb62c1ba869178be986156f7622d8c48ad80a552e9d08c36671ae232efefc8619c562e715f04ae52db2ad8e4a09e8c671b12289558117f9562d51beb59e29b10dd9eb232e8fcdb1cfdd14899acd693de14a7c076a4656386e23b06415b2c7a93b166cad1048bc605a49a79df3c03a3380de68a4f013e05e5283745d4078ebe308dc8881ced62ed571a93c69e8aae6e51f5e61e4ff75699aa32",
+          "ct": "8cf1182948f64274bae9a56362643e4c0a0f336ba0e60fb6559c0444fda0d03410f240432048d4dda78736db698970898aee32c5941057c87195bd151807505af56d939f0cf687b64ae21204203c0fe7bbada00d98a7dfef5378bfa01f5500230c7a453823d7eb9d604741182341adf0c90c652f7e3b549d8ac2090d78d8dfb9265ee2c2e92e760f76816f9cab794523b9bd6c4d22b94f8fbc07fa5fb6c55fb56570f5f9f22b7fe355ef36b20d31e17274d63fcac8904e67e3886afec43056d3bcbe683e7947a1fd8bebdfbc95ece9bd0418b74f7dbd745b5e8490b9891c124326753a5eb6f04150ca4c1a105874c21b90a52213ae8a483cfc7189f49491a1b0896a9171db2764d79ec1f98170f9f7a0bebe494246f708ea5bfb1ea4ba16df704d022a0b50d42d7b018995c1da346c1b9f8ff9432b830015d69ab2b4dcb6d24ea6c0b721552fd23171634895c0d1f3827e2954949e52db5fad0179d1b006c6591810526af9b7c3cd3c16d8df46254153b82c1156c360c6207c787d6074cac0ee638250273be768e6ebe14ccb0d7df728d085caefd2d6e24dbdaae063ad00225b1fa5015d620a87563780e0aa4eff4b500c4c1765dda555e224986b02b07f4be7dd955105ff5d1d61d35e66819744ba946f91ce302ee49a9ff4e3288f3d8ec5ff8b1936be6beed5cd8dccf4822802c3bf77a4c050d0893c13343dfbd7be796e",
+          "tag": "e7ce1fa9c9a48457efb48d09cc5c2c24",
+          "result": "valid"
+        },
+        {
+          "tcId": 87,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "c02c2c0f7af8aa219933eeb5cae06b047b231abe1678fa3c1764ba850ecd65d7",
+          "iv": "52f284156a66918965da70d2",
+          "aad": "38daa49513175a80",
+          "msg": "9a2ec2de2ce5df3d0431a40021eec52633a845be351d042acd384fadccb40af3885ce163877bae78c4c8759c39405621070585313868ac7b90a53ed9fe4f8b245e2ba817be9261363ba141b3bebbb18bdb6b32070b50fbd42373c1f9ec32ab85634c0efd845d59fceea4155a6ccd34fed3ce0f68863047b600097a7c604a25f8222509287fe383fee8f41a9d82fe909b9271fcc0f2501094d1bb111a35ae540714db20d73f52fa70d28bc0d5a160a6f7cc1208ad4177d32e1539ff74b67f68dace45a3a4fd8cf5e8af97205a9cdc4c0053f3005e99c79e850e77077f296856773bfca498e8127d7ba1895709ea47deb4d24603b2919adc140c33c249c4b5a60112bbb61e5e8fe4ed06bd31566086c1e7823a907b254a3e40b7d00b8d4c94a7f3d2a2d9a603796a18336da0f56af1d0b9b3fc2af717e0a84478bce8c8451fc1e4fe755f78723bdd82fb705810d43e925b5d69e248315b89b2dded9412e2736db550d8696f64e27ae92ae5e3d26b04c69710489ed17a6764e7ee9d5d947b009af46a0db26a503b11f496d6eb52dd56b98052620e0feec99c211710ca31d2a48231da19d02bb25ded8b862bd8c242e5f602757af181d0b469c0017427c00506ad19882a3c4ee1e2692d9b14046cd08d6e2d43bd20e33e928db64cdec8ada4263afddedd0526777db986b725fb1611e54dc63b9728af4ad950abe2e950d1239a89",
+          "ct": "83b19ed278195ab46de72ad88cbdebe1a164167217efa1c2f64ae1820ead80fe11ea034447149f83fb97d41f94ec350cc34271d11da22089bba9578901eea60d9c1a710bb55ff5b1c7fdce513e598de145166ad4a8e1ade5f924ade4c657809026f2c2c32aa5415a744920ffb436bf47ca88fe47b6c6673312381fb328447297ab3cd9e6781259b50996a49a1e33d7b0b443f8a278c3eb370fae028746138a51ecff1eddd4a31c4b5a33165a95515b7abc4f61ac5fbcd69681bb9a6e2bd6edd4c6a7a21b25228aae717061620a6a23df738abb6878a923b6a01d43d996ca7e42048799595f43df2799ef4f2b170870daa4861b1ec811d3c5bc886b9c17ef014fe00d0c04fae95bc56184abf3981829febd8091d55c65f02fc31d6e94a77023c669a62cfd0edb165d5cf4375b2cbf48e518989f7b7a1123ce4572b37081ed98125086c2649705a707b3a5162ab91f7ba0fceb2e24395c62f6bc8176961e4bf046cf8a5615810d28c7e6a0a12adcee66fd4ddc4733704d271d3a8ba601f7675c9db88df760fcdf818ff072237270ae5b0cef853fe9ee0317ff62e8631f431e8499a4ca7751c2336b7275f787ba78782992fd6e73a2d2dcc740076847a922880900f9778b2b09bf98575d0e4ac63ab8e88377e1969889cc5a05f32c774a045bb1ab680e3584428f86ccade4107f3ef18abc9af1c24fdd4bce7902fa5e06b4376c",
+          "tag": "4653b36f7430536fed993668db4fe243",
+          "result": "valid"
+        },
+        {
+          "tcId": 88,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "6aada828b2273ffb81dc794a8629e305cb646f9d266002bd313427d384838767",
+          "iv": "00dea4505cd5396f6ba408a5",
+          "aad": "",
+          "msg": "1d99ee022f9576ed69af8a7f3945362ab0c4691a4d333a3f5f85cf8d7db7fb8a069b48998cf286ffa4615e87398c3c3c1295d5bee272bdeb5166470a8923f7b79dc92b2a97de34ba87db2907ac84fb23d38f2e1af835f737488fc04fac70432d3a0b02a472f851025803aac692273273e27be1dd9679a4d626997c363ba706a7db1f4cdc07fe3c67fbec0aa8619038e05607d95a5ddc4b403cd6dabc41790adb6cd76eaeac3491c3cd6a8787e0f29c042b4e2afe987674b9495ef55768c696bc6c3df1c1e9a7c0456f478a1a1cc4c3a9b0f2cd3b42db8d0b6aa36dfec3d2c08d1398eeb75db61ae902d2da5a1efac7904b8ae32af1ff942c99769504bb5c56f5819e4f899e8bbacfd4682d82f41e179a9ddf9a0820cc4316f252d1d35597aeda43ab870887e67aabe79f046b03a9a83588994058a07baedbbbf9c01d833732efac89ae8173f902e831d579d31e4a409cef5e494a27bb6367e84fc57642048e44d687ce73dd9e71384182b262d63a715698132f218fc2c3611ed0dbf814799866c8c43b4aa7c13b5a53f9a337627d76bb960f60fa891f0076a538c396500cefd2dd1e4e024f9d83275f9b2c0ce6df41bb6488398fc657dba0efdae0019dd31b03227edc5229aff60cd083c0f0b66675baaf91c3206819a0c985bc3283600e9e6d62c6fab2c6aefd69829c75063c54ad11269ac5ec563ecd870c2af4cde6cec43e",
+          "ct": "e0ebc9ad51c2421c7e5add66854a184abee5b08da0281dba8ceed731016d93cc28bf8f58c56c0b976053799ef1019b68000b61429f2884fc5c0fc51dbc2832d9f0cf62e84ee2b2e4a71b44f6f29fa53546bac52bfb301b0132107b6e81592a14e59d7bf8d0b1649f72f536877c850d2b0ad6f2818225ad9ee74b3a91e6a53dc86fdb28dfc9edcccaaa4229b5e5af96c5d1b6c852a5a7cc2046deeb228c6cddda6899618203a070dc713f0f533c72f51b6c0ee57f6400a68f0f9a8bac249f6ba851153aaf58d9a311a9c699a53a4828157bf0abe63360696fd00fa42fa90483a04cde63b7eb4b12d988470a58a5a4ae6a507dcd6468c4a56bd84a39bf30a55109aeaaac08c5b3f6c482c8d4f3adf4f41b3cef09ee255d671a8a45c96535d55113414bbc72e07b02d8f548b7ff8511b71b52cf98eb85f951fc029b5a20927b876101f1e7993be9a33069c9c8711f198b8fce00727b8f5503bf27185db2e8fe8a0f79dbfa46a44c5369bd0121ac5dc048c5448efff93d65c05a3880e36de4b1f2fbc3fccefefd0109c2e6f6565a413f4fa616628fc28cd53c4493cd0ae307844e8f780412a5753c2c4c2f5246b1d063684aca3d5a929226cb2ca938d36e156bacf534b4d675be66b79b403c48106d32f0ec30cea379a092a577afede7a0de18e4eee6544ed7a7e14e24b1f1769d1d18f275e8ac7d665d97ead3e2fd78499f5d9c13",
+          "tag": "d7a76044b3762b0fdaa78c14d56a83be",
+          "result": "valid"
+        },
+        {
+          "tcId": 89,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "285215fdae568e13d4501fa7259ee663927ef005f495b1991cc0c4f8b4e521d8",
+          "iv": "908863b8e51baed66187c998",
+          "aad": "9b94574d8697d904",
+          "msg": "91675754494a79adc2727177662f81e915df62ae76984a6532c53beff09de23089642976c2cc244e26191bc97286381983c58e1790ed61c189fa6ad6fe61e0636d353d4ae71b16bd790d83a4e0fd4f8ff2333a9963ce15e083ce5e64bc25cc6b32cb84a2c9bb497aa4f6082abb1f1cf78374682882bf242f06b2849c7a907944f1eb0cb1e1619c93d05419ab77264d1b7336c5f454d52c35a1005bc97a1dac3c46c951983a45fa87f19be57fbcdad58562de4c6981925d5b6118a3e50439926723c1879d710b6c79e880ee5c3facd6fb54ed86e7329f1f9c461791937608339ac13930b1c515b7b2dc98324a4eca7213005d2cf274edb9c318794e608f8323aca43dc6a6063f6ab9ceb0d149601ecaf8134a8b0acfc55bcfff0717047c7259958866a48c3097fbe0d5f17fced6362675fc5a5201c132ff97e0d8e801a59b2562b289d91c587217c71de36c26e1cef3d1245cf86ac2ffd7afcd085915db585cb41ed7f8060dfbea6ad5399c0b2769b0f3672c9d81966ad063ab46da9e0a07c5c9f42b70fa5d60e9374c5849b13f72e99514e8e6460d02ec433924d1c76946b3b7379fe70e4eebe53afc581b8d6fbfc9f48bceb14a571bd3a20bb460fb107f2006af1839f1c2ce07940c8dc64bc02961f50997f3ebdf7472efd7b9cf4ad75ab53fdeee6c634935c62fe062db0e082941eeb2a5568528bf0de46819288d6446ad33",
+          "ct": "fd395a8a8a4d4f6404587fe9786e324a529a9c824fd6f09d1a489fa060d1a7fde3859ae324b631a3cc4b566e7270d91c09247f536a34bfe412e980da64bd995d87b25f9e4b39e634842d2112eedd5dadaacbccc701caf8e03988f4161700dbd9fc806eb2dabfa6d303dd6528a4ed256758e14d9e10b6d59fe4961c25384f0342b6277d503dd23d61d47ee4e30fbaf4fb2f2549dbb1a519f0da04b05e39b266067c9d27287f1fa91f69a81e63d7c207e6e7783061b02dda0fb3fc60b6aa9dcfa896a72f534a076779364443d9e6991317ff8c8249fa6d65510baab744bd1b697ef07d883f3b91d026ab982bec4101c454fd0dbce62f756414695873a3f5ec0d67821ca778268a968b5e8305fe97003c8c15355bd81505069887bb08f67f6e81d418c5bf85a904ec09cd6c04b3d6a7e088d02161e465d5322d3d7f4ac9bbe6e80fbda1fb9c6d6791a0f14419765789b043f2e231b7d05ffb0be6140a93e6161730f0e08467389487159c5a3fdae47ad2f65be4456e285ca14226bb2acb4f0e612f47bc70e801868e6d744f797b9d2b4933072bdbcbfbfad8a98b1704c963b53169943f1cc15c33631c84451f92b920e0b08883e65b4270b42bf2396fc27488e2a36c93a729995f0c245d2886ca54f70422eebe3510c42734a5500c7b1757df214b4dcec11eb6084e6405c8a0bd4b0b1c3c0a4b2923d197a287c23e5604271b756f",
+          "tag": "62188f853284fb3f7eacfc876cf906e4",
+          "result": "valid"
+        },
+        {
+          "tcId": 90,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "afd579aa1accc682aca54e142aa69df09802f020b24a42c41db58f6997edc678",
+          "iv": "9f79d1da957491069d774496",
+          "aad": "",
+          "msg": "bafc6e865c48bd34b7f9329e35cfb286cd4dc31f8316171218bf0471dffd35a330a181697ca5178688dd87efe527924f90d1c78ba40de70952ff44c26efe2159e59358f3931573df9373a73b91ba9592e12140cc009feedd2595e5b6f066b5ef6de99d4c31552cecb0614f1dce990e46e7694382f3cf3ccfcd1ea62e563e5f0dc36cb5a84e0c0b3f1f8f3fa9100f487195ff2e3169ad08136aa8ad566548c9836aa00dbac74716c26e838c1486a0084d3dfd692585e2e5ae7c75caf0e7af60219f96116ae963b4a5899cb30a120daaca7833776692c25ad7c185e6a2d70ce03ff156cd25d76153539d6855773e21142f9ba0313562875f105a2b770a15b533fbf5110dafb69329982ab44ed1b9f321d7b79ae15a19d9f3bd4c504c24b23b812d514c19ae2a347cc18c12ce915a0bad7cc89a8720d4ba5ee0964fe05e4cc59a13f92c670b8655071e216f19ad05f4bbcca6dc7feeb188d6269c58065c98fcbbac183a9abb3811d80cb476544bd74b26991f3df987f0ed0ea6238659ac09a2250fecc0723ffc51647b74bdf454f26e11112c8bbd797f09a3be8251c6b5b319ed9537278cc1abedb32aa10840984b96e8636b289335846ae4fbd4a00f6600d98ebe25885c68d7043ce0dc5229d7e9bd51bea9b8fe0552f40688429c482629ced623f6074858147e73da3ff4ad2ae45c1a1c8a6c5b3b2c3d568a756608179f63b580fd",
+          "ct": "112f4ce552e41a1e8c93f6ed3e1273b9dab4c1eeb5c100c2c2732af27f0160764012af269a50f04d10ba24bb43598547b700cfc480ab123f6e5c7488d674a637552ca03eb298af4ca2879830ca25f273713bd5bde16a06b31254b412bf6a8ce22efe73b15380fafe2ade9d5c57e6267d082b5adc06f55e8313b1d0753a46b988e7776b201a9d5896c349e8631f1b381c8f43247d0d9b171701fc94c5265ead84f3d44672bb799d3ddf8d63ae73d79104e48366f05d048df2ee54102d637b9c2d4d03200109be48b6d4c2fb9b0b45f7945c8c5468c97f36c9f4b9789a3a547348739dac3e7b1144884d501b4a073f04081de6287b66af2d0e3728cf2064be88975e578581e1e8d7c7d9c956d558c2fa6816721518f1e1de493e83628a42cce40f85c55d5973b397ea1d58ee473bf5ea59f35510e1903d22673c3d289121f3fed8ee4253e299a52410bbbd39daf1b87e43b5c4be3e4698943e5578f0744c2b0a4d39922d6c4b205e8259166a46230d326442492763dba8a2cd9d62c7e8715e43c891ce2f5333b02ea94ce6fa1c27e86e3488a9b7f26bb814d214b9d29eefa5a4a04040cdcbb1a13ca2f436e302f767da3a7675bcf501cee45f774eb64c0fcb64f1d2e5cd8dd9f9600e0b5197125a35249a0da6f64cadca4a769984bab62438af11c323de33014f627e945cb90f5be88291af1e7e169d7695db6289302ad99fec050c",
+          "tag": "e2fcadc31ad755139d38ecbfb75d1ddc",
+          "result": "valid"
+        },
+        {
+          "tcId": 91,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "5f44a54d8959406787895ad07ee415090a45e1171789a2236ef30b1fb8aa6f58",
+          "iv": "0184e1b899f829c859822f21",
+          "aad": "88794ff41cdc04a6",
+          "msg": "0a0e09595a1a5d0784ce1abe4aafea00e66b30fbfa4ec23b22d0701f72b9492ae7d9cca281474fd5b1aad8265486cdb8c74f23bdbc0148affc171829ab113b18df5d873f70b54c340276381689edd981a4ee6a9354a7a0b3055b2c17e8dce3910857d3022ecb6871c7fead7601789fb211d0a4eb345bd16cf2ee447d0cc6267ef2b7b43a89778f6fcb08176be0308df23906567cace11c19e8962047c2a5db9d26c964d67318308bcbae06af8cd95405c5eba980528e4fdb10c24c0be0904199a7222e309495c4117b244c28f835dd68006ad8ca6a0e3bc0621115e3d7aab15d553c54acdb15f3479e4de48ffbf358a5aae9366cfd8f9dcf6a8010a70ec9fdfe889612368356a3c722dc04684ce6acd54fca83b3f097144be4b0af9ec4eac6d6bc443df3e3a679f29ed7afc162f936d7212de96ba50857178efebf83647b09fd751d48fe97ee68dbcf72547835502646ea68e8b17cf88d4ceb0ac5522e19ece5b30a0d5cb382d8c72478a5ebb18b8460df0eec767b232b0ecd7b9d5837367bdc08d7cc15b9e89a611e0e5f6f852f6264f07b4be7eb4482f3253c6b662b2f0b663be4f2e66ed71002f723da349cbbe0e0d1bd1837ff13228baaa0da2a07853164b227313748dba26b629ca6c995367bb977809c2a35661c048589fe1cba874190a80c9a7005df968a9bef0abf2fe4841aeea7cd2ba8c0e897aea78fbc2948ad2f8a",
+          "ct": "ab64c27d42a6dd6d3a5882ae3a8d351026d48bbec73ddabdab59d0729680ca7edabb8acc71d23023394f21c205f4dcf3191bfeff50bedb42bcd3b20cacfbb0a201cceac62d8ee1cb187bf76abc9f0efc36fcf32e442a4aff52abc43e90e4f40dee972e9c8f78eba8dad3d5c3f065733e1e8d18fda5baa8b4d2cdbb9955d9f9ac5186605f5f7bd12efe38578878530fac56e0187e9d52dc1ec53b0fab591cda716ea608293f2d3c70666cdf966dc0ef4c7dead4b6b85f7585fa22225d792d1988186ce49046eec45d6adec620e8a4a16f5420630f3ac8020763d908d9fab35649e39153d65e06e792be350179b1a5b3ae3131a4c9ba05b6ca9afc8c8d9646aadfa275a65c0eb106f4c93eed0b536973698de3f7659e86e8bdec44c4c1e03b5e967abc89bbc6a831768673575d44b26caecfc82ad3ff5f48a9adc22fcdc000b915a1df8a027ac7d1f8524f3ca156202b2e288bb5d82c0574f8a1e2404bd5df52ac21dfee13ae509fea692ee5e42bae19a82b0249fdd43e725b8820c9a50d256064badb069d7ea142425290cb51ad10af493581a43640e69ebde9ac170f7835976cbff3800ef4fe07b1bbac842170d2ae0ef0c87b1cd8154cee3f46c064b6e68f1bf2aa1950dd658f2764f48885f450b1b2d634860fa233f9d8149e34e03348d4e506a75a0cf2636798826b2d6b7e55837628ab266395306722c924c70ff6081cd27e",
+          "tag": "c3342ce3b313cc8ce28c166d927a4474",
+          "result": "valid"
+        },
+        {
+          "tcId": 92,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7d00b48095adfa3272050607b264185002ba99957c498be022770f2ce2f3143c",
+          "iv": "87345f1055fd9e2102d50656",
+          "aad": "02",
+          "msg": "e5ccaa441bc814688f8f6e8f28b500b2",
+          "ct": "7e72f5a185af16a611921b438f749f0b",
+          "tag": "1242c670732334029adfe1c5001651e4",
+          "result": "valid"
+        },
+        {
+          "tcId": 93,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "6432717f1db85e41ac7836bce25185a080d5762b9e2b18444b6ec72c3bd8e4dc",
+          "iv": "87a3163ec0598ad95b3aa713",
+          "aad": "b648",
+          "msg": "02cde168fba3f544bbd0332f7adeada8",
+          "ct": "85f29a719557cdd14d1f8fffab6d9e60",
+          "tag": "732ca32becd515a1ed353f542e999858",
+          "result": "valid"
+        },
+        {
+          "tcId": 94,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7afa0f59dfcb5ad3a76490c5c804327c8d052be737a60fa8bcbf0a2c36630a43",
+          "iv": "25b7bdf4a6dcbf7c9a3ec2b3",
+          "aad": "8b71ac",
+          "msg": "623e6ba6d3166a338bfcc7af90a230c8",
+          "ct": "d46e8265a8c6a25393dd956bb44397ad",
+          "tag": "e28f3ad9e3ef4a3d94ee07bf538eaafb",
+          "result": "valid"
+        },
+        {
+          "tcId": 95,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2ec25b0ec7ac244224e9c7fc2fa5d3ef17809e19fd6e954158dd0d72738a4cc8",
+          "iv": "6fb0d1417cdfff4df37db08c",
+          "aad": "3a5ddf40",
+          "msg": "a1c933768a6d573ebf68a99e5e18dae8",
+          "ct": "2d3cb2d9303491e264f2904f0e0753f4",
+          "tag": "6c1db959362d217b2322b466536bfea0",
+          "result": "valid"
+        },
+        {
+          "tcId": 96,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "0a2cf52371cf9d9f95b10108fc82b4fd6110a8ba9a88a26083685ad29826891a",
+          "iv": "2538fc67afb9eab333f83290",
+          "aad": "9eec540bb0",
+          "msg": "0d8c691d044a3978d790432dc71d69f8",
+          "ct": "a988c03c71b956ff086d0470d706bd34",
+          "tag": "b35d7cbf2beb894b0c746e0730429e15",
+          "result": "valid"
+        },
+        {
+          "tcId": 97,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "307e886b38bb18b445f8a2c6d6f8932492a9cea8d041ba72eb5efdfa70d0b8d2",
+          "iv": "a071be999151e2a1c41c81e9",
+          "aad": "56e014d97c74",
+          "msg": "9aba22b495cb7ec887ddaa62019aa14d",
+          "ct": "32bf95d4c195dbaf58d9af4001c6e57d",
+          "tag": "4393808703d67a90870578046cd8b525",
+          "result": "valid"
+        },
+        {
+          "tcId": 98,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "dacd51a8a8e4d5905b4cbb947ef4013eb296889353f3c9ee35f5577b26737a51",
+          "iv": "3fa378a1befdddd61ae68cf4",
+          "aad": "bb5a3812f0aefd",
+          "msg": "e148313883a77da121124d06b1c77dca",
+          "ct": "2a207ca7e9da6b13a229604304d87eb1",
+          "tag": "8a6b6afec87d93ec6e8dbe13d84c0f8c",
+          "result": "valid"
+        },
+        {
+          "tcId": 99,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7b5fbbb202c16108fd13066446853a850d8b34e9da40519580da446a922f9162",
+          "iv": "aa077a5ce9161bde8d8edc40",
+          "aad": "f94bb92c1c668a695b",
+          "msg": "da471cd6935a0ca8307ddedc6b959962",
+          "ct": "548a5ca0ae49211cdf30bbdcb1352d31",
+          "tag": "204dacb98f8c8908cc5ea22bb23f901f",
+          "result": "valid"
+        },
+        {
+          "tcId": 100,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "1ffd101eb97531f6faa821ec4d5c5702725dd033d3b830bb760c4ef27ba983df",
+          "iv": "598114e8cf7fbdea8ad29683",
+          "aad": "2155627ec15a978fbcb2",
+          "msg": "28668ca8db535c7e8eb27491ad0fb7cb",
+          "ct": "28cedac24f14caa326c7fe401f68a87c",
+          "tag": "2bf1b2c43d3039f8f5ce359c1102f879",
+          "result": "valid"
+        },
+        {
+          "tcId": 101,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d2d0a973d5951af352cbee57ac9dab1c284c99af3b992ce015f219506f64888d",
+          "iv": "9acd213570ce9bb9d886c6ef",
+          "aad": "37ad668d4d4fe889949763",
+          "msg": "3f3f0076250352e1b6b5c12cfa12625e",
+          "ct": "7256e856872ad3a54b34a2a6bdca8838",
+          "tag": "3b12e4586e45223f78a6eea811efb863",
+          "result": "valid"
+        },
+        {
+          "tcId": 102,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "adcc520b381382237d05a6400a7dfbcd0771b6aa9edb7966131ddef6af21f1be",
+          "iv": "9183cdf3a8ba7397b6b2d5d5",
+          "aad": "b334375415f6215c0bf89a9a",
+          "msg": "958295619cf1b36f0b474663c0bc79eb",
+          "ct": "852c141b4239a31feeda03550d70a2be",
+          "tag": "5fc59287b92d3fcf7d66f13defb11b0d",
+          "result": "valid"
+        },
+        {
+          "tcId": 103,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "bd534f7adeca466844fb3ba34658be807f15c5291ed6026860a24f179b712c89",
+          "iv": "412c3e13ee1f7864bd15ce39",
+          "aad": "2866afff0bcc6135dc63af88c8",
+          "msg": "d92f8ce5d8d0ad2eb5f11af02ef63949",
+          "ct": "89d6d089c4a255952aca11b24a01ff95",
+          "tag": "f88fa4531204da315e7317970240ce9e",
+          "result": "valid"
+        },
+        {
+          "tcId": 104,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "910ade7d324d2c9688439e1f142e0e5f9d130ff832e507fe1985e5a26452a6d0",
+          "iv": "9be090dba93deff27adf99ee",
+          "aad": "ea2575f123268e936c8e4c8c1bb8",
+          "msg": "6e356094ed9d9a7053c7906c48ba3d9f",
+          "ct": "01ffb343c757b27843d8a900a36ce39d",
+          "tag": "a315541b7d6313c6fddf64b303d71d60",
+          "result": "valid"
+        },
+        {
+          "tcId": 105,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "8e34cf73d245a1082a920b86364eb896c4946467bcb3d58929fcb36690e6394f",
+          "iv": "6f573aa86baa492ba46596df",
+          "aad": "bd4cd02fc7502bbdbdf6c9a3cbe8f0",
+          "msg": "16ddd23ff53f3d23c06334487040eb47",
+          "ct": "c1b295936d56fadac03e5f742bff73a1",
+          "tag": "39c457dbab66382babb3b55800cda5b8",
+          "result": "valid"
+        },
+        {
+          "tcId": 106,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "cb5575f5c7c45c91cf320b139fb594237560d0a3e6f865a67d4f633f2c08f016",
+          "iv": "1a6518f02ede1da6809266d9",
+          "aad": "89cce9fb47441d07e0245a66fe8b778b",
+          "msg": "623b7850c321e2cf0c6fbcc8dfd1aff2",
+          "ct": "c84c9bb7c61c1bcb17772a1c500c5095",
+          "tag": "dbadf7a5138ca03459a2cd65831e092f",
+          "result": "valid"
+        },
+        {
+          "tcId": 107,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "a5569e729a69b24ba6e0ff15c4627897436824c941e9d00b2e93fddc4ba77657",
+          "iv": "564dee49ab00d240fc1068c3",
+          "aad": "d19f2d989095f7ab03a5fde84416e00c0e",
+          "msg": "87b3a4d7b26d8d3203a0de1d64ef82e3",
+          "ct": "94bc80621ed1e71b1fd2b5c3a15e3568",
+          "tag": "333511861796978401598b963722f5b3",
+          "result": "valid"
+        },
+        {
+          "tcId": 108,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "56207465b4e48e6d04630f4a42f35cfc163ab289c22a2b4784f6f9290330bee0",
+          "iv": "df8713e87ec3dbcfad14d53e",
+          "aad": "5e6470facd99c1d81e37cd44015fe19480a2a4d3352a4ff560c0640fdbda",
+          "msg": "e601b38557797da2f8a4106a089d1da6",
+          "ct": "299b5d3f3d03c087209a16e285143111",
+          "tag": "4b454ed198de117e83ec49fa8d8508d6",
+          "result": "valid"
+        },
+        {
+          "tcId": 109,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "077433022ab34d380fc192fc24c2edc6301fec6f24442f572a1087ff2e05b39a",
+          "iv": "28adcbc74364f26dd4b3108b",
+          "aad": "e0100eb116cdc5e22a3b9f9b4126c149595e75107f6e237c69e82960052270",
+          "msg": "03c874eeaaa6fa9f0da62c758fb0ad04",
+          "ct": "1e9687b35fbc8eaa1825ed3847798f76",
+          "tag": "0788bf70fd04030ecd1c96d0bc1fcd5d",
+          "result": "valid"
+        },
+        {
+          "tcId": 110,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "3937986af86dafc1ba0c4672d8abc46c207062682d9c264ab06d6c5807205130",
+          "iv": "8df4b15a888c33286a7b7651",
+          "aad": "ba446f6f9a0ced22450feb10737d9007fd69abc19b1d4d9049a5551e86ec2b37",
+          "msg": "dc9e9eaf11e314182df6a4eba17aec9c",
+          "ct": "605bbf90aeb974f6602bc778056f0dca",
+          "tag": "38ea23d99054b46b42ffe004129d2204",
+          "result": "valid"
+        },
+        {
+          "tcId": 111,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "36372abcdb78e0279646ac3d176b9674e9154eecf0d5469c651ec7e16b4c1199",
+          "iv": "be40e5f1a11817a0a8fa8949",
+          "aad": "d41a828d5e71829247021905402ea257dccbc3b80fcd5675056b68bb59e62e8873",
+          "msg": "81ce84ede9b35859cc8c49a8f6be7dc6",
+          "ct": "7b7ce0d824809a70de32562ccf2c2bbd",
+          "tag": "15d44a00ce0d19b4231f921e22bc0a43",
+          "result": "valid"
+        },
+        {
+          "tcId": 112,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "9f1479ed097d7fe529c11f2f5add9aaff4a1ca0b68997a2cb7f79749bd90aaf4",
+          "iv": "84c87dae4eee27730ec35d12",
+          "aad": "3f2dd49bbf09d69a78a3d80ea2566614fc379474196c1aae84583da73d7ff85c6f42ca42056a9792cc1b9fb3c7d261",
+          "msg": "a66747c89e857af3a18e2c79500087ed",
+          "ct": "ca82bff3e2f310ccc976672c4415e69b",
+          "tag": "57638c62a5d85ded774f913c813ea032",
+          "result": "valid"
+        },
+        {
+          "tcId": 113,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "0c1e7bebbd5ff8c00827bc862f12154cd59a4fb013446e5022aede44f7670645",
+          "iv": "10b7c0942a81d7c644cb35cb",
+          "aad": "4e3d056e4d11811c2f3c35a34692cbd0658320859e3ca134420b1c3584d793a62a07f7a48a9fbe9d51a0a87de10108075c5eba2c61407d952b53b3f5f7200b5975146df9a2e902f715b04c01ab759062e35c7b72feac1b1a6c8e69002feb49b1ce0b4b1746c6c31c771fd7cdf80d2b076d21d212c3723b939c1c1a72e997bd",
+          "msg": "bd68e65fec0e13228495e18fce6570b7",
+          "ct": "c97f89ea1a96aed679b4c836858fba45",
+          "tag": "16e236688142444cb538f4a45647f5cb",
+          "result": "valid"
+        },
+        {
+          "tcId": 114,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "991ef9a9cffc46c3816766326bde6fc2ca046970be6f7f30dceaa725e27ff37c",
+          "iv": "5ea95baaf3740ace298074e8",
+          "aad": "151c0676d7d742b21482fd07bc9f7b28d312b321d9ee75f4c2024e0ec39ab26ba867208fbffae06ee730de05087b16da2463eff9ab4b70801e582ad3bf83616bb9a61ed60c3074088c0be67320e26089cfc25bdf8037432a2ba490643767492a83a511bd5718a3c07b35321b42dd4ac5da398ebfef5d65637c6748932ae27fe9",
+          "msg": "c8144d069a953138f71a5c4550283e71",
+          "ct": "7013d5dec5bb66d15d2ecc893ab5fba9",
+          "tag": "9651df2f9cf77b52966a0bae6e19c135",
+          "result": "valid"
+        },
+        {
+          "tcId": 115,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "0d73ddcb28a05a3b194327bb70bb98da267d973edbc896e41b9d5051b7a2fdfe",
+          "iv": "e4f0b1637bcbcb146edc3dba",
+          "aad": "d7b6aa7b2e605cb175a799da9a7fef90345a0b49dc060fcb1d9a5dbdfb3a47fe7444e288bc213686cd80dea3988dfec658c9e781b6a9d556d7519b38fd214c511af9dae74714741a06a3a0fba77311ccddc9fcac514d69455744ceec9083ed07ad5246cf2a108268061b91bee84a1e83e9256435f75c6baf4dd6c2a35fa7bcc5ed",
+          "msg": "05374b488f5ab044552262d720199ae8",
+          "ct": "82feb5e5d88ea755ceb77456803e2bf2",
+          "tag": "e425b62274edbd7ab711117f0b2e4ece",
+          "result": "valid"
+        },
+        {
+          "tcId": 116,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "93af42407d97c760adab2706a37a943f77acbc8146ea5698a311e4a99b2663c5",
+          "iv": "00705ed71d411e9a43ea1323",
+          "aad": "543d01c9a4caed305a6a7a76754a9deb1255d76a33f6870cae73ca803400b703aead78575d719c837b64a7c590040cf957f5eee46b74dcfe29002f5bd6127aa57ba44e601ea2cdd16051dbffc33b655afc1887e7c1a5bd99e0a5b018e01e7bc80fa0dd1f82839e62b9ec618e7f085d21d5f26be55633329c1fe73956b5692d18ba380d47e1217342334059c391776445ed34214f6608b787ca280463be33bf7d50a2a018235a9e6b204d037025bd49b80de348d13a5a459e40f3507236e14f6a70b420ed55915fa1f9f32e5a2028f8e2755b690da6927e415a8d7283c084ac410c4db4eb20c7682cb3ac10e698fb04a275463d4c67875691e428343d0025ff",
+          "msg": "46665b3e125f845a5d72b8bf819b05f1",
+          "ct": "01733e218929a9e240da2d8f5342bdce",
+          "tag": "836af3f03a858c22df4a0913c3c3205f",
+          "result": "valid"
+        },
+        {
+          "tcId": 117,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "09ccd5f02ac621a91bfe26c45889fb40c034a739651e05f974e3d1b8f5467817",
+          "iv": "bb720368504f2602d6cccd57",
+          "aad": "d5c987f2f71e3a9caae4616687ed1ae2f00d5e3e2b4628e56e24e0fcb0d9a5c979bf38e3052a2b107fc64308763f1277af3ff6d80109dae056e1f53b08304ba7a7f555b66b556dc3869fb059ed519805f7daae22743d86f2319b95e9c0628a5c7de93e97971e8cdb0833edd36e4c3c0168b4617786c0bb5d433e11f2d390c52ce1beacb7bb31f2d0fa644bf1c616f3f2b2328fe295398eb908b85bf4cd04d697486f51b0dc0cfc08a37fe3e93e9a35e4f434e13c125fd553d554713fa9d431b3cec9f5c9562289a7e7cb6b54be24c9b4ba339444042efbdb8a0178a354a54946b0f4f3bb5804c49d7e19ce8f63b3f6892a7447d5e1bbfa64c78708693ec5f509",
+          "msg": "b783d9e8ce0d93a089c329491aef73d7",
+          "ct": "b755cf3739f9aece41a56a7158a4cd51",
+          "tag": "a7496a7f239a1b7e327af7ddcd868fcd",
+          "result": "valid"
+        },
+        {
+          "tcId": 118,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "5d97d19c96153a7cfef2e5f4e27211d3bcc1826c67a6cc0bb02a46f944a85a5f",
+          "iv": "669ea62069c7199d9ca2be41",
+          "aad": "d218d976cedc3dd23ce31944405bcd0e44d5fc776838f5154c786d20fb7a39ea2e2e426fa6ce7a011ca05b5f6615e20373f7c80e98cebf8518339ba65b60532de536d3cfecf2a6b8a88a64149feba8de320a697f6a1339b0739927dd22641b8745cd04fb5fcc136dd2f3c921694005dff53ce44213fbc13f67402f882b13b28198fca970847356e2a82a2e79912ff6a1a9de8f4fed47b45b445dcd6c7400fdbc4a5da53bdfa03bad3d99b2e6038e334529b9c6f23f5135eef61db819b7ab1c7da3d1beceb4c2d212250f15fd301901db51a08d2b496e6e1f3e45af39e9556aed00b90e06535418a650bf9ab9f0e5d753f8a2e5d17c1409aba72b50fc161b2d0557",
+          "msg": "400037002b7dd892f3e582a3386e9632",
+          "ct": "817080b5020f10f034e3087d41e0fc40",
+          "tag": "b113757aebb9b4ef7e5d873dd58b640a",
+          "result": "valid"
+        },
+        {
+          "tcId": 119,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "b4d739d35bd8877fd0750c84c3d1aaa81f4aadab959dca5bea0fb77b0c266c05",
+          "iv": "f34e40fa45b970c4dd5255cb",
+          "aad": "48c9ac49c659b0ad7f1197dcb86868889e5dcf677ab23cce1f75b4951477ed67f6cd0e5b2673401846a0440511eeceaec2149cf02944d2bf00ae30876ffc61c67e1f9f08581c840e50dbb419abcc7d06997ed2a95d5e9943ef83e341383ae4893944d9668e6b8e04a9a20aefdfa009312fdfc1c0f95c516daf3cb5b80ea4fe485f8dce62cc62bede36118c6d06832494c7633540e901beaffcd8a3570b1567ee018b412b7d74d447a7ca414c27193973051424224c449b3fbed90dd32b50013234fc0173eb1f28cc007b8330b84944ca75e54f32bea7b29cca4df44507c1c63dfbdcac4f6ad01f77541a30119c90f8b8df2d96d8dadd2389c372005f09c169dc9892e61b9c1eab8523d0175e6c36146781a01da5b5812cdf80ef31973d3b8fe1e74e866fb631d80dc25aa929447e63801c80afc78c81a5762192cf8eed57d74f44848ed2bbdd2ab41c8f009f99a207651d25e56576f4c7890286b752c59df4a87945d0efbe578bb900d56e5b406e769498918317c84470a3d27250f1c4fe740c6291d60263ce43c236f3640e3c1a93d113a01daf4aa8030f26e9e22679f066764230ab664cb155c0b08b75b553eddadb3a74e2122c26c035233c9b40f832412bc79a68af3d5d55283df540b334b3aa498f71c8101688fcd9c8b90520fae0194ff6f773effea4eba786cb3d81a451cb9d37003ff3fc7dc7bec3e80e94ea881c",
+          "msg": "0e45f9d687915b44da56b8bdd4588f04",
+          "ct": "15cf5c8d9865fe34b2c47b976bfcf60f",
+          "tag": "8982f56140bc1f11679f1577736b96ef",
+          "result": "valid"
+        },
+        {
+          "tcId": 120,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "33518a3fd6694b641188e7d473c9550ac6bb72b4aa4494c4109af816ab4571f3",
+          "iv": "158f6467508774fce7ccd9b9",
+          "aad": "886675ae18fc751ec295ed7a2370053b474a1859b6c87e8135fe56517b0770adeabedcc5ea2b759801d6e8b773881ea2b8cc0e82cf04c1f682668ec22761e3dcdc92b28990712e57172e1e8dd95bea6e946b4164fab6db2fc49426a7618e897c63d317a0d56817b60158b0f6c0abfa70adf0dad805ee6610467ee73d42fe4c6af40b468db8726db498fbce46e348859cf50e371f539ae4ce3c1a9f399c8561b017f9d7b2e7a2a9637343916e22605a854c390e1128b899b2cea4894d483e5663d9cd007d626ff6a82338ca00b90cf45e1062ef29112870c508ab9644a20df33ceca7c6a535bf78b2b7bf48e4638b9d227167fa26de3e4f6dafe81f4fa9222a0472fecd42280c438011f436b35cfee8e9a0b6ee97cadb63b15ace995c8e5e240132d5b74ddff4188960fa89351eefdd5daa719387980ac7192764fbf0e90f6bc83900695729b0c09bcded2795d33eeb438f3ac6d849aed9ac3b03979cc86e1bec297030d635fd6440b9c08c0f1dff1d837f437ce13b1f6903fe7b965ae1bb174a5e98e9fd11c2afe68eb87cf17c884542c641c06bb7e0124dc077ba2ff175f278805c4d3ae6278a750ba107f5b140ca374a42fe97447781d64f28b2f537ef59df384e8c8a78e51e5d471b7d37acaffde7323abd3b661cbdc38889db16a9d992084866f27f5ccb3556d41ac2a6a2c1fc4b9c1dcdc5d1025123184d64703a109593",
+          "msg": "16bb3f376160ed2935ebd144401b6332",
+          "ct": "8b84a0c2dc5c884fc4e6e562f6407178",
+          "tag": "413f8ea12d38c5a3e776f931a7e235e7",
+          "result": "valid"
+        },
+        {
+          "tcId": 121,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7e8d8c980ce323ecc0c70865e2ebcdff9846613d73e260825152ebd8fae138a8",
+          "iv": "7089fdbd6507a0c6cd616812",
+          "aad": "f8f24096168fbd649822b44c1e426232f936470d18432ba25bc412249b2cb80b4586335bc3794da9111c1b4390c6c1bc5c6c726e7c8276d16a6d4b843181a88713681565cbac82159f4cf3333988835938510ae766223047b5d9f04831cb451c90b1f1ea3f8b6fc0b2536344e5f01fc3169d0adb94081492ac3a7c78c8a443b2b7f88c6e3149ea9f5aa15b194d0f8125dbeb63cf386ce11e5cd8df0cbea51d0da859ca7b1a7b70ca03fad12678833cabe4f50912172340ae63234a6c19e07f94cf6cf0bc0e60468e6eabb5ba0a7881c20ca6a85e10f7d227d5bd255809cb3162edb321596d8f035bd63f5211a9c1d67cbc7fbd5664a642bee4c91f6a15dbaa7e816432cd0dd55d04b6ef52457e024f483d2a8d95ce5c88d9a09ea7c28a6e6b3d35cced43224e84681374c7489688f3fd3385b9af77b760308db3407280f0d8586e2b60c6795ed38ea233070ae639c13118ba39476bc9cf447ae8dbead6dd512de32685aeb88da2b3c5f982fc68e31487ca166e511e0a60a7a7844c90681a32e7a59846c8d8406a28a2b8b0a99bbd1b6ee0130bb72ed0017c5b5aff1348cf8fe5f554b42773478109b3977091d4dd7982e65a1072044c3b54874e8156f6610b4ffa6fe799db173b024150835f130d6fd369488fc19e8cc5fbb50aa8dd8701cba2e5a71ca2b6831bcf8efb36afb50d8768c2984026b83187a5682779f3ac69839729",
+          "msg": "66628635128705e67c81309e9fdad58b",
+          "ct": "ccdecc5587d68c9d05af127461339cfb",
+          "tag": "261a1df437594665341798182d5333f3",
+          "result": "valid"
+        },
+        {
+          "tcId": 122,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "00000000000000000000000000000000",
+          "msg": "65b63bf074b7283992e24b1ac0df0d22b555dbe2254d94a43f1de748d3cc6f0d",
+          "ct": "0000000000000000000000000000000000000000000000000000000000000000",
+          "tag": "39f4fce3026d83789ffd1ee6f2cd7c4f",
+          "result": "valid"
+        },
+        {
+          "tcId": 123,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "00000000000000000000000000000000",
+          "msg": "65b63bf074b7283992e24b1ac0df0d22b555dbe2254d94a43f1de748d3cc6f0d20c142fe898fbbe668d4324394434c1b18b58ead710aed9c31db1f2a8a1f1bb2",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "tag": "f5eaa804605c3a4785f9d7f13b6f67d6",
+          "result": "valid"
+        },
+        {
+          "tcId": 124,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "00000000000000000000000000000000",
+          "msg": "65b63bf074b7283992e24b1ac0df0d22b555dbe2254d94a43f1de748d3cc6f0d20c142fe898fbbe668d4324394434c1b18b58ead710aed9c31db1f2a8a1f1bb24405c183af94ee1ad630cd931158a6213d48c8fff10d0a1f9ef760188e658802aad55e41a1d99069a18db55c56af7c10a6f21ecc8af9b7ce0a7ea0b67426e925",
+          "ct": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "tag": "9b5c43a78d954e8a3c659eebc13d5d55",
+          "result": "valid"
+        },
+        {
+          "tcId": 125,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffffffffffffffffffffffffffffff",
+          "msg": "9a49c40f8b48d7c66d1db4e53f20f2dd4aaa241ddab26b5bc0e218b72c3390f2",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "37e3399d9ca696799f08f4f72bc0cdd8",
+          "result": "valid"
+        },
+        {
+          "tcId": 126,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffffffffffffffffffffffffffffff",
+          "msg": "9a49c40f8b48d7c66d1db4e53f20f2dd4aaa241ddab26b5bc0e218b72c3390f2df3ebd0176704419972bcdbc6bbcb3e4e74a71528ef51263ce24e0d575e0e44d",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "3d52710bec86d4ea9fea2ff269549191",
+          "result": "valid"
+        },
+        {
+          "tcId": 127,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffffffffffffffffffffffffffffff",
+          "msg": "9a49c40f8b48d7c66d1db4e53f20f2dd4aaa241ddab26b5bc0e218b72c3390f2df3ebd0176704419972bcdbc6bbcb3e4e74a71528ef51263ce24e0d575e0e44dbbfa3e7c506b11e529cf326ceea759dec2b737000ef2f5e061089fe7719a77fd552aa1be5e266f965e724aa3a95083ef590de13375064831f5815f498bd916da",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "51356329e280b12d55d3d98f0a580cbe",
+          "result": "valid"
+        },
+        {
+          "tcId": 128,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "00000080000000800000008000000080",
+          "msg": "65b63b7074b728b992e24b9ac0df0da2b555db62254d94243f1de7c8d3cc6f8d",
+          "ct": "0000008000000080000000800000008000000080000000800000008000000080",
+          "tag": "c152a4b90c548c71dc479edeaf9211bf",
+          "result": "valid"
+        },
+        {
+          "tcId": 129,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "00000080000000800000008000000080",
+          "msg": "65b63b7074b728b992e24b9ac0df0da2b555db62254d94243f1de7c8d3cc6f8d20c1427e898fbb6668d432c394434c9b18b58e2d710aed1c31db1faa8a1f1b32",
+          "ct": "00000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080",
+          "tag": "40ef6383052d91c2e4b4611b0e32c5ff",
+          "result": "valid"
+        },
+        {
+          "tcId": 130,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "00000080000000800000008000000080",
+          "msg": "65b63b7074b728b992e24b9ac0df0da2b555db62254d94243f1de7c8d3cc6f8d20c1427e898fbb6668d432c394434c9b18b58e2d710aed1c31db1faa8a1f1b324405c103af94ee9ad630cd131158a6a13d48c87ff10d0a9f9ef760988e658882aad55ec1a1d990e9a18db5dc56af7c90a6f21e4c8af9b74e0a7ea0367426e9a5",
+          "ct": "0000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080",
+          "tag": "ae9b542541e84fc74542eed6be638fee",
+          "result": "valid"
+        },
+        {
+          "tcId": 131,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "80000000800000008000000080000000",
+          "msg": "e5b63bf0f4b7283912e24b1a40df0d223555dbe2a54d94a4bf1de74853cc6f0d",
+          "ct": "8000000080000000800000008000000080000000800000008000000080000000",
+          "tag": "10fee3ecfba9cdf797bae37a626ec83b",
+          "result": "valid"
+        },
+        {
+          "tcId": 132,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "80000000800000008000000080000000",
+          "msg": "e5b63bf0f4b7283912e24b1a40df0d223555dbe2a54d94a4bf1de74853cc6f0da0c142fe098fbbe6e8d4324314434c1b98b58eadf10aed9cb1db1f2a0a1f1bb2",
+          "ct": "80000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000",
+          "tag": "7490795bdbbbf5d0aecb9a4f65aa379f",
+          "result": "valid"
+        },
+        {
+          "tcId": 133,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "80000000800000008000000080000000",
+          "msg": "e5b63bf0f4b7283912e24b1a40df0d223555dbe2a54d94a4bf1de74853cc6f0da0c142fe098fbbe6e8d4324314434c1b98b58eadf10aed9cb1db1f2a0a1f1bb2c405c1832f94ee1a5630cd939158a621bd48c8ff710d0a1f1ef760180e6588022ad55e4121d99069218db55cd6af7c1026f21ecc0af9b7ce8a7ea0b6f426e925",
+          "ct": "8000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000",
+          "tag": "1d1096a8ca9e2bda2762c41d5b16f62f",
+          "result": "valid"
+        },
+        {
+          "tcId": 134,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffff7fffffff7fffffff7fffffff7f",
+          "msg": "9a49c48f8b48d7466d1db4653f20f25d4aaa249ddab26bdbc0e218372c339072",
+          "ct": "ffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7f",
+          "tag": "af8492c792bf8d8062be74ff6efb3869",
+          "result": "valid"
+        },
+        {
+          "tcId": 135,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffff7fffffff7fffffff7fffffff7f",
+          "msg": "9a49c48f8b48d7466d1db4653f20f25d4aaa249ddab26bdbc0e218372c339072df3ebd8176704499972bcd3c6bbcb364e74a71d28ef512e3ce24e05575e0e4cd",
+          "ct": "ffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7f",
+          "tag": "f24db68c46b67d6f402fa6c897913368",
+          "result": "valid"
+        },
+        {
+          "tcId": 136,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffff7fffffff7fffffff7fffffff7f",
+          "msg": "9a49c48f8b48d7466d1db4653f20f25d4aaa249ddab26bdbc0e218372c339072df3ebd8176704499972bcd3c6bbcb364e74a71d28ef512e3ce24e05575e0e4cdbbfa3efc506b116529cf32eceea7595ec2b737800ef2f56061089f67719a777d552aa13e5e266f165e724a23a950836f590de1b3750648b1f5815fc98bd9165a",
+          "ct": "ffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7f",
+          "tag": "43f651ab2e2eb0f04bf689a40d32da24",
+          "result": "valid"
+        },
+        {
+          "tcId": 137,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "7fffffff7fffffff7fffffff7fffffff",
+          "msg": "1a49c40f0b48d7c6ed1db4e5bf20f2ddcaaa241d5ab26b5b40e218b7ac3390f2",
+          "ct": "7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff",
+          "tag": "60d95294a3694cfaa64b2f63bc1f82ec",
+          "result": "valid"
+        },
+        {
+          "tcId": 138,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "7fffffff7fffffff7fffffff7fffffff",
+          "msg": "1a49c40f0b48d7c6ed1db4e5bf20f2ddcaaa241d5ab26b5b40e218b7ac3390f25f3ebd01f6704419172bcdbcebbcb3e4674a71520ef512634e24e0d5f5e0e44d",
+          "ct": "7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff",
+          "tag": "beaca0b47027196176186d944019c1c8",
+          "result": "valid"
+        },
+        {
+          "tcId": 139,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "7fffffff7fffffff7fffffff7fffffff",
+          "msg": "1a49c40f0b48d7c6ed1db4e5bf20f2ddcaaa241d5ab26b5b40e218b7ac3390f25f3ebd01f6704419172bcdbcebbcb3e4674a71520ef512634e24e0d5f5e0e44d3bfa3e7cd06b11e5a9cf326c6ea759de42b737008ef2f5e0e1089fe7f19a77fdd52aa1bede266f96de724aa3295083efd90de133f506483175815f490bd916da",
+          "ct": "7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff",
+          "tag": "d4811028a577d4dd69d6b35d717f73e3",
+          "result": "valid"
+        },
+        {
+          "tcId": 140,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "00000000ffffffff00000000ffffffff",
+          "msg": "65b63bf08b48d7c692e24b1a3f20f2ddb555dbe2dab26b5b3f1de7482c3390f2",
+          "ct": "00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff",
+          "tag": "10fb61272b555bee104f5a71818716d6",
+          "result": "valid"
+        },
+        {
+          "tcId": 141,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "00000000ffffffff00000000ffffffff",
+          "msg": "65b63bf08b48d7c692e24b1a3f20f2ddb555dbe2dab26b5b3f1de7482c3390f220c142fe7670441968d432436bbcb3e418b58ead8ef5126331db1f2a75e0e44d",
+          "ct": "00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff",
+          "tag": "4756764e59583504182877d8c33120f0",
+          "result": "valid"
+        },
+        {
+          "tcId": 142,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "00000000ffffffff00000000ffffffff",
+          "msg": "65b63bf08b48d7c692e24b1a3f20f2ddb555dbe2dab26b5b3f1de7482c3390f220c142fe7670441968d432436bbcb3e418b58ead8ef5126331db1f2a75e0e44d4405c183506b11e5d630cd93eea759de3d48c8ff0ef2f5e09ef76018719a77fdaad55e415e266f96a18db55ca95083efa6f21ecc750648310a7ea0b68bd916da",
+          "ct": "00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff",
+          "tag": "95a2b12a4a280089d4bd4f904253e754",
+          "result": "valid"
+        },
+        {
+          "tcId": 143,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffffff00000000ffffffff00000000",
+          "msg": "9a49c40f74b728396d1db4e5c0df0d224aaa241d254d94a4c0e218b7d3cc6f0d",
+          "ct": "ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000",
+          "tag": "60dcd45974bebe032eb7b86c9d063452",
+          "result": "valid"
+        },
+        {
+          "tcId": 144,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffffff00000000ffffffff00000000",
+          "msg": "9a49c40f74b728396d1db4e5c0df0d224aaa241d254d94a4c0e218b7d3cc6f0ddf3ebd01898fbbe6972bcdbc94434c1be74a7152710aed9cce24e0d58a1f1bb2",
+          "ct": "ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000",
+          "tag": "f0e6a3c1f28ad92d0dbc900be291d877",
+          "result": "valid"
+        },
+        {
+          "tcId": 145,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffffff00000000ffffffff00000000",
+          "msg": "9a49c40f74b728396d1db4e5c0df0d224aaa241d254d94a4c0e218b7d3cc6f0ddf3ebd01898fbbe6972bcdbc94434c1be74a7152710aed9cce24e0d58a1f1bb2bbfa3e7caf94ee1a29cf326c1158a621c2b73700f10d0a1f61089fe78e658802552aa1bea1d990695e724aa356af7c10590de1338af9b7cef5815f497426e925",
+          "ct": "ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000",
+          "tag": "57eff4a525eeff2ebd7a28eb894282be",
+          "result": "valid"
+        },
+        {
+          "tcId": 146,
+          "comment": "Flipped bit 0 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f5409bb729039d0814ac514054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 147,
+          "comment": "Flipped bit 1 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f6409bb729039d0814ac514054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 148,
+          "comment": "Flipped bit 7 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "74409bb729039d0814ac514054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 149,
+          "comment": "Flipped bit 8 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4419bb729039d0814ac514054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 150,
+          "comment": "Flipped bit 31 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409b3729039d0814ac514054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 151,
+          "comment": "Flipped bit 32 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb728039d0814ac514054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 152,
+          "comment": "Flipped bit 33 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb72b039d0814ac514054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 153,
+          "comment": "Flipped bit 63 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d8814ac514054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 154,
+          "comment": "Flipped bit 64 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d0815ac514054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 155,
+          "comment": "Flipped bit 77 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d08148c514054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 156,
+          "comment": "Flipped bit 80 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d0814ac504054323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 157,
+          "comment": "Flipped bit 96 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d0814ac514055323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 158,
+          "comment": "Flipped bit 97 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d0814ac514056323f44",
+          "result": "invalid"
+        },
+        {
+          "tcId": 159,
+          "comment": "Flipped bit 120 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d0814ac514054323f45",
+          "result": "invalid"
+        },
+        {
+          "tcId": 160,
+          "comment": "Flipped bit 121 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d0814ac514054323f46",
+          "result": "invalid"
+        },
+        {
+          "tcId": 161,
+          "comment": "Flipped bit 126 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d0814ac514054323f04",
+          "result": "invalid"
+        },
+        {
+          "tcId": 162,
+          "comment": "Flipped bit 127 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d0814ac514054323fc4",
+          "result": "invalid"
+        },
+        {
+          "tcId": 163,
+          "comment": "Flipped bit 63 and 127 in tag expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "f4409bb729039d8814ac514054323fc4",
+          "result": "invalid"
+        },
+        {
+          "tcId": 164,
+          "comment": "Tag changed to all zero expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "00000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 165,
+          "comment": "tag change to all 1 expected tag:f4409bb729039d0814ac514054323f44",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "ffffffffffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 166,
+          "comment": "Flipped bit 0 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "28914007a6119dd3f109bba21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 167,
+          "comment": "Flipped bit 1 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "2b914007a6119dd3f109bba21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 168,
+          "comment": "Flipped bit 7 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "a9914007a6119dd3f109bba21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 169,
+          "comment": "Flipped bit 8 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29904007a6119dd3f109bba21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 170,
+          "comment": "Flipped bit 31 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914087a6119dd3f109bba21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 171,
+          "comment": "Flipped bit 32 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a7119dd3f109bba21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 172,
+          "comment": "Flipped bit 33 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a4119dd3f109bba21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 173,
+          "comment": "Flipped bit 63 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119d53f109bba21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 174,
+          "comment": "Flipped bit 64 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119dd3f009bba21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 175,
+          "comment": "Flipped bit 77 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119dd3f129bba21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 176,
+          "comment": "Flipped bit 80 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119dd3f109baa21ce9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 177,
+          "comment": "Flipped bit 96 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119dd3f109bba21de9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 178,
+          "comment": "Flipped bit 97 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119dd3f109bba21ee9a7d6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 179,
+          "comment": "Flipped bit 120 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119dd3f109bba21ce9a7d7",
+          "result": "invalid"
+        },
+        {
+          "tcId": 180,
+          "comment": "Flipped bit 121 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119dd3f109bba21ce9a7d4",
+          "result": "invalid"
+        },
+        {
+          "tcId": 181,
+          "comment": "Flipped bit 126 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119dd3f109bba21ce9a796",
+          "result": "invalid"
+        },
+        {
+          "tcId": 182,
+          "comment": "Flipped bit 127 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119dd3f109bba21ce9a756",
+          "result": "invalid"
+        },
+        {
+          "tcId": 183,
+          "comment": "Flipped bit 63 and 127 in tag expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "29914007a6119d53f109bba21ce9a756",
+          "result": "invalid"
+        },
+        {
+          "tcId": 184,
+          "comment": "Tag changed to all zero expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "00000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 185,
+          "comment": "tag change to all 1 expected tag:29914007a6119dd3f109bba21ce9a7d6",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995a",
+          "tag": "ffffffffffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 186,
+          "comment": "Flipped bit 0 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "67405a16e8b44eba92aa47f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 187,
+          "comment": "Flipped bit 1 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "64405a16e8b44eba92aa47f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 188,
+          "comment": "Flipped bit 7 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "e6405a16e8b44eba92aa47f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 189,
+          "comment": "Flipped bit 8 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66415a16e8b44eba92aa47f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 190,
+          "comment": "Flipped bit 31 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a96e8b44eba92aa47f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 191,
+          "comment": "Flipped bit 32 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e9b44eba92aa47f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 192,
+          "comment": "Flipped bit 33 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16eab44eba92aa47f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 193,
+          "comment": "Flipped bit 63 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44e3a92aa47f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 194,
+          "comment": "Flipped bit 64 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44eba93aa47f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 195,
+          "comment": "Flipped bit 77 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44eba928a47f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 196,
+          "comment": "Flipped bit 80 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44eba92aa46f5cea52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 197,
+          "comment": "Flipped bit 96 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44eba92aa47f5cfa52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 198,
+          "comment": "Flipped bit 97 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44eba92aa47f5cca52b7a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 199,
+          "comment": "Flipped bit 120 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44eba92aa47f5cea52b7b",
+          "result": "invalid"
+        },
+        {
+          "tcId": 200,
+          "comment": "Flipped bit 121 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44eba92aa47f5cea52b78",
+          "result": "invalid"
+        },
+        {
+          "tcId": 201,
+          "comment": "Flipped bit 126 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44eba92aa47f5cea52b3a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 202,
+          "comment": "Flipped bit 127 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44eba92aa47f5cea52bfa",
+          "result": "invalid"
+        },
+        {
+          "tcId": 203,
+          "comment": "Flipped bit 63 and 127 in tag expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "66405a16e8b44e3a92aa47f5cea52bfa",
+          "result": "invalid"
+        },
+        {
+          "tcId": 204,
+          "comment": "Tag changed to all zero expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "00000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 205,
+          "comment": "tag change to all 1 expected tag:66405a16e8b44eba92aa47f5cea52b7a",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "d03bcb3ca52d48d1d203b1e7b1a5995af1a0466a61bb386a2e12d189a2c4ea15e9",
+          "tag": "ffffffffffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 206,
+          "comment": "edge case for poly1305 key:ffffffefeb344f6bc37ba77ea2ee06dfe8c7f4ae10810422124fc5e1bd7fe301",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "dc8ce708bf26aab862d97e1b42f31ef38c382cf07174142ea564920612997b1c2e38aca2438b588d5459493e97e7fa330ff9bc3b9458297ba0967d86ed090b435103478f2869b93ee29c837e95fb6b9903f3b735b7345428eb93b3db1d9b5187cebb889aa177d83e4f63fc9a5c0596eed939883d06aacdfdea44fdecdf5cb7fc",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "c296436246c3a7c4b3ba09ab2a6a0889",
+          "result": "valid"
+        },
+        {
+          "tcId": 207,
+          "comment": "edge case for poly1305 key:278de313ffffffdfffe9acbf3ea59357c4e16a5bc120d346af4a8cf694a84374",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "0001020304050607051e9373",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "931227274a89d0b3aade7fac62c96262c1e77b8dafd248f10ad37c6ccb69cb7131b041593c8bb8c3db38f39dd8a124c424fce4389dede1d3cb9d46cf95970aea9856b6e313d756197baf4fcb58df275bca8a2188f9e8a1ad04354ede542ddc30e8b735b2f5905f5811799282be94ae842ec126c55d2e667235e9acf1d48798f0",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "99a3b0fff6fdcbcce9dc5820f2a64861",
+          "result": "valid"
+        },
+        {
+          "tcId": 208,
+          "comment": "edge case for poly1305 key:0050799fe9e74fcffcffffcfd21aa8b5cb5aa2c6ab347b6886eedaca4bfff3c0",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "0001020304050607048c3c5f",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "0df91f31230e8941e700a752fef08c897c511ed618fdf8a378a1f439013b40a48d4634c27d9ada7c0bb6f3fa92e341425903d7ecd0c49bee4c77e84b11f1c721922308642885b813fae364da32eaf120d6a43a74fb1632443667bfea6eef1be73eb1c3c0b5a57cee8dc4feed4a1fb9ae02f7b1695588c3c878451cb6ee0cb3dc",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "eaff8f47ef9268fd0d94e8a9c4b78d24",
+          "result": "valid"
+        },
+        {
+          "tcId": 209,
+          "comment": "edge case for poly1305 key:dc46b3c53be153ccd4986678ffffffafe484c316c93f64195da65a2742fd3fec",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "1fde9b9ec8b247d42bbee2016d6715ba428a85431430eada56a2c5dc944b6aa6cef0b056a2eecc51d30838e640615e1458e0943e30f91ba41b4362fa9ed6037b21d14da7b4f76f9f68fa8903138d563ce2590af1201c7cfec2290cfce98a822ebb8d1ed9dc4e20d241755aff91cdfd10fdb69efa0d5c8082692601cbfbb955c7",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "86ed21fda080a7d13981078d86b3e3cd",
+          "result": "valid"
+        },
+        {
+          "tcId": 210,
+          "comment": "edge case for poly1305 key:946aff9f2a13f56f92a5f9cfee3cdb1fef6d98d5a55ab563cb28620cd57f19d2",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "66115e67ecd3d4178c4c60e713ab4e5e66f8d1f971da17437a2b5e04fbca1671e847139a5f4e3f8e92d7a3b71eb4ff0e50354c0c1580af3662d5f8151e3f7e8264a0085c32ddfcbeb01a8be4c34d53319800ac4ef9d4e4014524bc7cd3387242e774f4d1a7a0521e42ec44844d0bd8b9d73fec959212fd7e8eacf4d984996d9b",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "34f9e0faa515eee0e784e6ef2678befa",
+          "result": "valid"
+        },
+        {
+          "tcId": 211,
+          "comment": "edge case for poly1305 key:0000003059ffce96438a246ff9536787d92bc40eafa0241a2972780ef6ca1ef8",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060726c6961b",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "e97244259af5a379238da0cad2a5f493655ec0e5024fd553bbb3deb66a94036d106c3d513407b2dd1cc5936c4c9c1e4f4b37b54dec261c601dc99e90680e23e2dc5c9a8d503d8bea49a8cdca3706bfd2a3daa0afb19a70fd3d355fc37c13f3f9e5c8d0864a5f80a780b36d4698ec2ce9ccc27b97ecbe672e41628ebd773acb81",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "3c94b9fe60bdb35c6b7b73b765083492",
+          "result": "valid"
+        },
+        {
+          "tcId": 212,
+          "comment": "edge case for poly1305 key:3fa0ea9c030000a036217d42e775ad189b96e24ee591952e2922ff151334b9ec",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "0001020304050607013da060",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "9453aa159c3d87f17e21e88adabc37e553b904d00eefc66b8e0905e23576fbdc9c7bea9777f3b8368481932534b3344d309e6307cddfe7b3549300dd9cda7efe9d43c8a115912a392904079ee92bcd33099f7022ea94c1e7353b89bfc54de3ceb56f529a1a608bb5a970e1359609d1f56806b37f8605f4c27451da6066fc557a",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "2b11cf9f8db8490d409fc62afd7379f3",
+          "result": "valid"
+        },
+        {
+          "tcId": 213,
+          "comment": "edge case for poly1305 key:a556cb502baf395b020000f03c5108fb1cf76df1b8a8f724e877bd3c588d3285",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060707db33de",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "2e1836640d810c2709fb83ccf1aef3a971085d1bbfb58a425abf75ccec70b3abde0e80539e83a82546e7372a19481547053308dd7842675e9c4f61302426da0d71c1da3102031030ed928152be009b15b52f71b5911991d39f68a8658d99729df2bbef31c8989f9604558df9f2aba4b3766c58aaef3548de545ec1f080225a88",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "c9c8366920f88381407712cec61e6607",
+          "result": "valid"
+        },
+        {
+          "tcId": 214,
+          "comment": "edge case for poly1305 key:0c327fbcc564555545d4fe75020000d0a65799f363ec51b1c5c427b4a04af190",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060702a11942",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "0ecb4d85c956b5268c9b35a8c63b4e9d3e5cb72b64ef98773841b947bd7d59ef7d0eb0e1c050d49a5424ce7deb527d76087e4746674c958965df32d9e5fb03b46501706128d481217aaeae2f78f9259273358a2954cac0bc2fbfe77447d1d387b9314c6541b69f1270b3438b1042b2b4663e62ba4d49c07ac6f163034afa80af",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "2373cfa2ab24446ad5a236167b8027fe",
+          "result": "valid"
+        },
+        {
+          "tcId": 215,
+          "comment": "edge case for poly1305 key:415f08302f210340240d0e903e2b01205ba43e106aebd7e2481016b31118b1ae",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506073c0df637",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "2e8e45e903bfab32f2f0d49d9a3e449bef6f4093e2722cdab2cf935c1822b830fb5a4056516d560dfc8638c9a57d2927200a56f0b67153271d498e8f08dc888c61ef634f7ae40f4608f96f92fea5a1e5bd45131120098dc5de0378e58f2ddb46fa4aa5adb38fe006bb19b69146382f77a79e06214def547cfb5ce37a7008b9b6",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "5f93946478d8081e7247f414ad39a515",
+          "result": "valid"
+        },
+        {
+          "tcId": 216,
+          "comment": "edge case for poly1305 key:feffff1ff6b87403fd6435b09775bc92491a0ae62c5842a30e3b82710cc2dad1",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "9de836aa579585081f330a7c4036e20e38ef15eff3945184d231867f505fffdf",
+          "iv": "00000000101112130bc672c3",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "3619cb470af86dceceb6940f2d9abb34c9a9131476053387445ffebbe240d4f9818377855652f46a8219c7f71c3554f8acef8258de4b7d17c0f3d353ac981cc6a13287be1e6b41dc6d133df4ababebdf43d665ce7a4a5c982a0b139cb8202eebc74173e3224a440e4c37d2b595f384290e939ba016df0d49b36cdb4bd91c39",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "133fe62391744d11ce44594b96c53baf",
+          "result": "valid"
+        },
+        {
+          "tcId": 217,
+          "comment": "edge case for poly1305 key:bf358f18ffffffbf4b62ed6e1f53790785c4dabdfc72e2a219d377a682c85f38",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "9de836aa579585081f330a7c4036e20e38ef15eff3945184d231867f505fffdf",
+          "iv": "000000001011121303e9b9a4",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "af205bda819f7451be0f28667d4b01b59ff2daa8173cab52046c3c9e0d989889c5e021ef7afd06e9ce6cc30e3a6ebab509134ba10d10e570c55587c13eee53e73be54804c8539ffbf23b35922b1ca37b9e9bc24ee204837ca5a294ce05d12600c7eff6aee32270db2feff47dc5a04176169e15850628e6035f78994f9f5603",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "e3451adb9d23a7710a1aafba26f56387",
+          "result": "valid"
+        },
+        {
+          "tcId": 218,
+          "comment": "edge case for poly1305 key:d0b7b3a352a4010ffeffffbfe8cc66dc6e5e7451dc61762c5753174fed88e746",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "9de836aa579585081f330a7c4036e20e38ef15eff3945184d231867f505fffdf",
+          "iv": "00000000101112130700b982",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "68c67272036fb652a0182eeb4781358e4704a4a702fd731bf3b3ea994717989e7d9104e0ae81732a8c7e9a82b3d31d541761a366b67c3396f1a6c67e293ddb65a59e42541dda144dc6c78388cfca982e23350958ac5b3d54a1722fd64733577862e1879c9e9445ebdec5315d1706db7ebbedd4c779935e72057e5b0ecde081",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "b0bb8a55ff5f52a5043c6e7795847557",
+          "result": "valid"
+        },
+        {
+          "tcId": 219,
+          "comment": "edge case for poly1305 key:7bee33931a4157a8cb701becfeffff4fbe7e69f19cd065313bb49a252628dd3d",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "9de836aa579585081f330a7c4036e20e38ef15eff3945184d231867f505fffdf",
+          "iv": "0000000010111213019836bb",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "c483b7334ebe2e879b0c3f9db4fcd9f5219062360d6ce44cdae0f94e04c8345ea7e3ae33855118741dcafe0de4ae98c4e43af7b12b04ee8ab175625823ac040e5abac4403f1d45238adcb8c0cf44bd56917f9f5d93974c82b56951986a9c0450bd9047b5a616e814526ad0580e3ecd8189c9fef2cdb979a22ad3a01930fbd1",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "f4fc25f4c5543a9afee9819e2904fb68",
+          "result": "valid"
+        },
+        {
+          "tcId": 220,
+          "comment": "edge case for poly1305 key:7cb5fbdffb40ff5f3c7de74f655ffc1fac03013a7fe468440b861ebe0ab1650a",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "9de836aa579585081f330a7c4036e20e38ef15eff3945184d231867f505fffdf",
+          "iv": "00000000101112131d59f288",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "bc7f4f15fd1e4c1399740836670abe39a05707be19956ce169b32321759e0f213ae19ad34aa612b3a29f02c4bbac9f785a55a3adfe419ab891bbe0acee9921322ea21002c9dd3dcdd13a7f8554dddc10f9b529ce94be7050937dab76557b7eb17c685aad8f0797e39d62553988989aab1d9764fe431cc1d4c595062ce93ce9",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "5e67a7b8733e0e4b01ac2178a205ae7e",
+          "result": "valid"
+        },
+        {
+          "tcId": 221,
+          "comment": "edge case for poly1305 key:00000090e6e328c242cde5c83e3d8262d467f2bcd53d3755c781f3c6a2cb0648",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "9de836aa579585081f330a7c4036e20e38ef15eff3945184d231867f505fffdf",
+          "iv": "00000000101112130552a411",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "eaccaa778935ef249e0900149dd889462d2a061486ba102b8caebe465f3959fb3119ebb5689676ffdd6d851a26739e772b54a2f5f473ea9c7e58ccbc4cfc953e8c420b2175d9dd519265630bb79bd87a601b113231a8b16ce54c331347ec04c2b1c9160f38207aa46e96feb06dee883eb422fa14908df300bb1a1ef758c408",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "177a77fce114a4349c4f8d5ec825d06f",
+          "result": "valid"
+        },
+        {
+          "tcId": 222,
+          "comment": "edge case for poly1305 key:9e98d64e000000505a07183c5c68c63c14c9266dd37ff86aafc22ddbdb355617",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "9de836aa579585081f330a7c4036e20e38ef15eff3945184d231867f505fffdf",
+          "iv": "00000000101112130c807a72",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "a76c330e015060a17e64cb7b6d753f201f75be8759fd7539fb92b22aef54c9d3029dba0c15cbf7c95135888319c6b2e6276da21e0c351fd522b29aabb5883a3291d6f427de773b124390ef6fd96621ffbc42dfbf7a34da272cbc9ccb1a498d078033d1ac3bf7e92715948b06d69d5c5039e9164ba9c3a02219ec5908206b3b",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "623c7d4424f5497aedfd1339cf8cecce",
+          "result": "valid"
+        },
+        {
+          "tcId": 223,
+          "comment": "edge case for poly1305 key:1048a92e65f5e63102000080d9ae08de4319a7c45fdbe707b9ec1b7e0d635161",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "9de836aa579585081f330a7c4036e20e38ef15eff3945184d231867f505fffdf",
+          "iv": "00000000101112130397a143",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "228a7e15bcce13051de9145f77f7f4ff7921828b4f99efc4ff55ee0d9344955b69ec2d4798b0517f0273c4456ae5ffc5929cbe74ddb0da51d4f2b4df7578a31240c88ae922c3c5eca7b97d72d497062050a587447c562b343d5c71921944872f9fd06b8f34b3eb5d4341f5ff8a907dd7c2e1676b81252726ba54814da51eab",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "1c18b69354b189731a1a83fe8f0d57c9",
+          "result": "valid"
+        },
+        {
+          "tcId": 224,
+          "comment": "edge case for poly1305 key:01517a2ceb89bbfb5741f7d9000000401a65b132ad661072a00ffe7defbb18a5",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "9de836aa579585081f330a7c4036e20e38ef15eff3945184d231867f505fffdf",
+          "iv": "000000001011121308cb0f3f",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "c7d843188ab193dfef5c4daf583f952cd4b195f240fa2e704d021723023c123371a41e87dfc6e6c3874a42f331cf035988a38c72ba2da854b1208f98bf8cc29948169481ab3a402d5fcc7ff78f9e31925576dc3938074b8c5b27960e3afc750ad686563688b7441787288d5256c1301d563b7744843bd1ab4eff5be6f1653d",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "2045815b8211b9a2995effe0b8ed9868",
+          "result": "valid"
+        },
+        {
+          "tcId": 225,
+          "comment": "edge case for poly1305 key:bc90156087e0125006d90c30babd0590427bff19de1f2e7d0757a79528731138",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "9de836aa579585081f330a7c4036e20e38ef15eff3945184d231867f505fffdf",
+          "iv": "00000000101112130d8fcf4e",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "cfc3db8631c81c69023a3c8a9ad66c35053685144c4fa2a9510add72e211dad9ca5b982e4c194591fdb74116280311d1299ad81227258cb52f079bbcb12aff161d278dec33a326d71276b3de01a8327ee7f45f94179dff18a3fe643e56c30cfd03871c8110ab00f6612b9e17a4647360d7847bb63a3122613c2e7cdddd08ae",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "1ae2ed84ea9774d78d782bf8d972a8b8",
+          "result": "valid"
+        },
+        {
+          "tcId": 226,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffffffffffffffffffffffffffffff415771fda4fbcc55c377f73203e60226",
+          "msg": "e48caf8a76183327c9561a4651c07c822ccd1642c06607d0d4bc0afb4de15915dbfa3b0b422e77e15c64bf6247031f15fdb643117809821870000adf83834da5",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "000102030405060708090a0b0c0d0e0f",
+          "result": "valid"
+        },
+        {
+          "tcId": 227,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b",
+          "aad": "f1ffffffffffffffffffffffffffffff615af39eddb5fcd2519190d5507d3b06",
+          "msg": "e48caf8a76183327c9561a4651c07c822ccd1642c06607d0d4bc0afb4de15915dbfa3b0b422e77e15c64bf6247031f15fdb643117809821870000adf83834da5",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "00000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 228,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b",
+          "aad": "b5ffffffffffffffffffffffffffffff764e5d82ce7da0d44148484fd96a6107",
+          "msg": "e48caf8a76183327c9561a4651c07c822ccd1642c06607d0d4bc0afb4de15915dbfa3b0b422e77e15c64bf6247031f15fdb643117809821870000adf83834da5",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 229,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b",
+          "aad": "fdffffffffffffffffffffffffffffff2bdbf16d8ea4d39dab8dcb3d4bc4e104",
+          "msg": "e48caf8a76183327c9561a4651c07c822ccd1642c06607d0d4bc0afb4de15915dbfa3b0b422e77e15c64bf6247031f15fdb643117809821870000adf83834da5",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "00000080000000800000008000000080",
+          "result": "valid"
+        },
+        {
+          "tcId": 230,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b",
+          "aad": "a9ffffffffffffffffffffffffffffffaccd5eb31d8fc909e84b0de7de23bb08",
+          "msg": "e48caf8a76183327c9561a4651c07c822ccd1642c06607d0d4bc0afb4de15915dbfa3b0b422e77e15c64bf6247031f15fdb643117809821870000adf83834da5",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "ffffff7fffffff7fffffff7fffffff7f",
+          "result": "valid"
+        },
+        {
+          "tcId": 231,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b",
+          "aad": "d2ffffffffffffffffffffffffffffffdd4b933e7b1a7ed93cc7c050db71dc03",
+          "msg": "e48caf8a76183327c9561a4651c07c822ccd1642c06607d0d4bc0afb4de15915dbfa3b0b422e77e15c64bf6247031f15fdb643117809821870000adf83834da5",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "01000000010000000100000001000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 232,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b",
+          "aad": "ffffffffffffffffffffffffffffffffa08164425d7642e9e90fc8d5c32d2cf6",
+          "msg": "e48caf8a76183327c9561a4651c07c822ccd1642c06607d0d4bc0afb4de15915dbfa3b0b422e77e15c64bf6247031f15fdb643117809821870000adf83834da5",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "ffffffff000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 233,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x0.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "c68ce708bf26aab862d97e1b42f31ef37bb66f8090c149e452ec7f20327eb2ea2e38aca2438b588d5459493e97e7fa330ff9bc23c897df6b00af86931d6c81555103478f2869b93ee29c837e95fb6b9903f3b72debfba2384baa48ceedfedb91",
+          "ct": "e5ffffffffffffffffffffffffffffff0871bc8f1e4aa235087712d9df183609ffffffffffffffffffffffffffffffffffffffe7a33009ef5fc604ea0f9a75e9ffffffffffffffffffffffffffffffffffffffe7a33009ef5fc604ea0f9a75e9",
+          "tag": "3572162777262c518eef573b720e8e64",
+          "result": "valid"
+        },
+        {
+          "tcId": 234,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x0.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "40115e67ecd3d4178c4c60e713ab4e5e390ef93aeb61aa307f141323c38e0685fa47139a5f4e3f8e92d7a3b71eb4ff0e259445f4ffc31bce540190edd6ad207876a0085c32ddfcbeb01a8be4c34d5331eda1a5b6139750f973f0d4841baa2cb8",
+          "ct": "d9ffffffffffffffffffffffffffffffa009d73c6544428cfac0b2d8c7bbef0bedffffffffffffffffffffffffffffff8a5ef60715bc4b07c92b9707376da105edffffffffffffffffffffffffffffff8a5ef60715bc4b07c92b9707376da105",
+          "tag": "19532d9fa0b5fbd582aaeda830602f1d",
+          "result": "valid"
+        },
+        {
+          "tcId": 235,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x0.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "19de9b9ec8b247d42bbee2016d6715babc286fd979807951b183a188930ad15edcf0b056a2eecc51d30838e640615e14890e659fd3028c904e65018fdfd6038333d14da7b4f76f9f68fa8903138d563c33b7fb50c3e7ebca970f6f89a88a82d6",
+          "ct": "f9ffffffffffffffffffffffffffffff015d1565924f6c7418de9babf8be4407edffffffffffffffffffffffffffffff2e110e5e1c0468cbaad99c8abeffff07edffffffffffffffffffffffffffffff2e110e5e1c0468cbaad99c8abeffff07",
+          "tag": "47e5d4294239db73b836c04070ff5b2d",
+          "result": "valid"
+        },
+        {
+          "tcId": 236,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x1.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "c78ce708bf26aab862d97e1b42f31ef376209eef141691fba5d10eaf581affe62e38aca2438b588d5459493e97e7fa330e73d2dc3bbd954989cb8433b7d6597b5103478f2869b93ee29c837e95fb6b990279d9d218d1e81ac2ce4a6e474403bf",
+          "ct": "e4ffffffffffffffffffffffffffffff05e74de09a9d7a2aff4a6356b57c7b05fffffffffffffffffffffffffffffffffe759118501a43cdd6a2064aa520adc7fffffffffffffffffffffffffffffffffe759118501a43cdd6a2064aa520adc7",
+          "tag": "347216375f5b7b5c4e6bff4912fd9473",
+          "result": "valid"
+        },
+        {
+          "tcId": 237,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x1.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "49115e67ecd3d4178c4c60e713ab4e5ee02b87aeae8c3da8895f8cb0f6b9cc80f447139a5f4e3f8e92d7a3b71eb4ff0ecc4b7b803a5f8f4647df169080fe567a78a0085c32ddfcbeb01a8be4c34d5331047e9bc2d60bc471602e52f94df95aba",
+          "ct": "d0ffffffffffffffffffffffffffffff792ca9a820a9d5140c8b2d4bf28c250ee3ffffffffffffffffffffffffffffff6381c873d020df8fdaf5117a613ed707e3ffffffffffffffffffffffffffffff6381c873d020df8fdaf5117a613ed707",
+          "tag": "adbd2cafc8c8f0e51250e7b81c9d0a2d",
+          "result": "valid"
+        },
+        {
+          "tcId": 238,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x1.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "1fde9b9ec8b247d42bbee2016d6715ba839f811ad0310c77052f45320b0d9560c4f0b056a2eecc51d30838e640615e1470d6b14fd209fedf261fd1d250d3478d2bd14da7b4f76f9f68fa8903138d563cca6f2f80c2ec9985ff75bfd4278fc6d8",
+          "ct": "ffffffffffffffffffffffffffffffff3eeafba63bfe1952ac727f1160b90039f5ffffffffffffffffffffffffffffffd7c9da8e1d0f1a84c2a34cd731fabb09f5ffffffffffffffffffffffffffffffd7c9da8e1d0f1a84c2a34cd731fabb09",
+          "tag": "232c882f7a1a2f808ccf26496cff5b3d",
+          "result": "valid"
+        },
+        {
+          "tcId": 239,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x5.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "fc8ce708bf26aab862d97e1b42f31ef38b79403dfaabc0d8c18d23a3469c13e62e38aca2438b588d5459493e97e7fa330a4b941e6b66fcc2ed7d8cb3e8cc7ffc5103478f2869b93ee29c837e95fb6b9906419f10480a8191a67842ee185e2538",
+          "ct": "dffffffffffffffffffffffffffffffff8be933274202b099b164e5aabfa9705fffffffffffffffffffffffffffffffffa4dd7da00c12a46b2140ecafa3a8b40fffffffffffffffffffffffffffffffffa4dd7da00c12a46b2140ecafa3a8b40",
+          "tag": "30721677ff2eb8894e5a9d8492b7b0af",
+          "result": "valid"
+        },
+        {
+          "tcId": 240,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xa.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "fa8ce708bf26aab862d97e1b42f31ef39bcbb8da477d580d772de4229bba7de22938aca2438b588d5459493e97e7fa331e9dedf9dd64a0681bac2969549425bc5603478f2869b93ee29c837e95fb6b991297e6f7fe08dd3b50a9e734a4067f78",
+          "ct": "d9ffffffffffffffffffffffffffffffe80c6bd5c9f6b3dc2db689db76dcf901f8ffffffffffffffffffffffffffffffee9bae3db6c376ec44c5ab104662d100f8ffffffffffffffffffffffffffffffee9bae3db6c376ec44c5ab104662d100",
+          "tag": "2b7216c7873744c20ec5e2cdb260d3fa",
+          "result": "valid"
+        },
+        {
+          "tcId": 241,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xa.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "66115e67ecd3d4178c4c60e713ab4e5e891b797521ba925b24090aaf6c4482bae847139a5f4e3f8e92d7a3b71eb4ff0e6d50c32d05a946cb8cea57c9f1442cb164a0085c32ddfcbeb01a8be4c34d5331a565236fe9fd0dfcab1b13a03c432071",
+          "ct": "ffffffffffffffffffffffffffffffff101c5773af9f7ae7a1ddab5468716b34ffffffffffffffffffffffffffffffffc29a70deefd6160211c050231084adccffffffffffffffffffffffffffffffffc29a70deefd6160211c050231084adcc",
+          "tag": "e17c273f31758e752322ae4869c1bfbb",
+          "result": "valid"
+        },
+        {
+          "tcId": 242,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x13.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "ee8ce708bf26aab862d97e1b42f31ef3b9f55bd56e0fd74b46063a96354cfbee3238aca2438b588d5459493e97e7fa3320c78886a6f6292d6cc5fbddb546a2b04d03478f2869b93ee29c837e95fb6b992ccd8388859a547e27c0358045d4f874",
+          "ct": "cdffffffffffffffffffffffffffffffca3288dae0843c9a1c9d576fd82a7f0de3ffffffffffffffffffffffffffffffd0c1cb42cd51ffa933ac79a4a7b0560ce3ffffffffffffffffffffffffffffffd0c1cb42cd51ffa933ac79a4a7b0560c",
+          "tag": "22721657b0130d28cf1ec65153c41182",
+          "result": "valid"
+        },
+        {
+          "tcId": 243,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x14.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "ef8ce708bf26aab862d97e1b42f31ef3b46fca24d353ff5e49eac51540e840ea3038aca2438b588d5459493e97e7fa333d311e572202011a75e948586fe268b44f03478f2869b93ee29c837e95fb6b99313b1559016e7c493eec86059f703270",
+          "ct": "ccffffffffffffffffffffffffffffffc7a8192b5dd8148f1371a8ecad8ec409e1ffffffffffffffffffffffffffffffcd375d9349a5d79e2a80ca217d149c08e1ffffffffffffffffffffffffffffffcd375d9349a5d79e2a80ca217d149c08",
+          "tag": "2172166798485c338f9a6d60f3b21891",
+          "result": "valid"
+        },
+        {
+          "tcId": 244,
+          "comment": "Intermediate sum of poly1305 after processing64 bytes is 0xffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "f59d56151de28bef83505f6d89c0b0f7f75b2fa8e6dce386075db283ec85ee62555baffad423af25f66069bb69fb6f4d",
+          "ct": "d6ee4ee25d3bdea81e76de8934cc51fb849cfca7685708575dc6df7a01e36a81849cfca7685708575dc6df7a01e36a81",
+          "tag": "831312cbb0f165dc3e8ff52125f48640",
+          "result": "valid"
+        },
+        {
+          "tcId": 245,
+          "comment": "Intermediate sum of poly1305 after processing64 bytes is 0x100000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "f717f8d5b28032d5c8e8061cd44d71e4f2d55de772fe7a91ce85e410db3e2d8d50d5ddb5400136323fb83f285e40aca2",
+          "ct": "d464e022f259679255ce87f8694190e881128ee8fc759140941e89e93658a96e81128ee8fc759140941e89e93658a96e",
+          "tag": "821312db9826b5e7fe0a9d30c5e28d4f",
+          "result": "valid"
+        },
+        {
+          "tcId": 246,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x7ffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "f28ce708bf26aab862d97e1b42f31ef3e68a922c9219d30f07554d7d99f2bde92c38aca2438b588d5459493e97e7fa33e24c07dd98f9b253ab0c318d9b14f6b15303478f2869b93ee29c837e95fb6b99ee460cd3bb95cf00e009ffd06b86ac75",
+          "ct": "d1ffffffffffffffffffffffffffffff954d41231c9238de5dce20847494390afdffffffffffffffffffffffffffffff124a4419f35e64d7f465b3f489e2020dfdffffffffffffffffffffffffffffff124a4419f35e64d7f465b3f489e2020d",
+          "tag": "c1045769d487d545cef3f0d34b7a8733",
+          "result": "valid"
+        },
+        {
+          "tcId": 247,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x7ffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "1fde9b9ec8b247d42bbee2016d6715badf0599194b0ce890cc1d8eb383b57f38dcf0b056a2eecc51d30838e640615e1435df81077d068077ce805ea592f6f88833d14da7b4f76f9f68fa8903138d563c8f661fc86de3e72d17ea30a3e5aa79dd",
+          "ct": "ffffffffffffffffffffffffffffffff6270e3a5a0c3fdb56540b490e801ea61edffffffffffffffffffffffffffffff92c0eac6b200642c2a3cc3a0f3df040cedffffffffffffffffffffffffffffff92c0eac6b200642c2a3cc3a0f3df040c",
+          "tag": "6cf2f9230af8679e7ecb19421362fce3",
+          "result": "valid"
+        },
+        {
+          "tcId": 248,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0xfffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "dc8ce708bf26aab862d97e1b42f31ef32e6784d857df07543d0dc72f179935fbede8c8baf01ee2044b162cbb343b355acc29d82327cd93f2bfd918034ed5c42a",
+          "ct": "ffffffffffffffffffffffffffffffff5da057d7d954ec856796aad6faffb1183c2f9be74c6a4576e0b09a7a5c2330963c2f9be74c6a4576e0b09a7a5c233096",
+          "tag": "64e7efd24516a83e2c87e06a76e2dea3",
+          "result": "valid"
+        },
+        {
+          "tcId": 249,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "f78ce708bf26aab862d97e1b42f31ef34c6ead26f84a0225d557745d32fc72e72c38aca2438b588d5459493e97e7fa3364db334b69bee579383e61ae742c71bb5303478f2869b93ee29c837e95fb6b9968d138454ad2982a733baff384be2b7f",
+          "ct": "d4ffffffffffffffffffffffffffffff3fa97e2976c1e9f48fcc19a4df9af604fdffffffffffffffffffffffffffffff94dd708f021933fd6757e3d766da8507fdffffffffffffffffffffffffffffff94dd708f021933fd6757e3d766da8507",
+          "tag": "e6cc6729d79ba558cd73b03cba54d660",
+          "result": "valid"
+        },
+        {
+          "tcId": 250,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "12de9b9ec8b247d42bbee2016d6715ba327f3a1befb4287c17450391ed0eb854d6f0b056a2eecc51d30838e640615e141460d3545c29ddc790711b8e7533698539d14da7b4f76f9f68fa8903138d563caed94d9b4cccba9d491b7588026fe8d0",
+          "ct": "f2ffffffffffffffffffffffffffffff8f0a40a7047b3d59be1839b286ba2d0de7ffffffffffffffffffffffffffffffb37fb895932f399c74cd868b141a9501e7ffffffffffffffffffffffffffffffb37fb895932f399c74cd868b141a9501",
+          "tag": "74dda12e0558877bc0e40c3eace0af29",
+          "result": "valid"
+        },
+        {
+          "tcId": 251,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x10000000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "f08ce708bf26aab862d97e1b42f31ef34fd8c3757c9f2938dc3b07d85898bfe22a38aca2438b588d5459493e97e7fa336155412415cbdd760142b62c2ec83fbf5503478f2869b93ee29c837e95fb6b996d5f4a2a36a7a0254a477871de5a657b",
+          "ct": "d3ffffffffffffffffffffffffffffff3c1f107af214c2e986a06a21b5fe3b01fbffffffffffffffffffffffffffffff915302e07e6c0bf25e2b34553c3ecb03fbffffffffffffffffffffffffffffff915302e07e6c0bf25e2b34553c3ecb03",
+          "tag": "e5cc6739bfd0f4638def574b5a43dd6f",
+          "result": "valid"
+        },
+        {
+          "tcId": 252,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x10000000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "1bde9b9ec8b247d42bbee2016d6715ba85b67664ee49fa347fbfd2dd92007c57def0b056a2eecc51d30838e640615e14fb27ee075b3c0f0f682babdde63dad8731d14da7b4f76f9f68fa8903138d563c419e70c84bd96855b141c5db91612cd2",
+          "ct": "fbffffffffffffffffffffffffffffff38c30cd80586ef11d6e2e8fef9b4e90eefffffffffffffffffffffffffffffff5c3885c6943aeb548c9736d887145103efffffffffffffffffffffffffffffff5c3885c6943aeb548c9736d887145103",
+          "tag": "502455343d39db87947d7346a8e0af39",
+          "result": "valid"
+        },
+        {
+          "tcId": 253,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffffffffffff00000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "f28ce708bf26aab862d97e1b42f31ef3df03ca84082f7f70ad8e4004cabd2ce42b38aca2438b588d5459493e97e7fa3328fd413caab1d02bf1c65753aa2ad3b95403478f2869b93ee29c837e95fb6b9924f74a3289ddad78bac3990e5ab8897d",
+          "ct": "d1ffffffffffffffffffffffffffffffacc4198b86a494a1f7152dfd27dba807faffffffffffffffffffffffffffffffd8fb02f8c11606afaeafd52ab8dc2705faffffffffffffffffffffffffffffffd8fb02f8c11606afaeafd52ab8dc2705",
+          "tag": "0fca702228817d53ee64d142b192e665",
+          "result": "valid"
+        },
+        {
+          "tcId": 254,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffff0000000100000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "f38ce708bf26aab862d97e1b42f31ef31ffc31ae69399394b8c338674c3dfde92938aca2438b588d5459493e97e7fa33477ec8cf3ea3d4d5d76d85ad2b7f0bb85603478f2869b93ee29c837e95fb6b994b74c3c11dcfa9869c684bf0dbed517c",
+          "ct": "d0ffffffffffffffffffffffffffffff6c3be2a1e7b27845e258559ea15b790af8ffffffffffffffffffffffffffffffb7788b0b55040251880407d43989ff04f8ffffffffffffffffffffffffffffffb7788b0b55040251880407d43989ff04",
+          "tag": "efc3b035ded6b460bfce6f494955e677",
+          "result": "valid"
+        },
+        {
+          "tcId": 255,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffff0000000100000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "4f115e67ecd3d4178c4c60e713ab4e5e4156269fe3da101eeb0abf8dda20fe8fff47139a5f4e3f8e92d7a3b71eb4ff0e6aece983e64f97e43ff5295bc884fa7773a0085c32ddfcbeb01a8be4c34d5331a2d909c10a1bdcd318046d320583f6b7",
+          "ct": "d6ffffffffffffffffffffffffffffffd85108996dfff8a26ede1e76de151701e8ffffffffffffffffffffffffffffffc5265a700c30c72da2df2eb129447b0ae8ffffffffffffffffffffffffffffffc5265a700c30c72da2df2eb129447b0a",
+          "tag": "3ea8f9b2012321e63d5fb5bc2c5d332d",
+          "result": "valid"
+        },
+        {
+          "tcId": 256,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffff0000000100000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "1fde9b9ec8b247d42bbee2016d6715baf999461058f6d7733e5cd0d1639d9025cbf0b056a2eecc51d30838e640615e14520a0da50439db00e289e1791342068e24d14da7b4f76f9f68fa8903138d563ce8b3936a14dcbc5a3be38f7f641e87db",
+          "ct": "ffffffffffffffffffffffffffffffff44ec3cacb339c2569701eaf20829057cfafffffffffffffffffffffffffffffff5156664cb3f3f5b06357c7c726bfa0afafffffffffffffffffffffffffffffff5156664cb3f3f5b06357c7c726bfa0a",
+          "tag": "bf7fbd422cbf0e700fd1605be8fd212f",
+          "result": "valid"
+        },
+        {
+          "tcId": 257,
+          "comment": "Intermediate sum of poly1305 after processing64 bytes is 0x3ffffffffffff8000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "2bfd0d56ece98771756d60d9d9106cd0c6fc106936c7ef347c078fd71c54228164fc903b0438a3978d3a54ef992aa3ae",
+          "ct": "088e15a1ac30d236e84be13d641c8ddcb53bc366b84c04e5269ce22ef132a662b53bc366b84c04e5269ce22ef132a662",
+          "tag": "345fc9fe573c136c1be83730500ce662",
+          "result": "valid"
+        },
+        {
+          "tcId": 258,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xfffffffffffff0000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "f68ce708bf26aab862d97e1b42f31ef37cc2255decdf8e0fe1373591da0e28e42838aca2438b588d5459493e97e7fa33e291fb4838019c51dfb7141515bb53b15703478f2869b93ee29c837e95fb6b99ee9bf0461b6de10294b2da48e5290975",
+          "ct": "d5ffffffffffffffffffffffffffffff0f05f652625465debbac58683768ac07f9ffffffffffffffffffffffffffffff1297b88c53a64ad580de966c074da70df9ffffffffffffffffffffffffffffff1297b88c53a64ad580de966c074da70d",
+          "tag": "336f97a5faa995a2a03781b591588da8",
+          "result": "valid"
+        },
+        {
+          "tcId": 259,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xf06eea00ea77bc00b4f34e80fffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "c68ce708bf26aab862d97e1b42f31ef37ab66f8090c149e452ec7f20327eb2ea0438aca2438b588d5459493e97e7fa338d2613ea0ef8b656b247373ecec015bc7b03478f2869b93ee29c837e95fb6b99812c18e42d94cb05f942f9633e524f78",
+          "ct": "e5ffffffffffffffffffffffffffffff0971bc8f1e4aa235087712d9df183609d5ffffffffffffffffffffffffffffff7d20502e655f60d2ed2eb547dc36e100d5ffffffffffffffffffffffffffffff7d20502e655f60d2ed2eb547dc36e100",
+          "tag": "9351c680c8a5d34882d42145e89745c4",
+          "result": "valid"
+        },
+        {
+          "tcId": 260,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x3f0f9115ff158843ff4b0cb17effffffc.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "c68ce708bf26aab862d97e1b42f31ef374b66f8090c149e452ec7f20327eb2ea2e38aca2438b588d5459493e97e7fa33acd9ec859e0866620cc24c8a97d5d9f55103478f2869b93ee29c837e95fb6b99a0d3e78bbd641b3147c782d767478331",
+          "ct": "e5ffffffffffffffffffffffffffffff0771bc8f1e4aa235087712d9df183609ffffffffffffffffffffffffffffffff5cdfaf41f5afb0e653abcef385232d49ffffffffffffffffffffffffffffffff5cdfaf41f5afb0e653abcef385232d49",
+          "tag": "d79266cd25a784599a0a8e31fc84d604",
+          "result": "valid"
+        },
+        {
+          "tcId": 261,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0xffffffffffffffff0000000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "f78ce708bf26aab862d97e1b42f31ef34251cd29b0aaa960557c9ea2828334e4e4e231db0a27fac9ec9e744886eb0133c5232142ddf48b3f185140f0fc05f043",
+          "ct": "d4ffffffffffffffffffffffffffffff31961e263e2142b10fe7f35b6fe5b00735256286b6535dbb4738c289eef304ff35256286b6535dbb4738c289eef304ff",
+          "tag": "9d671d407d7660459d5d582d83915efe",
+          "result": "valid"
+        },
+        {
+          "tcId": 262,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffff00000000ffffffff00000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "f58ce708bf26aab862d97e1b42f31ef373bd9f01bf3331b12e31dd14cf11feee1d38aca2438b588d5459493e97e7fa33625c6965f61a1c36118c747076d5b7b76203478f2869b93ee29c837e95fb6b996e56626bd57661655a89ba2d8647ed73",
+          "ct": "d6ffffffffffffffffffffffffffffff007a4c0e31b8da6074aab0ed22777a0dccffffffffffffffffffffffffffffff925a2aa19dbdcab24ee5f6096423430bccffffffffffffffffffffffffffffff925a2aa19dbdcab24ee5f6096423430b",
+          "tag": "7b207c2c3278c64f0d6b913fe371fe63",
+          "result": "valid"
+        },
+        {
+          "tcId": 263,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffff00000000ffffffff00000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "1fde9b9ec8b247d42bbee2016d6715bad64add2aa3c5a30a31d9e65e90f93ad1cbf0b056a2eecc51d30838e640615e14de9aeab86144d5464811b2373ba4cc8324d14da7b4f76f9f68fa8903138d563c6423747771a1b21c917bdc314cf84dd6",
+          "ct": "ffffffffffffffffffffffffffffffff6b3fa796480ab62f9884dc7dfb4daf88faffffffffffffffffffffffffffffff79858179ae42311dacad2f325a8d3007faffffffffffffffffffffffffffffff79858179ae42311dacad2f325a8d3007",
+          "tag": "62630c18de8c10876adb9f30f300963f",
+          "result": "valid"
+        },
+        {
+          "tcId": 264,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffffffffffffffffffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "dc8ce708bf26aab862d97e1b42f31ef3ec0933f0bfb91218cea0d74e061f559e2d38aca2438b588d5459493e97e7fa338d5b67e0acee534ce2d9791487b1ecb25203478f2869b93ee29c837e95fb6b9981516cee8f822e1fa9dcb7497723b676",
+          "ct": "ffffffffffffffffffffffffffffffff9fcee0ff3132f9c9943bbab7eb79d17dfcffffffffffffffffffffffffffffff7d5d2424c74985c8bdb0fb6d9547180efcffffffffffffffffffffffffffffff7d5d2424c74985c8bdb0fb6d9547180e",
+          "tag": "3672162bb1f3ff537ece013f1aca4f68",
+          "result": "valid"
+        },
+        {
+          "tcId": 265,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffffffffffffffffffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "1fde9b9ec8b247d42bbee2016d6715bacc3492272b8a4b112a4e7d7ccf092692cef0b056a2eecc51d30838e640615e1430ce678e9375b2af0b82c2d2fbd7928c21d14da7b4f76f9f68fa8903138d563c8a77f9418390d5f5d2e8acd48c8b13d9",
+          "ct": "ffffffffffffffffffffffffffffffff7141e89bc0455e348313475fa4bdb3cbffffffffffffffffffffffffffffffff97d10c4f5c7356f4ef3e5fd79afe6e08ffffffffffffffffffffffffffffffff97d10c4f5c7356f4ef3e5fd79afe6e08",
+          "tag": "feb6412b9031f076eddcd9426fff5b31",
+          "result": "valid"
+        },
+        {
+          "tcId": 266,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x100000000000000000000000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "dc8ce708bf26aab862d97e1b42f31ef3ee83a14f48db696291080edfcc898b882b38aca2438b588d5459493e97e7fa338ad5f6b0283a8b39ebedce92785da9b65403478f2869b93ee29c837e95fb6b9986dffdbe0b56f66aa0e800cf88cff372",
+          "ct": "ffffffffffffffffffffffffffffffff9d447240c65082b3cb93632621ef0f6bfaffffffffffffffffffffffffffffff7ad3b574439d5dbdb4844ceb6aab5d0afaffffffffffffffffffffffffffffff7ad3b574439d5dbdb4844ceb6aab5d0a",
+          "tag": "3572163b99284f5f3e4aa94dbab85677",
+          "result": "valid"
+        },
+        {
+          "tcId": 267,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x100000000000000000000000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "34de9b9ec8b247d42bbee2016d6715ba722b6549c9df0f4b04b5f7432203fa54cef0b056a2eecc51d30838e640615e1487de186cd28e43544c73de628fd1d60e21d14da7b4f76f9f68fa8903138d563c3d6786a3c26b240e9519b064f88d575b",
+          "ct": "d4ffffffffffffffffffffffffffffffcf5e1ff522101a6eade8cd6049b76f0dffffffffffffffffffffffffffffffff20c173ad1d88a70fa8cf4367eef82a8affffffffffffffffffffffffffffffff20c173ad1d88a70fa8cf4367eef82a8a",
+          "tag": "dafdf430c8124483c175404b6bff5b41",
+          "result": "valid"
+        },
+        {
+          "tcId": 268,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x100000000000000000000000000000001.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "dc8ce708bf26aab862d97e1b42f31ef3e87dd08ed4e4e04c5877616cbb02cabb2938aca2438b588d5459493e97e7fa33874f0401d457e336f4311f1152f957ba5603478f2869b93ee29c837e95fb6b998b450f0ff73b9e65bf34d14ca26b0d7e",
+          "ct": "ffffffffffffffffffffffffffffffff9bba03815a6f0b9d02ec0c9556644e58f8ffffffffffffffffffffffffffffff774947c5bff035b2ab589d68400fa306f8ffffffffffffffffffffffffffffff774947c5bff035b2ab589d68400fa306",
+          "tag": "3472164b815d9e6afec5505c5aa75d86",
+          "result": "valid"
+        },
+        {
+          "tcId": 269,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x100000000000000000000000000000001.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "4c115e67ecd3d4178c4c60e713ab4e5ebb5357ed314ad740b9910fad6f01d781f047139a5f4e3f8e92d7a3b71eb4ff0ec8042b414fdd1bba3a6c936b7ed678797ca0085c32ddfcbeb01a8be4c34d53310031cb03a389508d1d9dd702b3d174b9",
+          "ct": "d5ffffffffffffffffffffffffffffff225479ebbf6f3ffc3c45ae566b343e0fe7ffffffffffffffffffffffffffffff67ce98b2a5a24b73a74694819f16f904e7ffffffffffffffffffffffffffffff67ce98b2a5a24b73a74694819f16f904",
+          "tag": "e6022cc3ba20e3f9065fdfcc43a9dc40",
+          "result": "valid"
+        },
+        {
+          "tcId": 270,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x3fffffffffffffffffffffffffffffff6.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "c88ce708bf26aab862d97e1b42f31ef36be436e346f8f2b32f4cbbaef95150ef0438aca2438b588d5459493e97e7fa332fb76b5132e930f6d0acf70875e977b57b03478f2869b93ee29c837e95fb6b9923bd605f11854da59ba93955857b2d71",
+          "ct": "ebffffffffffffffffffffffffffffff1823e5ecc873196275d7d6571437d40cd5ffffffffffffffffffffffffffffffdfb12895594ee6728fc57571671f8309d5ffffffffffffffffffffffffffffffdfb12895594ee6728fc57571671f8309",
+          "tag": "3a7216d7ee1da018ce8412f251656b19",
+          "result": "valid"
+        },
+        {
+          "tcId": 271,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x3fffffffffffffffffffffffffffffff6.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "66115e67ecd3d4178c4c60e713ab4e5ef64296975af7fced168181f76c6508e1c947139a5f4e3f8e92d7a3b71eb4ff0e4975060f7ddef4a098699333b30fbf7c45a0085c32ddfcbeb01a8be4c34d53318140e64d918abf97bf98d75a7e08b3bc",
+          "ct": "ffffffffffffffffffffffffffffffff6f45b891d4d214519355200c6850e16fdeffffffffffffffffffffffffffffffe6bfb5fc97a1a469054394d952cf3e01deffffffffffffffffffffffffffffffe6bfb5fc97a1a469054394d952cf3e01",
+          "tag": "353e304fd8553286b26e0d59942fe7cd",
+          "result": "valid"
+        },
+        {
+          "tcId": 272,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x3fffffffffffffffffffffffffffffffa.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "c58ce708bf26aab862d97e1b42f31ef3783cf9302c7d22914b38aca2e7d374ef1d38aca2438b588d5459493e97e7fa33228f2d23597640d574f8e20c4f6b6bb56203478f2869b93ee29c837e95fb6b992e85262d7a1a3d863ffd2c51bff93171",
+          "ct": "e6ffffffffffffffffffffffffffffff0bfb2a3fa2f6c94011a3c15b0ab5f00cccffffffffffffffffffffffffffffffd2896ee732d196512b9160755d9d9f09ccffffffffffffffffffffffffffffffd2896ee732d196512b9160755d9d9f09",
+          "tag": "367216178ff1dc45ce73b02cd21f8755",
+          "result": "valid"
+        },
+        {
+          "tcId": 273,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0x35e50d79435e50d79435e50d79435e50.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "dc8ce708bf26aab862d97e1b42f31ef35db72f89d1402b1a0373ff0a9c5cd44b6d67af40798f5455501792953248ec234ca6bfd9ae5c25a3a4d8a62d48a61d53",
+          "ct": "ffffffffffffffffffffffffffffffff2e70fc865fcbc0cb59e892f3713a50a8bca0fc1dc5fbf327fbb124545a50e9efbca0fc1dc5fbf327fbb124545a50e9ef",
+          "tag": "0b4961c9525ea2f2cdad6273e1c7824c",
+          "result": "valid"
+        },
+        {
+          "tcId": 274,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0x35e50d79435e50d79435e50d79435e51.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "dc8ce708bf26aab862d97e1b42f31ef35f215ec87d62a264cadb519b4ac90a7668d1dd03e56eda6399ac7803e7dd22114910cd9a32bdab956d634cbb9d33d361",
+          "ct": "ffffffffffffffffffffffffffffffff2ce68dc7f3e949b590403c62a7af8e95b9168e5e591a7d11320acec28fc527ddb9168e5e591a7d11320acec28fc527dd",
+          "tag": "0a4961d93a93f1fd8d290a8281b6895b",
+          "result": "valid"
+        },
+        {
+          "tcId": 275,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x2fffffffffffffffffffffffffffffffb.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060710abb165",
+          "aad": "ffffffff",
+          "msg": "dc8ce708bf26aab862d97e1b42f31ef3d15ad590dd0f40ba18acd168f6ac777a0f38aca2438b588d5459493e97e7fa33932a097f1d39a04ad30f1b6c650260bf7003478f2869b93ee29c837e95fb6b999f2002713e55dd19980ad53195903a7b",
+          "ct": "ffffffffffffffffffffffffffffffffa29d069f5384ab6b4237bc911bcaf399deffffffffffffffffffffffffffffff632c4abb769e76ce8c66991577f49403deffffffffffffffffffffffffffffff632c4abb769e76ce8c66991577f49403",
+          "tag": "3572161355240943de9406292a64c551",
+          "result": "valid"
+        },
+        {
+          "tcId": 276,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x2fffffffffffffffffffffffffffffffb.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "4d115e67ecd3d4178c4c60e713ab4e5e6ee628fc4b5830184cd293364a213e84fe47139a5f4e3f8e92d7a3b71eb4ff0e29db953ad5458fea61f013ea1854fe7572a0085c32ddfcbeb01a8be4c34d5331e1ee75783911c4dd46015783d553f2b5",
+          "ct": "d4fffffffffffffffffffffffffffffff7e106fac57dd8a4c90632cd4e14d70ae9ffffffffffffffffffffffffffffff861126c93f3adf23fcda1400f9947f08e9ffffffffffffffffffffffffffffff861126c93f3adf23fcda1400f9947f08",
+          "tag": "e00d2e8bae5d09c28e9bf59409545d09",
+          "result": "valid"
+        },
+        {
+          "tcId": 277,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x2fffffffffffffffffffffffffffffffb.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "3ede9b9ec8b247d42bbee2016d6715ba8567a7fde812a3aa2f552a33c1718c58e2f0b056a2eecc51d30838e640615e14bb8729fd148f23b2a916b7f40f2f29810dd14da7b4f76f9f68fa8903138d563c013eb732046a44e8707cd9f27873a8d4",
+          "ct": "deffffffffffffffffffffffffffffff3812dd4103ddb68f86081010aac51901d3ffffffffffffffffffffffffffffff1c98423cdb89c7e94daa2af16e06d505d3ffffffffffffffffffffffffffffff1c98423cdb89c7e94daa2af16e06d505",
+          "tag": "b4ccb422bc5f7264aff73f3675ff5b19",
+          "result": "valid"
+        },
+        {
+          "tcId": 278,
+          "comment": "Intermediate sum of poly1305 after processing64 bytes is 0x5.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "43eadae036f733ea9b5b7eb22aee395db6f51a4d10bc2460810c229651556acf384ad82e3e280cad69f0df25b42b83b0",
+          "ct": "da047b7825db1802e8e8e1aac6ba88fc2ff2344b9e99ccdc04d8836d556083412ff2344b9e99ccdc04d8836d55608341",
+          "tag": "973e270a7afcab75348e14dbe19c5156",
+          "result": "valid"
+        },
+        {
+          "tcId": 279,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0x13.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "6a115e67ecd3d4178c4c60e713ab4e5e519cccebf72573dbee8c12f74255d18c0add1035861ffc0b7f40079b969f8c63b2af4fa3ccd16cb38f425c3996140def",
+          "ct": "f3ffffffffffffffffffffffffffffffc89be2ed79009b676b58b30c466038021d65fc5026ae3c7a12685bd377d48c921d65fc5026ae3c7a12685bd377d48c92",
+          "tag": "a22390224c5db0f01696743d870725c5",
+          "result": "valid"
+        },
+        {
+          "tcId": 280,
+          "comment": "Intermediate sum of poly1305 after processing64 bytes is 0x14.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "e235b8c21384557085c3f2eb2a8fa36058cffd2af743dacf96b4ae4d51b4e488d6703f49d9d7f2027e4853feb4ca0df7",
+          "ct": "7bdb195a00a87e98f6706df3c6db12c1c1c8d32c7966327313600fb655810d06c1c8d32c7966327313600fb655810d06",
+          "tag": "437d1efad21b0865a541b5cab62e2a44",
+          "result": "valid"
+        },
+        {
+          "tcId": 281,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "66115e67ecd3d4178c4c60e713ab4e5e8fab58574a322bac6f394474e4ce7eaec347139a5f4e3f8e92d7a3b71eb4ff0e71532dfb0e9141b00983394722829e7c4fa0085c32ddfcbeb01a8be4c34d5331b966cdb9e2c50a872e727d2eef8592bc",
+          "ct": "ffffffffffffffffffffffffffffffff16ac7651c417c310eaede58fe0fb9720d4ffffffffffffffffffffffffffffffde999e08e4ee117994a93eadc3421f01d4ffffffffffffffffffffffffffffffde999e08e4ee117994a93eadc3421f01",
+          "tag": "acf4ffa20c0d06d61a18e9a8d4c84d1d",
+          "result": "valid"
+        },
+        {
+          "tcId": 282,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0x100000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "61115e67ecd3d4178c4c60e713ab4e5e5efe679ba17384c55eb8cc193666fe8d04608c3503d217aa3f90a9b0e1b3b313bc12d3a3491c8712cf92f212e138329f",
+          "ct": "f8ffffffffffffffffffffffffffffffc7f9499d2f566c79db6c6de23253170313d86050a363d7db52b8f5f800f8b3e213d86050a363d7db52b8f5f800f8b3e2",
+          "tag": "cd466d06e75b7fd18d5fe21d9227d9a7",
+          "result": "valid"
+        },
+        {
+          "tcId": 283,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0x7ffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "9064b88a282052a1ee44df05ad213da679f8d1f971da17437a2b5e04fbca167151b2650ec945fec70588bc65a616a5f24f354c0c1580af3662d5f8151e3f7e82dd557ec8a4d63df7274594367bef09cd",
+          "ct": "098a19123b0c79499df7401d41758c07e0ffffffffffffffffffffffffffffff460a896b69f43eb668a0e02d475da503e0ffffffffffffffffffffffffffffff460a896b69f43eb668a0e02d475da503",
+          "tag": "ce8a3d4d887d95613d829b538ed01196",
+          "result": "valid"
+        },
+        {
+          "tcId": 284,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xfffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "43115e67ecd3d4178c4c60e713ab4e5eeef67bd4795b74015a3493905d544a86e847139a5f4e3f8e92d7a3b71eb4ff0e3197be28eff843592bd8fc8d578421d664a0085c32ddfcbeb01a8be4c34d5331f9a25e6a03ac086e0c29b8e49a832d16",
+          "ct": "daffffffffffffffffffffffffffffff77f155d2f77e9cbddfe0326b5961a308ffffffffffffffffffffffffffffffff9e5d0ddb05871390b6f2fb67b644a0abffffffffffffffffffffffffffffffff9e5d0ddb05871390b6f2fb67b644a0ab",
+          "tag": "08289f5199df476fe90475cb95225566",
+          "result": "valid"
+        },
+        {
+          "tcId": 285,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xfffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "39de9b9ec8b247d42bbee2016d6715ba4092e1f9a22c8b18184d805c128ade57c7f0b056a2eecc51d30838e640615e1464fe8b9bdd215a620973affefe93398528d14da7b4f76f9f68fa8903138d563cde471554cdc43d38d019c1f889cfb8d0",
+          "ct": "d9fffffffffffffffffffffffffffffffde79b4549e39e3db110ba7f793e4b0ef6ffffffffffffffffffffffffffffffc3e1e05a1227be39edcf32fb9fbac501f6ffffffffffffffffffffffffffffffc3e1e05a1227be39edcf32fb9fbac501",
+          "tag": "6d46d2230a9848d518f9d94bb2c49caa",
+          "result": "valid"
+        },
+        {
+          "tcId": 286,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0xffffffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "6b115e67ecd3d4178c4c60e713ab4e5e1e34412ab0a056e809d5d4b92be1128a4b2a651a62aeab26cf437fb195407574f3583a8c28603b9e3f41241395cbf4f8",
+          "ct": "f2ffffffffffffffffffffffffffffff87336f2c3e85be548c0175422fd4fb045c92897fc21f6b57a26b23f9740b75855c92897fc21f6b57a26b23f9740b7585",
+          "tag": "06df93f651ea5cc56911f30d3e58f997",
+          "result": "valid"
+        },
+        {
+          "tcId": 287,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0x10000000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "3fe606108f35869df4c7aa0128464a1265f8d1f971da17437a2b5e04fbca1671fdbe843a0ad9be25055992ab6dcbc9f153354c0c1580af3662d5f8151e3f7e8271599ffc674a7d152794baf8b03265ce",
+          "ct": "a608a7889c19ad7587743519c412fbb3fcffffffffffffffffffffffffffffffea06685faa687e546871cee38c80c900fcffffffffffffffffffffffffffffffea06685faa687e546871cee38c80c900",
+          "tag": "9264fc0f47febb30661254daf9a06189",
+          "result": "valid"
+        },
+        {
+          "tcId": 288,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0xffffffffffffffff00000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "6e8eb98cf7fffe4cd683568cf892991564f8d1f971da17437a2b5e04fbca1671c70f5d8b30c64bf2e6d1d613f40e0bf052354c0c1580af3662d5f8151e3f7e824be8464d5d5588c2c41cfe4029f7a7cf",
+          "ct": "f7601814e4d3d5a4a530c99414c628b4fdffffffffffffffffffffffffffffffd0b7b1ee90778b838bf98a5b15450b01fdffffffffffffffffffffffffffffffd0b7b1ee90778b838bf98a5b15450b01",
+          "tag": "69a124fc7f96e220d1a031ced5527279",
+          "result": "valid"
+        },
+        {
+          "tcId": 289,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x3ffffffffffff8000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "66115e67ecd3d4178c4c60e713ab4e5e18f125ef374c1454b680e23427e7dc69e447139a5f4e3f8e92d7a3b71eb4ff0e858b08eb1d581570a7cd1e48593b757568a0085c32ddfcbeb01a8be4c34d53314dbee8a9f10c5e47803c5a21943c79b5",
+          "ct": "ffffffffffffffffffffffffffffffff81f60be9b969fce8335443cf23d235e7f3ffffffffffffffffffffffffffffff2a41bb18f72745b93ae719a2b8fbf408f3ffffffffffffffffffffffffffffff2a41bb18f72745b93ae719a2b8fbf408",
+          "tag": "dfaf8a3a15d45e7f4c3430048d8589f0",
+          "result": "valid"
+        },
+        {
+          "tcId": 290,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x3ffffffffffff8000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "15de9b9ec8b247d42bbee2016d6715bacc1629a40cd11eafdf04138b45afe458eff0b056a2eecc51d30838e640615e14340ac9b45a5896a418a8cee8032e078f00d14da7b4f76f9f68fa8903138d563c8eb3577b4abdf1fec1c2a0ee747286da",
+          "ct": "f5ffffffffffffffffffffffffffffff71635318e71e0b8a765929a82e1b7101deffffffffffffffffffffffffffffff9315a275955e72fffc1453ed6207fb0bdeffffffffffffffffffffffffffffff9315a275955e72fffc1453ed6207fb0b",
+          "tag": "c6f23204865b0adde0070037d6538dd3",
+          "result": "valid"
+        },
+        {
+          "tcId": 291,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0xfffffffffffff0000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "b02ab747a310d6a3bbdb97018a3be8b341f8d1f971da17437a2b5e04fbca1671b7a338bc3423895f0fd96cdb27a787f277354c0c1580af3662d5f8151e3f7e823b44237a59b04a6f2d144488fa5e2bcd",
+          "ct": "29c416dfb03cfd4bc8680819666f5912d8ffffffffffffffffffffffffffffffa01bd4d99492492e62f13093c6ec8703d8ffffffffffffffffffffffffffffffa01bd4d99492492e62f13093c6ec8703",
+          "tag": "3408eb2b13a9b76befcedf699422d61f",
+          "result": "valid"
+        },
+        {
+          "tcId": 292,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xfdb3cec0ff9a5900ff513280fff6a94.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "40115e67ecd3d4178c4c60e713ab4e5e380ef93aeb61aa307f141323c38e0685f647139a5f4e3f8e92d7a3b71eb4ff0e3f769a30e8951ff2fb365fa780fdde7e7aa0085c32ddfcbeb01a8be4c34d5331f7437a7204c154c5dcc71bce4dfad2be",
+          "ct": "d9ffffffffffffffffffffffffffffffa109d73c6544428cfac0b2d8c7bbef0be1ffffffffffffffffffffffffffffff90bc29c302ea4f3b661c584d613d5f03e1ffffffffffffffffffffffffffffff90bc29c302ea4f3b661c584d613d5f03",
+          "tag": "09f4f2a3936d7461a67ce022176bb8dd",
+          "result": "valid"
+        },
+        {
+          "tcId": 293,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x3f024c313f0065a6ff00aecd7f0009567.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "40115e67ecd3d4178c4c60e713ab4e5e060ef93aeb61aa307f141323c38e0685ee47139a5f4e3f8e92d7a3b71eb4ff0e2bca70bfcdf1171ab611d12bed5d627a62a0085c32ddfcbeb01a8be4c34d5331e3ff90fd21a55c2d91e09542205a6eba",
+          "ct": "d9ffffffffffffffffffffffffffffff9f09d73c6544428cfac0b2d8c7bbef0bf9ffffffffffffffffffffffffffffff8400c34c278e47d32b3bd6c10c9de307f9ffffffffffffffffffffffffffffff8400c34c278e47d32b3bd6c10c9de307",
+          "tag": "2eb2679aadfd824a5fd8fa2e4a55a65c",
+          "result": "valid"
+        },
+        {
+          "tcId": 294,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffffffffffff0000000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "56115e67ecd3d4178c4c60e713ab4e5e6c7e1312c6774fae7d1e5d0cc609028ff547139a5f4e3f8e92d7a3b71eb4ff0e81c9e61cbeeed5546b1ce5d8fef21a7a79a0085c32ddfcbeb01a8be4c34d533149fc065e52ba9e634ceda1b133f516ba",
+          "ct": "cffffffffffffffffffffffffffffffff5793d144852a712f8cafcf7c23ceb01e2ffffffffffffffffffffffffffffff2e0355ef5491859df636e2321f329b07e2ffffffffffffffffffffffffffffff2e0355ef5491859df636e2321f329b07",
+          "tag": "5e89349f6b011cd6e24ee6ac2f590c21",
+          "result": "valid"
+        },
+        {
+          "tcId": 295,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffffffffffff0000000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "32de9b9ec8b247d42bbee2016d6715ba258d5d3e441683f546beba2e23755f5ccef0b056a2eecc51d30838e640615e149d13fdf8fa899836fa5c410d4ccd25ea21d14da7b4f76f9f68fa8903138d563c27aa6337ea6cff6c23362f0b3b91a4bf",
+          "ct": "d2ffffffffffffffffffffffffffffff98f82782afd996d0efe3800d48c1ca05ffffffffffffffffffffffffffffffff3a0c9639358f7c6d1ee0dc082de4d96effffffffffffffffffffffffffffffff3a0c9639358f7c6d1ee0dc082de4d96e",
+          "tag": "d1be7426cd12446fe52e8d45331e0835",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0xffffffff00000000ffffffff00000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "2ea8410b4dca8c9d5369a033d8db61e46cf8d1f971da17437a2b5e04fbca1671f0f58e8bba6cf1a52146273d8fe0c4fc5a354c0c1580af3662d5f8151e3f7e827c12954dd7ff3295038b0f6e521968c3",
+          "ct": "b746e0935ee6a77520da3f2b348fd045f5ffffffffffffffffffffffffffffffe74d62ee1add31d44c6e7b756eabc40df5ffffffffffffffffffffffffffffffe74d62ee1add31d44c6e7b756eabc40d",
+          "tag": "b24537fcb0dcb6200b0285cafc9c3a7d",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0xffffffffffffffffffffffffffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "17059a7c8883a28b90bd94ae44d1543662f8d1f971da17437a2b5e04fbca1671a23018bf8e68e413e99ac2d4ab3f8df154354c0c1580af3662d5f8151e3f7e822ed70379e3fb2723cb57ea8776c621ce",
+          "ct": "8eeb3be49baf8963e30e0bb6a885e597fbffffffffffffffffffffffffffffffb588f4da2ed9246284b29e9c4a748d00fbffffffffffffffffffffffffffffffb588f4da2ed9246284b29e9c4a748d00",
+          "tag": "43300400ea36e720361153ce0c5d637d",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0x100000000000000000000000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "aaa1b258fd4b54b497b520806a66d7aa68f8d1f971da17437a2b5e04fbca167199132a234a8c789bf8544547940ec3f35e354c0c1580af3662d5f8151e3f7e8215f431e5271fbbabda996d1449f76fcc",
+          "ct": "334f13c0ee677f5ce406bf988632660bf1ffffffffffffffffffffffffffffff8eabc646ea3db8ea957c190f7545c302f1ffffffffffffffffffffffffffffff8eabc646ea3db8ea957c190f7545c302",
+          "tag": "d79a0310124adc30c6b64cdef8993e8d",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0x3fffffffffffffffffffffffffffffffa.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "9841cfc927a57dc491ab35427ff935e66ef8d1f971da17437a2b5e04fbca1671a683c8f9f9e6780fda4940ddedd76bf258354c0c1580af3662d5f8151e3f7e822a64d33f9475bb3ff884688e302ec7cd",
+          "ct": "01af6e513489562ce218aa5a93ad8447f7ffffffffffffffffffffffffffffffb13b249c5957b87eb7611c950c9c6b03f7ffffffffffffffffffffffffffffffb13b249c5957b87eb7611c950c9c6b03",
+          "tag": "0aeb04ecf7def40c42025bbae5509169",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0x3fffffffffffffffffffffffffffffffa.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "f4ebbe3fca96bc4885b35582c43e0eb3588a85431430eada56a2c5dc944b6aa6b4570e8446e886bcbff82a24f49be5ed42e0943e30f91ba41b4362fa9ed6037b5b76f37550f12572040a9bc1a777edc5",
+          "ct": "14cada5efddb046351f2487c56a6e4f6e5ffffffffffffffffffffffffffffff8558412d1bf9b512930fed3d4b054406e5ffffffffffffffffffffffffffffff8558412d1bf9b512930fed3d4b054406",
+          "tag": "af7293eb09957d9de7432dd41316f0e4",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x35e50d79435e50d79435e50d79435e50.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "42115e67ecd3d4178c4c60e713ab4e5e0b61bf9b7caf83cc34da625593514289e847139a5f4e3f8e92d7a3b71eb4ff0e696a5c7fb9da9cd4a39c8591086db42d64a0085c32ddfcbeb01a8be4c34d5331a15fbc3d558ed7e3846dc1f8c56ab8ed",
+          "ct": "dbffffffffffffffffffffffffffffff9266919df28a6b70b10ec3ae9764ab07ffffffffffffffffffffffffffffffffc6a0ef8c53a5cc1d3eb6827be9ad3550ffffffffffffffffffffffffffffffffc6a0ef8c53a5cc1d3eb6827be9ad3550",
+          "tag": "8fc4f77a6ee052a4c314780b8df9a2d0",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x35e50d79435e50d79435e50d79435e50.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "1ade9b9ec8b247d42bbee2016d6715ba571a3fca3cda7def4c93d4a382ca3a57eaf0b056a2eecc51d30838e640615e1476cddbee2f185776174f6df3bbe5b38105d14da7b4f76f9f68fa8903138d563ccc7445213ffd302cce2503f5ccb932d4",
+          "ct": "faffffffffffffffffffffffffffffffea6f4576d71568cae5ceee80e97eaf0edbffffffffffffffffffffffffffffffd1d2b02fe01eb32df3f3f0f6dacc4f05dbffffffffffffffffffffffffffffffd1d2b02fe01eb32df3f3f0f6dacc4f05",
+          "tag": "e178b0d5eb9bc551fa645c49f9f17667",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x35e50d79435e50d79435e50d79435e51.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "00010203040506072dd4cd40",
+          "aad": "ffffffff",
+          "msg": "4b115e67ecd3d4178c4c60e713ab4e5ef28e4d0f20ca1644470c9cdac6000887ed47139a5f4e3f8e92d7a3b71eb4ff0e1464775bacd5c69fe26e1a74968ea27e61a0085c32ddfcbeb01a8be4c34d5331dc51971940818da8c59f5e1d5b89aebe",
+          "ct": "d2ffffffffffffffffffffffffffffff6b896309aeeffef8c2d83d21c235e109faffffffffffffffffffffffffffffffbbaec4a846aa96567f441d9e774e2303faffffffffffffffffffffffffffffffbbaec4a846aa96567f441d9e774e2303",
+          "tag": "232ff78a96f347b453ba711b79367ee0",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x35e50d79435e50d79435e50d79435e51.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "1fde9b9ec8b247d42bbee2016d6715babe31a501536a7c91e4a102cc27cdfe09d2f0b056a2eecc51d30838e640615e14dd9416a12e2f81bdee023d462feef7833dd14da7b4f76f9f68fa8903138d563c672d886e3ecae6e73768534058b276d6",
+          "ct": "ffffffffffffffffffffffffffffffff0344dfbdb8a569b44dfc38ef4c796b50e3ffffffffffffffffffffffffffffff7a8b7d60e12965e60abea0434ec70b07e3ffffffffffffffffffffffffffffff7a8b7d60e12965e60abea0434ec70b07",
+          "tag": "bdbf63db237d195ecefdc251f5f17677",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0x5.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "97311cd6e2d25a7b4eaa16f0a61ca6246b8a85431430eada56a2c5dc944b6aa695136310b6b6b5c17c9f8c02ba7d0aeb71e0943e30f91ba41b4362fa9ed6037b7a329ee1a0af160fc76d3de7e99102c3",
+          "ct": "771078b7d59fe2509aeb0b0e34844c61d6ffffffffffffffffffffffffffffffa41c2cb9eba7866f50684b1b05e3ab00d6ffffffffffffffffffffffffffffffa41c2cb9eba7866f50684b1b05e3ab00",
+          "tag": "d71bc70d5adc74e7dfd89406fc15f044",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0xa.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "34de9b9ec8b247d42bbee2016d6715ba74cf7e9d82b7e8ed9ec965f6ea310951dc104940e08a4222556828eba459f65a4a006d28729d95d79d2372f77aeeab35",
+          "ct": "d4ffffffffffffffffffffffffffffffc9ba04216978fdc837945fd581859c08ed1f06e9bd9b718c799feff21bc757b1ed1f06e9bd9b718c799feff21bc757b1",
+          "tag": "21e63987d494673f3040ae9de2bc0da0",
+          "result": "valid"
+        },
+        {
+          "tcId": 307,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0x13.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "e72b83514e5e50509070359c1cac7e1c428a85431430eada56a2c5dc944b6aa6dad35950d8a9b55a472f9bb8860a526358e0943e30f91ba41b4362fa9ed6037b35f2a4a1ceb01694fcdd2a5dd5e65a4b",
+          "ct": "070ae7307913e87b443128628e349459ffffffffffffffffffffffffffffffffebdc16f985b886f46bd85ca13994f388ffffffffffffffffffffffffffffffffebdc16f985b886f46bd85ca13994f388",
+          "tag": "e4fb945d6a2d0b947834317cc415f024",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0x14.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "8c6165f445443588041b6e044fb6baae728a85431430eada56a2c5dc944b6aa6881a54c09516a1f1cae7b9dd71130ee168e0943e30f91ba41b4362fa9ed6037b673ba931830f023f7115083822ff06c9",
+          "ct": "6c40019572098da3d05a73fadd2e50ebcfffffffffffffffffffffffffffffffb9151b69c807925fe6107ec4ce8daf0acfffffffffffffffffffffffffffffffb9151b69c807925fe6107ec4ce8daf0a",
+          "tag": "c0424863a20e5fa04ccd9784c015f034",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "Intermediate sum of poly1305 after processing96 bytes is 0xffffffff.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "18e36174545fa7ec9ea9f05d7057c5ca638a85431430eada56a2c5dc944b6aa6434e1c5e71005b690ca5cb8d580b89ed79e0943e30f91ba41b4362fa9ed6037bac6fe1af6719f8a7b7577a680be781c5",
+          "ct": "f8c2051563121fc74ae8eda3e2cf2f8fdeffffffffffffffffffffffffffffff724153f72c1168c720520c94e7952806deffffffffffffffffffffffffffffff724153f72c1168c720520c94e7952806",
+          "tag": "aa7293ffe5db30a31f2581e0e7ae56ed",
+          "result": "valid"
+        },
+        {
+          "tcId": 310,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x100000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "12de9b9ec8b247d42bbee2016d6715ba54305dff6b61c40b775c352d025c1a56d7f0b056a2eecc51d30838e640615e14bce574e9e11afedbdca021e53bb9188338d14da7b4f76f9f68fa8903138d563c065cea26f1ff998105ca4fe34ce599d6",
+          "ct": "f2ffffffffffffffffffffffffffffffe945274380aed12ede010f0e69e88f0fe6ffffffffffffffffffffffffffffff1bfa1f282e1c1a80381cbce05a90e407e6ffffffffffffffffffffffffffffff1bfa1f282e1c1a80381cbce05a90e407",
+          "tag": "42e5d43d1e808e79f017144d4498c235",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0xffffffffffffffff00000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "36de9b9ec8b247d42bbee2016d6715ba1132811b2f18321ba99b12432c7f865aa3352cd2d7ac70b4c6f5419767926e20352508ba45bba7410ebe1b8bb925334f",
+          "ct": "d6ffffffffffffffffffffffffffffffac47fba7c4d7273e00c6286047cb1303923a637b8abd431aea02868ed80ccfcb923a637b8abd431aea02868ed80ccfcb",
+          "tag": "14fba149d1c0edc8aa665851126b5afd",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0xfffffffffffff0000000000000.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "31de9b9ec8b247d42bbee2016d6715baff746ef53ec3357cbc3c3ce4ab1d2d51ed9eb456dc9d9b59f656a5d2d974d26a7b8e903e4e8a4cac3e1dffce07c38f05",
+          "ct": "d1ffffffffffffffffffffffffffffff42011449d50c2059156106c7c0a9b808dc91fbff818ca8f7daa162cb66ea7381dc91fbff818ca8f7daa162cb66ea7381",
+          "tag": "8cff61b7b3919ed6bde72b36e0d31326",
+          "result": "valid"
+        },
+        {
+          "tcId": 313,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0xffffffc086698d40c53e13805b346dc.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "19de9b9ec8b247d42bbee2016d6715babf286fd979807951b183a188930ad15ecef0b056a2eecc51d30838e640615e1464413d71939b9cb0a4d32ef115da9e1021d14da7b4f76f9f68fa8903138d563cdef8a3be837efbea7db940f762861f45",
+          "ct": "f9ffffffffffffffffffffffffffffff025d1565924f6c7418de9babf8be4407ffffffffffffffffffffffffffffffffc35e56b05c9d78eb406fb3f474f36294ffffffffffffffffffffffffffffffffc35e56b05c9d78eb406fb3f474f36294",
+          "tag": "369cf17011cae47539e2723f010cf980",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "Intermediate sum of poly1305 after processing112 bytes is 0x3f0000003f799672bf3ac1ec7fa4cb91f.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "19de9b9ec8b247d42bbee2016d6715babd286fd979807951b183a188930ad15ee3f0b056a2eecc51d30838e640615e14f25e78fe1b53ae416d1fbc698522618f0cd14da7b4f76f9f68fa8903138d563c48e7e6310bb6c91bb475d26ff27ee0da",
+          "ct": "f9ffffffffffffffffffffffffffffff005d1565924f6c7418de9babf8be4407d2ffffffffffffffffffffffffffffff5541133fd4554a1a89a3216ce40b9d0bd2ffffffffffffffffffffffffffffff5541133fd4554a1a89a3216ce40b9d0b",
+          "tag": "532eb8e272a8d171378b0d42dff2bed9",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0x100000000000000000000000000000001.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "3dde9b9ec8b247d42bbee2016d6715bac5629699cfd4d9036cef478ed705be5650f575882c3800f757ea6e0f8c6d47acc6e551e0be2fd7029fa1341352da1ac3",
+          "ct": "ddffffffffffffffffffffffffffffff7817ec25241bcc26c5b27dadbcb12b0f61fa3a21712933597b1da91633f3e64761fa3a21712933597b1da91633f3e647",
+          "tag": "f8800c5b6283dddfc41f935c01bd0d24",
+          "result": "valid"
+        },
+        {
+          "tcId": 316,
+          "comment": "Intermediate sum of poly1305 after processing80 bytes is 0x3fffffffffffffffffffffffffffffff6.",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060703e76f6f",
+          "aad": "ffffffff",
+          "msg": "1fde9b9ec8b247d42bbee2016d6715ba66d624f288f52941ca24865ce96f0d9736ff33a27c23f4976fc74f1fcd82f5cca0ef17caee342362a78c15031335a8a3",
+          "ct": "ffffffffffffffffffffffffffffffffdba35e4e633a3c646379bc7f82db98ce07f07c0b2132c73943308806721c542707f07c0b2132c73943308806721c5427",
+          "tag": "38bfb8318c627d86c34bab1f1ebd0db0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "ivSize": 0,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 317,
+          "comment": "nonce has size 0.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 64,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 318,
+          "comment": "nonce has size 8.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "0001020304050607",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 88,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 319,
+          "comment": "nonce has size 11.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 104,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 320,
+          "comment": "nonce has size 13.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 112,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 321,
+          "comment": "nonce has size 14.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 128,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 322,
+          "comment": "nonce has size 16.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 192,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 323,
+          "comment": "nonce has size 24.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 160,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 324,
+          "comment": "nonce has size 20.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 256,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 325,
+          "comment": "nonce has size 32.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/testing/kats/wycheproof/xchacha20_poly1305_test.json
+++ b/crates/testing/kats/wycheproof/xchacha20_poly1305_test.json
@@ -1,0 +1,4578 @@
+{
+  "algorithm": "XCHACHA20-POLY1305",
+  "schema": "aead_test_schema_v1.json",
+  "numberOfTests": 315,
+  "header": [
+    "Test vectors of type AeadTest test authenticated encryption with additional data.",
+    "The test vectors are intended for testing both encryption and decryption.",
+    "Test vectors with \"result\" : \"valid\" are valid encryptions.",
+    "Test vectors with \"result\" : \"invalid\" are using invalid parameters",
+    "or contain an invalid ciphertext or tag."
+  ],
+  "notes": {
+    "EdgeCaseCiphertext": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains values where the ciphertext is a special case. The purpose of the test vector is to detect incorrect poly1305 computations."
+    },
+    "EdgeCasePoly1305": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains an edge case for the integer arithmetic used to compute Poly1305. I.e., the goal of the test vector is to catch integer overflows."
+    },
+    "EdgeCasePolyKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains values where the key for Poly1305 has edge case values. E.g. the nonces have been constructed such that the Poly1305 key contains limbs with values such as 0. The goal of the test vector is to detect incorrect integer arithmetic in the Poly1305 computation."
+    },
+    "EdgeCaseTag": {
+      "bugType": "EDGE_CASE",
+      "description": "The tag contains an edge case. The goal of the test vector is to check for arithmetic errors in the final modular addition of CHACHA-POLY-1305."
+    },
+    "InvalidNonceSize": {
+      "bugType": "MODIFIED_PARAMETER",
+      "description": "RFC 7539 restricts the size of the nonce of CHACHA-POLY1305 to 12 bytes and XCHACHA-POLY1305 to 24 bytes. Other sizes are invalid."
+    },
+    "Ktv": {
+      "bugType": "BASIC",
+      "description": "Known test vector."
+    },
+    "ModifiedTag": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The test vector contains a ciphertext where the tag has been modified. The goal of the test vector is to detect implementations with partial or incorrect tag verification."
+    },
+    "Pseudorandom": {
+      "bugType": "FUNCTIONALITY",
+      "description": "The test vector contains pseudorandomly generated inputs. The goal of the test vector is to check the implementation for different input sizes."
+    }
+  },
+  "testGroups": [
+    {
+      "ivSize": 192,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "draft-arciszewski-xchacha-02",
+          "flags": [
+            "Ktv"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "404142434445464748494a4b4c4d4e4f5051525354555657",
+          "aad": "50515253c0c1c2c3c4c5c6c7",
+          "msg": "4c616469657320616e642047656e746c656d656e206f662074686520636c617373206f66202739393a204966204920636f756c64206f6666657220796f75206f6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73637265656e20776f756c642062652069742e",
+          "ct": "bd6d179d3e83d43b9576579493c0e939572a1700252bfaccbed2902c21396cbb731c7f1b0b4aa6440bf3a82f4eda7e39ae64c6708c54c216cb96b72e1213b4522f8c9ba40db5d945b11b69b982c1bb9e3f3fac2bc369488f76b2383565d3fff921f9664c97637da9768812f615c68b13b52e",
+          "tag": "c0875924c1c7987947deafd8780acf49",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "ab1562faea9f47af3ae1c3d6d030e3af230255dff3df583ced6fbbcbf9d606a9",
+          "iv": "6a5e0c4617e07091b605a4de2c02dde117de2ebd53b23497",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "e2697ea6877aba39d9555a00e14db041",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d821dce9b890ea37ae1c89e7cb6aeae9371b8179add0d08f5494718322ae0071",
+          "iv": "3ec3f7c45e687d75a895bf5e71809e7cdac32158bb48ec0d",
+          "aad": "8780fb400f94c55d",
+          "msg": "",
+          "ct": "",
+          "tag": "966c22d655b9e56326024f028cf887ad",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "303ccb2e1567c3d9f629a5c632dbc62a9a82c525674f67988b31bd1dee990538",
+          "iv": "05188738844ab90a8b11beef38eaec3e100d8f4f85ae7a41",
+          "aad": "",
+          "msg": "62",
+          "ct": "45",
+          "tag": "d15734f984d749fa3f0550a70c43dddf",
+          "result": "valid"
+        },
+        {
+          "tcId": 5,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "697c197c9e0023c8eee42ddf08c12c46718a436561b0c66d998c81879f7cb74c",
+          "iv": "cd78f4533c94648feacd5aef0291b00b454ee3dcdb76dcc8",
+          "aad": "6384f4714ff18c18",
+          "msg": "e1",
+          "ct": "b0",
+          "tag": "e5e35f5332f91bdd2d28e59d68a0b141",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "c11213bcff39a88b0e3ecc47b23acf6c3014e4708d80dcca162da7377b316ab3",
+          "iv": "b60ca1ab736deebe4d9da78bc7cbbab91be14a2f884240b7",
+          "aad": "",
+          "msg": "57f9",
+          "ct": "5e03",
+          "tag": "eed21c2cd3f395538d677602964ed578",
+          "result": "valid"
+        },
+        {
+          "tcId": 7,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "b0f51b8227013464943370e926b6ed1c9fb45b5994af829ff3a9f998b77d822c",
+          "iv": "4fd76cbf27cb387502a706461564e5a5c14e027d40bc6eef",
+          "aad": "322f82a87ee82997",
+          "msg": "ab8c",
+          "ct": "b56a",
+          "tag": "edcafa2c9032aff695e427fc2a344767",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "17afb080753f2aa0af0a7f4821f6ab2709a6b2b5b9f2f262910e3b27b82c6c1c",
+          "iv": "737e3e7699f788c4136938c0f65310684eacbb5f96ecd98d",
+          "aad": "",
+          "msg": "2af96a",
+          "ct": "31a461",
+          "tag": "2b745098b154bb90903b0240c3bc95e9",
+          "result": "valid"
+        },
+        {
+          "tcId": 9,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "b720aea3df85fb3fb00583eddbebc5c545bcdcb7f6f2a94c1087950e16d68278",
+          "iv": "1436f36466fce5db337a73ec18e269e6e985d91035128183",
+          "aad": "9d53316bd2aa3e3d",
+          "msg": "4799c4",
+          "ct": "d41c02",
+          "tag": "8faa889d7f189cd9473e19200ef03920",
+          "result": "valid"
+        },
+        {
+          "tcId": 10,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d7704e505826124ab02935e7349a4e13391e6dc020fee95cd30654cdc5d5f393",
+          "iv": "7c39999d498286d974d266b2f027a26d7fbcd330869d9f93",
+          "aad": "",
+          "msg": "c44efab6",
+          "ct": "a3b405bb",
+          "tag": "c50e2ddb97df1ee58561c97a7b746c24",
+          "result": "valid"
+        },
+        {
+          "tcId": 11,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "c70ef9ee59259019960c918bfc91237ed6786c73f2b62427e4cbd4d8096a1f03",
+          "iv": "eb4e36c637d1908db2c2ae9c72cfbae50655cb5f6504c4b6",
+          "aad": "8e0ac97934605052",
+          "msg": "2738c9d0",
+          "ct": "9406a621",
+          "tag": "916b78ee04b20b8cd90f00b81bb8091c",
+          "result": "valid"
+        },
+        {
+          "tcId": 12,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7fac2a879ffddf5e36e04e3edcb8aa6be18a8326b28f76b15623307badc1ece2",
+          "iv": "49875536d4946af49288f36684e25ff35998d50be6bcfcc2",
+          "aad": "",
+          "msg": "2c4c38f435",
+          "ct": "2a01d08fe2",
+          "tag": "9cbe5f3e782f57a33a45b1f4aeeeea6e",
+          "result": "valid"
+        },
+        {
+          "tcId": 13,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "48f1389d9222a80898ca26b5cfef5dc82dfc0af7cf66ea1e01bc5279e7414247",
+          "iv": "88ccb58d435ea760f19e1fa6172139a071c0c5143959a56c",
+          "aad": "5cbdd482f3429a27",
+          "msg": "945a1fd040",
+          "ct": "fb5daf8c6e",
+          "tag": "ec1682b61957493c2eb758d7a2b7a179",
+          "result": "valid"
+        },
+        {
+          "tcId": 14,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "737cdaa2ce1e4740e75af4aaf68c0296c1607bde871d2452e628f1456239c753",
+          "iv": "89c9806ad153b805f1bf5b50738319011d5fc070bb551ee1",
+          "aad": "",
+          "msg": "fae858dd3150",
+          "ct": "856c300cfceb",
+          "tag": "aaa9875ebd42a11d12cf0aca26021f4a",
+          "result": "valid"
+        },
+        {
+          "tcId": 15,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "9f7cd632bd5eb5f017b898590d645571ef56e521024eda36eff893a6ad04b935",
+          "iv": "5cbdc34772b54fb4fba9eca1e2745e0e3704d9d7b5c78fb4",
+          "aad": "71b29930f84a572d",
+          "msg": "53abb8943ada",
+          "ct": "6438fc8f8788",
+          "tag": "af05a4def2ad39a195a7b8c222050111",
+          "result": "valid"
+        },
+        {
+          "tcId": 16,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "ecf60cd2af8c7155c0be848ecdaa5baddad6bd5f254a2d98f47bef83999f60ee",
+          "iv": "a020b016d952a5948a3d226bb1b73efc39d46845f3bf0ca5",
+          "aad": "",
+          "msg": "ea30907da57d78",
+          "ct": "843f1039531fe1",
+          "tag": "efd99acdab540690ec91a7ad5697cb33",
+          "result": "valid"
+        },
+        {
+          "tcId": 17,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "a9376583c47176728d7b2ed1039f0b12b2c7a97563937f7fe976ce4548f7cb00",
+          "iv": "b1f05bb66d29bcddf7412f6a556ff7540aac452457dd69e6",
+          "aad": "0c87cc97c49e166a",
+          "msg": "4a3d9926dc9757",
+          "ct": "f99f3fb49ec920",
+          "tag": "91c3356ee6601ae7073673d2ef30293b",
+          "result": "valid"
+        },
+        {
+          "tcId": 18,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "bf9ae8ceceb8d3001da7652c4cec02adda8696294a4ab542b41b5ba86c096a75",
+          "iv": "f4f3484cacdce37cf5134a12f57903096acd3553607eb682",
+          "aad": "",
+          "msg": "6eb5e11b358c0ab1",
+          "ct": "5b596bab0890286e",
+          "tag": "d4474d9520f7178e9811f624209721ea",
+          "result": "valid"
+        },
+        {
+          "tcId": 19,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d447796ed4ceb2e43942700e7759e335f67afa8653748db95f924c94488195db",
+          "iv": "cc4781134455e89c836f7433bd0426776f945d82f6358276",
+          "aad": "06947c3afa797e99",
+          "msg": "77c46ada19c81849",
+          "ct": "80c8e9ac2cec97ce",
+          "tag": "9b62dcc8076098affcb6e7995aaa99a6",
+          "result": "valid"
+        },
+        {
+          "tcId": 20,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "08eb57d7bc113f7fbdda1b32237cdd06cccd52ef4a89a831c5e0564370c885ad",
+          "iv": "200a30270bc911dd3b8a8ea2a6e6ce75be9cfb0f5431db3d",
+          "aad": "",
+          "msg": "704df23a31893799ee",
+          "ct": "37d696264f781338c9",
+          "tag": "5fddaf74438159acc3c5667b5e84af13",
+          "result": "valid"
+        },
+        {
+          "tcId": 21,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "9f093b6bb75f1609ab1e00a4bf4667961d885f01deb6520c5bb16ec21e033766",
+          "iv": "a613e0b17fafb47c79614d39959b986ba2c97b0215676d41",
+          "aad": "00fc4f61d9777504",
+          "msg": "472578ece9fe828dc6",
+          "ct": "a55cbb308f81e449e9",
+          "tag": "8174bd595da1be72cc226e74c46a4af5",
+          "result": "valid"
+        },
+        {
+          "tcId": 22,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e421bb3269130c731d1947e7b5d233c11d195ceed1d08634743db9c252bfefa5",
+          "iv": "21b40036745f64b2aab3e89665cf4dab2b690d88721fe9a3",
+          "aad": "",
+          "msg": "1155c7f0ee3e1faa641e",
+          "ct": "8bd51b64fcd244f0b3aa",
+          "tag": "dbdd1558934b83ae4393ade73e9edadb",
+          "result": "valid"
+        },
+        {
+          "tcId": 23,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "8a275c90eb8688c5d9e82b74331cf104a2c8757d6257079b1d8035bb40d6a8d9",
+          "iv": "33dfa71a0cb2aca008e4c8e8a72dbda4c407bbadd5d7e1a5",
+          "aad": "e7c9d1dda90b699e",
+          "msg": "3c2da491f244acfbd1dc",
+          "ct": "e5aad5c055dc6df73cf0",
+          "tag": "96fc30292cc8381c345d5f2964ba5626",
+          "result": "valid"
+        },
+        {
+          "tcId": 24,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2d97a35e4b6617e5f4a0f50dcda7622f321cad936a246d9beada9d75e142ef3d",
+          "iv": "5a44801d2baabfe8cbee6da52bb51b5297856065fbf33944",
+          "aad": "",
+          "msg": "b94df0d444dac848ffcad4",
+          "ct": "2a41cc14a6a65bbb153758",
+          "tag": "1044cd75f2e61cbecbf3a7a77c13ef01",
+          "result": "valid"
+        },
+        {
+          "tcId": 25,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "70d11ca92903865c6a6d8ba497f5a2d65f23b72198d7fc7fdaeda6c2632f7e46",
+          "iv": "07590877a1e1df3a78fe4d04dd64b6cb79f1df45de17685b",
+          "aad": "d78dcb5431ef5669",
+          "msg": "f61bb0dd66e5905f1a7ea1",
+          "ct": "5b3193405830b6840a4474",
+          "tag": "4b10bef8e8a3c2e6ae87fb8fb2a8bdd5",
+          "result": "valid"
+        },
+        {
+          "tcId": 26,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "05c7317f07a0e89ce1b5ac41df8064faa9fd569ee1c357cd01a2872076477ac5",
+          "iv": "94f86b0fd8a6ed90d3780eca23a82f4387da82b0894ae317",
+          "aad": "",
+          "msg": "b63e50c9bcd01406b6f78f86",
+          "ct": "528dfb79ea182945f13bafb7",
+          "tag": "4fc22f4491449bb4ffe6a1eb266e2a91",
+          "result": "valid"
+        },
+        {
+          "tcId": 27,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "924aafdb5b8a206b3e49aefe8944918cdcc8ccb5bb4b8c4ee81b847aa6fa52a0",
+          "iv": "829cb09e40c2cc5f7648adc177e56ef53a58bfa16a859338",
+          "aad": "a67a57310055b193",
+          "msg": "68576b935acaab8b33ab62e3",
+          "ct": "2345bfc502f9c62d64ad87f9",
+          "tag": "6736f095a28b887238f80dc562eaa25c",
+          "result": "valid"
+        },
+        {
+          "tcId": 28,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "332b7ec9bf4a983eb02af7efee8ffaf5627b66f29e3e4728f50894fe176788d8",
+          "iv": "016dac89c624a9d425ae377132421c37c4486895bef270f0",
+          "aad": "",
+          "msg": "8289397a58921bb3201b29c505",
+          "ct": "d1f725ace69f7899ef51c11dd3",
+          "tag": "0d2858cc30497107a035929fdf2eb6af",
+          "result": "valid"
+        },
+        {
+          "tcId": 29,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "b75fd9dd7ecca4f3eab36c36a176530dd3ffc825c202613740311d11cd501804",
+          "iv": "e8252b018f9e0c3fbd4a6ad0d06346302b8ed7dcb206c3ad",
+          "aad": "4dc711c827a6f626",
+          "msg": "9800f8b835c4ff490ebd764914",
+          "ct": "6c0e9d31b8e45591726f4cfc63",
+          "tag": "2ce700f1f3dc7d3f60607058ac3b817e",
+          "result": "valid"
+        },
+        {
+          "tcId": 30,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2bddfb332f74ac31fcf91d652c7b41fbcb26a10f2792ecf8075478e645042f87",
+          "iv": "e698d39b3cec2634dbe035a55b8fce3b0041aabe4156f713",
+          "aad": "",
+          "msg": "813974b924c7618c63070d0247f0",
+          "ct": "23a49dbe4b699d481621d9fc2db6",
+          "tag": "ef2cfb8423ae6f9faaec81025e6e274b",
+          "result": "valid"
+        },
+        {
+          "tcId": 31,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "ea029c829c13a580b66aca21133a16933235c11c42905a640104a2ae9bb5cf82",
+          "iv": "d025b0188edc9c40a8d6fc807cead97749016c9016d62ea5",
+          "aad": "0b9df4ffd1c9ccbe",
+          "msg": "a67e672df18cfbe125b212d63ec8",
+          "ct": "0596f5709407a62fffce84240346",
+          "tag": "893772def69053b0aaf3bf1c21144ebf",
+          "result": "valid"
+        },
+        {
+          "tcId": 32,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "1c838d9f68e687fbdddc6dff7f2e44b277bfeb316ae5d11b3e935889b48539d8",
+          "iv": "9ce202557c11a57cb14e7e4bd7986f1cf6232196672d25ea",
+          "aad": "",
+          "msg": "37905d98be9839e02923d119a88d56",
+          "ct": "c5aa0caf82b963f1e9b84a789a77d3",
+          "tag": "59c3e2e43cc098ed413ece9d9a6fd47a",
+          "result": "valid"
+        },
+        {
+          "tcId": 33,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "51a99f0646767fbc01d7736df0340191acfbb5ae0288ed6fff2d34f0ea31470f",
+          "iv": "ffdca5c51a0852ab18dd484af6664b63ab4097d303450837",
+          "aad": "a2e44e165e7ca5f7",
+          "msg": "93553954f0be4e24185601ce5c3c34",
+          "ct": "f91d01453f568774115f75b5dad642",
+          "tag": "8fc36af6ae5ee3e05b38ed43598bbfcd",
+          "result": "valid"
+        },
+        {
+          "tcId": 34,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "6a1f808358461e75072a054e2fc4e4c3e7f882c57920dda3278d0c860ca704e3",
+          "iv": "25dc279923c1bcdaa7a36e7b884b51f62343abad71986037",
+          "aad": "",
+          "msg": "f242209c67698ea32c2152f8785b7d82",
+          "ct": "732715c60018fb0ed55c14c1fa9a5273",
+          "tag": "afe3c4f050bf001e1dfcb2313dd8edd2",
+          "result": "valid"
+        },
+        {
+          "tcId": 35,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7fb18b56f3f5122585754a3b6c6a4e523036e66793db569c3e8e28032e916eb6",
+          "iv": "c02c8c595064ac303b1be5df6ab43048856e97ae9962fb8f",
+          "aad": "8981c7260d514ab6",
+          "msg": "6e8c0bb3361908f5b33e059408651ae3",
+          "ct": "a7eb11bfaa0d1c2ce457598049399575",
+          "tag": "485a94f61aa5f47a3036e85a57effd2f",
+          "result": "valid"
+        },
+        {
+          "tcId": 36,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "3b11469dc670f5dfbe0aad7d15ee4862c92cb07842e5dcc48fa8e5fc817f1749",
+          "iv": "9a61cf35aecbd40a65b35a64b516896f3de7f977b5c9901d",
+          "aad": "",
+          "msg": "540731e4ba3e4e2fd623a1a13233736ee7",
+          "ct": "0fd7386b41396e0558495c45cdba029062",
+          "tag": "29f601a11f6a1072342c60b631de6085",
+          "result": "valid"
+        },
+        {
+          "tcId": 37,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e6d9fc8a9e3fa6ecadd9faffbb6ff387aa96502e60adadab029a9146ee39de28",
+          "iv": "6570889af7acab7f555337bdce05499e8eb0d8d3d1a77660",
+          "aad": "23230be73ba2a6fb",
+          "msg": "deec95974eeef6e2b99739bed2f4a74771",
+          "ct": "86d0fd1a325d501fe9efe83d3a3f62e346",
+          "tag": "1ed9a79616c787a8de2ff5cdac6af0c9",
+          "result": "valid"
+        },
+        {
+          "tcId": 38,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "cbaa654cd4ad70ae96d3412680e60522807e9b887ec6dbfcd6e71e917e29ce62",
+          "iv": "f3d84207ab5574e4bc74ae61b17ccaccc7c46eb3471e0e53",
+          "aad": "",
+          "msg": "f55aaf5a55432c20fb782c552e5ae096eb23",
+          "ct": "daea40da316b8e78254a737c57063c4ad8b7",
+          "tag": "e13ff7a7e2c85b1abb5350134dfa7f9b",
+          "result": "valid"
+        },
+        {
+          "tcId": 39,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "5b51ea4943ce173baa53f84a6ef59cb1e25b794768508b8dd8dcbfbc1744c18a",
+          "iv": "de1e034363b0daec9828159e7996faff33a5f63eb552eb5f",
+          "aad": "b6bea5c60f288109",
+          "msg": "953939dd7601f17071b2bf776e4b1ed629ce",
+          "ct": "eef62d53545698255648a483708c9cc93937",
+          "tag": "182529b1d07dbcb4bd89b3c5e4c8fac9",
+          "result": "valid"
+        },
+        {
+          "tcId": 40,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "c5d3917ffb42b0508296cb245d468b04bbaa2c8c8c32e845415a911ea85f95f1",
+          "iv": "74533cbe3ff9ec5a66604c88f5dae4d7efe4f604111f79fc",
+          "aad": "",
+          "msg": "0afab6dbab51f929332d743ccfbb9f34877bc9",
+          "ct": "03dfbb3407a55ab0dbc451d0289de44acb5f33",
+          "tag": "a050def2e06a9ed3d10be180bafa636d",
+          "result": "valid"
+        },
+        {
+          "tcId": 41,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "77cbd62759966c03b4487ce7cb3fca652c30198cdc0de5d447256e979e041c87",
+          "iv": "562f3b788783bbb72e465c9d04eb555f366c66de32356e7b",
+          "aad": "880ac1004984fb3e",
+          "msg": "0e677082f7dd9c56bd365310c15a18de78df6d",
+          "ct": "95a9bd7bf7e9836e5f8a75393c70da0d9b1d97",
+          "tag": "f028003066f8902c5d74ca6bc526e346",
+          "result": "valid"
+        },
+        {
+          "tcId": 42,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "40e231268005ff28c36bd00167ea39131d262f3a591b0d1508c11b00ed04a0b6",
+          "iv": "5fb9a00843c4b192bf6c3bc29451c237f30a607d3c637b85",
+          "aad": "",
+          "msg": "d34b950a1c4f2ae5c94a1fddd6574c5d9c0ab18f",
+          "ct": "4ad85a75f1a975bbf3ee5302b71949036e3a2198",
+          "tag": "b82c05b09328949aa70bb537e871cd70",
+          "result": "valid"
+        },
+        {
+          "tcId": 43,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d66e92c86712132b1e3f5ba3a4cd006b9de1fa444246d99ef02e5b190a73089d",
+          "iv": "7ade1bc01148ac071bfbe9870fe2023a7769b92312f45e0a",
+          "aad": "043cd9069dbd8cb5",
+          "msg": "1cf9f2a93cb056fa4222c5850872d9989bc8c185",
+          "ct": "dfca9d845c21093f43348a4f6e72e324e9673129",
+          "tag": "9defc3de90d493be2a1945d11c569095",
+          "result": "valid"
+        },
+        {
+          "tcId": 44,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "841404f7e07cdebeb48efd25a75444b6de170995cd460e38ff5930dc9cf5eba2",
+          "iv": "45ccb4a19073c79a4ac1e052d4664d0dd1c730a6a2e87fe8",
+          "aad": "",
+          "msg": "5d583f68421d00cd8d95896a091b9bb10b744c61c4",
+          "ct": "74634f111539fac80bb29d76ba656e5af90fd37f8e",
+          "tag": "c04ce25d27416ae5f181238acf9508bc",
+          "result": "valid"
+        },
+        {
+          "tcId": 45,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "77a812cdbce2b7327dbbaecf6f81340b0ac97589676939d1ff0e69c3373326a3",
+          "iv": "89248df60acfa757945d12647a14cc5bc6508bb2b9e4999c",
+          "aad": "91b46ee1f7a9361b",
+          "msg": "2573f8f0276ce3b2b38fb727575f376a2eeb305758",
+          "ct": "0c1afa5419abb32e479b181a6e51cd99eb041bc37d",
+          "tag": "6c0b51ea2fc63841893216b03eb47be0",
+          "result": "valid"
+        },
+        {
+          "tcId": 46,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "f2f9bdba59206e8c31a3338213d6a46a40aee237f631906aff076fe2d29d3b85",
+          "iv": "ec272b052c33c84a611512a483c3fcec40501240eb7a42ee",
+          "aad": "",
+          "msg": "408c4cac91b4bd3ce25c8971b1ed8adb20ed667f8393",
+          "ct": "59d9c3f18cbc59a3c04cdc6904cb860aae69a5485147",
+          "tag": "63e55e220873e295a5b86543334b1715",
+          "result": "valid"
+        },
+        {
+          "tcId": 47,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d9aa0213bfac5ee89f9ef2c6f616d8f71c3725dafe7926504e18b141192c33b0",
+          "iv": "a131b4b0582be36dcce56beb036ec4fc31147efed7ff4718",
+          "aad": "1bc37fc6729b401d",
+          "msg": "081280932efbce0a5500d76d41c7dd2ddbc3311dc0cd",
+          "ct": "d5a1f87dae98ab385d5d34626c295cca0ed6931635f4",
+          "tag": "25f2fa45c86c4cb0f02f99050e9d5ab7",
+          "result": "valid"
+        },
+        {
+          "tcId": 48,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d7b0b278c5ede48da2db2f6ec6f8b23282d3c940bd1eb59f7102bf69c683298d",
+          "iv": "df72b7fe00eb070276ba1b0de6b17a6100fe0d660bf3c6c7",
+          "aad": "",
+          "msg": "0f44c184d297c0a66467d54ac982f922b119d5b4c8b238",
+          "ct": "93034cdc9298d0086b8e8bbf3aea637484454015cf544d",
+          "tag": "b1e1dcf03663a995c6c14991b5558159",
+          "result": "valid"
+        },
+        {
+          "tcId": 49,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "bd5040047cd7bd0bd1ca22164058a2901feb383c1ccba5c71c853f186d4e2b9e",
+          "iv": "0378f12d4891c68477d90f16f2ff59287c81922b73cec608",
+          "aad": "04e0e991fb5a465e",
+          "msg": "29b7080f92c860ca4dd501f18b041c5cbc5c131783a720",
+          "ct": "83a8bbe26ad18129459f66f6dc771c653a3dbb88a00b11",
+          "tag": "791971c0f5ba2c8b7635924267c68f32",
+          "result": "valid"
+        },
+        {
+          "tcId": 50,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "3b96dbe28ee07208cdf703f1488f478134147363da1502249e025e0efe5cb663",
+          "iv": "c9f5d4dfd5dd2276d68b25c6178d9ef2f38756df4be9d4b3",
+          "aad": "",
+          "msg": "8f37fd7e3e2f6563a9883d4adb92b5c37242a56b73a6fb7e",
+          "ct": "1a0bc208b17fb629200e805da495db70c599ecb3c3b9cc94",
+          "tag": "08b9477bc98543019ddaa7ae380f83dd",
+          "result": "valid"
+        },
+        {
+          "tcId": 51,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "53fc679ebe23b70714ab4ce6c8b0de5df656dca27177512654da31f6848dbe6b",
+          "iv": "90b932e3464c8b66d3d2fec2bc9097289f147e05f18a9867",
+          "aad": "e1b2f309ce5fabe8",
+          "msg": "8b0b4038c0eebea97fa1f93b7c2f3576898e7cdc9fd702d0",
+          "ct": "e9dd13d48dd7258682311bfec967e1a1ebc562855f224f41",
+          "tag": "d9038207dbfc82a9a9d507fe254d57c2",
+          "result": "valid"
+        },
+        {
+          "tcId": 52,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "275ac60ffa734bf86601c951d0bd263b9651181c32f41fce90d59cb8d59da081",
+          "iv": "d758776af8d089ef14a075ddf683e6669ed8109fe5681833",
+          "aad": "",
+          "msg": "1fa3b565515a429f78fb36e93e048425ffb64bc9e9e68336b3",
+          "ct": "666f807a6e5d0253fe1967d45efea42cf1f421789b7f48e0dc",
+          "tag": "5d423636988dd257e5cbd40ee28ae94e",
+          "result": "valid"
+        },
+        {
+          "tcId": 53,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "ec4d4b14860a36fe8afb2861c1376db8004cc2d37eb1ebb609343daf24bc39fb",
+          "iv": "9628e46f25d08b206371449e7321d6bf5d811629e01ef32b",
+          "aad": "bbcbfa1779f4122c",
+          "msg": "201ec6c1d0675e818cb7a4e583ea1aa1afde1bbda1f0f549e1",
+          "ct": "369a80f75ad28fd05cb3c944e0a8c8b37ce65bbd1f6d4b355a",
+          "tag": "3ca5005eda0b99d6566ac841340ad23a",
+          "result": "valid"
+        },
+        {
+          "tcId": 54,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "53f9c2c335c1c5cde744e890f6bd291e4484925aaa036f1e74f0144603322648",
+          "iv": "ec3dae28ec71ceba5b97a933d30b9fb98a40d4c92e6f54ef",
+          "aad": "",
+          "msg": "00f4f6a8c09ecbff3e6e825ca676a5cb8373d4915ecaf5d317a1",
+          "ct": "b6faccf43dabd8965cb231fe96a2bdf2cb51e0b9afb6445c21eb",
+          "tag": "ee91b39d01a114f80a7c5e7e1a0b2868",
+          "result": "valid"
+        },
+        {
+          "tcId": 55,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "9bb8bc991f01fb26df610032e1bf6ed0e2652629a6726aec9c23df4fefbdb594",
+          "iv": "a7f4c26140ba7d8a884de794fb23a50c6647627fa85ef9f7",
+          "aad": "a6d7d9034512781c",
+          "msg": "ebcb0777bd1c3385376270e543521e11f4bac00d0f9c0192581e",
+          "ct": "c97a4ba644788bfdeeb0a5de228948902a57359879c82cf8ead9",
+          "tag": "bf51aa205497db895f008d828040150f",
+          "result": "valid"
+        },
+        {
+          "tcId": 56,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "69b8b0846c47226dbb278f83082b75476e89a77444bfa06de69395f16c6eed01",
+          "iv": "7e4c8d0e24ab24f500053964774c92f808bafc42be0f6a34",
+          "aad": "",
+          "msg": "3b406d4c07f2ef751ac701fe944b2392bd59fb0ee4b32e6cbf8958",
+          "ct": "28cf032caf586255ee3f3f70492d33458a7b42473b8e354d983dfd",
+          "tag": "58896a5d7618837701ed8dda9b18d82c",
+          "result": "valid"
+        },
+        {
+          "tcId": 57,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "aa6d2da8fe7ce3228f15e09ae8c7f3d1b0220679a3e0e13e7523060b5b8d09b6",
+          "iv": "26b2165f4b22415df4c052564b87d62c4c2c01df47c82cd8",
+          "aad": "f5fa84749ff438f4",
+          "msg": "92763e759a5c0b8c4d40d6398fa9e257900ff4b1f31000dbd9a15e",
+          "ct": "be95d62d6acb3e5344f6b4ddbddfb45fa479c2d1577a42967dc0ad",
+          "tag": "61ac094fefb1237c9d44ab7f4bbbf5f9",
+          "result": "valid"
+        },
+        {
+          "tcId": 58,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "31b9e848dfd3dd1ec05410975190109f550ee6e5235f040ce6faf6c380fba49d",
+          "iv": "b595d9204461e311915cc17df51a3bbfa55c3a98aafbbaee",
+          "aad": "",
+          "msg": "95272cdea7a15889059b4e1de058c869e1776384159539470b542ed8",
+          "ct": "2248e5332ed42c42fcb6a029e3d8f9f96cbc32d34fa5f302fabf1bf3",
+          "tag": "b777e88479292944c5d6ace1ffd24ac2",
+          "result": "valid"
+        },
+        {
+          "tcId": 59,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "da132c34b2291a15777d3ebda2ed0078028c215038c2410d822578dcc869ea8d",
+          "iv": "bc101b6d01bda7e13d402aa0023f0507ab02aa58758cb6aa",
+          "aad": "96fc6284d7eeb53c",
+          "msg": "331f3d53965bfee2edb463c5b21751eb445289287fada2aedae99258",
+          "ct": "b10f9fbd87f51ebeae1942b9afb59749987b1575babd8008b281a662",
+          "tag": "54ad4e664b86333223fca6869c501dc2",
+          "result": "valid"
+        },
+        {
+          "tcId": 60,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d7e5e9c008af44266c876fa6b02a453854703c1a4fd221573c382c8d512a982d",
+          "iv": "4adcd5ecf1506fe7a38adf5634b454bf90278c9ebffbac87",
+          "aad": "",
+          "msg": "f8b3ae84d6502d353d57c970da5f9bc53de7a5c6262ba7a7b2220d0ee1",
+          "ct": "ffb587ec97c7d11ca75629f066881f6b2c392fa71b73fc4cb4559a645d",
+          "tag": "ec9db510c3bb11831c20684d82e45053",
+          "result": "valid"
+        },
+        {
+          "tcId": 61,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "1e72be02d7ebf3c78b400efd005f5b6b983ede08443541475808d43e6d30eab8",
+          "iv": "055776b422138960f6631e3c58f3ba0688082747de4ae5f6",
+          "aad": "cec8c976f2e25979",
+          "msg": "f2654733ca29af4bb29347f7a6508ed87913e0faa885505928ac1ee86e",
+          "ct": "5d3ce03a6f43eab32a91b6eb87666af14e5e28d98d23c49c56557497d5",
+          "tag": "b324b10851d159bd3822705a9d638038",
+          "result": "valid"
+        },
+        {
+          "tcId": 62,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "98362eff7af1e38d3d77d4a013bb6bf3fb3690568bf897651c578b21572fd37e",
+          "iv": "cb52ad5674aff0762ef49fb3bed4722dcef2bcbc4f3c316a",
+          "aad": "",
+          "msg": "a40610eaf3a823c06936293473ca36a2952d0eb5e5bbc18be123a07f8bc8",
+          "ct": "aa6edcb0f49535b2d2fa2e5f0b29343ba0c9c1667c401c78a3a8b8a61ad2",
+          "tag": "98d5e90a5a64e411c98d7c9e91557f5c",
+          "result": "valid"
+        },
+        {
+          "tcId": 63,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "8f0e3dc43b86943ed4b0361fa5aa49999f24bc1e102bf3afb439e44f9ce43504",
+          "iv": "f2f09c3469e2cf73b07620e461d7b1ad999c5f7d54867d21",
+          "aad": "f5203e702570c4b1",
+          "msg": "dba4ed2a7938826c43548f6976d8f0ec1838fe71cc535b2a5d56e4d3d5ca",
+          "ct": "3d1add00e51e60b16825272790ff47c0d533bfe65484d105ee7a69896c48",
+          "tag": "a018e2629d5656920f1202e65624b056",
+          "result": "valid"
+        },
+        {
+          "tcId": 64,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "16a376d68b3105262a07558e5e448ecdcbe075770cf60e7b7db1420f4fa4e36d",
+          "iv": "17d6ff40ad135ac9df55fa5c0eaf03e5d91cdac63c684e8e",
+          "aad": "",
+          "msg": "bdb5500794edd38a398f18f83de03e16f135ea960d3b8c6578abc541aa1d03",
+          "ct": "1ca6389e16c2f43e9e89447991d1472c8283a8dd94fdf61c4f5aee746cb537",
+          "tag": "33107bbbc06e563abf48979dbc7c66b6",
+          "result": "valid"
+        },
+        {
+          "tcId": 65,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "8e1fb8cc57ca60ae091d27e292923272439c37f2dede36b2c2aaee96439d5a31",
+          "iv": "c306b69443bfdbedb5ce9f9bb6088132a88e8a175d3bd769",
+          "aad": "3fe9ad465d0aa3fa",
+          "msg": "1d884a83a5f9b00b8951ef81778bd7c991cdc911127eee9dfeff82c48ca937",
+          "ct": "e8ae311bf2e80d696c543cd272d3e50dc968a0ab47259c461e0dec35f77530",
+          "tag": "906de4c31eb2ce283eeb95388b0d83ce",
+          "result": "valid"
+        },
+        {
+          "tcId": 66,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2ed460a56867ee1a2877a8f3d2d98fb886cfcc8913e31c3d08f42374ba37ebb1",
+          "iv": "0140f2791eb81fd4b69edf2d9ba4b2d62eab1d296741583f",
+          "aad": "",
+          "msg": "318cc4bf151c3baaee5a783ec091ab618f2ecacf38c962ba9c32c323696cc94c",
+          "ct": "d34c1778d105d0e80d429c86b879d52835cf8aebc5a04a9084cff1f9646e040a",
+          "tag": "ac8a68605a0567c559442342b764b964",
+          "result": "valid"
+        },
+        {
+          "tcId": 67,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "b43328e39cc6f6e94ea601fbebadb4b41cfe6a52c3a4d5eeabaa9853db45ccb1",
+          "iv": "97438f178419732feaade58a5d5c21bed14d04c4add50465",
+          "aad": "1264b91e71865033",
+          "msg": "63cb5c20c9edf36757b795921437d3fd228af1fcdbb329505cbdde12afaf9f84",
+          "ct": "cc24cfa62063d11b2c31cf25ceb7308ca376feb1dd6bc102ed7db8ed46b06759",
+          "tag": "dda7fc160e23f57e8392809f1e3b5ee8",
+          "result": "valid"
+        },
+        {
+          "tcId": 68,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "92b9b40c00480a50ee16a86349a46e37b02d5ba74d2e5a67eaf333e467fa0152",
+          "iv": "daca1f50a4c0d9b77151c75f2e58ce404847d0aab493086d",
+          "aad": "",
+          "msg": "c857f3c55da61d72563912a2534e01b6426ba41bf417c15b725086d31a1645c94d",
+          "ct": "82be237be008228a8a9ff1a506d5b893cf9dcaa1dd33c0523b13582bcade4629ef",
+          "tag": "723437af0b684b6e04024352206cbaf9",
+          "result": "valid"
+        },
+        {
+          "tcId": 69,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "5c271bac09a0454c83d158bcc9ec331ca92e62726903b7bb5799adff47d671ee",
+          "iv": "ffcaddf85da09293c4352c81cbb5dd82e30b0f9e7623e92a",
+          "aad": "aaefd84240ade0ed",
+          "msg": "7c716a5b6cf0b8b0e1ff825ff9324bb5715b0d40af5338d5337f66de681932d423",
+          "ct": "ff98ead89d45d70f09b9e3f31f4ff56ae8b8cad1517294a8af3c962bad24a92efe",
+          "tag": "4b8a06a1613737d0f8e3fb88184b23e4",
+          "result": "valid"
+        },
+        {
+          "tcId": 70,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "c28403cce44ff256d055c2cbc84bb2d9773346e0d51bd38e80cebd861b03fa30",
+          "iv": "64cc9f3cc334abce364cec9efe8ad54117ff0bbb03e3e8b9",
+          "aad": "",
+          "msg": "f9e8f60b70044b03a189c26f1c8fd246239bc23f8adf0f88516f88d73d11c9290882bb6ad49d956b10c9f848180065",
+          "ct": "d0e84c6450f348d887c49c4b44ac38721d4a1742e72095c330249c7348bade49dc776d449272e0f3dd5422c2a6ab18",
+          "tag": "28c72dea441cffac2f7811286f8ea5dd",
+          "result": "valid"
+        },
+        {
+          "tcId": 71,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7c72c748ea0010c90e1dfbde8e91edf6ead2474148cf234e0559dcd881cc3b2b",
+          "iv": "7b97c8b1c06b69b99220042ab2ac65b88d8b4294b76b4bd1",
+          "aad": "7185f9cbf59d2095",
+          "msg": "9a1f6c42a8a0f3032e8dfa36e0f5750479276866c920672a0454c41bfae5dd74fbf0fbcc8e6fbf4843f20d06440837",
+          "ct": "4093dcbca1555835b78140fe7a3798a77bd97a01b0a7c1f7157fedb27c40d9d16cc3e935f649faf0dcf431636cd539",
+          "tag": "c7c9133ff17a296c987d72885182874d",
+          "result": "valid"
+        },
+        {
+          "tcId": 72,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7948151a374363d07dfb12869b7f90502f2de8117d3d72d5133b9b3e3dc78ef7",
+          "iv": "8052acef0423bb07a6fbaf8f63039f1eaa2cdefc61b31b18",
+          "aad": "",
+          "msg": "76e03034be5514561e99c32ab58901eabac0f67b40c366202ac8a08ee3f68c3b283c1adeefee6f5544330d4771e5148c5231ec27b3f3f9d81a3dca52e115e1b5",
+          "ct": "764ab84b844b57b0564f63ec70ad12d81dc3a0e65233a9bf06d6b2c653787eb991bc37a885a04509690ab49fd8dedcabe3c346df9036d735de3bf73ab03f5ba7",
+          "tag": "075248c91d1f246aebaa96c86627d18e",
+          "result": "valid"
+        },
+        {
+          "tcId": 73,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "50a1b2b155150936609d45596e9175f3271be548574405f827593fc5a0578c3a",
+          "iv": "f357e3b3d3d5e4187e34da08afd4817635adde91b676da1d",
+          "aad": "dc514d540551b9dc",
+          "msg": "e854b8531ace95c975a5b1497f3dec6d80b29ca673690411abe277bbfd29fa00133ee17570805c1c605452d648581be8db878e782f217b481b1268591593efc0",
+          "ct": "de03f775aee744e4148e008dfefa7156ce2a23a613d4d9cae99c3164f54a173f895a9466ef046c020179383d70c813e765f207860c79dcf627f17663ea76af20",
+          "tag": "b473a9f1d5312d556bd0b62d84bb0803",
+          "result": "valid"
+        },
+        {
+          "tcId": 74,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "92570a01d2b6123b67055400c8a9b0cb948e32c9b8520758cd1abd73f83c8507",
+          "iv": "6d609141e3e4331f55344c1f5e6fad589b39ec1d12b9fbf0",
+          "aad": "",
+          "msg": "e86fc97c194d37a5e1345d139fe82dd669b6350c435cb446fcbdcc90fe5859bb2ef1f69d930e29dc343b57dfd7ff3c382652939bbd1c978a790ed1dbe5ad1fcbe157925ab4335c649c2f80c19d541e9e7eb4feb64e596bc6d7df8aa3476e0a9f7e",
+          "ct": "98fc26e0cfd5a75b5bcd9e046e89c6e9dc5aaefdd5e8ea7e4d286dcdaca0fe6ae744d244678f91c9ccf6e294bd5586be671645ae87d3435836a5ab383b253602c25a6cc04353c076725b4fc4aff9b4dc9bd194fe92ef0a920f15d6b8fea9f19065",
+          "tag": "03bb49593f116a30a8390f96380a9888",
+          "result": "valid"
+        },
+        {
+          "tcId": 75,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "4a3bc8f5c4aab87c20772404a291c1d6d68eb12e5f3c82e582564d6300fc28c9",
+          "iv": "1a80def5bd8be8eef5f6643a5c1aed9947c3ee5ca0cb56df",
+          "aad": "e40cb55a18f2885f",
+          "msg": "2b0815f7eb0a83b9617e4f0906e9179b600b0c822bfb56c5012103aecb4550a57099dcebae00b6c06f3537fb1550c78b249d00a4007d23b882cb5511fdd53482575554028e9db437b8224368ead730d157a64d5571c706cbd9c0d2b10b3b14c3e2",
+          "ct": "7042beb6e4f08e583752f23048e2f3433e0821423d72a7e531b86684b57b32c5bdcc11164db0b8516d7b463cf7f8b0e3ed8a7d584345934ef184e4f8fee31e126601f08558c725aaa23d38c8017b07adbf1e742128795b03458b581b8cd9100bd9",
+          "tag": "b5e3df83f18cbc0bd99427b9a172bf1b",
+          "result": "valid"
+        },
+        {
+          "tcId": 76,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "951d6caceb0ad662c531293b71dffba198ab3ff2b9075834f46a1db81fd3879f",
+          "iv": "fb26a898fb8ff2b3bcfa60af0dfb35097648fef82709eb55",
+          "aad": "",
+          "msg": "95e3e4ad70752f97852689a652126ca1364bda1eb07b5171392383159a3794ad6e61adc30bd7488c4a87759a6d917620af7f56a51051b1a5f0b561afb8281032be1de27d4353fe8a8255d0806f45eb14038ce2a4340ae18d7ebdadca46794ff0a3ff8aeb70f9b9c23b49dc415e9ad18ff9ca5159705e2340e2eca033921dea",
+          "ct": "9575ef3e412bf8969380274f3d009ad03b3a509a1c5ddef6074f6fb5750b9148d65e5fd4e7ecc6759043999b6ae6cb843ad102f3f1a8d5ab9a923438b55842883507d049fc29748f24037de6d280635f668496843c4c35a1e07f9c37fec860d2f973008c459ad0aeff72f27847e6a20a001ce7ae1804e9c0bc5f3161b33403",
+          "tag": "1f80eefb91d2ca4ec36e252dffd06b7f",
+          "result": "valid"
+        },
+        {
+          "tcId": 77,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "041ed22e58e79cc56f1097ebc8fd90aa45c785581ff8ee8cbc095edc1aff31ba",
+          "iv": "54e4a681f0b6fe4829518bb630ac8875d805cdecb083cf6c",
+          "aad": "419a5fc35953477d",
+          "msg": "e6165f2968cf80ecccdcf6a17e35691d7dd7877fd6381c119d6be7d857e108f835bb13a37ba3c0b8418955ac29858188e298758df9b99351689443a7c085dfd391f1d270cc97e9a384c78bada2f16dabc65e3994f50cc471a54937e94fef5b0e8e4a2a8289d1402a8a21fb16883aa956cf66308dbca54ddea9c8860bf9a352",
+          "ct": "931e6478bc3628ae7b4a59740f397fd85276bdd481a7b5d242997d66838d3d774aab627af11df254eee7499cd00e55768fb5121161c4d7a28da7f82cdc2858e8ca4303560a6cfba61295a0147c4b05e5b5bcfc016bbd524220080baa982537c505139545294f4b69637d8ccd56804f7adcf118ce2b5a080663389c1f7313cc",
+          "tag": "985c0f3821e707ce7814c08f23a1da31",
+          "result": "valid"
+        },
+        {
+          "tcId": 78,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2e89767b15f18b855d04c0b6b47c1f8facc9a058e2194ad2ad901ef940ab54cb",
+          "iv": "3507ec4cd1a6c2eaf081ec32888e08839481f35b3b0f7872",
+          "aad": "",
+          "msg": "eff2e375228756f995b8ab52213177c4b7ca92bc81114f5c23aa64dd7eaff7b86ee2e674984c4b65bf4c5ff402e23902c005e05de25b3c6e8a64323aeafe04ec6cd1f6c851be39e55208d76476d3ed7100042eccb72cf1349ea101253b7a5a4a8677c1d6df5a54e9c24558e2d68c3f50acbd1ebbb4773884b0ff23d95a4ff60d",
+          "ct": "cf2e17f9d8c6562de6d3e8c8bc30ba2904cf5c3616d15ea77667186ee45f444ea264327dcf210b6735a39005b62529d557480ed0462e49d982cf5962e5ee6d8ccc388d5de102e676a55426ce5a873d2e84a2d841e7b30c7ab19035274886b3c5c979d065bdde9b0b9e466b22559e30a5a5abc4817312e15d2c0dcdd99d867361",
+          "tag": "c844d555bb43a83b4aa735b2aa1d566a",
+          "result": "valid"
+        },
+        {
+          "tcId": 79,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "6357cd94e2d9503288eaf3abf9604b050d4a483350a828029baaa9cae184f075",
+          "iv": "0a5914f29abb1cb48dc686159f09480370477f6069018e18",
+          "aad": "e2f0d2f16704527e",
+          "msg": "bb266ddea2f88c2f0fea7f0cf4a1a33363344fb49672b821f76863a9edaee638d75140d21d848efc475d3814911c8bb34202c4e7ae0de1a57cea6f3af7180be454d7bc6fa5c02a999dc71eba7d5553828c963c1b7c559afa2e30e788ef2d0b479d0da1f24fcda5548773e77abc716f498b08bfe69b1a7e4b6fef27ccc72686d4",
+          "ct": "4f0e805a2b3f2e1bfe3c06c83f5c77b9c4e562514a78f9f2cbf3206f68f686923656885878087d17da261666e798649d74841753525875f425e82a4795fdf8dfb629a8b1d2faa5594557d62f421f4e6a5dbb9f8336875f2fe2e2a4a1d0084358d9583e6b6662895a07c924c0a7cdba07be8a020e1b8ef3a0b5d007ec47a8e8cf",
+          "tag": "f130ad7a2b7dad5e8f8715eb5b93e45e",
+          "result": "valid"
+        },
+        {
+          "tcId": 80,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d23d7a466c1f6f337fab14a3d8d3f5ce9c7ba4538d2e4c60141bc38f5078f25e",
+          "iv": "8352ea169a7ed514bde45f27533dd134a3559a19c6a42c8e",
+          "aad": "",
+          "msg": "8e05a3b7fc665fc5b788c64a14e5c1632146e65efa62d5922aa46f4509b85253775c8ec512fe29a2f3a215da8a5eec965c708f5645e071cc37d28659100a55e2fe9707be91e483fcf99624921845d5645c0cf5d3d791d70de23c06f67c1ab8eb6509994583d9f76d8988175384c3094b30a13c84748f077d8d564390ea30c9fa41e71c314ee7ad880edbfb6b571474d3a93714ec518afa94ea9276d51faf7a4eeb2580615b574e2ea08cd42fcb8d7435d9a307f83048f88fefce92ccc0c0d0456e77ee69791c3e1f14824dd945d3df3b8fb223afb6a98b0b5d8669d24899352ccb7e519356fc29a2fed863c3a4a6e8bbc7613f0f8c8e0a356bc32e836eb2c6",
+          "ct": "bd60e4af1715c24ca68c6b531505ebdc7bccc2e352d6057a72ea1af789fc364b7a1d4ffc0e0d112c4843fdd5345b03365e777d9690ca1810d99c86320fac33345c60bdc0517bb3ec7c7871a9cd21975b458bcf85e5bb653cc3f76405dc8e2b100228d2b441cdc7506fdca6bdd81742b691d3f51d26719fc8d5054b32d27e0ba369dd84abf2de0fb0b7e5d4e4d2f07c50354410953bbfd5a32104f6fb474f125b6607355046e20583db21e234a357370208054c3c654461842267506aba01dcc7fdf9d30f16bec0d4d56b46a4c847d2ec50ed33bf05d87038028e0b9ff7f917bb70d2b70d6c8582a38fed6cb35fa763af7a6f85f3af389e918163a78f58ea47",
+          "tag": "a9f7953d8e3d783c42a5499e91bfa7c4",
+          "result": "valid"
+        },
+        {
+          "tcId": 81,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "239d4d81e6db48e39befc63e4c2cf43f5f6afc761f35a4aeab88360975e6c6e8",
+          "iv": "a63d05dde513b11626db0c217517cdfb374c637d3952de67",
+          "aad": "5fa9dcb4cfe11a53",
+          "msg": "3f5e507b2d472419357c279769c8e06bd2d85bd16aeb0f9604983f52e8c33e1ba4d18e2ec86be5e223a9da43c50cc18e81d7ed7555be044a43eaed139f48abb0561ef2eccb6be5f1a813b0502001292b4a370adc31e0aae4fcc7014f5a3ea2ac846c47f0dbcfc3205c80a132f62dc34a845c73650e69c0945b4ea401eb04ef9af037fb1d4f31fa872ede722f98fe015ef724aea9ae8887fa2bddf65677b3f755b33f5ea7d6fda97ee98d57e6e5180e01a42ee0a912f35e9a21759846a9b330e9f8c697af75243ef89338086ce825ef2cc88c440b86f9caa1941300a5be0de86574bec6d1cbf484571f87f9edd643715bf2d11d9adbcbac58a31809746da147",
+          "ct": "43102ece5117a897670d39b3c0670cf47abf6f22229077611c963413ce1ab84482e63ec2eafeed0bdb952daddc9ceb052742c11eceb12892a2003ea1d4932caa36694d3a8a8a1426785ba62d6f7eddfd12f4b68733bff727f5ffd2cde4f2a5bafbe2ab87b0c0e9b0ac168f91f95d067149187a6cf8921a18480be8f568f8b693397ec1e391c721600cbc2dccbf2b4b2940d0dd7f8b53fb0f2e0b71eda02efee96c53ed5f80c079570c94530f94c2662cda6d66396de9862335ff0578be7f27a2aae2088a07820614d5bb43a8b0a4157036d0f5f443baaeac1f5b140c1576a3a7b3b70e466d1174db986e12f2b04ec4fe5875bfbf97eeb1752b5a1e86ba9da6",
+          "tag": "da53e27547c482e54a5713b9b6593056",
+          "result": "valid"
+        },
+        {
+          "tcId": 82,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "750866ddba8fd49022ece52b9c75db2590977f97b1f84cc9415b25e970b56b66",
+          "iv": "2e70ba42cf3bf2e03ca0b96977e4b51ce4e6cfddc52d6b3e",
+          "aad": "",
+          "msg": "912d918ff59d30a8758efed4b2128aff6912eaca73df6f8224dabf753dcd7d50706fa357e8c60a6cf2aa54225b42c11f34ad33cb8286339512b941cce327a42bd4f516cd3cf93856f620fb33d81727c89867c540ca03e9f89ea91f94fefb606ab91b8cd5b1ab48a12686378a2cae1c644cb3e484be5846ce35f9c8ae1b906edfcd767f39cc68d6bc75629d2e8d85c0ff3c54c472415db58ae11295cb09c01dd9ce0b6b5e8ac3e88e984bbcabb0ad33f103a0ae042a2471eae95df8561cb1f2cbdb7c8151801e98fa349c917e826abb7868879c3695abff2fa52f5ddb17d9300f30d97dd69ae7eda57f8bd6ad5dd995ca9376b115bcd8d7da18e10077e02a8369",
+          "ct": "633ffdf55d979ff1a8cd9c9e515105824bece74ee2f8ca4cb225c329928b23aeebc1a20547a59a810da1297acbc4cb99d6c93be1d5a2d52a5a41c34325812972092ec35c2f2ecbbe50103594af2b3c3ae289cb64b814dcfee99b83f276e28231c4780e47149381ad4f0c109d8eec3cba20681d74cacfd22e6c25771b93a8174fd09ec865838b923f4611818d791b3163224d3d28e7d1df64ff55dd3d1b1ae255f7064ac13ad04aa119f7b812674ef4836d790628baa0d199eb3654c326be840f4713af84cd38309c34936c7295cbe0230ceef023902cf98425cdce33eba60230c566ecfc363139409fa61a287ca58d0ed195449b1174c9879a4bca02715ff850",
+          "tag": "cd54da1510cb008855709073542f7cf5",
+          "result": "valid"
+        },
+        {
+          "tcId": 83,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d4dee48fbebba975e563e2cf227596cd1cc88e93cf76ec7a2c6e7084f74f1650",
+          "iv": "d3c6c24e0096d9a8799e39c9a8c3bba65088e28b8ec199a1",
+          "aad": "8f6dac9e6de4f8d3",
+          "msg": "b73c79c785d51b81897bdeab7a5bffde249d937679f910c72297bafcbaf4344d5d5f140c0c0eb0e78054b00aee8cdb8a8b855a37d8078a355f7ec7e87c9641c19df95c93e83b958851a8d4a9e8d8bd9859de95e75825fbdcdcc439c827d6c0fcf57f309563015bac634c7e023c85e98abf34387176c0548b9addafa3c54fa59a3343b4d97f9762369cd62b2991d1a957d4479db8289055530369cff9076ed023fbe06035700532478e8ad074c738068c9cabc093851d23b05628b7ecec663797e380ba8de0122f87b1ef4b8988af03143c79e5cfac92a89728655606adfd2d9c56c4117b2ddbaec70b50f001490b04450fbc659a5a3229fa234bcc65f5aec84d",
+          "ct": "efb680df8e1efce6f0a468ea4840a8b6631a437969d045f45d676c723b01db31810315a53e4bdc0ca3ef0d9b7d1be37ec4a6baca7ae8ad4b3290978f86c80a1bf049fb5730fe34c2d3b8da5047f52a801339fd78385c8280556389acc59efefa93f232faa7830a15eb851729b724bbce81b58f7f710cd9e93ef8d1073f858e2aa39a9c62e763a9b81cbe8c041943c693b8f7bf8fbd7d14ff8f1b5e82ca0f5599ab7129210d9f47d9dd5277e8de702eec5c74be23bd40763f6172467fd48edccc89f43933dbc7395f389f0b6d5b7e79729aebc4059c94a24a2cf9ec2739dfb9076ee58b7d43c3e5d15e032b2f308e9c910dd1455e1bf8800b6cdb6bdcaeb78ebc",
+          "tag": "77c80363dd730d45cca7c61885bdbf98",
+          "result": "valid"
+        },
+        {
+          "tcId": 84,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "4ee5fba6efa0aa790956c0e01d64e38472f57dd7c3127339fa1a15c8d586c37a",
+          "iv": "74a03a7fbb487c3fc0216047ac626a5b1e2e852f474e8db9",
+          "aad": "",
+          "msg": "677c9c0e4ce8281ae101a47892c003d8d30befeab964ca9dc09a204f1c8c41f9f4a5ed8584a1be9c48260c3223a34c7ceba3ed58d95604155a0204da7aa300edd7707901bdedcc94665fa8a7de334f8105892bfff04db927399274f3b0b1122f35f478e0bf0e2e8837e2e7a3c4d3ff52a19212d0d81b41d062607c63ec7a9a53e5cb5a436db99fa6643ccaba9b81ad17f97be22d9b83e7ab8a920c075e1081e3c6da854082aced045e32016f64fa1264e0a1a586eedc9403543de3d7c8c91b1ed262578178096349e009fcd4a11f6186ba51a1b32056e82beb24f0e240aa75bf046e0dbb59a7f056d3e6ed8e0830bd9e7572c2d2e3fd3eaa059f8404f194c5fa4e",
+          "ct": "dca4fc4f10fe12c6b9a0c0afa2da0684b9c70ef77062b246acc95b50e595641c6c995621913759f88e2eae100383ce07bd314ca90b2206c8cd9b50c9ec015ff4d692d39f071269a8fa4cf146c478cbea7013a4961fccc8242974fe46955d4ead78897feb45c7ab68a189aad8c38cd97572b221eb42f6960b7db3c8bafb7563f849ce4b9c1711c997d64daa72d6643562f247212821f362a234a37850427538db719a07d79e58d5c29b8bd68b33ec2827227fa6449a3b92b6bd6e1227720a74c39d518e63990a57c30fe1472efd7c7b27a57f12b359e69782e13508bc2fd84b07c3bddf936c4b6cd826e2b9d5a3cdde3834f29037a65b00787d5105f6b238859d30",
+          "tag": "5c3ee84b4866a2b501989727c1a30efd",
+          "result": "valid"
+        },
+        {
+          "tcId": 85,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2ddb69b55249598c8db0489e36cada161ce5dd5256c99f64d9c07f3ca21071fa",
+          "iv": "e40f7f7b7e374d2318d28466c08ec4a242fbd3913862ab11",
+          "aad": "4ce4b59483d1b31a",
+          "msg": "12b17426946cccc0fc4ff7a8c40d22e8b71392b675076e8a46d2a95754614580e51a2ac0c6993dc3e78ffc82bf884df49337adae993ebf0c98b517f14774f537fc9388d68e0914f47a9a030b9f7272a6f9bf16741c28dac8d494962f30ba75011adf28bca3d195dc65b180fca2ec5eb66e9e435285d78dd14c25fdc73153b9da81aeec6ead15fa9259ef3fce55a89bd29b28976daea3c5258a1ca95266a5d066e383c3c0e0efe65af222214509467d5cc23cec13420a99810e29cf299de4aac9364d23dfd187cf0ca99ae52897806f85b3441b1efad0e1683a25fdf2a26a6e26c174e5c826975629d9caba126413dbc68d57947acd874fc4104b605ff88c4d01fd",
+          "ct": "cf5e81aeae083955e5b1ce875e8adeb03098c8422bf992b5ea3d190ca267741962130bcc2c29bb30af89b6a524c2d9a301ea11abff807f992870d6950b6abef19ebbab448f3c28320332647518dfa8b4447c11d87dc0d27f811f84457a6202d9d4ff142eed9eeb2acca6fc7283695d66683ee8f566c405edb00cb340552b294466a55d7d517dca45a5e5971f283ac171ece5f41f30af22a477755bd7ed331d0b90a8549aff71c0108bea0e2d68d10d0c572e7ce716eb80d574dd5682f423d61ef27b5003116b07c7284cb6015dee6775d57f0fdfab6ab444e7408ae58a0d2f25896a0fa6cb5b8ff8e443b8efa809a1e6ddef11e0387a2c63f768fb14b87cc983c2",
+          "tag": "1ef18bcd256bd2db1f04992525e69163",
+          "result": "valid"
+        },
+        {
+          "tcId": 86,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "35ffe94d95440433488600ff6f754b8cee1ebeeb4c5adbf8cf6b16cf8a4a2143",
+          "iv": "7e7167a32f5438269b5619a4ed951d69f4d2453fb54bf996",
+          "aad": "",
+          "msg": "3a744da9af70563533564fe485de0ad88d5d77f708ceb340e0634f257450f2b54b519bb5a960eb4662cbb55e99c524d7e84df4cbdfe0a0157b63cc46098d2f3b2f8e95ec5dfac46a8cb2aeb59d2efe29156fa217964ae596344176b68c2935ecb9a767590d7a4ea33d90816533d82804ea70ee47b76b13d22c188cefa6a55a6d27efd87de7a3b8f413976ec3c7b841590dc5714268418a7f282fec563a5b35e993bcdb2e3eb7d8c4be542a0db66558e8b56697c4788ffdaeeee99e245e88def0f4726ea0f7133d439012b869bcc0624b8b049b11530ec03c2ee7b11e90c67695d17ce8852b361e182a8ba8b50e0c7ca1783e2ed9c2a1e8c35a301d12875b8348d1b3a9ce5ed47217d6bd9ff622377e5cf339363f53da8c41e626a52db62dd366b393e7fc9712d5b0fef85a96ee8c85f57e7d53f8843ff98d4934534e745e3b5112ffb833cc576e79bd74ae09fc3929540c4a7bc4e31571575caf0f1c97c44dac51d27f895ab53329a787f09dc08998a2cb3eac3a7c1aa4b5e240e8923ea47a3c1c635b3bffd3d79c6367bdc2a59fa6c2cfc988df7f485176ee31e380557f45f0bb0f4fdc30fdba7fa1e9007bcbca9282dcc071653df8a841b6b2190ba5e3dc2bfe4980d1b3e66193afe16b3c6f80d89e7e96c667d670b314a79b2824a7cb9e45a28e49501dd561a21e2f9abbe1445e89e0c50ac759dbaf62d2c64455fa0d2a",
+          "ct": "f2d964333851c12a174d4882142867ee53ed1bbad3fd90f67c52a8259a8fd14da2604f361bb3593b0ff252b679978d35d9d8cfd4975a806ac3a980b52a3119d6cc76068204b424b38a7d62567346926d5f25e676d979f4245f591bc10138ea3291a5b4550f0b1dc9e6b51f3e939ba8f4aba3a9fff5df27b5834662bf8c2d21cd27541cad3d63808ff3e85da03fa0a236a77b4091d8dd3d78c2c2e97fc824cc8dc2ae25c88b699019a0eb197291ae6e6d65a26d1017ca43a32c5af921855f5c44326c00ac0260ba62164fc8c8ac4cd7dd0a8aaee8c24fdb10528b6d707e9010ee8ad13252333368644e06ff87ae0205b4417f8be2c2a7ddac1be26b84568a4d62accdf3c2a0af9969cc29c4081d2c0f84bafb6b43e9235926fd88fd58f7cb5bced82b131259deac09759324a9b93c0f89c15f02b159136b9fffb98ec6f356839990a9767f1b93068eef325a5dcd419a2e72086cf13f621bb9b29c2fb11b528345641663d7f199856db7822958ba1da9532a3e0461ef0cf4b2b10c860fcf4b925d9255a8e27243a9aa4bb5a2cd43994a59ffb7c3863c9e75dde5952f4537dd82e874b957db8c100d8d40136e4b0a4ebfa376486b9ab6866cbee2da89f217f2ef2a995c69d75384fbc22889fe743869d25a8e7fe7338e038bff593f0609c8ed2b0f82ac1a1a657640ed1f0148778efa0dae28a938522119ca7d7f659cf68ae18e",
+          "tag": "81d93ce2dd20fb262d611f16f3a179c2",
+          "result": "valid"
+        },
+        {
+          "tcId": 87,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "cd809df74f18d7b78e273958e375728d24cbfde80fcba3860a49732a0cabd4e7",
+          "iv": "667cebaed61975b622e88a80d5145d469e9b9406f9619fb3",
+          "aad": "4927e554ed572f7d",
+          "msg": "6dde905d7b8f92c849d9351d908473249c7546bc757f899975a1d6f2c624cc751475299b32d19c123493b25b9fbc0fb902ba1008ada7af0f09917e1806ff625f72b997f3d25010b2900a71233c90117e754d34d22b788bf4eba3f256cfb16194e952c6a9860f139bb135ae42659831bf1b7b963a2d7c4844bb376d0d42247b74d896eabee3211393ec2676249c9b9f347b81d7eb5d00194a4f228802fe9d94679c865f6973c2562f7ca0ae3509d3e842e37850ac2d0db5f0f64f31a8129a2e25c1e5ca9a1a14a327601df5299e5e9cfb282f71e36a531583c992e1318e74c3453668a538cecaf973f3b3717cd8ba6775308a1632f91552e56cb83f5f88d0abd9d7fb2fc99ec7384b3742cf18865f0c0063aa1e6dabfb3018d0763cddc2f8b433aca4a16a3c6c1783757da6da92c737c708e0d8fdb2aa6ae10a0f47da079e413531c199b7ba70df2d82c842837c7a5efe61afabd3f35889df6f9b0a30723298a395ddaf00d2c6769c82b4af8e9c1a76b8cedbfe84b40b0427f00efd8673374f769828016f18e31be92a24b73374db1bdf3369ba60ebab3b48d2820215f5a0e0b0da7ea7ecdb4f9127910ac66e2881ef4231e139dae494576f994213e60e820ca0622597117868b7513e614b533695d17fb03082a8db71a28d1bdf06a3b7903770d084b12e2d5098dab452a1aa1e68b91d3a3bdad60bd42e7e6a7087e81571e0",
+          "ct": "bf49a20fd1a0e81363738953124130e96b33ff3086c317312e1a204fd98ff3cb5c4b48ecdfa1ba3c1b1ca0c3c03dccbc2a9ed71c714d53db977f7d67893f6ff571ad7b21cf29b40d1f6e1d22dbe3f7e0871f4ef54804614779bf4d0d329ebbd7a3b1129ea29f86e7b7d78c2a01c465728c8d3c9db8407974731d65a28471ad4876fdc000c5bbf74cc463b78cee5f488a9f3bf6b1b7539e488bb657aa9603cf77d2752483d0387fed65e7ac7b96deec264de628aeba145573d540d78c33d73004fa7f88bb600f53f9cc7553fc89a8a01b5e9e21b4d103dbf908e5200deb939ba0f28fdec75ea45594fa55d8e31907a78c91be3b7fbac2e20e5f6a1adac249f4de506077597a0cad5ae0636d5d7e107f9543b8c8bf8b193bc63ae9dc7da14e97d736ca341adca464d0d559444384744ef089fcad59df6da9d390c2e4d3cc0768d6488ae4bf76c6059da14d60d17e528a70d91cd4158ca382b024ccb9b19d6db3c4ba0e138adff021fde3774deda9d6bdc06c750f5b4af2f257dcc7fe2756e47c392da36d5aed634cc2203c62f47a8da033989bcab92ee4689714aae100ef12ddf42df1d929c62785121af4713db1f54c9b09f012be2f3b09174e135e24544b54f6db6a2fcde1b707c675bf15e0020c2ff739b00b8c1c78df492168516e77f7a234bac73fc10af9450abae183a559fd2fbf9cba189fe2b60e1b966b9ae6226d2a",
+          "tag": "e643d6a1ff15c4124f54c12fb5b8571c",
+          "result": "valid"
+        },
+        {
+          "tcId": 88,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "5e3c95a09daf5f3d67eb1041b604a53b0ecdb595b608211b311fa70bdce7d582",
+          "iv": "ca2bd180360714ff332994f0134ade2b1f754f29681904d1",
+          "aad": "",
+          "msg": "c2e349ad5652cbfd971beef025298c961a3fc0351c2f658a76c287dbf29a35be32bf6ede0d6dc8c6d986dfc59500887491ce6cea4eedbbfd7002ba7dc1e8c71b33666f1b9aafcedda257b31dd6c83d6f61c5c63c63bf9f7f10fffa195ba13699ac84ab6326c2e68317edbdc17330061be733959b151b40b5fe820933f919b13c462dccce596eaf96a217c2d9f9d72ce2eae45936731b5885bc3786724bcf4ae01dbc23c9bb9fc9d6115deaa344fd4f038025af5282cfe9ad7c0f55dee3b35dc9cde839988bba8715120f9a4e6e4582e23368b7459e0795cd69148d05ab1d64242e1c38502f5d32123630417a0755ae862359eddd57ba09723d2761789d2caa3a2617a4628c89839921b9b9845d69d16b483edf7169021afeba72938adaa4c57d45e203fc0060dca09b047dc4321217382f978b74d8231d55837d1f95d2152d30155a63d9be83ed5db21f3a93f8c6246575a4d3304e4f10b01786ec9a4d479d9d76a4ff1f0a73ce95af2e93010eb882a616626b888ed80992149e2658098b67a03781b344ffa3e8ed3032e85f4dfa51f64a6cc5763145d3b61e52ab4b625fa05d354f873f03066fe35e2bfcabc92a515d2ba8bb67c921cc833922a69df6a4288b870f3053387640dd0f0cf6c81763755d371ee65838416730b001f22f1bdd49630727091cb6cc15bbc3fb16d6bc9346fd7af156e64831efb4e5806a86bf049f88",
+          "ct": "cda9e26964406611103137fbbec6d97fb4287aeac920ce0e81b8a2798df301da2a7ed83b87732a41590cc6a80e4408a6685bae08e62ed21ac3ce2eb62c28dd766bd290b322698040e37921bea776e6f1fe5184198b51150680083ea9f6ef9ec859c45efdd1eb18d32a0d50f54ce0a63f596dc8dfe09a8ca7ad785e287d21d9a2c1ca81c414889e9c8de4fe6727ea44dd3a6f5179a926ef05fb6dbefab837f8e14ed8273ac6ee0aec86f080cc45ef55b264fd2553cfba5efbb747aeaf3a26177543123d95fa705a2cf35fabc5e2881c2a4bb646289d29431848515125591c1864a924717eeb41fc05a67d291dd436ddc568fd7278afc1ede9f3deddbe14821c02ca7d9366713a614fb0c8a20981e9e16eaac5a955c0c165892d15b2416a6eac32ba0475cc1adcca2f7d66ba79cf031a1325f88c37fda65220b5f2ccd1d8c96591ba1a8efc681d19c3f3d3104974bde3473f4d65be04df02af3e29af7142c9ee8ee00fa30fc29e175cbed4197e5dc16e6a8c02ccbd0cddf0699328b707cf834cde8e77b4517994ca581eb6239d618dac9a68a87645dbbc15f20afe8e6bc5822b4e09735c07b4804c2a7a877ba13e625d5b89bca5ffe2d12f276c5b9d608375caa2e55017510e74faa55f85ff15f3891bc652fb3771b724e3c8d61c7f5668cc8ac680b19792c4a8561e469fd493e4d4ff7e8781a9c1a4ff0b4789a06f74f38277ff",
+          "tag": "363c0696e9d6c8eccd406119eeb803be",
+          "result": "valid"
+        },
+        {
+          "tcId": 89,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "ce9c044e573cb130c536e7257a30f7f1519bc55f24c74cd8b95e23c75afcd076",
+          "iv": "ad2c8c1c80327109d8c642bf2a584843b6af94ca28ddb06e",
+          "aad": "67710b489ce8ab3c",
+          "msg": "c4e994074cf63f49018755741d01eb96ff0f102116d77564375055a30728370925168356eccc56db8b3c6ec4fcb5a765995b0323e6f4b7bddb5177c4cc83d85bd56acff5b23342792242ac399f6723e9b2412a504c39be4c5acd950aa7b8d4168decc2d93fa5649a08888ee43787e1044a3d9b109b67a81c5e7c50e0b12080e5843eef1dce7acaccd650353372b540902a1efda4dc283c9788f03454064f53158c1e0c3947e3be0d506b9552e84cf99cd571f06bc825bacca840f51a97b1080cb438e64a47da8836a3cacd1fed5d327187c0562302513485f060aba2c94187ba959561740dc485abb1b680b7a834c278ce720e7430b39d7d7d95bc8c9743e19af09e75c58b9d448d3248a778c00dfec5382e40cbe56fa2daf3860d8aa3c0bc26a63930f32fb43a3e2dfd2281f5b35c3f4dcb0f52465cd73949642123866075574526239d0213118f80fc54d55bbf50389b729375f8f3dd47bf901cfff96884b1296ff5a3894d9bc427d4548cc6ab9bd57044fb798affafd3de6ff98857f17f86a89345f3d9b163e3df8de3ade684708e379d80442a4d47409d67a95d9ebfe16eeae2541165f64d1bd20733527b05dd97264291a345fb82dc322730c51de3a737c475909166eff27a2a3244993bcc69990ca48e816913c4a736a3538d8dd4d14617f1dec7956ced9f508118b99b347b7cefa3aba7a2a0e3e3bdc518300598e795",
+          "ct": "85b9dffb33b7ec0fbe40c464deeed3764a4bea0febc6992b3a1d72351082e2393f78bce8c5c1c41caa8f91624709cc9240cd71fd8a3a219282cc24e6479be2edddeae9b75816c69846d066b9ee5e9b85ec5cc8a0ea634729764b264868874058e179600b99a9726f0f3fdcfa529cdbcc8f3bd86ac93e70420c76c99ec7fa164853f468ae30fe575d0221d4e7748f8ff77e5ef65aa93e96f07790b6febac55106fc3cd406884ec263547c4585f078455fb255900ce52cfc45e74b07b92951cbd3baa49085a8798f1fce765ce13febdedebf14a76153d07bf57a4e0af4ecf0973d00cbda9f4e5daddcef2da71ece9c16b59ee9002838be2f3f5d1822977b2e93e6cee342c191158c2d32cdfac5b6bbbb54b99b4cf39b053eb40c178031d91cbf69210e5e073f4a89a2b616f0d3449d8d7bcf10c97956af8b4a51682a75ee28e5737eff3aeda63747f40189d88c20994c5d9c89487065777427f2b44dc3c06ff18345f81a1a1fb6174cc102e35e9f1746ac33980c1e695ae19cb9dcb8e765aff62b736d68c127d547c65813f4e285e08829af38500237f226e43a76d6c813da21f8581c0e201f58c787274844eb29aac1228e09f68a86377d5169e5642c8a02429f2cda82a59dbad3dca1424455877074faa3aa182b78a4bc1b595198fe5f82d105afa9189808255be28ca7538cddc839ba6dda6f437ef8a28e09e68be797aea896",
+          "tag": "0e686e2051d603dd5ecf53949222be1e",
+          "result": "valid"
+        },
+        {
+          "tcId": 90,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "23fa8ebe1b5261178770c1d70f2741afdcba95596cd0d05478664878a39982ab",
+          "iv": "2d19b47ed2b39a55bd1a8171e0b974691f1d07f4327d8833",
+          "aad": "",
+          "msg": "4467ca60cf6d9aba5dfaab067b985f9816b6ea111a98a5c9a2ff1a66e3971d9f3fbb95f530b15a5daae15b2767ce0751c14801c103db28d01ae49d948bfbacf75c91e668641d17b25284388ef7e77dbf48a2fa9237851b7e6470a3364be3440c0006347d248fed49e16b8f8cac6577582da60cf67422860082aa08d9ea4a5299cb5be9f9ddf83c820f4402eb963fa930445bc492f6502fc2f6921214c3e9737d5ed30ab58a4354e05dbe74df0b89984a29f674b402cc6caae4c61fcae8bb8898f1f60d9d1adad77ab037e0b6772b890ee2c70bfb17b41dd82aa742bfa2c48632bc9d52254587ad857bb3700e79bf1e96c25eaa1b01e5eaa79f2783aee3664af4830a0aefb529e1753c660f9ea84e3016834dd155074a250a5a1fd9f425e9430fe6079c5be504f7ce93e58bffc7db6be08ab59938b90077aff318723f1553ff986cf0265f59cc521ef70ef698acfc7b4344492aacc2a28f7ac66da50e5e52568cf042317335efe21107b2304aae017f10bfc69ad5c5ea5d3a439b18f3edb462fa1a05953833b124399b0ae772a8105d6c81115090c3d66603d44a19a79be6756eda1476e328d8823cf77feb715c09ddbcb14c929ccae21072df92a0e6d1133e27d6b32f0ad69abb668962fcb8fa433cac1791ef88c357bc12830a78e007503bbafeeefba014196fab6a4747c5cf01d92f8a61448e5858a1906e468d044dade04cb6",
+          "ct": "9961accbcbed29571a3b55a923bb682b5ef84a2a9ec3b9af7f36ddf81ffcc802c1d49d22dea740801e11116095a05dce789cac7fbe79ba52cfd540cd024ce46816ef0f7a179bcf4c8a4841873f43fdffe722e0e6bd126048715cf5a788318125218c40be06ffd5d6d7d9e1b4478fb3787d951fbdc43b12b8f98d2b3a7e5e75f74e59a6d515c42be5aa2723b378a9662c595c2a9c6e5e2f07733fdf507c1ad88fa740dc976e15928bf8c610ff9c0d4664bfea4a418d00028cc468586db375e81cdac19ae7bca612892fd6a4f2994f196292863b0106ae0ce6c121c1132ad8cfc836c6c3292da89dcdad99012513cd6c1b35217acd73f1b215b437af12dcd925199c9069ee350568c166a64abd09098f6c5e0215019741d3ec0efd3694861733f72063019b65d5294cbde1367c34c4ebc876de0e420522b4610f8b189d8ac4794f8c5ebe6ee0a061ae2220bba0c2c5f6b0cfe8a122304edebfe6fc62eb64ea6a3026fc8e7c1d4a30d3d4cd9ca5532e8084a01305ee53e2abde062575756221d35a0805703d5afadf47b216375d1e8dd136e41bf817985c601685165fc93a7f43127393a70e37d371667e5ff2b01fecc4516240ab52140a0c4146eb00b6f2235950714de675c5cc8c6588fe3100f3ece39fe7beaffc760abc090bb12645d2f73c2ed0d116caed7a567f705e870d51f1a4ffc90e45b8a67593ba601d24b3a8c6c0369c",
+          "tag": "7f46e4b12bed144ab99487b94298677b",
+          "result": "valid"
+        },
+        {
+          "tcId": 91,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "eca2e0788408366ec298c98eeff22672974da0ad661f8f5342946288096fc66d",
+          "iv": "616738c0adf3dd2afab0cb6db5d3c2a60c4fafd79b5634a4",
+          "aad": "26b398c1c5b130b4",
+          "msg": "9056fcfc0f99947cdb322c5ecacbc5c95e263ada770c07a9615e38b60236a9b9dad41ae81fcf5e13df67beb0be56cc4cd7c6bcac931ef5f70485facd16e59e5dd82dfbbccb356ec530d6dfa11a3579e1e2a0464cbf569ec750678b6d880d002bed41ffb409add7cb1d7f5b7ab87e7e437e5f02bb045c6ed1e7dc1d2c3aac65a9bbb4994b7c37d05adda1dc13f4db0b6bde76d3a7454177fa98c4062e5be2bd5e9ef318ee47cf32fd7cad5666af34db60923bb1e207f2c2130fd0b4b46572fccde27914f76bab96810cbe51d0e401bf8546c0f8a79eedd7945299d385b01c499751a02cca18dd21119016b9063e34d80b59e315a306fc0b7b1adaaf7e36122a17f499436a0e76406d163faae2d3bc063aa1ae06b5ce9e06deca97047907aff8d745c36d9a5111bcd8586a4c34946dde4be3c9b8dcdc166f5c33a54e9656da229aee4c716f951a60bd90aaec1887185c51fda90a9d113a0fbcc20b134181a119060c67e28d790c12e82878086ef3826667a86c3847f96c683364a6f9d22aab31da7cd016211dcb1bce7e39894a4fd22a50d63de409042f0be6fbcc038becf1c85b2d3517dba2e668d40360b41f96cdb74e57b02fe9a9c1073dab1c9e7dca8e6de2a25607d56540ea2d48f12ff58f4ec887c4a68817ae76dd168534396aa2c9566a2be7aecd490b4a99a46b95fa35671412a61fca486c6f763410dd11c9e826cde9a5",
+          "ct": "84ee85bd835640e1603833527f5c125f5bdea8eaa065bea8411e6aa8ed8af5727117f567ff041528570059ac6f9d4a09ea6ae3104acd079202702d149f2cb569fa404430c9022296a371fb0e563af7392ccd7bff87e5c5a30514f5fac080eeb244379f98f02c15d07e546a08e5387ab361ddde214529bbd3dee206b25a45b87fafe9e3777a48d34785fccdc6396bb937bf4b4f35984c8a66612337bfa3549dfbe82efdaea89055a9efb1802570fe0ddd7f4da26b24589c463aba92cc89f594b71fdbfd11563ddcf0f03dd01b9e9e545939c3b594588ef5653908aed3b2ce1c7199c12c20b3e83ce315296c6db0ec6b120d743c12ba9e8b4991067480da061fa11c719074f0b567a7f9fb881be5809ff5542b6540fe41e516b9c70ede2a1ca6b3e0c7c60068616c68cc07748ade154401d1e126de427ab9a6c6fc69e75fe0b8b2b3e0bbbaa03694a2c1d92421e91f023010270317a5997ffb017409701ddbfe2297b18513b80534d9a407e4c7664c9f9887db22180c7ea640d5b3c236fed09bb287198355c93736cf2c472fc28d79fe159ffeabd82845b780f461a6c2a8338ab742fa676f61f0bb929a5e3b8c167e4b5844537c1de0c06415f30c9ff4675fb5ad0fd1baa04384c97e83b7b6380d29b68ce8a7f3384497788d8cbdb33ee11b94e12c2b58975bea222a7a4dd5ae6034f1284f5a71e28d28ed41fb9a36d6ffbb7a5356",
+          "tag": "8f2e7dc16340f6d0eaf7f237e828dd4f",
+          "result": "valid"
+        },
+        {
+          "tcId": 92,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "57f37ad4992d336d13c3967c701e60c7842a55195687bbc1f680a33e78e0658a",
+          "iv": "74ef0301cc545539723c78ea9e2d75b851ea8641df1685d5",
+          "aad": "f5",
+          "msg": "58fea87518e42b504a9c53035081aabb",
+          "ct": "fe59e8bf4250dc02843f3be602a7aeaa",
+          "tag": "012c6e4f5017c78b96247763c8ff5f68",
+          "result": "valid"
+        },
+        {
+          "tcId": 93,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "aec0407a0cfa59096a489edc29e40cc67843ce71a95afc8deaa409a655aeba3d",
+          "iv": "4a75dc9936c891cf5385f84e2a6d484c612115b9ce053f86",
+          "aad": "b93b",
+          "msg": "8afe8b8b22ed249e21a44247345ede5f",
+          "ct": "7b2f702cf01a0007f4bd949230197e78",
+          "tag": "56bddc4fdccf099f128b177b3cc73520",
+          "result": "valid"
+        },
+        {
+          "tcId": 94,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "9b0400ac1a917c7571430b78eca2c108e1824a078f21eb1995bfeae7fcc51f83",
+          "iv": "91752e5f97bdadb6a9811c2144e27f73baa9458b6c58c9a0",
+          "aad": "d0926a",
+          "msg": "2b512160837e427a04c6bd9105cd2304",
+          "ct": "f95dda4c5457dae8daffdf0ba5439ba7",
+          "tag": "3e97e87d976efe3de7d84df933ac980d",
+          "result": "valid"
+        },
+        {
+          "tcId": 95,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "85b2f31409600b36ba8013f79b6aa84c9509546e218edb75c77d743a781c9bf4",
+          "iv": "95150d436a72c173e502ac22df904f26c0f4edffc29ca98b",
+          "aad": "6cb8a59b",
+          "msg": "44872f0602c76c1d4d36fd462cc886f0",
+          "ct": "9d2527bc8df2e71d20864e7789ce2a84",
+          "tag": "acd61c1b526988ec6105855ebdb7533a",
+          "result": "valid"
+        },
+        {
+          "tcId": 96,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "76b087aa42ca8bb9a42133eb9279da0d0093b4e5028f4edd1c2183f81e6754b7",
+          "iv": "383cd40e9aad35c35e3a46021b90acc87d51255be3443a7b",
+          "aad": "20976ec087",
+          "msg": "671e3615661511a8e668941126908c84",
+          "ct": "9d403b239c7497781bfb4468bd930cfe",
+          "tag": "83dc6dfb3ae111ab05ac30116b89d65e",
+          "result": "valid"
+        },
+        {
+          "tcId": 97,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "335d796b0dff04636e39bbc408ad6aef0d423fc1772994e61409396c9c1ff1b2",
+          "iv": "da3fe15576474fe36bc3d2c42fe505617454c23aa1475e80",
+          "aad": "03caf0a03be7",
+          "msg": "f3a55e4591e697a9f1aaac2eda219c59",
+          "ct": "610417044213e2a64c1b9b2fd1839268",
+          "tag": "444c11cdb783c3b432365ebe12378c9a",
+          "result": "valid"
+        },
+        {
+          "tcId": 98,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "0a059d6ed699ffed57c6734b67eed5bd62d508772e0d1edfb5793f805908b035",
+          "iv": "c991adee7c6e2bc5aeefd24c11be59a429b3198a3ea372cb",
+          "aad": "16317d3050bf51",
+          "msg": "b1ecd5c730695626454e8f89a598ad23",
+          "ct": "25a22c28b26f1712ba56b46e0103c444",
+          "tag": "ef27336fed160e6bbf257fb0e7770aa8",
+          "result": "valid"
+        },
+        {
+          "tcId": 99,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "b992dd885d0499a17268656665fde641be102d2fb642992d97e3107ee9aba20b",
+          "iv": "b755995c547fdf21a2398d1f4adc6476d1291b1723a331ee",
+          "aad": "df2f4f832de7a1518e",
+          "msg": "5fc0609d86c5bd4e5e9e335cb1954458",
+          "ct": "ceb42438dc40f7a0cc38ca0b9a48091f",
+          "tag": "7c1045faf49b58415ccdd2a1e2bc4429",
+          "result": "valid"
+        },
+        {
+          "tcId": 100,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "58fcfc12acbb234bf13d28b856693a0952245bc0c1d751c52bca708c7a196137",
+          "iv": "dd62b11c6826d2c53a8be69860f359a703594efaa42411a6",
+          "aad": "faa3abe6bc4eeb5316bf",
+          "msg": "66cc8a0fad0f6b05f0422b53ce8fecb3",
+          "ct": "dbb22f3a39c46abe3cee3980c1df88bf",
+          "tag": "81da8bfd8ebbc1eca4870f8196156e3b",
+          "result": "valid"
+        },
+        {
+          "tcId": 101,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2765b4d865629fc232d37ca5e240a8532dc9a3e381daa7ca547ff5da5c417e41",
+          "iv": "ca05d9a76be1149bcc4ef529b305854f7990b20aaffec384",
+          "aad": "9a227709205f1f740ed232",
+          "msg": "fe956a36f31adcc13ccd325f7a17f59c",
+          "ct": "4905c8641a0ee3ea6687ed7452527903",
+          "tag": "7d574e549b5cd377992de204627de5fa",
+          "result": "valid"
+        },
+        {
+          "tcId": 102,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "430878f3ab311fb40d2c9b0f534a4043350f0ff495c80122355ec2b7557cb831",
+          "iv": "a37403e233f4fed7e00d9bf3a5407eae04fee3d667b65493",
+          "aad": "af191751f447cc49efff74f8",
+          "msg": "6e775f424e7d9d8e23cdbf14607d3a44",
+          "ct": "06218a47245edaa15a9f1162ec011d3b",
+          "tag": "478423cbe48897ce756e3adbd9a1ee9a",
+          "result": "valid"
+        },
+        {
+          "tcId": 103,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "a2c4d1d5ab1dc812200e18ccee9ef797195633d355a873c90f6d051041177cfd",
+          "iv": "1ed54a330d347fb9ffcc68cabe540f2ff300cc3ee2691255",
+          "aad": "455fd94646f6edf9aef71275e0",
+          "msg": "cfac1a30be69f203e6efda92a19682c1",
+          "ct": "27f9bbdc89a079abba54ddc01781f11a",
+          "tag": "edce3ba94ea658694368d78878ad9227",
+          "result": "valid"
+        },
+        {
+          "tcId": 104,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "89f5bf87986d39fdfa8debf5a9810d3cf186f277f5fdc3f849ac7dcce6381205",
+          "iv": "6cf744267d87aa512f949e66579c074c6ac371d5228adff3",
+          "aad": "d5736a239a1e598560a84a81a60b",
+          "msg": "9775a1e1ca33d579075e0a80f2bf1184",
+          "ct": "a712f0a4c9932e6413bf501508693a5c",
+          "tag": "db8c77d539a6b41b6fc2d32ddd612ba3",
+          "result": "valid"
+        },
+        {
+          "tcId": 105,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "67af73796c9eba6ac7a847825cc56fac92595a8eb17ae2fece4a1f09c9d8c85f",
+          "iv": "7c76e9bd896c75245444f96fcfc419da23cf09b3be3610f8",
+          "aad": "c3036660fc872e55b0697104be59a2",
+          "msg": "3454b49cf7d10ec416770f76aa73bff7",
+          "ct": "e2322c9638222677e4b6f7fa474accaa",
+          "tag": "82712972e906ea74f99dfb642c560db0",
+          "result": "valid"
+        },
+        {
+          "tcId": 106,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "73005bc9d00e9688afcb340ea7cf81113d49e33d628e13b89949920102b1a9c1",
+          "iv": "367a95373b3f2bd4f2bfb03619368639fcc19eccdeccd04f",
+          "aad": "f15449e7c7810a11609f5da5e33b9085",
+          "msg": "c47c17dcd3efabfe2de42702f27a840f",
+          "ct": "7732ee206cd5734558c2f05f5bc1907b",
+          "tag": "4e32369f9ba08950b27b7952c3804fe8",
+          "result": "valid"
+        },
+        {
+          "tcId": 107,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "3a0c554dc2242950ec97b63a7f1de739ce18c247f4ce1f23b539b51feb82bec8",
+          "iv": "36213fcb5bff9b54db3c6af8c24a758b29b1143970b44168",
+          "aad": "17bc7a713365234f08e703a652816245d6",
+          "msg": "c04a2ebfcc30967e691a9ef1c52bcf6b",
+          "ct": "8ed2c330b349dac3709bbc8ca2fd6d52",
+          "tag": "b6c38642002ac48847c715b317b26a86",
+          "result": "valid"
+        },
+        {
+          "tcId": 108,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "6419d685e6804488ad4f09870db55f2448b82d4715e1d5fefa00ca9e08f21bc8",
+          "iv": "bd605dba58a18d5a38fcab1f92f6cb406a276d8d0ca7fb30",
+          "aad": "7f1e1f7fcb831cd7501e9608fda8ccb3c54f537ad601c033fdba7f7dc419",
+          "msg": "676d9476348a31c6873016ab196852fe",
+          "ct": "a4fc8309e455d263bc6b4c95e6c79cb4",
+          "tag": "9a439843444888d056b3e45a718a000d",
+          "result": "valid"
+        },
+        {
+          "tcId": 109,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "d92d949112061c11471efa77552daeda52b390efcac420c453c5b8499048983d",
+          "iv": "505a1b8d68cc2f77a10ad67cdeea4393a2ea6db590f5be17",
+          "aad": "bb044891ccae7f4f9493b8728293b772613c4ef2c088b3922f14466ea32a7a",
+          "msg": "161dc03e36cee9f246fd3a45481eea46",
+          "ct": "1351d5642bfa9eaf78efd34733bc0b5c",
+          "tag": "d666424d2d66969944f2b1a9dba68ebc",
+          "result": "valid"
+        },
+        {
+          "tcId": 110,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "2390931b9c99b9ac7e56bbbb86e6794b36ec3175432f731bea2e3a12c83e559b",
+          "iv": "972f9e74b0d118734549fe0d237f0c6249c43674ceaa328d",
+          "aad": "cf8c4a35d879e5051b1cff63ac64580ee80a8d80e9b6c90ff841fab3673aa573",
+          "msg": "0a182ff667eeccab0f8054405879dc36",
+          "ct": "7454d60539e1738ab6ff8609443a90f5",
+          "tag": "dd67f6363f66d20541d0aa24008be6ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 111,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "f563e70eefbe6cfd7a0b0d167a8b381fd14105ff4426fa326e9c2e4ca059a53e",
+          "iv": "3654bf38ffe7d4dabab310657322af2da359fcaf79a81044",
+          "aad": "c69f4dca85af6c39b5991f9386622f98acdb24f66b785cb3636a212ec13bed601b",
+          "msg": "5133dcb7ed3fa91add15224a4a9d21a9",
+          "ct": "bb5efe5a45ea17d63eb75509452daf51",
+          "tag": "31502fc74e063f0636bf9799f02c147a",
+          "result": "valid"
+        },
+        {
+          "tcId": 112,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "7c6410343a2938b9cf2d82419ee8c645fc9ed819b3b2ef876af0b1221ac4590a",
+          "iv": "f2f43b87fbb56938060cc9638d3d61ff2ebf26d037e4564e",
+          "aad": "760cd62e1d1123fd7d49b670037adb6dae66e7c8a0ca95ffed67a5965a35ca21c0ad9aa069d4edd48b71d5c93077ad",
+          "msg": "998c2e5f2900a0ab445b443b14e343e2",
+          "ct": "5e8d9d12295525439d0a9fde1a585ca4",
+          "tag": "5b7be3245ab2cd28d6b8a4b884e7547c",
+          "result": "valid"
+        },
+        {
+          "tcId": 113,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "ef72ae93643c8c4d2a0e9400e75077e451d9631cce343bcd5baabb092db9948b",
+          "iv": "a7b7bf6d320cfd2b351e5a4224631811a228938f841d8e21",
+          "aad": "1833c1458212c35798782337310f2b188fef2616aed491614dea16a2b35bf93ebddacf3ab5c64c2f7dc8b97d43ea150f18bd12431177eebd8ff870e415b53676f27f8785ee402fb6d0c0c82645475aa4c81d61a53090c4db1ed03389b6375a0fa0a69b26f8d8501a7fdf96f4f4e7cbbbcdcba8378550073f82c34cefed5918",
+          "msg": "90a964825e207d675bd794ee417b9d24",
+          "ct": "af1fe25e716e2f418bd83a47271a096c",
+          "tag": "152f7b1fea4c552ad5f613adfc3f067c",
+          "result": "valid"
+        },
+        {
+          "tcId": 114,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "be568ff6d60aeadd7df5d5bacc1e71890eb193e8378e536b213d57de22b5ad10",
+          "iv": "aaa41f115ebd0a62af455052331873c74b1be3352efac5d0",
+          "aad": "d419f50d9a16c23752e71952d9c30202d1cd9da6ec9262dc14f3e02abe9becf16352a9af8d6653dcc726bc4d9e20236f1b28ec9b203bf963531aa12055999060ee1b6f0504143b825f1e193bec3141e559d08a033473c6389957cf641c5e7b1aec0b180dbb9da18a9f2e0169668e363db2e702fd2e75e97cf5c0d499bdbcae61",
+          "msg": "94dfe2a79f4ca9aa641834fc29913f33",
+          "ct": "b9e997ba66925921ef1c9d5c586ba7bd",
+          "tag": "8aea703cdce04ad9487235f115a5233c",
+          "result": "valid"
+        },
+        {
+          "tcId": 115,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "c430893bc69eb3c022d5649102b002e92b77839efcc8723c6d964e5263dc1afb",
+          "iv": "4a2fa044f0ef80c6f76f98c2aa49d18509a63a1b09a04b2c",
+          "aad": "5ebb258b26670135cdb43c1facbcfed2a07a1a92ba718ce13fa7e1ca0f6a5aac65a4fc63369e5db493c243458557ce26d58d3be03fa4cd6ec020113430b1e08444804d6e74d4a162a3faa1c632aee623d6a4dd7f721da9256812602e63cc9cb426ca854f44282e4ee2467a114aa8680d13c1a0e14bef3132a06f23696ea93c49b8",
+          "msg": "5e4a3ab5dfab7fb23777d3c089e18b0f",
+          "ct": "65ca5062f134173f4fd68cd631e40fa4",
+          "tag": "87611bba36e141b0fda9ad6721cd067a",
+          "result": "valid"
+        },
+        {
+          "tcId": 116,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "33db78d4cc8e21c105f9c3088954d7693fc66c9674730d498493ac3cea86e53e",
+          "iv": "4854fde9be370465380fb9f1331e6bd2914402e64c562113",
+          "aad": "aa90591aa603ea70d94545ec8738d70ef327d5f94b869adecffc1e455a8827b7627ea92cc72ee5fd465e46bc8fcdd2647276a27859c0112a35e88a9d46e788e2084b4a9ff6d1089a231c1d38ea84bbfd03e5a04b54224d4709d94580c0a6a0b91876f6bed97595d673a620e486c03c59a9b1b1ac83e0e7e225ae2e68d48f12901e4b4f7f92ebd5dbbba3e8895743f80adb15e6ed7fe069d9381eac54cdb3d1207b0ea7d8ffcdc51d596570e5a0c8675d415bc898e470ec7b3dcad43a361c80ee65a7d47677f77c33505e1a1b26f9393384c5f01e495be7cc3d894cc8b937462fcd35cc8c681408a8ed3e159c521d2a18caf1283670bf02154db998e158495c",
+          "msg": "424fd251d16cf9dce5c243eb1da20ce2",
+          "ct": "e7d2be9f7cda40c7722c3e194b1661ec",
+          "tag": "16c48bb1ce252b0030c378bab696d473",
+          "result": "valid"
+        },
+        {
+          "tcId": 117,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "e2d83a17ba32596a9ab41352ed109fa5594bba97a6bed10d79854dda4b430288",
+          "iv": "9469e9d9788ed077cffab3ee76d85eb282e2280e10a74fa4",
+          "aad": "762a386780bf7bc594d9febca06d84283867cc87b4390a349da4e29711d77ab43ff8c538b74736d3da2a5d5d5ba10ef51d5920808ed56f2aab12da115e5d73ef039a7733d67cbf52399a4adb6bac805fc2a788f7c4419350fda3f514c30f5a7c517cd04e7360f9b59b76ea8375536d10015a21d6166230b3e690499c53ae852c4a91b89a8ed7a30c9ef5f83be5445861b92f4cc7fb74a7f8879f93e303b25919c71e479e0d755168cfb07114970a5dc669a31f84b972bf1354c47942a917a886664358f2079b3820cfee483eea5115a2e4fe94881ab5801c0984302d0cc6e9743c06dc214796f067020b91998693244a19790a62429167c786e6dc47a7c988be",
+          "msg": "e49751def18f6377b2c72c75ec922c8b",
+          "ct": "bd345332cbfd27840c24074f9b69bea9",
+          "tag": "d5171c6e25f7d78ee0d12dadecca8132",
+          "result": "valid"
+        },
+        {
+          "tcId": 118,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "23338f531db34d5574c54444a661bcfc9bc165cfa2d90ea4df7eef4932980022",
+          "iv": "d9bce71405eeab0a3539675fbeb00341c77126a6b0393271",
+          "aad": "dc8248e679503fcd06f6b5d28f5928d94f0632c1f090b9b84c5a89d15146dc1c25aae104afb6403e06a4c181fb6e01af8d3446f07e584f20cc033bb5f256ff543cc0e7e0876365154cee635ad520aa3313f891d942b9ac2696d6e35b5ee5dbb71e57abb323617bf54b185e02cfc187064739baaea3eeed45d483cdeb64d8b12425d0797e31370646eb9e36fc271cd3de612f85856194311ea7f25003ccf08cda7ae23bdf591985437f46bde206dda835886c9d4948c537e1c7987da17f06a8a128b4456df48ed4a57d2f4f582e57d0bfb88dc9df9f386e29e2a003fd1d05dec48b605d847eb98906454ecd9b609b7a42ca892267089f16683edb9eaac84619ecdf",
+          "msg": "b9bb3ee1382622cf60e8300b63ab5413",
+          "ct": "587fc5765489eda000991e8c17d4f205",
+          "tag": "5daa40748f72bfffdf5ee963c1e4e0d6",
+          "result": "valid"
+        },
+        {
+          "tcId": 119,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "4e895fb5ffb8a95b86c54e0d46277903a02bb22d077c913f63dd9aced27ad8c5",
+          "iv": "e13c4fcec17f92081f5cdf0b11cabf47e3c99c3447831263",
+          "aad": "a97c0f1ec230dde1a01666606deb83577e3b7f6b19869bcc50abbb2dc7888e9f93a887d119685e1c5e6925af90102de1a39f97a8c2015e9c11b87d1a81211f3596bda65155ceed7dcdc91559df4bc3884bbac18df4aac984a73f55c87d32514e1889df5964919db2c8c0bada2b375c249dc9aa8205d151810be94969857facd138ff2ac22d1319c6ef3d14aef95c1cd9ffb869f9aaf7b95c09a08c03d6502a6bf54b3fea2276b0d6b1693537589932c3effcd8bade3cef6dca982b8175d10797b37384aef71616618dd5bfbd5c60cc8e8fefcadc6913403e8a882c4640dc60bfc030c6cf7aebc9e506fb87c3d598807c0cfaf7cf1f750e95ca86adb5dc6187aa0367e9dff571a3ddd0c68e3db024c0409f3424640aa72f9157f2a657e396d7dd01ec1f712f898c3594cf6a89a9b35c769677cd14d380f0133f026b153cfc43e89ec210693ad9969e30d897f53c0a2245e42e91cc59aef50fddf2301921afba7d60c9e8ebb4801127310d643cf92856582620643df759c94c62384ce88f66091f678d842519f2dba4bf33ad4f66d7cf41e4015590df4fa8db76ec2279b3124b204a4decb7b8ca4f8544c1e9c3723eb8acffc00cbc41e4d3b939ac4f0e1fc8837022e306ae9c098193698979fa7e233244c575a00e88b9b5ef67287ad0568390f31befe7a2a24850c319362703e189c422b41ea518ce4f10debe5b0f1270221e",
+          "msg": "9e9f4216b43c447c1c9930600b18486e",
+          "ct": "29687a45bba7b7159e09ed5ecb45552a",
+          "tag": "69b63f3911e1f6ef494d96e99787cb9f",
+          "result": "valid"
+        },
+        {
+          "tcId": 120,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "002199dc9a444d14ccf77edad5c68295122e42447e79a3be6619941a66e0356a",
+          "iv": "614a4e9a615f347d52e36aa890bfdcc4bce42dcaa2a0d7f4",
+          "aad": "ce89fdfd36b1643eee83d35d34647fab5a2d5be2051004a370e3f5765ea98fb58ee7e6db279aa2f38b3780078497fcafa51f4621d79371758209a7af8299a2d8a5e46254af7874f553c46a41369a1107e545cc0bf63e4a5a6be4fc66a64d3a398582a87c39353c38933f5814d74f2eddb95fa908790120e433cb8240905152abdfd41690fe05ef03ff3fa0ca7feed5334d1247dcd28a82907622fc424a6388068d8359f7417ab621adf9f7574b400e9ee163d555ce8a93eed399402878fe4fec9087e04de23b4ba71e1364cd805da8c4c35479e258e4ac2effb57f3514c3bc14760c5b28a7c7271b04163f8ced02ef8eb06ae9cb689aa387b3419d6125fbaeaefa914f65fb9f16dc44bd1ba548e86439187c015108f9e623de160f20d6c6adaa8e634b131f5582fd41fc27824184fbea7325cba038fd2a318102b130fd1251dd8fc4f3fbd1d98a605a2c7850c259f4f16f182376eea25935969f5deb9c6eca19bfa039420729618a642f43b79845e91a62e0cc95f97ed39f1e761b216b48db299cb88160e558d24146ede296f7e015dca76e2bf8196ea48b9549b3ff8c03817428f8bd4d84a6103127f2312c02268d85f45d0db53f7117920986ec01451b22647889249c9fbbafd2f57766d44149cb0e87ddc9452ca95ad6342af198eb5231d318a676b05f8c6b0d44ff5fb3e0d00c0432e2546b491c23b932372907caa14ed1",
+          "msg": "2b30edf11720f3457466ebacb2c20677",
+          "ct": "6f2ca0ee464b473937a8107723cae13d",
+          "tag": "58d920b7922030137c8d0133d626cc1e",
+          "result": "valid"
+        },
+        {
+          "tcId": 121,
+          "comment": "",
+          "flags": [
+            "Pseudorandom"
+          ],
+          "key": "4fdef70eeb3c60769b602afaff9a65112f645c8e3e9dcdd7a6ecb13eb066ff90",
+          "iv": "770308621b27d9dfbc8895cbe14ea137f6253dca748fb71e",
+          "aad": "14a20b713e172d98593ffe4fc128ab18b77b1f3c9014534facdf9281d5cb58cea4463ef39901f3014b5b99488b6e8b24e756e4b614c04ed303e83e0f653d6fd3dbdb68e7a1960801b4e6e150c9d0cd20fbabd317fc3653a7350f5b85745d9af3c6a5000e6a3649a3e5f5e451d3c7c6450c540a62dc2b597821be88c577e7c442d3a5dd937a5d204833e9f0a961c397059ce82195978c9cb260dba1c83022a594d61c623de890a2aa9c918b868185f738e0620e8be1c85b29f3a62bfa971f8819ecfff31a2ac8e188f71fc9cfb07e5c17f24d696567d44d1b8d38081f1d8b62a442ee006820f53c583ba8641cd2485da36a8803d68b3736c4e7e436483e752c8ad5f5a3763a9d818d35e02e9451674418b283380adcd57564ada5c392c5c4cd7515b87ebbc7af769a10bb22861451c115f272a27d2c98568a54f247c2f9b7a78ec2524ceb5b45fd444c877c4d3f9ab582e931e31d6adef86500f71b73bae6b2b8a9f05dad82d10dfa8ac69fd30f0dc884d359b30ea80ca43ec0762f6938739180b656b61e651fb6b27ba099721e79a1683f8d2debf914756f768a20b44d01eb0fb560392fd7a8fd691e01fe0d48c05137b7b562ef7fc89d48bd563382b283231331893864fd480fbda73426d8161cd70d61d5f501151432ed16c59161e4bbf2622cdff5d3e844f17ab3fead7d55bd1286f2e6f3d28d7f9578872b7164058e17cc0e",
+          "msg": "e5c159dfdffbd12f8ceea2adadf780e9",
+          "ct": "b985816343b98e03794a09561e593857",
+          "tag": "6e5216b416b7cae070eb8684498c1d74",
+          "result": "valid"
+        },
+        {
+          "tcId": 122,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "00000000000000000000000000000000",
+          "msg": "60e28a8f89adf230daab792c94dfebe766eda542d7c092d97ccb7501486fc6a3",
+          "ct": "0000000000000000000000000000000000000000000000000000000000000000",
+          "tag": "52ca5edfb3c4fca83d5776154188a08d",
+          "result": "valid"
+        },
+        {
+          "tcId": 123,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "00000000000000000000000000000000",
+          "msg": "60e28a8f89adf230daab792c94dfebe766eda542d7c092d97ccb7501486fc6a31ec9568c72a762296f76685b29a5f903cb0198722ad071bde29b48a62d367f3b",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "tag": "a7c21e96322a7f8c453961640791f3e6",
+          "result": "valid"
+        },
+        {
+          "tcId": 124,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "00000000000000000000000000000000",
+          "msg": "60e28a8f89adf230daab792c94dfebe766eda542d7c092d97ccb7501486fc6a31ec9568c72a762296f76685b29a5f903cb0198722ad071bde29b48a62d367f3b1e90919140f50187df7df42caa37287538c16d481265de62bbf98c235d595c824575acd33c51e271f13844673cb5dafd249dbd394b866c34aecd42c57f2630e5",
+          "ct": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "tag": "70b88b3bf88b8f11f7513545b8dbfa63",
+          "result": "valid"
+        },
+        {
+          "tcId": 125,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "ffffffffffffffffffffffffffffffff",
+          "msg": "9f1d757076520dcf255486d36b20141899125abd283f6d2683348afeb790395c",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "c29cd2ef4874d93267c935cd9ffd34f1",
+          "result": "valid"
+        },
+        {
+          "tcId": 126,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "ffffffffffffffffffffffffffffffff",
+          "msg": "9f1d757076520dcf255486d36b20141899125abd283f6d2683348afeb790395ce136a9738d589dd6908997a4d65a06fc34fe678dd52f8e421d64b759d2c980c4",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "02add84dfa902f0d4a11d3bdc096417e",
+          "result": "valid"
+        },
+        {
+          "tcId": 127,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "ffffffffffffffffffffffffffffffff",
+          "msg": "9f1d757076520dcf255486d36b20141899125abd283f6d2683348afeb790395ce136a9738d589dd6908997a4d65a06fc34fe678dd52f8e421d64b759d2c980c4e16f6e6ebf0afe7820820bd355c8d78ac73e92b7ed9a219d440673dca2a6a37dba8a532cc3ae1d8e0ec7bb98c34a2502db6242c6b47993cb5132bd3a80d9cf1a",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "82a067b3b3e51cd9d139a5222ea70258",
+          "result": "valid"
+        },
+        {
+          "tcId": 128,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "00000080000000800000008000000080",
+          "msg": "60e28a0f89adf2b0daab79ac94dfeb6766eda5c2d7c092597ccb7581486fc623",
+          "ct": "0000008000000080000000800000008000000080000000800000008000000080",
+          "tag": "2bd279a556e3dde6151e698e0496b3aa",
+          "result": "valid"
+        },
+        {
+          "tcId": 129,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "00000080000000800000008000000080",
+          "msg": "60e28a0f89adf2b0daab79ac94dfeb6766eda5c2d7c092597ccb7581486fc6231ec9560c72a762a96f7668db29a5f983cb0198f22ad0713de29b48262d367fbb",
+          "ct": "00000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080",
+          "tag": "dc37087d3aaa8b97e985152fa9f1ee04",
+          "result": "valid"
+        },
+        {
+          "tcId": 130,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "00000080000000800000008000000080",
+          "msg": "60e28a0f89adf2b0daab79ac94dfeb6766eda5c2d7c092597ccb7581486fc6231ec9560c72a762a96f7668db29a5f983cb0198f22ad0713de29b48262d367fbb1e90911140f50107df7df4acaa3728f538c16dc81265dee2bbf98ca35d595c024575ac533c51e2f1f13844e73cb5da7d249dbdb94b866cb4aecd42457f263065",
+          "ct": "0000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080",
+          "tag": "3b1dbe65bafcd37fdb15b34fafabc07f",
+          "result": "valid"
+        },
+        {
+          "tcId": 131,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "80000000800000008000000080000000",
+          "msg": "e0e28a8f09adf2305aab792c14dfebe7e6eda54257c092d9fccb7501c86fc6a3",
+          "ct": "8000000080000000800000008000000080000000800000008000000080000000",
+          "tag": "196d7dc0f19cc39bb61a84285e9c73d6",
+          "result": "valid"
+        },
+        {
+          "tcId": 132,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "80000000800000008000000080000000",
+          "msg": "e0e28a8f09adf2305aab792c14dfebe7e6eda54257c092d9fccb7501c86fc6a39ec9568cf2a76229ef76685ba9a5f9034b019872aad071bd629b48a6ad367f3b",
+          "ct": "80000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000",
+          "tag": "8bca9ea23dcecb4010dbc15f2556513b",
+          "result": "valid"
+        },
+        {
+          "tcId": 133,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "80000000800000008000000080000000",
+          "msg": "e0e28a8f09adf2305aab792c14dfebe7e6eda54257c092d9fccb7501c86fc6a39ec9568cf2a76229ef76685ba9a5f9034b019872aad071bd629b48a6ad367f3b9e909191c0f501875f7df42c2a372875b8c16d489265de623bf98c23dd595c82c575acd3bc51e27171384467bcb5dafda49dbd39cb866c342ecd42c5ff2630e5",
+          "ct": "8000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000800000008000000080000000",
+          "tag": "9d7afc7f6670538f0149050bd417e525",
+          "result": "valid"
+        },
+        {
+          "tcId": 134,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "ffffff7fffffff7fffffff7fffffff7f",
+          "msg": "9f1d75f076520d4f255486536b20149899125a3d283f6da683348a7eb79039dc",
+          "ct": "ffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7f",
+          "tag": "e994b729a655f8f48e024354dcef21d4",
+          "result": "valid"
+        },
+        {
+          "tcId": 135,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "ffffff7fffffff7fffffff7fffffff7f",
+          "msg": "9f1d75f076520d4f255486536b20149899125a3d283f6da683348a7eb79039dce136a9f38d589d5690899724d65a067c34fe670dd52f8ec21d64b7d9d2c98044",
+          "ct": "ffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7f",
+          "tag": "cd37ef66f2102302a6c41ef31e364660",
+          "result": "valid"
+        },
+        {
+          "tcId": 136,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "ffffff7fffffff7fffffff7fffffff7f",
+          "msg": "9f1d75f076520d4f255486536b20149899125a3d283f6da683348a7eb79039dce136a9f38d589d5690899724d65a067c34fe670dd52f8ec21d64b7d9d2c98044e16f6eeebf0afef820820b5355c8d70ac73e9237ed9a211d4406735ca2a6a3fdba8a53acc3ae1d0e0ec7bb18c34a2582db624246b479934b5132bdba80d9cf9a",
+          "ct": "ffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7f",
+          "tag": "b73b3589f174d86aed75271837d73c3c",
+          "result": "valid"
+        },
+        {
+          "tcId": 137,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "7fffffff7fffffff7fffffff7fffffff",
+          "msg": "1f1d7570f6520dcfa55486d3eb20141819125abda83f6d2603348afe3790395c",
+          "ct": "7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff",
+          "tag": "fbf9b30e0b9c1240ee0528ba82e961a8",
+          "result": "valid"
+        },
+        {
+          "tcId": 138,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "7fffffff7fffffff7fffffff7fffffff",
+          "msg": "1f1d7570f6520dcfa55486d3eb20141819125abda83f6d2603348afe3790395c6136a9730d589dd6108997a4565a06fcb4fe678d552f8e429d64b75952c980c4",
+          "ct": "7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff",
+          "tag": "1ea55841efece2587f6f72c2a2d1e329",
+          "result": "valid"
+        },
+        {
+          "tcId": 139,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "7fffffff7fffffff7fffffff7fffffff",
+          "msg": "1f1d7570f6520dcfa55486d3eb20141819125abda83f6d2603348afe3790395c6136a9730d589dd6108997a4565a06fcb4fe678d552f8e429d64b75952c980c4616f6e6e3f0afe78a0820bd3d5c8d78a473e92b76d9a219dc40673dc22a6a37d3a8a532c43ae1d8e8ec7bb98434a25025b6242c6347993cbd132bd3a00d9cf1a",
+          "ct": "7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff7fffffff",
+          "tag": "5adef66e4501595bc742d55c126b1896",
+          "result": "valid"
+        },
+        {
+          "tcId": 140,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "00000000ffffffff00000000ffffffff",
+          "msg": "60e28a8f76520dcfdaab792c6b20141866eda542283f6d267ccb7501b790395c",
+          "ct": "00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff",
+          "tag": "81682925f4f8a57392d2a9d4157f2c86",
+          "result": "valid"
+        },
+        {
+          "tcId": 141,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "00000000ffffffff00000000ffffffff",
+          "msg": "60e28a8f76520dcfdaab792c6b20141866eda542283f6d267ccb7501b790395c1ec9568c8d589dd66f76685bd65a06fccb019872d52f8e42e29b48a6d2c980c4",
+          "ct": "00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff",
+          "tag": "077001742d67566612633a0b3f3f8c99",
+          "result": "valid"
+        },
+        {
+          "tcId": 142,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "00000000ffffffff00000000ffffffff",
+          "msg": "60e28a8f76520dcfdaab792c6b20141866eda542283f6d267ccb7501b790395c1ec9568c8d589dd66f76685bd65a06fccb019872d52f8e42e29b48a6d2c980c41e909191bf0afe78df7df42c55c8d78a38c16d48ed9a219dbbf98c23a2a6a37d4575acd3c3ae1d8ef1384467c34a2502249dbd39b47993cbaecd42c580d9cf1a",
+          "ct": "00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff",
+          "tag": "1c0e1d3c611eda884919789540fc27f1",
+          "result": "valid"
+        },
+        {
+          "tcId": 143,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "ffffffff00000000ffffffff00000000",
+          "msg": "9f1d757089adf230255486d394dfebe799125abdd7c092d983348afe486fc6a3",
+          "ct": "ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000",
+          "tag": "93fe07aa08403068124e020ecb06a9f8",
+          "result": "valid"
+        },
+        {
+          "tcId": 144,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "ffffffff00000000ffffffff00000000",
+          "msg": "9f1d757089adf230255486d394dfebe799125abdd7c092d983348afe486fc6a3e136a97372a76229908997a429a5f90334fe678d2ad071bd1d64b7592d367f3b",
+          "ct": "ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000",
+          "tag": "a2fff56fff5358337de7f91689e8a8cb",
+          "result": "valid"
+        },
+        {
+          "tcId": 145,
+          "comment": "",
+          "flags": [
+            "EdgeCaseCiphertext"
+          ],
+          "key": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "ffffffff00000000ffffffff00000000",
+          "msg": "9f1d757089adf230255486d394dfebe799125abdd7c092d983348afe486fc6a3e136a97372a76229908997a429a5f90334fe678d2ad071bd1d64b7592d367f3be16f6e6e40f5018720820bd3aa372875c73e92b71265de62440673dc5d595c82ba8a532c3c51e2710ec7bb983cb5dafddb6242c64b866c345132bd3a7f2630e5",
+          "ct": "ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000",
+          "tag": "db4ad6b24a53d2617f7262d2a586d5ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 146,
+          "comment": "Flipped bit 0 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0418b3e73e52c3be2eaba76807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 147,
+          "comment": "Flipped bit 1 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0718b3e73e52c3be2eaba76807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 148,
+          "comment": "Flipped bit 7 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "8518b3e73e52c3be2eaba76807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 149,
+          "comment": "Flipped bit 8 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0519b3e73e52c3be2eaba76807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 150,
+          "comment": "Flipped bit 31 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3673e52c3be2eaba76807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 151,
+          "comment": "Flipped bit 32 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73f52c3be2eaba76807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 152,
+          "comment": "Flipped bit 33 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73c52c3be2eaba76807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 153,
+          "comment": "Flipped bit 63 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c33e2eaba76807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 154,
+          "comment": "Flipped bit 64 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c3be2faba76807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 155,
+          "comment": "Flipped bit 77 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c3be2e8ba76807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 156,
+          "comment": "Flipped bit 80 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c3be2eaba66807b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 157,
+          "comment": "Flipped bit 96 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c3be2eaba76806b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 158,
+          "comment": "Flipped bit 97 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c3be2eaba76805b784e1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 159,
+          "comment": "Flipped bit 120 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c3be2eaba76807b784e0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 160,
+          "comment": "Flipped bit 121 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c3be2eaba76807b784e3",
+          "result": "invalid"
+        },
+        {
+          "tcId": 161,
+          "comment": "Flipped bit 126 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c3be2eaba76807b784a1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 162,
+          "comment": "Flipped bit 127 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c3be2eaba76807b78461",
+          "result": "invalid"
+        },
+        {
+          "tcId": 163,
+          "comment": "Flipped bit 63 and 127 in tag expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "0518b3e73e52c33e2eaba76807b78461",
+          "result": "invalid"
+        },
+        {
+          "tcId": 164,
+          "comment": "Tag changed to all zero expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "00000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 165,
+          "comment": "tag change to all 1 expected tag:0518b3e73e52c3be2eaba76807b784e1",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "",
+          "ct": "",
+          "tag": "ffffffffffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 166,
+          "comment": "Flipped bit 0 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2464a8ce1a360e8352971c8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 167,
+          "comment": "Flipped bit 1 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2764a8ce1a360e8352971c8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 168,
+          "comment": "Flipped bit 7 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "a564a8ce1a360e8352971c8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 169,
+          "comment": "Flipped bit 8 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2565a8ce1a360e8352971c8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 170,
+          "comment": "Flipped bit 31 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a84e1a360e8352971c8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 171,
+          "comment": "Flipped bit 32 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1b360e8352971c8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 172,
+          "comment": "Flipped bit 33 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce18360e8352971c8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 173,
+          "comment": "Flipped bit 63 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e0352971c8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 174,
+          "comment": "Flipped bit 64 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e8353971c8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 175,
+          "comment": "Flipped bit 77 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e8352b71c8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 176,
+          "comment": "Flipped bit 80 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e8352971d8110885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 177,
+          "comment": "Flipped bit 96 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e8352971c8111885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 178,
+          "comment": "Flipped bit 97 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e8352971c8112885031",
+          "result": "invalid"
+        },
+        {
+          "tcId": 179,
+          "comment": "Flipped bit 120 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e8352971c8110885030",
+          "result": "invalid"
+        },
+        {
+          "tcId": 180,
+          "comment": "Flipped bit 121 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e8352971c8110885033",
+          "result": "invalid"
+        },
+        {
+          "tcId": 181,
+          "comment": "Flipped bit 126 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e8352971c8110885071",
+          "result": "invalid"
+        },
+        {
+          "tcId": 182,
+          "comment": "Flipped bit 127 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e8352971c81108850b1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 183,
+          "comment": "Flipped bit 63 and 127 in tag expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "2564a8ce1a360e0352971c81108850b1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 184,
+          "comment": "Tag changed to all zero expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "00000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 185,
+          "comment": "tag change to all 1 expected tag:2564a8ce1a360e8352971c8110885031",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f",
+          "ct": "b70886f2313d015e1fe741365f5e35f1",
+          "tag": "ffffffffffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 186,
+          "comment": "Flipped bit 0 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8161d3df064071df8082a0f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 187,
+          "comment": "Flipped bit 1 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8261d3df064071df8082a0f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 188,
+          "comment": "Flipped bit 7 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "0061d3df064071df8082a0f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 189,
+          "comment": "Flipped bit 8 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8060d3df064071df8082a0f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 190,
+          "comment": "Flipped bit 31 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d35f064071df8082a0f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 191,
+          "comment": "Flipped bit 32 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df074071df8082a0f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 192,
+          "comment": "Flipped bit 33 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df044071df8082a0f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 193,
+          "comment": "Flipped bit 63 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df0640715f8082a0f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 194,
+          "comment": "Flipped bit 64 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df064071df8182a0f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 195,
+          "comment": "Flipped bit 77 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df064071df80a2a0f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 196,
+          "comment": "Flipped bit 80 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df064071df8082a1f813417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 197,
+          "comment": "Flipped bit 96 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df064071df8082a0f812417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 198,
+          "comment": "Flipped bit 97 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df064071df8082a0f811417f05",
+          "result": "invalid"
+        },
+        {
+          "tcId": 199,
+          "comment": "Flipped bit 120 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df064071df8082a0f813417f04",
+          "result": "invalid"
+        },
+        {
+          "tcId": 200,
+          "comment": "Flipped bit 121 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df064071df8082a0f813417f07",
+          "result": "invalid"
+        },
+        {
+          "tcId": 201,
+          "comment": "Flipped bit 126 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df064071df8082a0f813417f45",
+          "result": "invalid"
+        },
+        {
+          "tcId": 202,
+          "comment": "Flipped bit 127 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df064071df8082a0f813417f85",
+          "result": "invalid"
+        },
+        {
+          "tcId": 203,
+          "comment": "Flipped bit 63 and 127 in tag expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "8061d3df0640715f8082a0f813417f85",
+          "result": "invalid"
+        },
+        {
+          "tcId": 204,
+          "comment": "Tag changed to all zero expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "00000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 205,
+          "comment": "tag change to all 1 expected tag:8061d3df064071df8082a0f813417f05",
+          "flags": [
+            "ModifiedTag"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "000102",
+          "msg": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "ct": "b70886f2313d015e1fe741365f5e35f1080e0f78ccfb51809417e879689418ef98",
+          "tag": "ffffffffffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 206,
+          "comment": "edge case for poly1305 key:ffffff3f24ac6f2f6436cec230be9ab31d8434bf94e1042d20952749a99cf641",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112133e8775b2",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "7ee395bd21ada42ed12310d34918a28e596a49ee7a22f623d756b896663f68733e6c71a344f4726ac24e330679f25e492be08603aaa23f1e88c10299047c8e585983332a8b6eadcd9b6061b63fe3b58a2021b38c7cf379fe9a9f6d114f3cfe422f91af78c6fd87d4269af0e3e471abed457ae75c027e134c96cf4d9a4a646288",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "4921f7c24a2d42f4da7ad9d45e8ec26c",
+          "result": "valid"
+        },
+        {
+          "tcId": 207,
+          "comment": "edge case for poly1305 key:bf358f18ffffffbf4b62ed6e1f53790785c4dabdfc72e2a219d377a682c85f38",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121303e9b9a4",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "af205bda819f7451be0f28667d4b01b59ff2daa8173cab52046c3c9e0d989889c5e021ef7afd06e9ce6cc30e3a6ebab509134ba10d10e570c55587c13eee53e73be54804c8539ffbf23b35922b1ca37b9e9bc24ee204837ca5a294ce05d12600c7eff6aee32270db2feff47dc5a04176169e15850628e6035f78994f9f56035c",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "b86b0a8e9427af3516950efc81d935d5",
+          "result": "valid"
+        },
+        {
+          "tcId": 208,
+          "comment": "edge case for poly1305 key:d0b7b3a352a4010ffeffffbfe8cc66dc6e5e7451dc61762c5753174fed88e746",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130700b982",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "68c67272036fb652a0182eeb4781358e4704a4a702fd731bf3b3ea994717989e7d9104e0ae81732a8c7e9a82b3d31d541761a366b67c3396f1a6c67e293ddb65a59e42541dda144dc6c78388cfca982e23350958ac5b3d54a1722fd64733577862e1879c9e9445ebdec5315d1706db7ebbedd4c779935e72057e5b0ecde0814d",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "3661dc6ddd1852221050ff5b8d58c13f",
+          "result": "valid"
+        },
+        {
+          "tcId": 209,
+          "comment": "edge case for poly1305 key:7bee33931a4157a8cb701becfeffff4fbe7e69f19cd065313bb49a252628dd3d",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "c483b7334ebe2e879b0c3f9db4fcd9f5219062360d6ce44cdae0f94e04c8345ea7e3ae33855118741dcafe0de4ae98c4e43af7b12b04ee8ab175625823ac040e5abac4403f1d45238adcb8c0cf44bd56917f9f5d93974c82b56951986a9c0450bd9047b5a616e814526ad0580e3ecd8189c9fef2cdb979a22ad3a01930fbd15e",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "02c70e4defe897a47a65063a468db630",
+          "result": "valid"
+        },
+        {
+          "tcId": 210,
+          "comment": "edge case for poly1305 key:df39fb3f36d8e58f91abffdff9f5feaf109d0e960edcf2b728446ec175ad4c7b",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112133f1a8eb1",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "85e40e2106db6aba0fb236d3c980a72e58ce538db7aa3b0326a23d52175c7465c454d8206b4d8aedd51d8cc47424f6124d2586370f4eb51153d215e48347abf8791a6d6d3da4871ab2c0fe5718878c3942365fc75887e6ea6e779911f883fe90b6c0e5870769a860cf619f91c7eeaad69212325404ec4de4d3ab5e7aa89537a4",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "ecccb94178b76a769c91c27d921fcc6c",
+          "result": "valid"
+        },
+        {
+          "tcId": 211,
+          "comment": "edge case for poly1305 key:00000090e6e328c242cde5c83e3d8262d467f2bcd53d3755c781f3c6a2cb0648",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "eaccaa778935ef249e0900149dd889462d2a061486ba102b8caebe465f3959fb3119ebb5689676ffdd6d851a26739e772b54a2f5f473ea9c7e58ccbc4cfc953e8c420b2175d9dd519265630bb79bd87a601b113231a8b16ce54c331347ec04c2b1c9160f38207aa46e96feb06dee883eb422fa14908df300bb1a1ef758c408f5",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "f00ee0097d7dffbd3e4b216c45da89ef",
+          "result": "valid"
+        },
+        {
+          "tcId": 212,
+          "comment": "edge case for poly1305 key:9e98d64e000000505a07183c5c68c63c14c9266dd37ff86aafc22ddbdb355617",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130c807a72",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "a76c330e015060a17e64cb7b6d753f201f75be8759fd7539fb92b22aef54c9d3029dba0c15cbf7c95135888319c6b2e6276da21e0c351fd522b29aabb5883a3291d6f427de773b124390ef6fd96621ffbc42dfbf7a34da272cbc9ccb1a498d078033d1ac3bf7e92715948b06d69d5c5039e9164ba9c3a02219ec5908206b3bd2",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "8691693787763ec6c7bf957658b51370",
+          "result": "valid"
+        },
+        {
+          "tcId": 213,
+          "comment": "edge case for poly1305 key:1048a92e65f5e63102000080d9ae08de4319a7c45fdbe707b9ec1b7e0d635161",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130397a143",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "228a7e15bcce13051de9145f77f7f4ff7921828b4f99efc4ff55ee0d9344955b69ec2d4798b0517f0273c4456ae5ffc5929cbe74ddb0da51d4f2b4df7578a31240c88ae922c3c5eca7b97d72d497062050a587447c562b343d5c71921944872f9fd06b8f34b3eb5d4341f5ff8a907dd7c2e1676b81252726ba54814da51eab8c",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "7fc8d4bb91c543b9bf5dbf1e7277d823",
+          "result": "valid"
+        },
+        {
+          "tcId": 214,
+          "comment": "edge case for poly1305 key:01517a2ceb89bbfb5741f7d9000000401a65b132ad661072a00ffe7defbb18a5",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121308cb0f3f",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "c7d843188ab193dfef5c4daf583f952cd4b195f240fa2e704d021723023c123371a41e87dfc6e6c3874a42f331cf035988a38c72ba2da854b1208f98bf8cc29948169481ab3a402d5fcc7ff78f9e31925576dc3938074b8c5b27960e3afc750ad686563688b7441787288d5256c1301d563b7744843bd1ab4eff5be6f1653d44",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "834c91a6580bf514dfcb5e2f456efe3c",
+          "result": "valid"
+        },
+        {
+          "tcId": 215,
+          "comment": "edge case for poly1305 key:e73c0100fbd50c408e3c06701c3908209a66d9388dd8e29458376300cb04f56a",
+          "flags": [
+            "EdgeCasePolyKey"
+          ],
+          "key": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213d580ecf3",
+          "aad": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "msg": "56d20c8500203274099502f38d547f3008588f396cb521a2bae1800514f1f797c00386d52c09fd64a28b393431848e13dda47f65536bfc681ca73b55a7fc019a4c8358186e009ad3e22a5f08a59b19ca4b3bf11269fecaa49a9e9aff53a02ce2f235fba061ee95eae6177f1153502a50428122a73c83695f17dff5cfde23fdf9",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "ca3de68e124484e8bb825b069afaa53d",
+          "result": "valid"
+        },
+        {
+          "tcId": 216,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "abffffffffffffffffffffffffffffff5a20e89e14ed5af85da66b5e4bdbe002",
+          "msg": "660336ffb732a4dcda556c2539d3d2de6cdaed0d7d9104593f8ed69bf0db8aa33c0e746482b7dc53d40b8a5331ca33b874639cdc7a787badd436bcd56e798af3",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "000102030405060708090a0b0c0d0e0f",
+          "result": "valid"
+        },
+        {
+          "tcId": 217,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "ffffffffffffffffffffffffffffffff7c85b8e5991711f804915250b99cf7a7",
+          "msg": "660336ffb732a4dcda556c2539d3d2de6cdaed0d7d9104593f8ed69bf0db8aa33c0e746482b7dc53d40b8a5331ca33b874639cdc7a787badd436bcd56e798af3",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "00000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 218,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "a8ffffffffffffffffffffffffffffff57599fb21558a903b6a3193419537e06",
+          "msg": "660336ffb732a4dcda556c2539d3d2de6cdaed0d7d9104593f8ed69bf0db8aa33c0e746482b7dc53d40b8a5331ca33b874639cdc7a787badd436bcd56e798af3",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 219,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "c1fffffffffffffffffffffffffffffffd71560c5091b863662ffaebc0dd2501",
+          "msg": "660336ffb732a4dcda556c2539d3d2de6cdaed0d7d9104593f8ed69bf0db8aa33c0e746482b7dc53d40b8a5331ca33b874639cdc7a787badd436bcd56e798af3",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "00000080000000800000008000000080",
+          "result": "valid"
+        },
+        {
+          "tcId": 220,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "f9ffffffffffffffffffffffffffffff169a825d7ecbf7e107396a2a3dfb4508",
+          "msg": "660336ffb732a4dcda556c2539d3d2de6cdaed0d7d9104593f8ed69bf0db8aa33c0e746482b7dc53d40b8a5331ca33b874639cdc7a787badd436bcd56e798af3",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "ffffff7fffffff7fffffff7fffffff7f",
+          "result": "valid"
+        },
+        {
+          "tcId": 221,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "d9ffffffffffffffffffffffffffffffe344f9752a885ccd1a3fa5a9c4187d04",
+          "msg": "660336ffb732a4dcda556c2539d3d2de6cdaed0d7d9104593f8ed69bf0db8aa33c0e746482b7dc53d40b8a5331ca33b874639cdc7a787badd436bcd56e798af3",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "01000000010000000100000001000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 222,
+          "comment": "edge case for tag",
+          "flags": [
+            "EdgeCaseTag"
+          ],
+          "key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+          "iv": "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "aad": "d7ffffffffffffffffffffffffffffffa6627ce99c9c49deb89855b0f9e3f407",
+          "msg": "660336ffb732a4dcda556c2539d3d2de6cdaed0d7d9104593f8ed69bf0db8aa33c0e746482b7dc53d40b8a5331ca33b874639cdc7a787badd436bcd56e798af3",
+          "ct": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "tag": "ffffffff000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 223,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "ceb62cbb6fdf40d883c45cb4b0a82da13e4866c40629725ae6d371e4d8ad3a8f0cc553287840e73cc66c3066e115108b995d6f8990f1b8db1b0c1d14b5157441789895de7fe538acf5c6ceb56e54a73d",
+          "ct": "113caf3ebbe98a82548702641e4b4fbaffffffffffffffffffffffffffffffff3708d0f8f5cf1fea3d966ff22dac4cf1ffffffffffffffffffffffffffffffff3708d0f8f5cf1fea3d966ff22dac4cf1",
+          "tag": "e0f1d382b53c44a2e7228920468fc301",
+          "result": "valid"
+        },
+        {
+          "tcId": 224,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "66757c7a2bc935a528bca12f511c9de4edc981d8e14e366b2a473b6e64915977d6327c2f727007290405a06b3346a385f7a66391086c4befc6b8a2acf8a71cbfa26fbad975d5d8b937af5eb8bc0714331a16e6e08912f3bc9ca081f72056468a",
+          "ct": "b9ffffffffffffffffffffffffffffff2c7e18e31898bbce336bb57543c39c07edffffffffffffffffffffffffffffff9104f3e767620ccb224b4047b24d9701edffffffffffffffffffffffffffffff9104f3e767620ccb224b4047b24d9701",
+          "tag": "85d066d0fcfb58a260119f937ff6fcf0",
+          "result": "valid"
+        },
+        {
+          "tcId": 225,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "f1db96d6b3f84355fbbf2ddb9bd9dfd13e4866c40629725ae6d371e4d8ad3a8f522ec32558e6cbf8c2aff5f84497e6aa995d6f8990f1b8db1b0c1d14b5157441267305d35f431468f1050b2bcbd6511c",
+          "ct": "2e51155367ce890f2cfc730b353abdcaffffffffffffffffffffffffffffffff69e340f5d569332e3955aa6c882ebad0ffffffffffffffffffffffffffffffff69e340f5d569332e3955aa6c882ebad0",
+          "tag": "cb2bc99a81872febc3d8bf4d02fcc332",
+          "result": "valid"
+        },
+        {
+          "tcId": 226,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "94ecf8e2c78542c6d432bb62e5ca49c03e4866c40629725ae6d371e4d8ad3a8fa0733221388cbfa4cfeeba722e097bca995d6f8990f1b8db1b0c1d14b5157441d42ef4d73f296034fc4444a1a148cc7c",
+          "ct": "4b667b6713b3889c0371e5b24b292bdbffffffffffffffffffffffffffffffff9bbeb1f1b50347723414e5e6e2b027b0ffffffffffffffffffffffffffffffff9bbeb1f1b50347723414e5e6e2b027b0",
+          "tag": "b665beb24dd21a34a08ef67abe68c463",
+          "result": "valid"
+        },
+        {
+          "tcId": 227,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "20757c7a2bc935a528bca12f511c9de4912872920d5254968fc6c13fc3322ab71d9d6963d744039c9dd8f076ee9f54a240f27ac535c5bc6e82d14d0968cc8366",
+          "ct": "ffffffffffffffffffffffffffffffff509feba9f484d93396ea4f24e460efc72650eab35acbfb4a6622afe2222608d82650eab35acbfb4a6622afe2222608d8",
+          "tag": "e427fb2cdcadf4503623265e1232b761",
+          "result": "valid"
+        },
+        {
+          "tcId": 228,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "5a1ac415bf4a4cec651996d1d7e465e73e4866c40629725ae6d371e4d8ad3a8fc4b9103af8b8962cd168054f5b0c5e15995d6f8990f1b8db1b0c1d14b5157441b0e4d6ccff1d49bce2c2fb9cd44de9a3",
+          "ct": "859047906b7c86b6b25ac801790707fcffffffffffffffffffffffffffffffffff7493ea75376efa2a925adb97b5026fffffffffffffffffffffffffffffffffff7493ea75376efa2a925adb97b5026f",
+          "tag": "8cd9a8e2e567f1c558fa63d53642c5c5",
+          "result": "valid"
+        },
+        {
+          "tcId": 229,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "20757c7a2bc935a528bca12f511c9de46371f7678420063894f20774a6078b31b7baeeb66fb35662a6ecb6b90ca33b2bead5fd108d32e990b9e50bc68af0ecef",
+          "ct": "ffffffffffffffffffffffffffffffffa2c66e5c7df68b9d8dde896f81554e418c776d66e23caeb45d16e92dc01a67518c776d66e23caeb45d16e92dc01a6751",
+          "tag": "675b66d9da27123221c1e0b74d70c0a6",
+          "result": "valid"
+        },
+        {
+          "tcId": 230,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "083d49c720dbf27a7d0d5c9db81f076e3e4866c40629725ae6d371e4d8ad3a8ff5a5282072a1fb55cc12865835d204d9995d6f8990f1b8db1b0c1d14b515744181f8eed6750424c5ffb8788bba93b36f",
+          "ct": "d7b7ca42f4ed3820aa4e024d16fc6575ffffffffffffffffffffffffffffffffce68abf0ff2e038337e8d9ccf96b58a3ffffffffffffffffffffffffffffffffce68abf0ff2e038337e8d9ccf96b58a3",
+          "tag": "0f0d148fe4e10ea743981e2f7280ce0a",
+          "result": "valid"
+        },
+        {
+          "tcId": 231,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "13757c7a2bc935a528bca12f511c9de4de3546118ca2e1ac763ceb954a5c0d71c4327c2f727007290405a06b3346a385c53f3112b832422c696ed23b9e214331b06fbad975d5d8b937af5eb8bc071433288fb463394cfa7f3376f16046d01904",
+          "ct": "ccffffffffffffffffffffffffffffff1f82df2a75746c096f10658e6d0ec801ffffffffffffffffffffffffffffffffa39da164d73c05088d9d30d0d4cbc88fffffffffffffffffffffffffffffffffa39da164d73c05088d9d30d0d4cbc88f",
+          "tag": "90e049a04573a6ae5d55692c13a6c366",
+          "result": "valid"
+        },
+        {
+          "tcId": 232,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "2b757c7a2bc935a528bca12f511c9de469b6fa7209e85746e562d244ada24671e2327c2f727007290405a06b3346a38573b5fb693469c30ed6c27f5cbad51abc966fbad975d5d8b937af5eb8bc0714339e057e18b5177b5d8cda5c0762244089",
+          "ct": "f4ffffffffffffffffffffffffffffffa8016349f03edae3fc4e5c5f8af08301d9ffffffffffffffffffffffffffffff15176b1f5b67842a32319db7f03f9102d9ffffffffffffffffffffffffffffff15176b1f5b67842a32319db7f03f9102",
+          "tag": "fe3ac27946d51ed8b27b49d7be1a24f0",
+          "result": "valid"
+        },
+        {
+          "tcId": 233,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "20757c7a2bc935a528bca12f511c9de4d31fb639f3b874a66837b63ff839f21fc795addcfd3be3cdbba9c876d1880c059afabe7a1fba5c3fa4a0750957dbdbc1",
+          "ct": "ffffffffffffffffffffffffffffffff12a82f020a6ef903711b3824df6b376ffc582e0c70b41b1b405397e21d31507ffc582e0c70b41b1b405397e21d31507f",
+          "tag": "afed73d8da9d8739f4f015ae7df44aac",
+          "result": "valid"
+        },
+        {
+          "tcId": 234,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "9813086d54536cdc5ac8eed1daf12db83e4866c40629725ae6d371e4d8ad3a8fcd7add4701bf0337bc0f0d1feb47eab1995d6f8990f1b8db1b0c1d14b5157441b9271bb1061adca78fa5f3cc64065d07",
+          "ct": "47998be88065a6868d8bb00174124fa3fffffffffffffffffffffffffffffffff6b75e978c30fbe147f5528b27feb6cbfffffffffffffffffffffffffffffffff6b75e978c30fbe147f5528b27feb6cb",
+          "tag": "579f218ee45784ae16c85325a2045910",
+          "result": "valid"
+        },
+        {
+          "tcId": 235,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "20757c7a2bc935a528bca12f511c9de4bb3bbcee6fc481508650324725dcbba258f0a70f70d7d6da8b4e448f8ceacb98059fb4a9925669289447f9f00ab91c5c",
+          "ct": "ffffffffffffffffffffffffffffffff7a8c25d596120cf59f7cbc5c028e7ed2633d24dffd582e0c70b41b1b405397e2633d24dffd582e0c70b41b1b405397e2",
+          "tag": "eb9cebd74f006042c4e200b0b01542a3",
+          "result": "valid"
+        },
+        {
+          "tcId": 236,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "20757c7a2bc935a528bca12f511c9de411911908ba49c1890b2b808abb7a692f821afded256a969518c432db16549815df75ee4bc7eb296707cd8fa490074fd1",
+          "ct": "ffffffffffffffffffffffffffffffffd0268033439f4c2c12070e919c28ac5fb9d77e3da8e56e43e33e6d4fdaedc46fb9d77e3da8e56e43e33e6d4fdaedc46f",
+          "tag": "d2251ee57e2fb53f4d2861c8ac82c2a6",
+          "result": "valid"
+        },
+        {
+          "tcId": 237,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "20757c7a2bc935a528bca12f511c9de432fd5bdccf30a19b33e05c1623536ca3e736432111a3af8301f96d58ce7f9d99ba595087f32210711ef0d027482c4a5d",
+          "ct": "fffffffffffffffffffffffffffffffff34ac2e736e62c3e2accd20d0401a9d3dcfbc0f19c2c5755fa0332cc02c6c1e3dcfbc0f19c2c5755fa0332cc02c6c1e3",
+          "tag": "b9372d87cbf3cfe55ee27c17c538cb50",
+          "result": "valid"
+        },
+        {
+          "tcId": 238,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "60757c7a2bc935a528bca12f511c9de4d99f90973fd28582e4d1f031ecd46071fd327c2f727007290405a06b3346a385a0fcfb73e13c30e391a2445ae46a07b8896fbad975d5d8b937af5eb8bc0714334d4c7e02604288b0cbba67013c9b5d8d",
+          "ct": "bfffffffffffffffffffffffffffffff182809acc6040827fdfd7e2acb86a501c6ffffffffffffffffffffffffffffffc65e6b058e3277c77551a6b1ae808c06c6ffffffffffffffffffffffffffffffc65e6b058e3277c77551a6b1ae808c06",
+          "tag": "7f297e53b139808e9502ef74a859149f",
+          "result": "valid"
+        },
+        {
+          "tcId": 239,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "cdb62cbb6fdf40d883c45cb4b0a82da1764866c40629725ae6d371e4d8ad3a8f39bddd583541f044a0c50403d97cd173d15d6f8990f1b8db1b0c1d14b51574414de01bae32e42fd4936ffad0563d66c5",
+          "ct": "123caf3ebbe98a82548702641e4b4fbab7ffffffffffffffffffffffffffffff02705e88b8ce08925b3f5b9715c58d09b7ffffffffffffffffffffffffffffff02705e88b8ce08925b3f5b9715c58d09",
+          "tag": "53ff434cd43f64142e4eb106c12d22ab",
+          "result": "valid"
+        },
+        {
+          "tcId": 240,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "cfb62cbb6fdf40d883c45cb4b0a82da13e4866c40629725ae6d371e4d8ad3a8f92d8c312995cc78a7f3bc84c64f3f7e0995d6f8990f1b8db1b0c1d14b5157441e68505e49ef9181a4c91369febb24056",
+          "ct": "103caf3ebbe98a82548702641e4b4fbaffffffffffffffffffffffffffffffffa91540c214d33f5c84c197d8a84aab9affffffffffffffffffffffffffffffffa91540c214d33f5c84c197d8a84aab9a",
+          "tag": "6de463b996392430a1f7603acbf06458",
+          "result": "valid"
+        },
+        {
+          "tcId": 241,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "20757c7a2bc935a528bca12f511c9de4e6c0a76a06208c6d350d415616bdc77bdd327c2f727007290405a06b3346a385b812b7a7bcc5a60ba487ce313d3034bda96fbad975d5d8b937af5eb8bc07143355a232d63dbb1e58fe9fed6ae5c16e88",
+          "ct": "ffffffffffffffffffffffffffffffff27773e51fff601c82c21cf4d31ef020be6ffffffffffffffffffffffffffffffdeb027d1d3cbe12f40742cda77dabf03e6ffffffffffffffffffffffffffffffdeb027d1d3cbe12f40742cda77dabf03",
+          "tag": "56cc4bc6243ebe997c281791c6b9dae4",
+          "result": "valid"
+        },
+        {
+          "tcId": 242,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "4163ca83e98b91787fe62f6ea63ac7557d4866c40629725ae6d371e4d8ad3a8f3e2e20dedc30539a05ea262142331e73da5d6f8990f1b8db1b0c1d14b51574414a73e628db958c0a3640d8f2cd72a9c5",
+          "ct": "9ee949063dbd5b22a8a571be08d9a54ebcffffffffffffffffffffffffffffff05e3a30e51bfab4cfe1079b58e8a4209bcffffffffffffffffffffffffffffff05e3a30e51bfab4cfe1079b58e8a4209",
+          "tag": "f1ffa375f1d7a6b002e5cb157689c30e",
+          "result": "valid"
+        },
+        {
+          "tcId": 243,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "61757c7a2bc935a528bca12f511c9de4d77679af35a19d32849ca367faf79d77374ce8b7587ec72cc6569a7a415c37e06a23fb11baff78ded95f2705c70fe024",
+          "ct": "beffffffffffffffffffffffffffffff16c1e094cc7710979db02d7cdda558070c816b67d5f13ffa3dacc5ee8de56b9a0c816b67d5f13ffa3dacc5ee8de56b9a",
+          "tag": "b48e23d35e55823f3cf998b4509af5a9",
+          "result": "valid"
+        },
+        {
+          "tcId": 244,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "22757c7a2bc935a528bca12f511c9de47aa9293f848bc54ca42b1de6b9295977d9327c2f727007290405a06b3346a3853f5770f4b50f54461e64d97ceb5cd6bbad6fbad975d5d8b937af5eb8bc071433d2e7f5853471ec15447cfa2733ad8c8e",
+          "ct": "fdffffffffffffffffffffffffffffffbb1eb0047d5d48e9bd0793fd9e7b9c07e2ffffffffffffffffffffffffffffff59f5e082da011362fa973b97a1b65d05e2ffffffffffffffffffffffffffffff59f5e082da011362fa973b97a1b65d05",
+          "tag": "cd7999d15359fea5abcde195222f70f3",
+          "result": "valid"
+        },
+        {
+          "tcId": 245,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "4d4ff564ef5c001455d6ab18b5be7833794866c40629725ae6d371e4d8ad3a8f20a38035611bfa77fb134d518a2c817ade5d6f8990f1b8db1b0c1d14b515744154fe46c366be25e7c8b9b382056d36cc",
+          "ct": "92c576e13b6aca4e8295f5c81b5d1a28b8ffffffffffffffffffffffffffffff1b6e03e5ec9402a100e912c54695dd00b8ffffffffffffffffffffffffffffff1b6e03e5ec9402a100e912c54695dd00",
+          "tag": "8be59b8dc48414c38ac1e134018dd017",
+          "result": "valid"
+        },
+        {
+          "tcId": 246,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "2baccaafdb3346afab51cf6ca9bf83b2734866c40629725ae6d371e4d8ad3a8f1611d1bd4e0df8df789b20a43ef4237ed45d6f8990f1b8db1b0c1d14b5157441624c174b49a8274f4b31de77b1b594c8",
+          "ct": "f426492a0f058cf57c1291bc075ce1a9b2ffffffffffffffffffffffffffffff2ddc526dc382000983617f30f24d7f04b2ffffffffffffffffffffffffffffff2ddc526dc382000983617f30f24d7f04",
+          "tag": "f5b7de6ae9f158590b6d52f38922c3d0",
+          "result": "valid"
+        },
+        {
+          "tcId": 247,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "20757c7a2bc935a528bca12f511c9de41dfdca63bd24505a2e3b049daef6f2f6fd36d2b227b7f8c1f3b5b6d004d00ceca059c114c5364733ecbc0baf8283db28",
+          "ct": "ffffffffffffffffffffffffffffffffdc4a535844f2ddff37178a8689a43786c6fb5162aa380017084fe944c8695096c6fb5162aa380017084fe944c8695096",
+          "tag": "384026cdab82472dc54b4ba9217fb59d",
+          "result": "valid"
+        },
+        {
+          "tcId": 248,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "6589beb1a8139fc7569e5c863cff95d63e4866c40629725ae6d371e4d8ad3a8fc7f11e2eda7e7b6ae3a71f559261ad12995d6f8990f1b8db1b0c1d14b5157441b3acd8d8dddba4fad00de1861d201aa4",
+          "ct": "ba033d347c25559d81dd0256921cf7cdfffffffffffffffffffffffffffffffffc3c9dfe57f183bc185d40c15ed8f168fffffffffffffffffffffffffffffffffc3c9dfe57f183bc185d40c15ed8f168",
+          "tag": "c48494721457aaea39b2b8438934c69d",
+          "result": "valid"
+        },
+        {
+          "tcId": 249,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "64757c7a2bc935a528bca12f511c9de4b64c89f4d83fd76911f3114eb89d6f77e4327c2f727007290405a06b3346a3858ee34546bde0db4d82b1487fc137fbbc906fbad975d5d8b937af5eb8bc0714336353c0373c9e631ed8a96b2419c6a189",
+          "ct": "bbffffffffffffffffffffffffffffff77fb10cf21e95acc08df9f559fcfaa07dfffffffffffffffffffffffffffffffe841d530d2ee9c696642aa948bdd7002dfffffffffffffffffffffffffffffffe841d530d2ee9c696642aa948bdd7002",
+          "tag": "696327c05b16bfeab2a0ceb6c29bff8c",
+          "result": "valid"
+        },
+        {
+          "tcId": 250,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130bc672c3",
+          "aad": "ffffffff",
+          "msg": "17757c7a2bc935a528bca12f511c9de42bf1e8c3cae137826817909236391576df327c2f727007290405a06b3346a385049f830d5d449986c0a5eaa316da86bcab6fbad975d5d8b937af5eb8bc071433e92f067cdc3a21d59abdc9f8ce2bdc89",
+          "ct": "c8ffffffffffffffffffffffffffffffea4671f83337ba27713b1e89116bd006e4ffffffffffffffffffffffffffffff623d137b324adea2245608485c300d02e4ffffffffffffffffffffffffffffff623d137b324adea2245608485c300d02",
+          "tag": "dadc9ec5edb38881bd72467fc4f8efda",
+          "result": "valid"
+        },
+        {
+          "tcId": 251,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "62f65842de9b27c2bdd1e3fc9335ebf704426812cbdeb02b7f0f31f7ae2eec0c393a74b64ceffd62400652c2b587fcbb9c539dcf217cb7ce368a316725553be4d4089139785582165dff825fac20d39f",
+          "ct": "7bdd3a06567777057b3e01465a29658bffffffffffffffffffffffffffffffffd34e50ea3b5826f1670d8ff207c1ece9ffffffffffffffffffffffffffffffffd34e50ea3b5826f1670d8ff207c1ece9",
+          "tag": "fcd6af3bd5299ca9be309df2fb8249c3",
+          "result": "valid"
+        },
+        {
+          "tcId": 252,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "e6d49dbb7713af3839101d4536e37183ea6230c3b307688df8c2214fb6a2d48d048bcc630d7faf432b2d5ac5d89a4c8e8d538a0fa44b3ce1c553496db07698c7",
+          "ct": "ffffffffffffffffffffffffffffffff11dfa72e872627597832ef47e773c77eeeffe83f7ac874d00c2687f56adc5cdceeffe83f7ac874d00c2687f56adc5cdc",
+          "tag": "dbe0d67149e837f4215e57b5a91ed53c",
+          "result": "valid"
+        },
+        {
+          "tcId": 253,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "e4d49dbb7713af3839101d4536e371839e9da1a61409887a4b4839276235bafe5a8ba863145d9c8167b57efba408c01fd353ee0fbd690f2389cb6d53cce41456",
+          "ct": "fdffffffffffffffffffffffffffffff6520364b2028c7aecbb8f72f33e4a90db0ff8c3f63ea471240bea3cb164ed04db0ff8c3f63ea471240bea3cb164ed04d",
+          "tag": "f763ababa9a7d11b623a2fd9e91bb377",
+          "result": "valid"
+        },
+        {
+          "tcId": 254,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "d6d49dbb7713af3839101d4536e371831abe58ce620a385c6d2b039ffac360f3068bdba38848246cd8f422cf4db9efad22d9eadb4498985fb14cb242df7dc411ebb93e2cbcf25b18c50df252541ec08915cd51f82dd4846038eae2e06a91a9a7",
+          "ct": "cfffffffffffffffffffffffffffffffe103cf23562b7788eddbcd97ab127300ecffffffffffffffffffffffffffffff417588eb9a1bd06e78397cda05d7000aecffffffffffffffffffffffffffffff417588eb9a1bd06e78397cda05d7000a",
+          "tag": "da8f4144be3e02eb0c61a6728d199fbf",
+          "result": "valid"
+        },
+        {
+          "tcId": 255,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "c5d49dbb7713af3839101d4536e37183bae49a4a9da8918f1056decd0c8a76f31a8bdba38848246cd8f422cf4db9efadc266a45e30fa7f73d271719f62b53712f7b93e2cbcf25b18c50df252541ec089f5721f7d59b6634c5bd7213dd7595aa4",
+          "ct": "dcffffffffffffffffffffffffffffff41590da7a989de5b90a610c55d5b6500f0ffffffffffffffffffffffffffffffa1cac66eee7937421b04bf07b81ff309f0ffffffffffffffffffffffffffffffa1cac66eee7937421b04bf07b81ff309",
+          "tag": "d9b65fc6562d1c449d104cc35d931244",
+          "result": "valid"
+        },
+        {
+          "tcId": 256,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "e5d49dbb7713af3839101d4536e37183abfdc5f51676ca3b1b1a1693969cc1f62f8a17a2fb1ec4da27f2531ee97e5165a65251ce522a5778c98c40b68192852c",
+          "ct": "fcffffffffffffffffffffffffffffff50405218225785ef9bead89bc74dd205c5fe33fe8ca91f4900f98e2e5b384137c5fe33fe8ca91f4900f98e2e5b384137",
+          "tag": "a04f8884523552b052b4985f9a917354",
+          "result": "valid"
+        },
+        {
+          "tcId": 257,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "e3d49dbb7713af3839101d4536e37183632b04a788e5e9fda972ed52ff8c39f67e67af4f0180affc4aa930ea130f3a4bf7bfe923a8b43c5ea4d723427be3ee02",
+          "ct": "faffffffffffffffffffffffffffffff9896934abcc4a6292982235aae5d2a0594138b137637746f6da2eddaa1492a1994138b137637746f6da2eddaa1492a19",
+          "tag": "71fe51676029e0eed9df51ad19175c28",
+          "result": "valid"
+        },
+        {
+          "tcId": 258,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "ccd49dbb7713af3839101d4536e37183b4eefd4c449626bc07adf993fb711ff1168bdba38848246cd8f422cf4db9efade8c9dc6630050571f33e314b2ec76019fbb93e2cbcf25b18c50df252541ec089dfdd67455949194e7a9861e99b2b0daf",
+          "ct": "d5ffffffffffffffffffffffffffffff4f536aa170b76968875d379baaa00c02fcffffffffffffffffffffffffffffff8b65be56ee864d403a4bffd3f46da402fcffffffffffffffffffffffffffffff8b65be56ee864d403a4bffd3f46da402",
+          "tag": "38a713c614017796442af1227d176a35",
+          "result": "valid"
+        },
+        {
+          "tcId": 259,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "c2d49dbb7713af3839101d4536e371838eafebbea1ca60c8685387eba9f451fb158bdba38848246cd8f422cf4db9efad36018b6bd18ba212c31fc1538532e98ff8b93e2cbcf25b18c50df252541ec08901153048b8c7be2d4ab991f130de8439",
+          "ct": "dbffffffffffffffffffffffffffffff75127c5395eb2f1ce8a349e3f8254208ffffffffffffffffffffffffffffffff55ade95b0f08ea230a6a0fcb5f982d94ffffffffffffffffffffffffffffffff55ade95b0f08ea230a6a0fcb5f982d94",
+          "tag": "e980599ea00354840537d58e50f03cd6",
+          "result": "valid"
+        },
+        {
+          "tcId": 260,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "e9d49dbb7713af3839101d4536e3718393449a2d487b9c9f5fae20625fe988f0378bdba38848246cd8f422cf4db9efad11e9e7dae8689e5c03b00558a91fb61bdab93e2cbcf25b18c50df252541ec08926fd5cf9812482638a1655fa1cf3dbad",
+          "ct": "f0ffffffffffffffffffffffffffffff68f90dc07c5ad34bdf5eee6a0e389b03ddffffffffffffffffffffffffffffff724585ea36ebd66dcac5cbc073b57200ddffffffffffffffffffffffffffffff724585ea36ebd66dcac5cbc073b57200",
+          "tag": "85da7997cb968c8aaeaa950d843fbd8e",
+          "result": "valid"
+        },
+        {
+          "tcId": 261,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "ccd49dbb7713af3839101d4536e371839392612dbe23cf7f719eea1dfcb78ef3178bdba38848246cd8f422cf4db9efad97871e4d75103b4e7cde93d1f511801bfab93e2cbcf25b18c50df252541ec089a093a56e1c5c2771f578c37340fdedad",
+          "ct": "d5ffffffffffffffffffffffffffffff682ff6c08a0280abf16e2415ad669d00fdfffffffffffffffffffffffffffffff42b7c7dab93737fb5ab5d492fbb4400fdfffffffffffffffffffffffffffffff42b7c7dab93737fb5ab5d492fbb4400",
+          "tag": "219c6cb099cf809023e4891ef510a327",
+          "result": "valid"
+        },
+        {
+          "tcId": 262,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "ecd49dbb7713af3839101d4536e371838cabacdf37f169eb7d4222e3478819f53c8bdba38848246cd8f422cf4db9efad11a5aad2e97554f9ea0ba90ba1d71a10d1b93e2cbcf25b18c50df252541ec08926b111f1803948c663adf9a9143b77a6",
+          "ct": "f5ffffffffffffffffffffffffffffff77163b3203d0263ffdb2eceb16590a06d6ffffffffffffffffffffffffffffff7209c8e237f61cc8237e67937b7dde0bd6ffffffffffffffffffffffffffffff7209c8e237f61cc8237e67937b7dde0b",
+          "tag": "e8bce1be713f679a33db7f2745905a36",
+          "result": "valid"
+        },
+        {
+          "tcId": 263,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "c3d49dbb7713af3839101d4536e37183023f5d5bd1564fbe48fc3a28a30642fe158bdba38848246cd8f422cf4db9efad5e25119113702f56ee1cc1f5efdb0b35f8b93e2cbcf25b18c50df252541ec0896931aab27a3c336967ba91575a376683",
+          "ct": "dafffffffffffffffffffffffffffffff982cab6e577006ac80cf420f2d7510dffffffffffffffffffffffffffffffff3d8973a1cdf3676727690f6d3571cf2effffffffffffffffffffffffffffffff3d8973a1cdf3676727690f6d3571cf2e",
+          "tag": "bef4a8ad5a34c084b8a98921244af331",
+          "result": "valid"
+        },
+        {
+          "tcId": 264,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "10d735efd9bf85634ff5e390179aee8c34426812cbdeb02b7f0f31f7ae2eec0c72e8f56d3441aef764850b463c13db51ac539dcf217cb7ce368a316725553be49fda10e200fbd183797cdbdb25b4f475",
+          "ct": "09fc57ab5153d5a4891a012ade8660f0cfffffffffffffffffffffffffffffff989cd13143f67564438ed6768e55cb03cfffffffffffffffffffffffffffffff989cd13143f67564438ed6768e55cb03",
+          "tag": "1acd414f4c60dfb0f3de7300fb2aced0",
+          "result": "valid"
+        },
+        {
+          "tcId": 265,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "cbd49dbb7713af3839101d4536e37183f00c31ec5c6eaad4e2ac19766da096f1118bdba38848246cd8f422cf4db9efad97eaf1bdfa3d843dba03cc0dbffe1812fcb93e2cbcf25b18c50df252541ec089a0fe4a9e9371980233a59caf0a1275a4",
+          "ct": "d2ffffffffffffffffffffffffffffff0bb1a601684fe500625cd77e3c718502fbfffffffffffffffffffffffffffffff446938d24becc0c737602956554dc09fbfffffffffffffffffffffffffffffff446938d24becc0c737602956554dc09",
+          "tag": "fde190d22582a64ec60fa233fe023c11",
+          "result": "valid"
+        },
+        {
+          "tcId": 266,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "e6d49dbb7713af3839101d4536e371839af4c9a5e497c3a60e631936d2508ed9d51ebb05b4ef317a058cb2dcb4af22da5cc6fd691ddba2d8ebf2a174dc43f693",
+          "ct": "ffffffffffffffffffffffffffffffff61495e48d0b68c728e93d73e83819d2a3f6a9f59c358eae922876fec06e932883f6a9f59c358eae922876fec06e93288",
+          "tag": "f0da2cd127265511cba33f1405c83d32",
+          "result": "valid"
+        },
+        {
+          "tcId": 267,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "65f65842de9b27c2bdd1e3fc9335ebf72f426812cbdeb02b7f0f31f7ae2eec0cbd57f9021df7bde4f1eace236bd7ee51b7539dcf217cb7ce368a316725553be450651c8d294dc290ec131ebe7270c175",
+          "ct": "7cdd3a06567777057b3e01465a29658bd4ffffffffffffffffffffffffffffff5723dd5e6a406677d6e11313d991fe03d4ffffffffffffffffffffffffffffff5723dd5e6a406677d6e11313d991fe03",
+          "tag": "e683cf34f10a11cd01dc68539c140a22",
+          "result": "valid"
+        },
+        {
+          "tcId": 268,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "63f65842de9b27c2bdd1e3fc9335ebf704426812cbdeb02b7f0f31f7ae2eec0c2b8f4bbf208e40878cb387631a14bd1a9c539dcf217cb7ce368a316725553be4c6bdae3014343ff3914a57fe03b3923e",
+          "ct": "7add3a06567777057b3e01465a29658bffffffffffffffffffffffffffffffffc1fb6fe357399b14abb85a53a852ad48ffffffffffffffffffffffffffffffffc1fb6fe357399b14abb85a53a852ad48",
+          "tag": "0d2a9042b94827867b85d1915bf18864",
+          "result": "valid"
+        },
+        {
+          "tcId": 269,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "e9d49dbb7713af3839101d4536e37183d3a60109fcf31f1a7a851f43698939f1098bdba38848246cd8f422cf4db9efadb0ec59a5984d358c73db79fb52a3bb1be4b93e2cbcf25b18c50df252541ec08987f8e286f10129b3fa7d2959e74fd6ad",
+          "ct": "f0ffffffffffffffffffffffffffffff281b96e4c8d250cefa75d14b38582a02e3ffffffffffffffffffffffffffffffd3403b9546ce7dbdbaaeb76388097f00e3ffffffffffffffffffffffffffffffd3403b9546ce7dbdbaaeb76388097f00",
+          "tag": "3a3c8dbaf78cfc81790ec915b90ff334",
+          "result": "valid"
+        },
+        {
+          "tcId": 270,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "eed49dbb7713af3839101d4536e3718343bbb9605eda56e9ed28ce61af968cf5008bdba38848246cd8f422cf4db9efadce015376e54d6c1052eb8618af9b5613edb93e2cbcf25b18c50df252541ec089f915e8558c01702fdb4dd6ba1a773ba5",
+          "ct": "f7ffffffffffffffffffffffffffffffb8062e8d6afb193d6dd80069fe479f06eaffffffffffffffffffffffffffffffadad31463bce24219b9e488075319208eaffffffffffffffffffffffffffffffadad31463bce24219b9e488075319208",
+          "tag": "f0ba2eb2a4b51e8d0b81671692d75431",
+          "result": "valid"
+        },
+        {
+          "tcId": 271,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "613657d2fc45c4fe38e881b9bc7cf27e2a426812cbdeb02b7f0f31f7ae2eec0c8e5e9d5340b0e9792fb5387902be5e50b2539dcf217cb7ce368a316725553be4636c78dc740a960d324ce8e41b197174",
+          "ct": "781d359674a99439fe07630375607c02d1ffffffffffffffffffffffffffffff642ab90f370732ea08bee549b0f84e02d1ffffffffffffffffffffffffffffff642ab90f370732ea08bee549b0f84e02",
+          "tag": "2a1f4d3fcbc515ac82aedaf4cf62f7c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 272,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "e7d49dbb7713af3839101d4536e371832e82802049e965438b03880603fb85f71a8bdba38848246cd8f422cf4db9efad10bd9cb07157904cdd7760b8c0417f1cf7b93e2cbcf25b18c50df252541ec08927a92793181b8c7354d1301a75ad12aa",
+          "ct": "feffffffffffffffffffffffffffffffd53f17cd7dc82a970bf3460e522a9604f0ffffffffffffffffffffffffffffff7311fe80afd4d87d1402ae201aebbb07f0ffffffffffffffffffffffffffffff7311fe80afd4d87d1402ae201aebbb07",
+          "tag": "0eb1c0c51bec6194402f3e24917fd93e",
+          "result": "valid"
+        },
+        {
+          "tcId": 273,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "c0d49dbb7713af3839101d4536e3718377417ace069aa201e93e94471fbc6bf2158bdba38848246cd8f422cf4db9efad91a8f7e9761cae9ee9c21b1e5e7864e3f8b93e2cbcf25b18c50df252541ec089a6bc4cca1f50b2a160644bbceb940955",
+          "ct": "d9ffffffffffffffffffffffffffffff8cfced2332bbedd569ce5a4f4e6d7801fffffffffffffffffffffffffffffffff20495d9a89fe6af20b7d58684d2a0f8fffffffffffffffffffffffffffffffff20495d9a89fe6af20b7d58684d2a0f8",
+          "tag": "d5d135d4f35b489e5026342de1fe904d",
+          "result": "valid"
+        },
+        {
+          "tcId": 274,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "c9d49dbb7713af3839101d4536e371830d5e25bb60ddf7939d5a2223467859fb178bdba38848246cd8f422cf4db9efadec98953f1fff631551656bfdfb44e418fab93e2cbcf25b18c50df252541ec089db8c2e1c76b37f2ad8c33b5f4ea889ae",
+          "ct": "d0fffffffffffffffffffffffffffffff6e3b25654fcb8471daaec2b17a94a08fdffffffffffffffffffffffffffffff8f34f70fc17c2b249810a56521ee2003fdffffffffffffffffffffffffffffff8f34f70fc17c2b249810a56521ee2003",
+          "tag": "31a4646b15b181561ce73cecdca3dee2",
+          "result": "valid"
+        },
+        {
+          "tcId": 275,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "e6d49dbb7713af3839101d4536e37183d5624243a6b4726cde162e54406a1e35058bdba38848246cd8f422cf4db9efad78d04c90c47eb6f9a23a930d37f27b1ce8b93e2cbcf25b18c50df252541ec0894fc4f7b3ad32aac62b9cc3af821e16aa",
+          "ct": "ffffffffffffffffffffffffffffffff2edfd5ae92953db85ee6e05c11bb0dc6efffffffffffffffffffffffffffffff1b7c2ea01afdfec86b4f5d95ed58bf07efffffffffffffffffffffffffffffff1b7c2ea01afdfec86b4f5d95ed58bf07",
+          "tag": "4d2739a575701b7e5cc314101da1bc1d",
+          "result": "valid"
+        },
+        {
+          "tcId": 276,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "88e97d53e8211eb86f53db41116f9af91d426812cbdeb02b7f0f31f7ae2eec0cee683b6b14e3b9847ee1761e5652255985539dcf217cb7ce368a316725553be4035adee42059c6f06318a6834ff50a7d",
+          "ct": "91c21f1760cd4e7fa9bc39fbd8731485e6ffffffffffffffffffffffffffffff041c1f376354621759eaab2ee414350be6ffffffffffffffffffffffffffffff041c1f376354621759eaab2ee414350b",
+          "tag": "50223669d16fb8f48cf2bd4b6fe89b0b",
+          "result": "valid"
+        },
+        {
+          "tcId": 277,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "e6d49dbb7713af3839101d4536e37183dc791bd2a55db1062640e9f5346f658b5ef2ae8b018ecd254458bc57c25f37f2d72ae8e7a8ba5e87aa26afffaab3e3bb",
+          "ct": "ffffffffffffffffffffffffffffffff27c48c3f917cfed2a6b027fd65be7678b4868ad7763916b663536167701927a0b4868ad7763916b663536167701927a0",
+          "tag": "342c5d9f452e543ff01f780e1d842785",
+          "result": "valid"
+        },
+        {
+          "tcId": 278,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112130552a411",
+          "aad": "ffffffff",
+          "msg": "c9d49dbb7713af3839101d4536e37183441ecb2b2acd21814d88694cf932b5f10d8bdba38848246cd8f422cf4db9efadea2618b76c66c6d7e5c926b9fd56d511e0b93e2cbcf25b18c50df252541ec089dd32a394052adae86c6f761b48bab8a7",
+          "ct": "d0ffffffffffffffffffffffffffffffbfa35cc61eec6e55cd78a744a8e3a602e7ffffffffffffffffffffffffffffff898a7a87b2e58ee62cbce82127fc110ae7ffffffffffffffffffffffffffffff898a7a87b2e58ee62cbce82127fc110a",
+          "tag": "1adf9ba17fd4a17b9845d70d49c10e1a",
+          "result": "valid"
+        },
+        {
+          "tcId": 279,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "46e1c47ac0fd4564f8644238fdea86fcc7ee7caaca844d5b031262aeb26fe0b72cd554203c21345c59229130a2541fa434cec27aac6e7a9dba6594941a231041093b09a65907b31abc750781c0b48ef99d9626abf381de85a1f32da926e88827",
+          "ct": "ffffffffffffffffffffffffffffffff690445956e674d191acbb7408a1cb9bdffffffffffffffffffffffffffffffff86e27cfb95bf55f4730e82f529f7def3ffffffffffffffffffffffffffffffff86e27cfb95bf55f4730e82f529f7def3",
+          "tag": "83e97752d064b61cdf5ebf49f992bd45",
+          "result": "valid"
+        },
+        {
+          "tcId": 280,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "54e1c47ac0fd4564f8644238fdea86fc1d101f6db25d60e613bff6e64f5de80c20d554203c21345c59229130a2541fa4ff63ee22c0efd621e529e1eae90bf2b6053b09a65907b31abc750781c0b48ef9563b0af39f007239febf58d7d5c06ad0",
+          "ct": "edffffffffffffffffffffffffffffffb3fa265216be60a40a662308772eb106f3ffffffffffffffffffffffffffffff4d4f50a3f93ef9482c42f78bdadf3c04f3ffffffffffffffffffffffffffffff4d4f50a3f93ef9482c42f78bdadf3c04",
+          "tag": "28fd79556c3a7d24e7ffbd50dd98d34d",
+          "result": "valid"
+        },
+        {
+          "tcId": 281,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "86b8fe53835f40ba8213ee0678482ee7cf0d979ec97b79b9c6b040814d34439fb2cd057eae46b25879b4fba028ecface",
+          "ct": "3fa6c5d6bc5dfa21858853c17a5d57e461e7aea16d9879fbdf69956f75471a9561e7aea16d9879fbdf69956f75471a95",
+          "tag": "98709e9422f937316819e76c0375e5b2",
+          "result": "valid"
+        },
+        {
+          "tcId": 282,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "45e1c47ac0fd4564f8644238fdea86fc87e490deb9fa9565eb580bda19ce760a2bd554203c21345c59229130a2541fa4da5a6ab4a4bedbbad294a6de5ba01fb70e3b09a65907b31abc750781c0b48ef973028e65fb517fa2c9021fe3676b87d1",
+          "ct": "fcffffffffffffffffffffffffffffff290ea9e11d199527f281de3421bd2f00f8ffffffffffffffffffffffffffffff6876d4359d6ff4d31bffb0bf6874d105f8ffffffffffffffffffffffffffffff6876d4359d6ff4d31bffb0bf6874d105",
+          "tag": "f5ad8c70e8bc7a6a2fa9b18fe1cd9996",
+          "result": "valid"
+        },
+        {
+          "tcId": 283,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "46e1c47ac0fd4564f8644238fdea86fcf5e77daad1941b4a23f35c5b43e1ef502ed554203c21345c59229130a2541fa431b1e6497971c037c2d77c92c5dca8b50b3b09a65907b31abc750781c0b48ef998e90298269e642fd941c5aff91730d3",
+          "ct": "ffffffffffffffffffffffffffffffff5b0d449575771b083a2a89b57b92b65afdffffffffffffffffffffffffffffff839d58c840a0ef5e0bbc6af3f6086607fdffffffffffffffffffffffffffffff839d58c840a0ef5e0bbc6af3f6086607",
+          "tag": "c25e9f8b643f78b07752a5cee50260df",
+          "result": "valid"
+        },
+        {
+          "tcId": 284,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "58e1c47ac0fd4564f8644238fdea86fccf050749c93280b29388313e2098ef0e07d554203c21345c59229130a2541fa4496fd646698336fc6546ae354f488cb0223b09a65907b31abc750781c0b48ef9e0373297366c92e47ed01708738314d6",
+          "ct": "e1ffffffffffffffffffffffffffffff61ef3e766dd180f08a51e4d018ebb604d4fffffffffffffffffffffffffffffffb4368c750521995ac2db8547c9c4202d4fffffffffffffffffffffffffffffffb4368c750521995ac2db8547c9c4202",
+          "tag": "6772a18e00153fb87ff3a3d5c90876e7",
+          "result": "valid"
+        },
+        {
+          "tcId": 285,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "bfa29b96710a9f35f3bcefc083a32ce28017b0e159a1a4c556d0415b43d34198fdd722013e9c6f24e9d4fa7a260bf8c9",
+          "ct": "06bca0134e0825aef427520781b655e12efd89defd42a4874f0994b57ba018922efd89defd42a4874f0994b57ba01892",
+          "tag": "1782ad8c1f0b9105d428b64ab3f25f89",
+          "result": "valid"
+        },
+        {
+          "tcId": 286,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "19e1c47ac0fd4564f8644238fdea86fc280a6927a6a2d3c0dd079836b0e7300d75d554203c21345c59229130a2541fa4daeddee3e5521f459bed4f3afb7ec2b4503b09a65907b31abc750781c0b48ef973b53a32babdbb5d807bf607c7b55ad2",
+          "ct": "a0ffffffffffffffffffffffffffffff86e050180241d382c4de4dd888946907a6ffffffffffffffffffffffffffffff68c16062dc83302c5286595bc8aa0c06a6ffffffffffffffffffffffffffffff68c16062dc83302c5286595bc8aa0c06",
+          "tag": "e070935c7578b81f7b3486510134bc4c",
+          "result": "valid"
+        },
+        {
+          "tcId": 287,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "46e1c47ac0fd4564f8644238fdea86fc48a44aa257dca8fd87617a6a501e14433cd554203c21345c59229130a2541fa4b519587aa3a793e8b9fe9462c5b967b2193b09a65907b31abc750781c0b48ef91c41bcabfc4837f0a2682d5ff972ffd4",
+          "ct": "ffffffffffffffffffffffffffffffffe64e739df33fa8bf9eb8af84686d4d49efffffffffffffffffffffffffffffff0735e6fb9a76bc8170958203f66da900efffffffffffffffffffffffffffffff0735e6fb9a76bc8170958203f66da900",
+          "tag": "cf1b5e8a10e017b2e7d5a0ef4bcbe745",
+          "result": "valid"
+        },
+        {
+          "tcId": 288,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "68e1c47ac0fd4564f8644238fdea86fc175f8489942fd588ed0439bd1c061b0a7503b2487adc75e8cffe1a1efde274951405a71680d39122a04862b0939d5a7c",
+          "ct": "d1ffffffffffffffffffffffffffffffb9b5bdb630ccd5caf4ddec5324754200a6291997b902be4b692374d1a04994cea6291997b902be4b692374d1a04994ce",
+          "tag": "5939be6b498f6f99f60a1d44d775830e",
+          "result": "valid"
+        },
+        {
+          "tcId": 289,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "189a048f42071517f4f14b49d2aa9095672f11ea89a32e245495edd3f3daf54d1aef830aee9ee5c5eb9156f296024c1c",
+          "ct": "a1843f0a7d05af8cf36af68ed0bfe996c9c528d52d402e664d4c383dcba9ac47c9c528d52d402e664d4c383dcba9ac47",
+          "tag": "0444508bd77eaa0cdd66f1454727288a",
+          "result": "valid"
+        },
+        {
+          "tcId": 290,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "46e1c47ac0fd4564f8644238fdea86fc4fb413ceef1a933cd186a129011d88b62cd554203c21345c59229130a2541fa406df1dcf2f1baf26b4e42a180ea7fe59093b09a65907b31abc750781c0b48ef9af87f91e70f40b3eaf729325326c663f",
+          "ct": "ffffffffffffffffffffffffffffffffe15e2af14bf9937ec85f74c7396ed1bcffffffffffffffffffffffffffffffffb4f3a34e16ca804f7d8f3c793d7330ebffffffffffffffffffffffffffffffffb4f3a34e16ca804f7d8f3c793d7330eb",
+          "tag": "cd32365b2decd1268472c14c9568844d",
+          "result": "valid"
+        },
+        {
+          "tcId": 291,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "47e1c47ac0fd4564f8644238fdea86fce306e70e70e13db456753143841d5e092cd554203c21345c59229130a2541fa4ad9fc914839eedaa29f74d38e804dd87093b09a65907b31abc750781c0b48ef904c72dc5dc7149b23261f405d4cf45e1",
+          "ct": "feffffffffffffffffffffffffffffff4decde31d4023df64face4adbc6e0703ffffffffffffffffffffffffffffffff1fb37795ba4fc2c3e09c5b59dbd01335ffffffffffffffffffffffffffffffff1fb37795ba4fc2c3e09c5b59dbd01335",
+          "tag": "29ed1452759a7222a010144c9605c141",
+          "result": "valid"
+        },
+        {
+          "tcId": 292,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "46e1c47ac0fd4564f8644238fdea86fc444bbda21327a8d4e1c08ff0d1d4b8842cd554203c21345c59229130a2541fa4439a187975962319377852a544770370093b09a65907b31abc750781c0b48ef9eac2fca82a7987012ceeeb9878bc9b16",
+          "ct": "ffffffffffffffffffffffffffffffffeaa1849db7c4a896f8195a1ee9a7e18efffffffffffffffffffffffffffffffff1b6a6f84c470c70fe1344c477a3cdc2fffffffffffffffffffffffffffffffff1b6a6f84c470c70fe1344c477a3cdc2",
+          "tag": "99b28d5d623a5b1e33a89f580a72f747",
+          "result": "valid"
+        },
+        {
+          "tcId": 293,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "46e1c47ac0fd4564f8644238fdea86fcb746ca829d38302f95d535ea593c87232cd554203c21345c59229130a2541fa4d5234f7183e0e0dc7dfbbebec7aa7115093b09a65907b31abc750781c0b48ef97c7baba0dc0f44c4666d0783fb61e973",
+          "ct": "ffffffffffffffffffffffffffffffff19acf3bd39db306d8c0ce004614fde29ffffffffffffffffffffffffffffffff670ff1f0ba31cfb5b490a8dff47ebfa7ffffffffffffffffffffffffffffffff670ff1f0ba31cfb5b490a8dff47ebfa7",
+          "tag": "5264b285766620af101ec123053e02fe",
+          "result": "valid"
+        },
+        {
+          "tcId": 294,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "64e1c47ac0fd4564f8644238fdea86fcc6172283180a29fea446f7b48bd2630d15d554203c21345c59229130a2541fa4880477a5ae1b39af2146108f010f09b7303b09a65907b31abc750781c0b48ef9215c9374f1f49db73ad0a9b23dc491d1",
+          "ct": "ddffffffffffffffffffffffffffffff68fd1bbcbce929bcbd9f225ab3a13a07c6ffffffffffffffffffffffffffffff3a28c92497ca16c6e82d06ee32dbc705c6ffffffffffffffffffffffffffffff3a28c92497ca16c6e82d06ee32dbc705",
+          "tag": "a1603295210dafa0c68b860b96bb5037",
+          "result": "valid"
+        },
+        {
+          "tcId": 295,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "46e1c47ac0fd4564f8644238fdea86fcc4ee7caaca844d5b031262aeb26fe0b72cd554203c21345c59229130a2541fa4dfb23c4d6db2595988afd8d58f7f69b9093b09a65907b31abc750781c0b48ef976ead89c325dfd41933961e8b3b4f1df",
+          "ct": "ffffffffffffffffffffffffffffffff6a0445956e674d191acbb7408a1cb9bdffffffffffffffffffffffffffffffff6d9e82cc5463763041c4ceb4bcaba70bffffffffffffffffffffffffffffffff6d9e82cc5463763041c4ceb4bcaba70b",
+          "tag": "9d2d728111c195e011a9728a66def42d",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "46e1c47ac0fd4564f8644238fdea86fcc6ee7caaca844d5b031262aeb26fe0b768d554203c21345c59229130a2541fa4ca72ba767e082aa00175ce701a0721b34d3b09a65907b31abc750781c0b48ef9632a5ea721e78eb81ae3774d26ccb9d5",
+          "ct": "ffffffffffffffffffffffffffffffff680445956e674d191acbb7408a1cb9bdbbffffffffffffffffffffffffffffff785e04f747d905c9c81ed81129d3ef01bbffffffffffffffffffffffffffffff785e04f747d905c9c81ed81129d3ef01",
+          "tag": "64a57d238f08d758ac140c098c47865d",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "5ae1c47ac0fd4564f8644238fdea86fc77633cc9187ba4ceddf46f379072090c8c752dd3fd0a5c3a6c18461a70ebce3ded73388d0705b8f003ae3eb41e94e0d4",
+          "ct": "e3ffffffffffffffffffffffffffffffd98905f6bc98a48cc42dbad9a80150065f5f860c3ed49799cac528d52d402e665f5f860c3ed49799cac528d52d402e66",
+          "tag": "5f10f4f3d2c6826682b117f70eb16d08",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "50e1c47ac0fd4564f8644238fdea86fc5c3aa7080d28e6077d7409b699d7e209853687bf10d648223ed62db122adfecfe43092e1ead9ace85160551f4cd2d026",
+          "ct": "e9fffffffffffffffffffffffffffffff2d09e37a9cbe64564addc58a1a4bb03561c2c60d3088381980b437e7f061e94561c2c60d3088381980b437e7f061e94",
+          "tag": "93909cf19d78f96ed37b39eb99a7fa0d",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "46e1c47ac0fd4564f8644238fdea86fc3bc3cd497e98135b2b04cdbdbb75cd6120d554203c21345c59229130a2541fa434423a81d2f05326636f053b697272b2053b09a65907b31abc750781c0b48ef99d1ade508d1ff73e78f9bc0655b9ead4",
+          "ct": "ffffffffffffffffffffffffffffffff9529f476da7b131932dd18538306946bf3ffffffffffffffffffffffffffffff866e8400eb217c4faa04135a5aa6bc00f3ffffffffffffffffffffffffffffff866e8400eb217c4faa04135a5aa6bc00",
+          "tag": "6b6e3853371aa81e21077f4b7214c347",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "5ae1c47ac0fd4564f8644238fdea86fcff0ed36e3ec9ebb36b1ba38e6020310f0493c0b7d8b8155dd1878b94803aa63e6595d5e922b7f197be31f33aee4588d7",
+          "ct": "e3ffffffffffffffffffffffffffffff51e4ea519a2aebf172c2766058536805d7b96b681b66defe775ae55bdd914665d7b96b681b66defe775ae55bdd914665",
+          "tag": "a959b2fc2f4e9e7027c519faaa863410",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "d91304a1257fcdbf7a5a9a30c45a96685115c6c05b1cffbde6262a11c78ca6f508ae4b3c02c806435f1b4044f708bfa54dd3417ec62ed0963694e99ecc2b314d2d4016ba67ee8105ba4cd6f595e82ef8",
+          "ct": "600d3f241a7d77247dc127f7c64fef6bffffffffffffffffffffffffffffffffdb84e0e3c116cde0f9c62e8baaa35ffeffffffffffffffffffffffffffffffffdb84e0e3c116cde0f9c62e8baaa35ffe",
+          "tag": "820d964d720737c2ec79eca0f7effbc6",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "5de1c47ac0fd4564f8644238fdea86fcc4c5f77bd1b5ccad0b8428631907a80823d554203c21345c59229130a2541fa4b6a8491461064bfdfd52c770b6f1b3b2063b09a65907b31abc750781c0b48ef91ff0adc53ee9efe5e6c47e4d8a3a2bd4",
+          "ct": "e4ffffffffffffffffffffffffffffff6a2fce447556ccef125dfd8d2174f102f0ffffffffffffffffffffffffffffff0484f79558d764943439d11185257d00f0ffffffffffffffffffffffffffffff0484f79558d764943439d11185257d00",
+          "tag": "4a876d43c438d4f5b639c62685754f1d",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "9034612ba071d2bc424d84cf237ba894ff817a46f44de742b96eae58232bcd428241e8a693702ca3066a157946f37413",
+          "ct": "292a5aae9f73682745d63908216ed197516b437950aee700a0b77bb61b589448516b437950aee700a0b77bb61b589448",
+          "tag": "bafa91827af78e023853ef42ab516182",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "add90613d6c986201ba3ae9a173b5eac4543dad828c28642b9112329ae795c20388348384fff4da306159808cba1e571",
+          "ct": "14c73d96e9cb3cbb1c38135d152e27afeba9e3e78c218600a0c8f6c7960a052aeba9e3e78c218600a0c8f6c7960a052a",
+          "tag": "c86e6a5b6b519f712061abb1333927c9",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "46e1c47ac0fd4564f8644238fdea86fcfa4b11421c5c21efe8f5447b46af57df24d554203c21345c59229130a2541fa4398426a3f6bb7f3e6a018272852ad0b7013b09a65907b31abc750781c0b48ef990dcc272a954db2671973b4fb9e148d1",
+          "ct": "ffffffffffffffffffffffffffffffff54a1287db8bf21adf12c91957edc0ed5f7ffffffffffffffffffffffffffffff8ba89822cf6a5057a36a9413b6fe1e05f7ffffffffffffffffffffffffffffff8ba89822cf6a5057a36a9413b6fe1e05",
+          "tag": "915d502bc1bec68bc76c7bb8817a838c",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "edge case intermediate sums in poly1305",
+          "flags": [
+            "EdgeCasePoly1305"
+          ],
+          "key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213019836bb",
+          "aad": "ffffffff",
+          "msg": "441a90490c5d18bc2a5f653225918fea5c15c6c05b1cffbde6262a11c78ca6f54eea4562aa6383c708f727326092325a40d3417ec62ed0963694e99ecc2b314d6b0418e4cf450481eda0b1830272a307",
+          "ct": "fd04abcc335fa2272dc4d8f52784f6e9f2ffffffffffffffffffffffffffffff9dc0eebd69bd4864ae2a49fd3d39d201f2ffffffffffffffffffffffffffffff9dc0eebd69bd4864ae2a49fd3d39d201",
+          "tag": "bec80e43d01bffa65046718859dbaeaa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "ivSize": 0,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 307,
+          "comment": "nonce has size 0.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 64,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 308,
+          "comment": "nonce has size 8.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "0001020304050607",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 88,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 309,
+          "comment": "nonce has size 11.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 96,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 310,
+          "comment": "nonce has size 12.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 104,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 311,
+          "comment": "nonce has size 13.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 112,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 312,
+          "comment": "nonce has size 14.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 128,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 313,
+          "comment": "nonce has size 16.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 160,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 314,
+          "comment": "nonce has size 20.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f10111213",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "ivSize": 256,
+      "keySize": 256,
+      "tagSize": 128,
+      "type": "AeadTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "tests": [
+        {
+          "tcId": 315,
+          "comment": "nonce has size 32.",
+          "flags": [
+            "InvalidNonceSize"
+          ],
+          "key": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "iv": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad": "",
+          "msg": "",
+          "ct": "",
+          "tag": "",
+          "result": "invalid"
+        }
+      ]
+    }
+  ]
+}

--- a/libcrux-ml-dsa/tests/wycheproof_sign.rs
+++ b/libcrux-ml-dsa/tests/wycheproof_sign.rs
@@ -47,10 +47,10 @@ macro_rules! wycheproof_sign_test {
                         let signature = $sign(&signing_key, &message, &context, signing_randomness);
 
                         if let Err(SigningError::ContextTooLongError) = signature {
-                            assert!(test.result == SignResult::Invalid)
+                            assert!(test.result == TestResult::Invalid)
                         }
 
-                        if test.result == SignResult::Valid {
+                        if test.result == TestResult::Valid {
                             assert_eq!(signature.unwrap().as_slice(), test.sig.as_slice());
                         }
                     }
@@ -76,14 +76,14 @@ macro_rules! wycheproof_sign_test {
                         let signature = $sign(&signing_key, &message, &context, signing_randomness);
 
                         if let Err(SigningError::ContextTooLongError) = signature {
-                            assert!(test.result == SignResult::Invalid)
+                            assert!(test.result == TestResult::Invalid)
                         }
 
                         if let Ok(signature) = signature {
-                            if test.result == SignResult::Valid {
+                            if test.result == TestResult::Valid {
                                 // check that the signature matches the expected signature
                                 assert_eq!(signature.as_slice(), test.sig.as_slice());
-                            } else if test.result == SignResult::Invalid {
+                            } else if test.result == TestResult::Invalid {
                                 // if a signature is generated, but it is invalid,
                                 // check that our own implementation agrees with this judgement,
                                 let verification_result =

--- a/libcrux-ml-dsa/tests/wycheproof_verify.rs
+++ b/libcrux-ml-dsa/tests/wycheproof_verify.rs
@@ -51,17 +51,21 @@ macro_rules! wycheproof_verify_test {
                         $verify(&verification_key, &message, &context, &signature);
 
                     match test.result {
-                        VerifyResult::Valid => assert!(
+                        TestResult::Valid => assert!(
                             verification_result.is_ok(),
                             "failed tc_id {} (unexpected invalid): {}",
                             test.tc_id,
                             test.comment
                         ),
-                        VerifyResult::Invalid => assert!(
+                        TestResult::Invalid => assert!(
                             verification_result.is_err(),
                             "failed tc_id {} (unexpected valid): {}",
                             test.tc_id,
                             test.comment
+                        ),
+                        TestResult::Acceptable => panic!(
+                            "tc_id: {}, contains result \"acceptable\", update test",
+                            test.tc_id
                         ),
                     }
                 }

--- a/libcrux-ml-kem/tests/wycheproof.rs
+++ b/libcrux-ml-kem/tests/wycheproof.rs
@@ -6,6 +6,7 @@ macro_rules! wycheproof_test {
     ($name:ident, $parameter_set:expr, $module:path) => {
         mod $name {
             use super::*;
+            use libcrux_kats::wycheproof::TestResult;
 
             #[test]
             fn keygen_and_decaps() {
@@ -37,7 +38,7 @@ macro_rules! wycheproof_test {
                         assert_eq!(shared_secret_from_decapsulate, test.shared_secret.as_ref());
 
                         // assert result is valid
-                        assert_eq!(test.result, MlKemResult::Valid);
+                        assert_eq!(test.result, TestResult::Valid);
                     }
                 }
             }
@@ -49,7 +50,7 @@ macro_rules! wycheproof_test {
                 for test_group in katfile.encaps_tests() {
                     for test in &test_group.tests {
                         // all tests have an Invalid results and a `ModulusOverflow` flag
-                        assert_eq!(test.result, MlKemResult::Invalid);
+                        assert_eq!(test.result, TestResult::Invalid);
                         assert_eq!(test.flags, vec![Flag::ModulusOverflow]);
                         // convert to encapsulation key
                         let bytes: [u8; _] = test


### PR DESCRIPTION
This PR is split into two commits:

- kats: add {x}chacha20poly1305 wycheproof vectors
- chacha20poly1305: use libcrux-kats vectors


Working on the second commit, I realized that the previous test code was not working as intended.

```rust
let mut ctxt = msg.clone();
let tag = match libcrux_chacha20poly1305::encrypt(key, msg, &mut ctxt, aad, nonce) {
    Ok((_v, t)) => t,
    Err(_) => {
        *tests_run += 1;
        continue;
    }
};
```

This will always silently fail, because `encrypt` requires the `ctxt` buffer to be big enough to hold the ciphertext **and tag**. `encrypt` will always return an `Err(AeadError::CiphertextTooShort)` which is silently ignored in the `Err` branch of the `match` and treated as a success.

The second commit also handles the `TestResult::Invalid` cases differently than before. These test are either due to wrong Nonce sizes, or due to a modified tag. As per the [flag description](https://github.com/C2SP/wycheproof/blob/6d9d6de30f02e229dfc160323722c3ddac866181/testvectors_v1/chacha20_poly1305_test.json#L42):
> The test vector contains a ciphertext where the tag has been modified. The goal of the test vector is to detect implementations with partial or incorrect tag verification.
Which is why the new test code now tries to decrypt these ciphertexts+tags, and fails if decryption succeeds.


At the moment, these tests are not executed in CI. I created #1411 to track this.

[skip changelog]