### PR TITLE
[kats/p256] Add wycheproof test vectors and tests for p256 ECDH/ECDSA

### DIFF
--- a/crates/algorithms/p256/Cargo.toml
+++ b/crates/algorithms/p256/Cargo.toml
@@ -30,6 +30,8 @@ check-secret-independence = [
 
 
 [dev-dependencies]
+libcrux-p256 = { workspace = true, features = ["expose-hacl"] }
 libcrux-traits = { workspace = true, features = [
     "generic-tests",
 ] }
+libcrux-kats = { workspace = true, features = ["ecdh"] }

--- a/crates/algorithms/p256/Cargo.toml
+++ b/crates/algorithms/p256/Cargo.toml
@@ -30,8 +30,9 @@ check-secret-independence = [
 
 
 [dev-dependencies]
+der = "0.8.0"
 libcrux-p256 = { workspace = true, features = ["expose-hacl"] }
 libcrux-traits = { workspace = true, features = [
     "generic-tests",
 ] }
-libcrux-kats = { workspace = true, features = ["ecdh"] }
+libcrux-kats = { workspace = true, features = ["ecdh", "ecdsa"] }

--- a/crates/algorithms/p256/tests/wycheproof.rs
+++ b/crates/algorithms/p256/tests/wycheproof.rs
@@ -1,0 +1,105 @@
+use libcrux_kats::wycheproof::{ecdh, TestResult};
+use libcrux_p256::{compressed_to_raw, ecdh_api::EcdhSlice, uncompressed_to_raw};
+
+#[test]
+fn ecdh_secp256r1() {
+    let test_set = ecdh::TestSet::load_secp256r1_ecpoint();
+    let mut tests_run = 0;
+
+    for test_group in test_set.test_groups {
+        for test in &test_group.tests {
+            // The ecpoint format gives us sec 1 encoded public keys as hex strings and private keys
+            // encoded as hex formatted big integers
+
+            // strip leading 0 bytes
+            let sk = test
+                .private_key
+                .iter()
+                .position(|b| *b != 0)
+                .map_or(test.private_key.as_slice(), |pos| &test.private_key[pos..]);
+
+            assert!(
+                sk.len() <= 32,
+                "0 prefix stripped sk is larger than 32 bytes, tc_id: {}",
+                test.tc_id
+            );
+            let mut sk_bytes = [0; 32];
+            // sk is a 32-byte big endian big integer, so we pad the lower bytes with 0
+            sk_bytes[32 - sk.len()..].copy_from_slice(sk);
+
+            let mut pk_bytes = [0; 64];
+            if test.public_key.len() == 65 {
+                assert!(
+                    uncompressed_to_raw(&test.public_key, &mut pk_bytes),
+                    "tc_id: {}, invalid uncompressed public key",
+                    test.tc_id
+                );
+            } else if test.public_key.len() == 33 {
+                let valid = compressed_to_raw(&test.public_key, &mut pk_bytes);
+                if !valid {
+                    assert_eq!(
+                        TestResult::Invalid,
+                        test.result,
+                        "tc_id: {}, test has invalid compressed point but test result is {:?}",
+                        test.tc_id,
+                        test.result
+                    );
+                    tests_run += 1;
+                    continue;
+                }
+            } else {
+                assert_eq!(
+                    TestResult::Invalid,
+                    test.result,
+                    "tc_id: {}, public key has invalid size {}, but test result is {:?}",
+                    test.tc_id,
+                    test.public_key.len(),
+                    test.result
+                );
+                assert!(
+                    test.flags.contains(&"InvalidEncoding".to_string()),
+                    "tc_id: {}, public key is invalid but test does not contain InvalidEncoding flag ",
+                    test.tc_id
+                );
+                tests_run += 1;
+                continue;
+            }
+
+            let mut derived = [0u8; 64];
+            let result = libcrux_p256::P256::derive_ecdh(&mut derived, &pk_bytes, &sk_bytes);
+
+            match test.result {
+                // XXX: In the future, wycheproof might add acceptable test cases which we (want to) reject.
+                // This needs to be split then.
+                TestResult::Valid | TestResult::Acceptable => {
+                    assert!(
+                        result.is_ok(),
+                        "tc_id {}: expected success or acceptable but ECDH failed",
+                        test.tc_id,
+                    );
+                    // Wycheproof shared secret is just the X coordinate (first 32 bytes)
+                    assert_eq!(
+                        test.shared_secret,
+                        derived[..32],
+                        "tc_id {}: shared secret mismatch",
+                        test.tc_id,
+                    );
+                }
+                TestResult::Invalid => {
+                    assert!(
+                        result.is_err(),
+                        "tc_id: {}, expected invalid test but ECDH derive succeeded",
+                        test.tc_id
+                    );
+                }
+            }
+            tests_run += 1;
+        }
+    }
+
+    assert_eq!(
+        test_set.number_of_tests, tests_run,
+        "invalid number of tests run"
+    );
+    println!("Ran {tests_run} ecdh_secp256r1_ecpoint tests",);
+}

--- a/crates/algorithms/p256/tests/wycheproof.rs
+++ b/crates/algorithms/p256/tests/wycheproof.rs
@@ -1,5 +1,16 @@
-use libcrux_kats::wycheproof::{ecdh, TestResult};
-use libcrux_p256::{compressed_to_raw, ecdh_api::EcdhSlice, uncompressed_to_raw};
+use std::any::type_name_of_val;
+
+use libcrux_kats::wycheproof::{ecdh, ecdsa, TestResult};
+use libcrux_p256::{
+    compressed_to_raw, ecdh_api::EcdhSlice, ecdsa_verif_p256_sha2, ecdsa_verif_p256_sha512,
+    uncompressed_to_raw,
+};
+
+fn pad_slice_to_arr(b: &[u8]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[32 - b.len()..].copy_from_slice(b);
+    out
+}
 
 #[test]
 fn ecdh_secp256r1() {
@@ -23,9 +34,8 @@ fn ecdh_secp256r1() {
                 "0 prefix stripped sk is larger than 32 bytes, tc_id: {}",
                 test.tc_id
             );
-            let mut sk_bytes = [0; 32];
             // sk is a 32-byte big endian big integer, so we pad the lower bytes with 0
-            sk_bytes[32 - sk.len()..].copy_from_slice(sk);
+            let sk_bytes = pad_slice_to_arr(sk);
 
             let mut pk_bytes = [0; 64];
             if test.public_key.len() == 65 {
@@ -102,4 +112,149 @@ fn ecdh_secp256r1() {
         "invalid number of tests run"
     );
     println!("Ran {tests_run} ecdh_secp256r1_ecpoint tests",);
+}
+
+/// A P-256 Signature
+#[derive(Clone, Default)]
+struct Signature {
+    r: [u8; 32],
+    s: [u8; 32],
+}
+
+/// ASN.1 DER parser for ECDSA signatures.
+/// Returns None if the signature is malformed.
+fn decode_signature(sig: &[u8]) -> Option<Signature> {
+    use der::{asn1::UintRef, Decode, Reader};
+    // Adapted from https://docs.rs/ecdsa/0.16.9/src/ecdsa/der.rs.html#357-370
+    fn decode_der_rust_crypto(der_bytes: &[u8]) -> der::Result<(UintRef<'_>, UintRef<'_>)> {
+        let mut reader = der::SliceReader::new(der_bytes)?;
+        let header = der::Header::decode(&mut reader)?;
+        header.tag().assert_eq(der::Tag::Sequence)?;
+
+        let (r, s) = reader.read_nested(header.length(), |reader| {
+            let r = UintRef::decode(reader)?;
+            let s = UintRef::decode(reader)?;
+            Ok::<_, der::Error>((r, s))
+        })?;
+        reader.finish()?;
+        Ok((r, s))
+    }
+    let (r, s) = decode_der_rust_crypto(sig).ok()?;
+    if r.as_bytes().len() > 32 || s.as_bytes().len() > 32 {
+        return None;
+    }
+    Some(Signature {
+        r: pad_slice_to_arr(r.as_bytes()),
+        s: pad_slice_to_arr(s.as_bytes()),
+    })
+}
+
+/// Generic ecdsa_secp256r1_sha test function
+///
+/// The [`ecdsa::TestSet`] and signature verification function must correspond to each other.
+fn ecdsa_secp256r1_sha_test<F>(test_set: ecdsa::TestSet, verify: F)
+where
+    F: Fn(u32, &[u8], &[u8], &[u8], &[u8]) -> bool,
+{
+    let mut tests_run = 0;
+    let mut decoding_sig_failed = 0;
+
+    for test_group in test_set.test_groups {
+        let mut pk_bytes = [0; 64];
+        if test_group.key.key.len() == 65 {
+            assert!(
+                uncompressed_to_raw(&test_group.key.key, &mut pk_bytes),
+                "test group with invalid uncompressed public key. Key (DER): {}",
+                test_group.public_key_der
+            );
+        } else {
+            panic!(
+                "test group with invalid public key length. Key (DER): {}",
+                test_group.public_key_der
+            );
+        }
+        for test in &test_group.tests {
+            let Some(sig) = decode_signature(&test.sig) else {
+                let contains_expected_flag = test.flags.iter().any(|flag| {
+                    // Test cases with these flags can fail the decoding
+                    // Unfortunately, there are also test cases which have this flags, which **should** decode,
+                    // but then fail verification. There currently doesn't seem to be a good way to distinguish
+                    // between these.
+                    [
+                        "BerEncodedSignature",
+                        "InvalidEncoding",
+                        "MissingZero",
+                        "ModifiedSignature",
+                        "InvalidTypesInSignature",
+                        "RangeCheck",
+                        "ModifiedInteger",
+                        "IntegerOverflow",
+                        "InvalidSignature",
+                        "ArithmeticError",
+                    ]
+                    .contains(&flag.as_str())
+                });
+                decoding_sig_failed += 1;
+                assert_eq!(
+                    TestResult::Invalid,
+                    test.result,
+                    "tc_id: {}, signature decoding failed but test is valid",
+                    test.tc_id
+                );
+                assert!(
+                    contains_expected_flag,
+                    "tc_id: {}, decoding signature failed, but test contained unexpected flags",
+                    test.tc_id
+                );
+                tests_run += 1;
+                continue;
+            };
+
+            let valid = verify(test.msg.len() as u32, &test.msg, &pk_bytes, &sig.r, &sig.s);
+
+            match test.result {
+                TestResult::Valid => {
+                    assert!(
+                        valid,
+                        "tc_id: {}, test result is valid but verify failed",
+                        test.tc_id
+                    );
+                }
+                TestResult::Invalid => {
+                    assert!(
+                        !valid,
+                        "tc_id: {}, test result is invalid but verify succeeded",
+                        test.tc_id
+                    );
+                }
+                TestResult::Acceptable => {
+                    unreachable!("not present in test set")
+                }
+            }
+
+            tests_run += 1;
+        }
+    }
+
+    assert_ne!(
+        test_set.number_of_tests, decoding_sig_failed,
+        "invalid signature decode function"
+    );
+    assert_eq!(
+        test_set.number_of_tests, tests_run,
+        "invalid number of tests run"
+    );
+    println!("Ran {tests_run} {} tests", type_name_of_val(&verify),);
+}
+
+#[test]
+fn ecdsa_secp256r1_sha256() {
+    let test_set = ecdsa::TestSet::load_secp256r1_sha256();
+    ecdsa_secp256r1_sha_test(test_set, ecdsa_verif_p256_sha2);
+}
+
+#[test]
+fn ecdsa_secp256r1_sha512() {
+    let test_set = ecdsa::TestSet::load_secp256r1_sha512();
+    ecdsa_secp256r1_sha_test(test_set, ecdsa_verif_p256_sha512);
 }

--- a/crates/sys/platform/src/x86.rs
+++ b/crates/sys/platform/src/x86.rs
@@ -3,9 +3,9 @@
 #![allow(non_upper_case_globals)]
 
 #[cfg(target_arch = "x86")]
-use core::arch::x86::{CpuidResult, __cpuid, __cpuid_count};
+use core::arch::x86::{__cpuid, __cpuid_count, CpuidResult};
 #[cfg(target_arch = "x86_64")]
-use core::arch::x86_64::{CpuidResult, __cpuid, __cpuid_count};
+use core::arch::x86_64::{__cpuid, __cpuid_count, CpuidResult};
 use core::sync::atomic::{AtomicBool, Ordering};
 
 #[allow(non_camel_case_types)]

--- a/crates/testing/kats/Cargo.toml
+++ b/crates/testing/kats/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 
 [features]
+ecdh = []
 mldsa = []
 mlkem = []
 sha2 = ["dep:cavp"]

--- a/crates/testing/kats/Cargo.toml
+++ b/crates/testing/kats/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { version = "1.0" }
 
 [features]
 ecdh = []
+ecdsa = []
 mldsa = []
 mlkem = []
 sha2 = ["dep:cavp"]

--- a/crates/testing/kats/Readme.md
+++ b/crates/testing/kats/Readme.md
@@ -11,6 +11,11 @@ This crate provides KAT test vectors for:
 - ML-KEM (wycheproof)
     - keygen/decaps
     - encaps
+- p256 (wycheproof)
+    - ECDH
+    - ECDSA
+- poly1305 (boringssl)
+- SHA-2 (NIST)
 
 ⚠️ NOTE: This crate serves as an internal testing dependency for other `libcrux`
 crates, and is not intended to be used directly.

--- a/crates/testing/kats/Readme.md
+++ b/crates/testing/kats/Readme.md
@@ -17,7 +17,7 @@ crates, and is not intended to be used directly.
 
 ## Source
 
-The JSON files for wycheproof ML-KEM and ML-DSA were taken from `https://github.com/C2SP/wycheproof`
+The JSON files for wycheproof were taken from `https://github.com/C2SP/wycheproof`
 * As of commit [6d9d6de30f02e229dfc160323722c3ddac866181](https://github.com/C2SP/wycheproof/tree/6d9d6de30f02e229dfc160323722c3ddac866181)
 
 The JSON files for ACVP ML-KEM and ML-DSA were taken from `https://github.com/usnistgov/ACVP-Server`

--- a/crates/testing/kats/src/wycheproof.rs
+++ b/crates/testing/kats/src/wycheproof.rs
@@ -3,6 +3,9 @@
 #[cfg(feature = "ecdh")]
 pub mod ecdh;
 
+#[cfg(feature = "ecdsa")]
+pub mod ecdsa;
+
 #[cfg(feature = "mldsa")]
 pub mod mldsa;
 

--- a/crates/testing/kats/src/wycheproof.rs
+++ b/crates/testing/kats/src/wycheproof.rs
@@ -1,5 +1,8 @@
 //! Wycheproof Known Answer Tests
 
+#[cfg(feature = "ecdh")]
+pub mod ecdh;
+
 #[cfg(feature = "mldsa")]
 pub mod mldsa;
 
@@ -7,3 +10,4 @@ pub mod mldsa;
 pub mod mlkem;
 
 pub mod schema_common;
+pub use schema_common::TestResult;

--- a/crates/testing/kats/src/wycheproof/ecdh.rs
+++ b/crates/testing/kats/src/wycheproof/ecdh.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+use super::schema_common::TestResult;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestSet {
+    pub number_of_tests: usize,
+    pub test_groups: Vec<TestGroup>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestGroup {
+    pub tests: Vec<Test>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Test {
+    pub tc_id: usize,
+    pub flags: Vec<String>,
+    #[serde(rename = "public", with = "hex::serde")]
+    pub public_key: Vec<u8>,
+    #[serde(rename = "private", with = "hex::serde")]
+    pub private_key: Vec<u8>,
+    #[serde(rename = "shared", with = "hex::serde")]
+    pub shared_secret: Vec<u8>,
+    pub result: TestResult,
+}
+
+impl TestSet {
+    pub fn load_secp256r1_ecpoint() -> Self {
+        let data = include_str!("../../wycheproof/ecdh_secp256r1_ecpoint_test.json");
+        serde_json::from_str(data).expect("could not deserialize ecdh_secp256r1_ecpoint KAT file")
+    }
+}

--- a/crates/testing/kats/src/wycheproof/ecdsa.rs
+++ b/crates/testing/kats/src/wycheproof/ecdsa.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+
+use super::schema_common::TestResult;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestSet {
+    pub number_of_tests: usize,
+    pub test_groups: Vec<TestGroup>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestGroup {
+    #[serde(rename = "publicKey")]
+    pub key: EcdsaPublicKey,
+    pub public_key_der: String,
+    pub tests: Vec<Test>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcdsaPublicKey {
+    /// Uncompressed public key bytes (04 || X || Y)
+    #[serde(rename = "uncompressed", with = "hex::serde")]
+    pub key: Vec<u8>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Test {
+    pub tc_id: usize,
+    pub flags: Vec<String>,
+    #[serde(with = "hex::serde")]
+    pub msg: Vec<u8>,
+    #[serde(with = "hex::serde")]
+    pub sig: Vec<u8>,
+    pub result: TestResult,
+}
+
+impl TestSet {
+    pub fn load_secp256r1_sha256() -> Self {
+        let data = include_str!("../../wycheproof/ecdsa_secp256r1_sha256_test.json");
+        serde_json::from_str(data).expect("could not deserialize ecdsa_secp256r1_sha256 KAT file")
+    }
+
+    pub fn load_secp256r1_sha512() -> Self {
+        let data = include_str!("../../wycheproof/ecdsa_secp256r1_sha512_test.json");
+        serde_json::from_str(data).expect("could not deserialize ecdsa_secp256r1_sha512 KAT file")
+    }
+}

--- a/crates/testing/kats/src/wycheproof/mldsa.rs
+++ b/crates/testing/kats/src/wycheproof/mldsa.rs
@@ -1,7 +1,5 @@
 //! Wycheproof ML-DSA Known Answer Tests
 //!
-//! The JSON files for ML-DSA were taken from <https://github.com/C2SP/wycheproof>, as of commit [cd136e97040de0842c3a198670b1c5e4f423c940](https://github.com/C2SP/wycheproof/tree/cd136e97040de0842c3a198670b1c5e4f423c940).
-//!
 //! ### Example usage
 //! ```rust
 //! use libcrux_kats::wycheproof::mldsa::{ParameterSet, MlDsaSignTestsNoSeed};

--- a/crates/testing/kats/src/wycheproof/mlkem.rs
+++ b/crates/testing/kats/src/wycheproof/mlkem.rs
@@ -1,7 +1,5 @@
 //! Wycheproof ML-KEM Known Answer Tests
 //!
-//! The JSON file for ML-KEM was taken from <https://github.com/C2SP/wycheproof>, as of commit [cd136e97040de0842c3a198670b1c5e4f423c940](https://github.com/C2SP/wycheproof/tree/cd136e97040de0842c3a198670b1c5e4f423c940)
-//!
 //! ### Example usage
 //! ```rust
 //! use libcrux_kats::wycheproof::mlkem::{ParameterSet, MlKemTests};

--- a/crates/testing/kats/src/wycheproof/schema_common.rs
+++ b/crates/testing/kats/src/wycheproof/schema_common.rs
@@ -1,7 +1,12 @@
-//! Structs based on
-//! [`schemas/common.json`](https://github.com/C2SP/wycheproof/blob/cd136e97040de0842c3a198670b1c5e4f423c940/schemas/common.json)
-
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TestResult {
+    Valid,
+    Invalid,
+    Acceptable,
+}
 
 #[derive(PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/testing/kats/wycheproof/ecdh_secp256r1_ecpoint_test.json
+++ b/crates/testing/kats/wycheproof/ecdh_secp256r1_ecpoint_test.json
@@ -1,0 +1,3994 @@
+{
+  "algorithm": "ECDH",
+  "schema": "ecdh_ecpoint_test_schema_v1.json",
+  "numberOfTests": 355,
+  "header": [
+    "Test vectors of type EcdhWebTest are intended for",
+    "testing an ECDH implementations where the public key",
+    "is just an ASN encoded point."
+  ],
+  "notes": {
+    "AdditionChain": {
+      "bugType": "KNOWN_BUG",
+      "description": "The private key has an unusual bit pattern, such as high or low Hamming weight. The goal is to test edge cases for addition chain implementations."
+    },
+    "CVE-2017-8932": {
+      "bugType": "KNOWN_BUG",
+      "description": "A bug in the standard library ScalarMult implementation of curve P-256 for amd64 architectures in Go before 1.7.6 and 1.8.x before 1.8.2 causes incorrect results to be generated for specific input points.",
+      "effect": "An adaptive attack can be mounted to progressively extract the scalar input to ScalarMult by submitting crafted points and observing failures to the derive correct output.",
+      "cves": [
+        "CVE-2017-8932"
+      ]
+    },
+    "CompressedPoint": {
+      "bugType": "UNKNOWN",
+      "description": "The point in the public key is compressed. Not every library supports points in compressed format."
+    },
+    "CompressedPublic": {
+      "bugType": "FUNCTIONALITY",
+      "description": "The public key in the test vector is compressed. Some implementations do not support compressed points."
+    },
+    "EdgeCaseDoubling": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains an EC point that hits an edge case (e.g. a coordinate 0) when doubled. The goal of the test vector is to check for arithmetic errors in these test cases.",
+      "effect": "The effect of such arithmetic errors is unclear and requires further analysis."
+    },
+    "EdgeCaseEphemeralKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains an ephemeral public key that is an edge case."
+    },
+    "EdgeCaseSharedSecret": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a public key and private key such that the shared ECDH secret is a special case. The goal of this test vector is to detect arithmetic errors.",
+      "effect": "The seriousness of an arithmetic error is unclear. It requires further analysis to determine if the bug is exploitable."
+    },
+    "InvalidCompressedPublic": {
+      "bugType": "MODIFIED_PARAMETER",
+      "description": "The test vector contains a compressed public key that does not exist. I.e., it contains an x-coordinate that does not correspond to any points on the curve. Such keys should be rejected "
+    },
+    "InvalidCurveAttack": {
+      "bugType": "CONFIDENTIALITY",
+      "description": "The point of the public key is not on the curve. ",
+      "effect": "If an implementation does not check whether a point is on the curve then it is likely that the implementation is susceptible to an invalid curve attack. Many implementations compute the shared ECDH secret over a curve defined by the point on the public key. This curve can be weak and hence leak information about the private key."
+    },
+    "InvalidEncoding": {
+      "bugType": "MODIFIED_PARAMETER",
+      "description": "The test vector contains a public key with an invalid encoding."
+    },
+    "Normal": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a pseudorandomly generated, valid test case. Implementations are expected to pass this test."
+    },
+    "WrongCurve": {
+      "bugType": "CONFIDENTIALITY",
+      "description": "The public key and private key use distinct curves. Implementations are expected to reject such parameters.",
+      "effect": "Computing an ECDH key exchange with public and private keys can in the worst case lead to an invalid curve attack. Hence, it is important that ECDH implementations check the input parameters. The severity of such bugs is typically smaller if an implementation ensures that the point is on the curve and that the ECDH computation is performed on the curve of the private key. Some of the test vectors with modified public key contain shared ECDH secrets, that were computed over the curve of the private key."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdhEcpointTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "curve": "secp256r1",
+      "encoding": "ecpoint",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "normal case",
+          "flags": [
+            "Normal"
+          ],
+          "public": "0462d5bd3372af75fe85a040715d0f502428e07046868b0bfdfa61d731afe44f26ac333a93a9e70a81cd5a95b5bf8d13990eb741c8c38872b4a07d275a014e30cf",
+          "private": "0612465c89a023ab17855b0a6bcebfd3febb53aef84138647b5352e02c10c346",
+          "shared": "53020d908b0219328b658b525f26780e3ae12bcd952bb25a93bc0895e1714285",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "compressed public key",
+          "flags": [
+            "CompressedPublic",
+            "CompressedPoint"
+          ],
+          "public": "0362d5bd3372af75fe85a040715d0f502428e07046868b0bfdfa61d731afe44f26",
+          "private": "0612465c89a023ab17855b0a6bcebfd3febb53aef84138647b5352e02c10c346",
+          "shared": "53020d908b0219328b658b525f26780e3ae12bcd952bb25a93bc0895e1714285",
+          "result": "acceptable"
+        },
+        {
+          "tcId": 3,
+          "comment": "shared secret has x-coordinate that satisfies x**2 = 0",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "0458fd4168a87795603e2b04390285bdca6e57de6027fe211dd9d25e2212d29e62080d36bd224d7405509295eed02a17150e03b314f96da37445b0d1d29377d12c",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0000000000000000000000000000000000000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "shared secret has x-coordinate p-3",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04a1ecc24bf0d0053d23f5fd80ddf1735a1925039dc1176c581a7e795163c8b9ba2cb5a4e4d5109f4527575e3137b83d79a9bcb3faeff90d2aca2bed71bb523e7e",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "ffffffff00000001000000000000000000000000fffffffffffffffffffffffc",
+          "result": "valid"
+        },
+        {
+          "tcId": 5,
+          "comment": "shared secret has x-coordinate 2**16 + 0",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "041b0e7437c33d379929430d3ec10df59bed7fe2a1d950c5791e1e9ddeef1f4d70fbdb0e3bbce63a27f27838c685207f2ccaf689d25eb622744db1168ac92619e8",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0000000000000000000000000000000000000000000000000000000000010000",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "shared secret has x-coordinate 2**32 + 0",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "0408d6148d0244d243b3d0d1777de6375fa7ebeab477f19915d05994db04df219727737d4f8ce0a7f390becce92b2bcd5c054f18ecb58e5dd59baf88b4ed6abea8",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0000000000000000000000000000000000000000000000000000000100000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 7,
+          "comment": "shared secret has x-coordinate 2**64 + 0",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "042424f9d7ba0a89ce3c7c1e8f15dfd83004d86680967a82cbf9bb6b11dae5fd72e05c3687187b1cf28438a17a7469fa3b094b7d6f36cccc3492c0b0a61fab2a38",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0000000000000000000000000000000000000000000000010000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "shared secret has x-coordinate 2**96 + 0",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "044c9695b7668434fc85769acb10f0edcf87a96b7d5dc347b46bb304b0b1d3267fcf5d993bff2a8c774808231a34f41b33667d8ebeafd00689fa3a9bfa05a40c1c",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0000000000000000000000000000000000000001000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 9,
+          "comment": "shared secret has x-coordinate that satisfies x**2 = -3",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04a492fe4b4908b6d675d687551f99c617e4e5c97aa266958953129eb381f0153b111b95c94fa1d1ecd1d41d2785c1db5195875ae98051732a59ba7720f9089af6",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "6522aed9ea48f2623b8eeae3e213b99da32e74c9421835804d374ce28fcca662",
+          "result": "valid"
+        },
+        {
+          "tcId": 10,
+          "comment": "shared secret has x-coordinate that satisfies x**2 = 2",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04d5c96efd1907fd48de2ad715acf82eae5c6690fe3efe16a78d61c68d3bfd10df03eac816b9e7b776192a3f5075887c0e225617505833ca997cda32fd0f673c5e",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "507442007322aa895340cba4abc2d730bfd0b16c2c79a46815f8780d2c55a2dd",
+          "result": "valid"
+        },
+        {
+          "tcId": 11,
+          "comment": "shared secret has x-coordinate that satisfies x**2 = 5",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04c74d546f2fcc6dd392f85e5be167e358de908756b0c0bb01cb69d864ca083e1c93f959eece6e10ee11bd3934207d65ae28af68b092585a1509260eceb39b92ef",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "085ec5a4af40176b63189069aeffcb229c96d3e046e0283ed2f9dac21b15ad3c",
+          "result": "valid"
+        },
+        {
+          "tcId": 12,
+          "comment": "shared secret has x-coordinate that satisfies x**2 = 7",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "0434fc9f1e7a094cd29598d1841fa9613dbe82313d633a51d63fb6eff074cc9b9a4ecfd9f258c5c4d4210b49751213a24c596982bd1d54e0445443f21ef15492a5",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "190c25f88ad9ae3a098e6cffe6fd0b1bea42114eb0cedd5868a45c5fe277dff3",
+          "result": "valid"
+        },
+        {
+          "tcId": 13,
+          "comment": "shared secret has x-coordinate that satisfies x**2 = 8",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04f475f503a770df72c45aedfe42c008f59aa57e72b232f26600bdd0353957cb20bdb8f6405b4918050a3549f44c07a8eba820cdce4ece699888c638df66f54f7c",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "5f177bfe19baaaee597e68b6a87a519e805e9d28a70cb72fd40f0fe5a754ba45",
+          "result": "valid"
+        },
+        {
+          "tcId": 14,
+          "comment": "shared secret has x-coordinate that satisfies x**2 = 2**96 + 2",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04949304889050834006ecf11eba0e73f0dd2a5e77a5ea642a34a3f9989eda2d57384509cd42763c87cf460d1ad75664402986bb8cca0acdfc3685d2c9c7d32933",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "3476a8fa9c7448124aa945a2e1103eb91f95c7b4d91aaa1c35b8965191fc0fe0",
+          "result": "valid"
+        },
+        {
+          "tcId": 15,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 2",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04e25ead8342888d1fbd2bd211e9db5bc761da9cfa1e805078b53606df9e5444403d3421fa70f940dba104d842034d2efec9332161ccfb654a8e9f2ec42fc1a837",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "5555555555555555555555555555555555555555555555555555555555555554",
+          "result": "valid"
+        },
+        {
+          "tcId": 16,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 2",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04cb32ab951d7581e7602c89320d91d7043e9dc56a10348d586a08d1870753152bf96bd53e7cfc2434dc61a09f8f4853e4c6dd49e786194ec0a988d0e8d29378b8",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9",
+          "result": "valid"
+        },
+        {
+          "tcId": 17,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 4",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "040b9d56422ed9c2082dd9d46d231fd0141f92e79f5a12da4c77c488c87363f944e6e3c2ec9779615f242bc30d1c28c1f984b8c252243f5f1eaa3d855e1cc2d8a6",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "3333333333333333333333333333333333333333333333333333333333333333",
+          "result": "valid"
+        },
+        {
+          "tcId": 18,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 4",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "040507fabb16755f4885ae45b3d497822388f4e6a531de512c200480b4e56b892ab70746c1d8a20637eff17948e557a2b4da2562ba6b62991b426b7b3787a19693",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "result": "valid"
+        },
+        {
+          "tcId": 19,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 8",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "043b18caef2cd982c3b58f258cb76daa029383f42c8f3f083493f42c915935243a260830b7d25b66378c5d25fb0cf23d32527a2cdb7f7d7e6c89ebea8277738ed8",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",
+          "result": "valid"
+        },
+        {
+          "tcId": 20,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 8",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04123b1921231bee315e1ea66cb95318d6392f85695bbec03c334740ce7add768efec9a108770ff0eb448eee9f06367416d74b22a2f38157bb00d8c0be44ebf152",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+          "result": "valid"
+        },
+        {
+          "tcId": 21,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 16",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04924fb33985c8a687fc04c9dd05e531ca0e0223aa58d58351e922ef482043d30cf504745e769b6dcbefe404da37f717b3109d2af23450fcfe2f075c2dabbe7194",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00f9",
+          "result": "valid"
+        },
+        {
+          "tcId": 22,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 16",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "0422495c6884937a1bc05871e9ee1a2c43f8f14db19ee60bd2d89c4293042f5a9452cea27e6fe574a00e5f15fe11aa54f54ebd8bde3aa41c80bf9d5f7b1dc6efec",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00feff",
+          "result": "valid"
+        },
+        {
+          "tcId": 23,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 30",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04f3cb6754b7e2a86d064dfb9f903185aaa4c92b481c2c1a1ff276303bbc4183e49c318599b0984c3563df339311fe143a7d921ee75b755a52c6f804f897b809f7",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "7fff0001fffc0007fff0001fffc0007fff0001fffc0007fff0001fffc0007fff",
+          "result": "valid"
+        },
+        {
+          "tcId": 24,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 30",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04a8d93bebbaf25fa9a1f98c44b54dbf28634a5fd08402dba5d9e4873f8123da1db972d91a0eabadb630b271e6551b757d969301beddd11f82decdfbe4f9657f50",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "8000fffe0003fff8000fffe0003fff8000fffe0003fff8000fffe0003fff7ffe",
+          "result": "valid"
+        },
+        {
+          "tcId": 25,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 32",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "048d0086e678a0fe7b4ad7bd4f94a38267b9f9f1d2b82452db4cfb335595c26c55f78476a00a0153941da0b0b81c834682edc9fcc8bc21a7b5bacb460dbb566c19",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000fffe",
+          "result": "valid"
+        },
+        {
+          "tcId": 26,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 32",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "0402a96834fe3b54d440003521f2355aea48d0bbc576473fecc6975100c589865263255764891ffc108cfe754af52a4362953955ddfadcf752637c11edeaa6a807",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000fffefffd",
+          "result": "valid"
+        },
+        {
+          "tcId": 27,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 51",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "048721294f9eb3ba69a13ae7d933fa51c48393fe1b9b9b17a08cecff2ee6ad434d2c23cd11d26694c472dda8cea4133bbc68e1f234bc7e8bffcea9446091855491",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "8000003ffffff0000007fffffe000000ffffffc000001ffffff8000003fffffc",
+          "result": "valid"
+        },
+        {
+          "tcId": 28,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 51",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "043e99ec3c58ac3898936e4a61182b198823c9992209f67bf5291aa354fceb2f1312952518636add666320c8b7fa631541d0ca50796dbff0c1e72f94718776bd60",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "7fffffe000000ffffffc000001ffffff8000003ffffff0000007fffffdfffffe",
+          "result": "valid"
+        },
+        {
+          "tcId": 29,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 52",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04e9484e58f3331b66ffed6d90cb1c78065fa28cfba5c7dd4352013d3252ee4277bd7503b045a38b4b247b32c59593580f39e6abfa376c3dca20cf7f9cfb659e13",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "000003ffffff0000003ffffff0000003ffffff0000003ffffff0000003ffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 30,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 52",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04eb6eb532fe4af2a5a275ab4e9f728ae64e9dbc08e9359091d75e5334a6e08db64c146339c05d1d5782ebeeb86d3eb5c63e9f99f17187c039666c5237b736e9cd",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "fffffc000000ffffffc000000ffffffc000000ffffffc000000ffffffbffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 31,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 60",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "048e7b50f7d8c44d5d3496c43141a502f4a43f153d03ad43eda8e39597f1d477b8647f3da67969b7f989ff4addc393515af40c82085ce1f2ee195412c6f583774f",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "ffff00000003fffffff00000003fffffff00000003fffffff00000003fffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 32,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 60",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "0440d4f4f6d9a41ab6ea90d46610b924ab15ed4f259fd09ddd41a707782fa9e203a5080a7e118a50c4b3d2c43dcbbf35c39e276a0a50b33a9ffbe7c9095055fc25",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0000fffffffc0000000fffffffc0000000fffffffc0000000fffffffbfffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 33,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 62",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04a386ace573f87558a68ead2a20088e3fe928bdae9e109446f93a078c15741f0421261e6db2bf12106e4c6bf85b9581b4c0302a526222f90abc5a549206b11011",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "ff00000001fffffffc00000007fffffff00000001fffffffc00000007fffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 34,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 62",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04739b5c2189729b577ba1a467a1a0851c556b860f6b2016bcd50beb22ee9c0d7961ea43cf1ea7aad1a2360b0f37a74ca532dc8d1af26cdf89a87d93dcaa0c9564",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "00fffffffe00000003fffffff80000000fffffffe00000003fffffff80000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 35,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 64",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "046c03f055f710aea89341f0ef7a1c6d5c45a50923ce8adb33c2520f7881547748691f4dafcf6d5df8d9e6afda66ca81718bea8171abc87036a9c370385b60d969",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "00000000ffffffff00000000ffffffff00000000ffffffff00000000fffffffc",
+          "result": "valid"
+        },
+        {
+          "tcId": 36,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 64",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "048a3f60cfec64745bf625696f2fe4b6e4ce8208954f4fc4da21f87f9f7a2c3275b54d90851b39707586dc6cceccc5e50a1e4a955463107d1d87c8252df2110d6d",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 37,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 112",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04c827fb930fd51d926086191b502af83abb5f717debc8de29897a3934b2571ca05990c0597b0b7a2e42febd56b13235d1d408d76ed2c93b3facf514d902f6910a",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "ffffffff00000000000000ffffffffffffff00000000000000ffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 38,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 112",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04fc85bfee056478a1717582accd11ed49009891cbda5fe40b9f4c1742e127db2c97033f5f6405acfa57553f1e375a13e8d6e3a1151958c709be508e0bac7804d6",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "00000000ffffffffffffff00000000000000ffffffffffffff00000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 39,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 128",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "0438bf171cdbd4e2e7128528db43d80655b789e69e6ba1d36b62e4e59d8ecf4c51bbe3244e4fbf79f24512f30c4a605314749e2f20d858ec961060a2cab467013f",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0000000000000000ffffffffffffffff0000000000000000fffffffffffffffd",
+          "result": "valid"
+        },
+        {
+          "tcId": 40,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 128",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04249f4f517d7788d4622d762c4312101fba71fe2657f1f2c33c0613d2e21890b778f32da1b61ed9385cd52f5e7103f77b01b403fb6537a0c0e866195d0a448f34",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "7fffffffffffffff0000000000000000ffffffffffffffff0000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 41,
+          "comment": "shared secret has an x-coordinate of approx p//3",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04e9c0af0bf6dadd8fbe04c5cf3fce80683a9c267b0dc9850cbc1bcdfeb744c3516efe878223dd9dd924e83e3ab22c9bf304129ab59c1f3d30fb58b8770bf9d9bf",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "5555555500000000555555555555555555555555aaaaaaaaaaaaaaaaaaaaaaab",
+          "result": "valid"
+        },
+        {
+          "tcId": 42,
+          "comment": "shared secret has an x-coordinate of approx p//5",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "042b29f482bc43559f70447584919df1e03706ee63c987b6f7499ae29ab01ca828a4bd05d61f596e01623a8e2076c013889fbb0f9937e475a00ddd75e6a992e776",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "3333333300000000333333333333333333333333666666666666666666666666",
+          "result": "valid"
+        },
+        {
+          "tcId": 43,
+          "comment": "shared secret has an x-coordinate of approx p//7",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "042766dc8e289fd27625d4765eb014aa54a44a7d5724050b9446e363071c260913aff9f1dc5e71b666501b24d70805cb8e1a01ee90ca84cb0c6f7ea453df85f520",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "249249246db6db6ddb6db6db6db6db6db6db6db7000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 44,
+          "comment": "shared secret has an x-coordinate of approx p//9",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04d33314f13a7fe8357bfd7a11799498e55bc782c6f434856d733b668e1d05448348dc5aae3f6431dd20c018f54b1d65fd1864ddfeea04ad7533971237c60ac0c7",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "1c71c71c5555555571c71c71c71c71c71c71c71c8e38e38e38e38e38e38e38e4",
+          "result": "valid"
+        },
+        {
+          "tcId": 45,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "043cbc1b31b43f17dc200dd70c2944c04c6cb1b082820c234a300b05b7763844c74fde0a4ef93887469793270eb2ff148287da9265b0334f9e2609aac16e8ad503",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "7fffffffffffffffffffffffeecf2230ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 46,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "042830d96489ae24b79cad425056e82746f9e3f419ab9aa21ca1fbb11c7325e7d318abe66f575ee8a2f1c4a80e35260ae82ad7d6f661d15f06967930a585097ef7",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "000000000000000000000000111124f400000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 47,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04450b6b6e2097178e9d2850109518d28eb3b6ded2922a5452003bc2e4a4ec775c894e90f0df1b0e6cadb03b9de24f6a22d1bd0a4a58cd645c273cae1c619bfd61",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "000000000000000000000001ea77d449ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 48,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "047fffffffffffffffffffffffeecf2230ffffffffffffffffffffffffffffffff00000001c7c30643abed0af0a49fe352cb483ff9b97dccdf427c658e8793240d",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "6fd26661851a8de3c6d06f834ef3acb8f2a5f9c136a985ffe10d5eeb51edcfa3",
+          "result": "valid"
+        },
+        {
+          "tcId": 49,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04000000000000000000000000111124f4000000000000000000000000000000000000000d12d381b0760b1c50be8acf859385052c7f53cde67ce13759de3123a0",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "f1f0e43b374feb7e7f96d4ffe7519fa8bb6c3cfd25f6f87dab2623d2a2d33851",
+          "result": "valid"
+        },
+        {
+          "tcId": 50,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04000000000000000000000001ea77d449ffffffffffffffffffffffffffffffff000000007afbc0b325e820646dec622fb558a51c342aa257f4b6a8ec5ddf144f",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "1b085213a9c89d353e1111af078c38c502b7b4771efba51f589b5be243417bdc",
+          "result": "valid"
+        },
+        {
+          "tcId": 51,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "043cbc1b31b43f17dc200dd70c2944c04c6cb1b082820c234a300b05b7763844c7b021f5b006c778ba686cd8f14d00eb7d78256d9b4fccb061d9f6553e91752afc",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "7fffffffffffffffffffffffeecf2230ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 52,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "042830d96489ae24b79cad425056e82746f9e3f419ab9aa21ca1fbb11c7325e7d3e754198fa8a1175e0e3b57f1cad9f517d528290a9e2ea0f96986cf5a7af68108",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "000000000000000000000000111124f400000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 53,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04450b6b6e2097178e9d2850109518d28eb3b6ded2922a5452003bc2e4a4ec775c76b16f0e20e4f194524fc4621db095dd2e42f5b6a7329ba3d8c351e39e64029e",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "000000000000000000000001ea77d449ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 54,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "047fffffffffffffffffffffffeecf2230fffffffffffffffffffffffffffffffffffffffd383cf9bd5412f50f5b601cad34b7c00746823320bd839a71786cdbf2",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "6fd26661851a8de3c6d06f834ef3acb8f2a5f9c136a985ffe10d5eeb51edcfa3",
+          "result": "valid"
+        },
+        {
+          "tcId": 55,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04000000000000000000000000111124f400000000000000000000000000000000fffffff1ed2c7e5089f4e3af4175307a6c7afad480ac3219831ec8a621cedc5f",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "f1f0e43b374feb7e7f96d4ffe7519fa8bb6c3cfd25f6f87dab2623d2a2d33851",
+          "result": "valid"
+        },
+        {
+          "tcId": 56,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04000000000000000000000001ea77d449fffffffffffffffffffffffffffffffffffffffe85043f4dda17df9b92139dd04aa75ae4cbd55da80b495713a220ebb0",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "1b085213a9c89d353e1111af078c38c502b7b4771efba51f589b5be243417bdc",
+          "result": "valid"
+        },
+        {
+          "tcId": 57,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "049a0f0e3dd31417bbd9e298bc068ab6d5c36733af26ed67676f410c804b8b2ca1b02c82f3a61a376db795626e9400557112273a36cddb08caaa43953965454730",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "7fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 58,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "048e5d22d5e53ec797c55ecd68a08a7c3361cd99ca7fad1a68ea802a6a4cb58a918ea7a07023ef67677024bd3841e187c64b30a30a3750eb2ee873fbe58fa1357b",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0000000000000000000000001f6bd1e500000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 59,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04293aa349b934ab2c839cf54b8a737df2304ef9b20fa494e31ad62b315dd6a53c118182b85ef466eb9a8e87f9661f7d017984c15ea82043f536d1ee6a6d95b509",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "000000000000000000000002099f55d5ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 60,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "047fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffff267bfdf8a61148decd80283732dd4c1095e4bb40b9658408208dc1147fffffff",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "44236c8b9505a19d48774a3903c0292759b0f826e6ac092ff898d87e53d353fc",
+          "result": "valid"
+        },
+        {
+          "tcId": 61,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "040000000000000000000000001f6bd1e5000000000000000000000000000000004096edd6871c320cb8a9f4531751105c97b4c257811bbc32963eaf39ffffffff",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "3ebbace1098a81949d5605dd94a7aa88dc396c2c23e01a9c8cca5bb07bfbb6a1",
+          "result": "valid"
+        },
+        {
+          "tcId": 62,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04000000000000000000000002099f55d5ffffffffffffffffffffffffffffffff152c1a22d823a27855ed03f8e2ab5038bb1df4d87e43865f2daf6948ffffffff",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "67cb63566c7ceb12fdd85ce9d2f77c359242bbaa0ea1bf3cf510a4a26591d1f1",
+          "result": "valid"
+        },
+        {
+          "tcId": 63,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "049a0f0e3dd31417bbd9e298bc068ab6d5c36733af26ed67676f410c804b8b2ca14fd37d0b59e5c893486a9d916bffaa8eedd8c5ca3224f73555bc6ac69abab8cf",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "7fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 64,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "048e5d22d5e53ec797c55ecd68a08a7c3361cd99ca7fad1a68ea802a6a4cb58a9171585f8edc1098998fdb42c7be1e7839b4cf5cf6c8af14d1178c041a705eca84",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "0000000000000000000000001f6bd1e500000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 65,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": "04293aa349b934ab2c839cf54b8a737df2304ef9b20fa494e31ad62b315dd6a53cee7e7d46a10b99156571780699e082fe867b3ea257dfbc0ac92e1195926a4af6",
+          "private": "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared": "000000000000000000000002099f55d5ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 66,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "047fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffffd984020659eeb722327fd7c8cd22b3ef6a1b44c0469a7bf7df723eeb80000000",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "44236c8b9505a19d48774a3903c0292759b0f826e6ac092ff898d87e53d353fc",
+          "result": "valid"
+        },
+        {
+          "tcId": 67,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "040000000000000000000000001f6bd1e500000000000000000000000000000000bf69122878e3cdf447560bace8aeefa3684b3da97ee443cd69c150c600000000",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "3ebbace1098a81949d5605dd94a7aa88dc396c2c23e01a9c8cca5bb07bfbb6a1",
+          "result": "valid"
+        },
+        {
+          "tcId": 68,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04000000000000000000000002099f55d5ffffffffffffffffffffffffffffffffead3e5dc27dc5d88aa12fc071d54afc744e20b2881bc79a0d25096b700000000",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "67cb63566c7ceb12fdd85ce9d2f77c359242bbaa0ea1bf3cf510a4a26591d1f1",
+          "result": "valid"
+        },
+        {
+          "tcId": 69,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 = 0",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04000000000000000000000000000000000000000000000000000000000000000066485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "cfe4077c8730b1c9384581d36bff5542bc417c9eff5c2afcb98cc8829b2ce848",
+          "result": "valid"
+        },
+        {
+          "tcId": 70,
+          "comment": "ephemeral key has x-coordinate p-3",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04ffffffff00000001000000000000000000000000fffffffffffffffffffffffc19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "4c25702d10cd12ec7e77c4f1979237976d6aa809c645d75a59d399a52377eb7b",
+          "result": "valid"
+        },
+        {
+          "tcId": 71,
+          "comment": "ephemeral key has x-coordinate 2**16 + 0",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04000000000000000000000000000000000000000000000000000000000001000073ca30641acabe581170b4d5253f7a342b039a87ab2447badad08ece2cf19f52",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "4cfd639fd80c84b935c33cfaacceeb256b2f7e273c3ae5f0ff92b74957376f22",
+          "result": "valid"
+        },
+        {
+          "tcId": 72,
+          "comment": "ephemeral key has x-coordinate 2**32 + 0",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "040000000000000000000000000000000000000000000000000000000100000000328bbc85099acc7685cf4bb5e18d72c57271615ccd46377bfacb0e8501aa76fb",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "581bb2ea633af1e59b15c1342d5e14adb58f613a231149f7df7a69c0eca95b2c",
+          "result": "valid"
+        },
+        {
+          "tcId": 73,
+          "comment": "ephemeral key has x-coordinate 2**64 + 0",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04000000000000000000000000000000000000000000000001000000000000000010048b687675af9815297d73a7f25b1a3c42d33c64b466991a7573b4954aa0b0",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "9920473de58a319ebd87d57f4f6c09093c5e0072c01bc8df0dc60b8a7a684c6f",
+          "result": "valid"
+        },
+        {
+          "tcId": 74,
+          "comment": "ephemeral key has x-coordinate 2**96 + 0",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "0400000000000000000000000000000000000000010000000000000000000000007d12de58d54423eb85ae8d157ae416fb004a7eb522ac1b67047ef3cdf9acdc3f",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "d9cd0d10ed4d3dc01f4216d229e21c6a447227a5bc2592c359b2d689a2dee3a8",
+          "result": "valid"
+        },
+        {
+          "tcId": 75,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 = -3",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "046522aed9ea48f2623b8eeae3e213b99da32e74c9421835804d374ce28fcca6622c7fda3c84b704f27ffc0b2ab350d8cbc33a34df0c811155ed4389d2710e3fa9",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "af8bc612853197a6ee8b4af7300c0bc623f0cf4e4b301f47d66c27e8ecce9268",
+          "result": "valid"
+        },
+        {
+          "tcId": 76,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 = 2",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04507442007322aa895340cba4abc2d730bfd0b16c2c79a46815f8780d2c55a2dd4619d69f9940f51663aa12381bc7cf678bd1a72a49fbc11b0b69cb22d1af9f2d",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "4e173a80907f361fe5a5d335ba7685d5eba93e9dfc8d8fcdb1dcd2d2bde27507",
+          "result": "valid"
+        },
+        {
+          "tcId": 77,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 = 5",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04085ec5a4af40176b63189069aeffcb229c96d3e046e0283ed2f9dac21b15ad3c7859f97cb6e203f46bf3438f61282325e94e681b60b5669788aeb0655bf19d38",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "d874b55678d0a04d216c31b02f3ad1f30c92caaf168f34e3a743356d9276e993",
+          "result": "valid"
+        },
+        {
+          "tcId": 78,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 = 7",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04190c25f88ad9ae3a098e6cffe6fd0b1bea42114eb0cedd5868a45c5fe277dff321b8342ef077bc6724112403eaee5a15b4c31a71589f02ded09cd99cc5db9c83",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "11a8582057463fc76fda3ab8087eb0a420b0d601bb3134165a369646931e52a6",
+          "result": "valid"
+        },
+        {
+          "tcId": 79,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 = 8",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "045f177bfe19baaaee597e68b6a87a519e805e9d28a70cb72fd40f0fe5a754ba4562ca1103f70a2006cd1f67f5f6a3580b29dc446abc90e0e910c1e05a9aa788cd",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "73220471ec8bad99a297db488a34a259f9bc891ffaf09922e6b5001f5df67018",
+          "result": "valid"
+        },
+        {
+          "tcId": 80,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 = 2**96 + 2",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "043476a8fa9c7448124aa945a2e1103eb91f95c7b4d91aaa1c35b8965191fc0fe04ddac138688df5123fa5760d670247893f9ad5cad5e88895a0ae7fdf97b8f412",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "f4e5f1757c8a03a3aec57b598b66a93bb356a6917e26b60489c0d06236ac6a37",
+          "result": "valid"
+        },
+        {
+          "tcId": 81,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 2",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "0455555555555555555555555555555555555555555555555555555555555555540a46712790e63f981f0103b2a609fa691c5291a17974eb0c3b518faac21535d6",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "be033e3db6216d3b3f9d66c96ca3b24475813ba8eb7820d7d6ff29c72fd39c64",
+          "result": "valid"
+        },
+        {
+          "tcId": 82,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 2",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9389142d4676cee2332eb8909fa13f95f20cdb3acc831a231802a4858a973ca63",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "a0da0b184f59ab0fdc0a6b03157c1b75269b284608b74a6e826f77104c42a9bd",
+          "result": "valid"
+        },
+        {
+          "tcId": 83,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 4",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04333333333333333333333333333333333333333333333333333333333333333311489212aff79cbed5b6440161d57c98a34e6b80ec3854c3b2855af35f0d17e1",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "ac03527f79d801081da4c0adcbba92e983ed46254354fd98e23ab659ee02a6cd",
+          "result": "valid"
+        },
+        {
+          "tcId": 84,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 4",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc75552486fd8e6bc424492204207fece59d93fb124390497f841d9c808c8cc3ec",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "0d2759dae57c906a8cca8541a56f429a6ffedf028212f7f0ad06b696ee655caf",
+          "result": "valid"
+        },
+        {
+          "tcId": 85,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 8",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "040f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f03425ba0d8a018b42861e816c79a17d3b47df8f5f7107c181168e9edc62cb3cf",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "ff6e930d08290769ef982bc568b0b45f88b7d5219b00667820793b3e824c1615",
+          "result": "valid"
+        },
+        {
+          "tcId": 86,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 8",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f017b41bf72c9f5ec204dba0deb5dfaa43b793a83b243060d0375b969e0416bd56",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "bd106c43e45272091553f476e015fbb0982764c018d5f0666834ae0dc5dca131",
+          "result": "valid"
+        },
+        {
+          "tcId": 87,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 16",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "0400ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00f918461138bca461c00fc474da0e4e35309be520e2e109e17a1cecb892b96598f6",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "b661d2bf35efdd264f32a3bb254cd6443e8115a297aba1d31610495d7c560dd5",
+          "result": "valid"
+        },
+        {
+          "tcId": 88,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 16",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00feff2d6c62a47883c5899cac06b1367c21948689d522674a60f43f4b808adf618b0b",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "e818ea3c65c24330b7b8894680fe349b17f450e9d878292f1390ead78085ed1f",
+          "result": "valid"
+        },
+        {
+          "tcId": 89,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 30",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "047fff0001fffc0007fff0001fffc0007fff0001fffc0007fff0001fffc0007fff2e2213caf03033e0fd0f7951154f6e6c3a9244a72faca65e9ce9eeb5c8e1cea9",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "55d0a203e22ffb523c8d2705060cee9d28308b51f184beefc518cff690bad346",
+          "result": "valid"
+        },
+        {
+          "tcId": 90,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 30",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "048000fffe0003fff8000fffe0003fff8000fffe0003fff8000fffe0003fff7ffe1d3b684a87958143f250bf5a2f7859fd036620b4dc18dacd1d0c8c42eeb2e54a",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "50af11f10d130df5f9adcdd0103ff3d42808582487330932c2546022bf7c6a18",
+          "result": "valid"
+        },
+        {
+          "tcId": 91,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 32",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "040000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000fffe7ccb5c10c028f331230dd0a005e9faf37864c198c5bf7d91bdd71624520d4b04",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "ec90224ee61b2ed7cb6b9716e248aa099dbf1eae41d1ca477e8e5ba4a512913e",
+          "result": "valid"
+        },
+        {
+          "tcId": 92,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 32",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000fffefffd620bbe0a621748ea2b0e0dfa463169e7c805412f4374dc9755c4db93989a7529",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "cf1acfa0595265623fbfee5d8498e609b6590760d1b04f31f3470cd1af3ba9dd",
+          "result": "valid"
+        },
+        {
+          "tcId": 93,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 51",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "048000003ffffff0000007fffffe000000ffffffc000001ffffff8000003fffffc0c3527bd081c1c07b313bc1a0c3f845fb2fe22557699ccc8f1354e61a27b7f88",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "967e55f853dad60f678bd35a46bd3c7dc6cf7d18526ac0890af80ade84461005",
+          "result": "valid"
+        },
+        {
+          "tcId": 94,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 51",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "047fffffe000000ffffffc000001ffffff8000003ffffff0000007fffffdfffffe232aa1c67f77cfb00e73898cf431831073c6b2a4bfa1135881a0595720759ece",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "f21a20024d8315ae877f90af5b0c68b6a50214fea797942870c35f4ca127e591",
+          "result": "valid"
+        },
+        {
+          "tcId": 95,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 52",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04000003ffffff0000003ffffff0000003ffffff0000003ffffff0000003ffffff1582fa32e2d4a89dfcfb3d0b149f667dba3329490f4d64ee2ad586c0c9e8c508",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "06fa1059935e47a9fd667e13f469614eb257cc9a7e3fc599bfb92780d59b146d",
+          "result": "valid"
+        },
+        {
+          "tcId": 96,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 52",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04fffffc000000ffffffc000000ffffffc000000ffffffc000000ffffffbffffff73f471909cfde3db2c13523bcf372877c28d23ed1ff6a3326df6bbc4b756723e",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "2e83d496538e7bd16b530d93b960317394b5f8b9da5128a03d08b3c8fbb46561",
+          "result": "valid"
+        },
+        {
+          "tcId": 97,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 60",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04ffff00000003fffffff00000003fffffff00000003fffffff00000003fffffff2c63650e6a5d332e2987dd09a79008e8faabbd37e49cb016bfb92c8cd0f5da77",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "e3c18e7d7377dc540bc45c08d389bdbe255fa80ca8faf1ef6b94d52049987d21",
+          "result": "valid"
+        },
+        {
+          "tcId": 98,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 60",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "040000fffffffc0000000fffffffc0000000fffffffc0000000fffffffbfffffff71664ef90d87525ddf7815e676ae3b96c25ed9e7bdaa05da96227a1fe38c3d11",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "bc0a152832a8972bbeceb522e661e5249cc7455bf93cba324e810ab62a2e58c1",
+          "result": "valid"
+        },
+        {
+          "tcId": 99,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 62",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04ff00000001fffffffc00000007fffffff00000001fffffffc00000007fffffff5df80fc6cae26b6c1952fbd00ed174ee1209d069335f5b48588e29e80b9191ad",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "f503ac65637e0f17cb4408961cb882c875e4c6ef7a548d2d52d8c2f681838c55",
+          "result": "valid"
+        },
+        {
+          "tcId": 100,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 62",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "0400fffffffe00000003fffffff80000000fffffffe00000003fffffff8000000007bc25fb4d2b4cd12a16515725d64cdbd5bc86b7f84ef005c9e51d0700a3a4b8",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "68e8765c71a63f3458e8edb2e52f499a1de13ae1ff1c95f18c4adad9d898667a",
+          "result": "valid"
+        },
+        {
+          "tcId": 101,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 64",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "0400000000ffffffff00000000ffffffff00000000ffffffff00000000fffffffc4de9de6942e770033f5f1defbb36249e6bdf45a33e2ef4ec75a7ad880b5432c8",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "4060db7a9bf8ca17a5ffa614a85f9a25ed6f1854dc0f2396b9e8439ea8807a55",
+          "result": "valid"
+        },
+        {
+          "tcId": 102,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 64",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000462e0f7377a81a3a47a28e62dd8105687e457496c61fdce49ba1aaeefcf10b44",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "9e6b02ef374c5b7c8d1021d1e0520ef5f6e3cb7e454d6630bd270decc0343f1e",
+          "result": "valid"
+        },
+        {
+          "tcId": 103,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 112",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04ffffffff00000000000000ffffffffffffff00000000000000ffffffffffffff7a116c964a4cd60668bf89cffe157714a3ce21b93b3ca607c8a5b93ac54ffc0a",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "516d6d329b095a7c7e93b4023d4d05020c1445ef1ddcb3347b3a27d7d7f57265",
+          "result": "valid"
+        },
+        {
+          "tcId": 104,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 112",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "0400000000ffffffffffffff00000000000000ffffffffffffff0000000000000012a69aaa5d3ac4cee07592ea0989dd9f426a0e4d16807b6c6d04baa628a659c0",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "e7e84fa13b2c443d0a5c3ea60cf87e772c7faf9f18ef5a0d77113dd6c92c8d17",
+          "result": "valid"
+        },
+        {
+          "tcId": 105,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 128",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "040000000000000000ffffffffffffffff0000000000000000fffffffffffffffd137bd006820a8be23475ea25d8fa05c8ed47fca1236cd5d1f07667db6fcd2979",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "6c7b3006dccdb0b021f00307200793374419358b1367800ace76d988b10ff699",
+          "result": "valid"
+        },
+        {
+          "tcId": 106,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 128",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "047fffffffffffffff0000000000000000ffffffffffffffff0000000000000000322a5313a994312a3f047d5a9c6cdeda173f1d3b35143b3b1a594f7dbe544d0e",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "b522e81a22720c57040f2e02781728577cb5603ea280be7a1c84750e33d7c963",
+          "result": "valid"
+        },
+        {
+          "tcId": 107,
+          "comment": "ephemeral key has an x-coordinate of approx p//3",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "045555555500000000555555555555555555555555aaaaaaaaaaaaaaaaaaaaaaab79dfbfa5e66fbea30e75ecc703e65db43e027416c01f6e20fe129be0e43457d8",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "f9ee8b2b668e2a76ed66dfc57006b6403ef8e388c066a0b0493ee0425f8dbe3e",
+          "result": "valid"
+        },
+        {
+          "tcId": 108,
+          "comment": "ephemeral key has an x-coordinate of approx p//5",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04333333330000000033333333333333333333333366666666666666666666666610a4ea9bc365e1b224b173e9fd688a5234932ec90a5cb9ecc0a22a109927e73b",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "1b78098993807e9df54800e2c0f836ea1c4604f7b3c9401311784f69ac4657bb",
+          "result": "valid"
+        },
+        {
+          "tcId": 109,
+          "comment": "ephemeral key has an x-coordinate of approx p//7",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "04249249246db6db6ddb6db6db6db6db6db6db6db70000000000000000000000005ebbe906d14cfa3e7e90d397973f093a6c678a23bcb2896189ffece5a1ca398e",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "7ee2972f263079a49b5bfc664bcf42c2573af3514340e8e726e08881aa2d33b1",
+          "result": "valid"
+        },
+        {
+          "tcId": 110,
+          "comment": "ephemeral key has an x-coordinate of approx p//9",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": "041c71c71c5555555571c71c71c71c71c71c71c71c8e38e38e38e38e38e38e38e46ef488581fbbd6b4ef78d03cdd161272243fdcc10979fd8e8fd199b98a63d378",
+          "private": "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared": "7b5020080ce9bd76083ff132dc28ea996314be1a4ac21f987fbbe859f902fab1",
+          "result": "valid"
+        },
+        {
+          "tcId": 111,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04851eb1b8699d1cc01c6b6048139797dab3981c924f9ef81bd1f464c3182c870901285b2ae7cbcabfd5bccb9441eb3376b491595f60a1ec21dbe9f972bc32abbe",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "6d03fef6b354840f4642fba1c8fce9f7d1cda8ae27b6ca01510fb44573fdaffb",
+          "result": "valid"
+        },
+        {
+          "tcId": 112,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f576e22747f6c77a8f685a7a7b527363e0fe7d351a9e3f5923fff2bf97e91af41e575d400331cfc9f97180d8a48c418c5a982609fab88937d2590bfdaf37d6a4",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "98009cee0e8ea4fb42dfb70a5ada46ece32e2885a4f9c3a6afba13e82f87e113",
+          "result": "valid"
+        },
+        {
+          "tcId": 113,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04310785fa42c37bd200781d70e3859b39b2fa1d286a3b6c4f605a41e045634b81b8d32564a7a232c5d47407a7795c01eda819f23a5a190149eb8c9abf94ed7c49",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "e8f0e427cc30ae50197d2bbf3a451667a470797d5abe55ff1b1d6de88e41372c",
+          "result": "valid"
+        },
+        {
+          "tcId": 114,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0481bfb55b010b1bdf08b8d9d8590087aa278e28febff3b05632eeff09011c5579732d0e65267ea28b7af8cfcb148936c2af8664cbb4f04e188148a1457400c2a7",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "b485f3364354b738dc5402729b880c90c502d9ab52ccf81e3d21602c7b9bd909",
+          "result": "valid"
+        },
+        {
+          "tcId": 115,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0402495ac9f43e45aae30d3366e351cc08828cf3e11cc3b7209fbd1730c4a14f4e4aaa98dbe0d94caa44538fcf7949eb44debb7bcd228a54d9cd9b3c2eddf94611",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e5781ddaf18dcfc33f4879a2660b7a32a599fc32ea5a1beb28a48caa3e6ec7b7",
+          "result": "valid"
+        },
+        {
+          "tcId": 116,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04efe7754ed4c0b3c1dd301bc1ed69800aa2ff5d51fb85937715e60d2e7bcada8e4ea7e547a04c3869106b56245c27da9737b9e8160c05fb0d86040276708fb9fb",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "b5a0ec92aecc3010d27d2263d3da66e3d2f3395d23947024a3f4744454622027",
+          "result": "valid"
+        },
+        {
+          "tcId": 117,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0466aeda76d73983caf2de921af389268ceffd278fb9eccf928702b1f4271b43f1d646d6cf8bc11a0ef97cd64c08a11f72f94af4e6b3c9870b8eb3a5b036c04fb8",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "8462e9df7960ece33089e5a98d61da4faaf3660f93d75f7cc5e397b64cd1591d",
+          "result": "valid"
+        },
+        {
+          "tcId": 118,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f483602787972cf7b7582d8e2f2c7998e537ca57eba69718b68d96240f035b1b55dcb4f7be7b79c469ba8a0b104900d7053ffcac04f394be925fe0cff2e969c3",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "d44d05d246e61892c1056e28865f60574dbeb6be62680776a537b0b2c3e6b4dc",
+          "result": "valid"
+        },
+        {
+          "tcId": 119,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04579be77fa6698c4baf0132d2f7993ed76dfd36d78b584605e1be024595e3ad51c069473e1b25fd94a42b68ccb3004a851593a3af78f922d90920d8a877c365f3",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "0550ab2f9500b8580dad07073506da9b2db71bd974a85f81dfd148e260bc8ec1",
+          "result": "valid"
+        },
+        {
+          "tcId": 120,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "047f8128d883be31873efedab699206f889b776be270e163df43035409fa5215f1f36c3581f8f8d569a4323f8700ca09792150421521e2ef0a96ae9a4caed0e02c",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "1312f05b3e5cae60f27c9485cfd00584cce3f961fee2fdf103c32a79ba17ffbb",
+          "result": "valid"
+        },
+        {
+          "tcId": 121,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04ee5d94bfb5db9cfe511a3aa70bafc93db93107383c12f5bebffd90c621a2051db4fce13261d54ab29c3c699b77358edb54c71801f3fe2a0d5cdf2ee3f184b4d6",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "be4792922519717e235366d64709c51b027d440c6fb8c216fbd92498aaf71277",
+          "result": "valid"
+        },
+        {
+          "tcId": 122,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "040ec4f8845226e864c088505d721a2155190d4caa9a1f5a3f0afdf2ff49cf6d8bad01fd3808aa03442cf5396e10e13efd24cbd5a52862822eb62dfd27b5040600",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "05a2ed58207e0d6a99f37a6da640f8b3b1acaf0c16826bc4fd1eb1e2a6a1534c",
+          "result": "valid"
+        },
+        {
+          "tcId": 123,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "043107892f3427842c8d6aa60afb1d3b1441e28a67f10e1198a07265125bbda7e2ca9d6df758904f2207cddb862806af0b8cb66ad72b161b4dc959acf614fc2f90",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "def48de01d86d7260e5c2a6439068542437a20b140dcd45623dd1ec0d1394742",
+          "result": "valid"
+        },
+        {
+          "tcId": 124,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0409e5c414b7f5073858553b8b8b4295488e3f3ab966581f240a6124251512270f8fc12563fb9bd6f97b445417cfb14cf9944bac1a26c176b532b698ea8c1bed6f",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "c06f7373e67ee8c64dd86127fff8b2d23d284420d30e571a79fbb9b54aa70dfe",
+          "result": "valid"
+        },
+        {
+          "tcId": 125,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f93b07969211cafc1a30c5c578c8bf35be63a04daa2ba434da8b5e4b83769ef554b022e4f7f406bc93e71a8719ad0ccc392755ceb274e248829a72540e95f169",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "7a966ea1fd7c32b1fe01eb14b50d835d92c31f0a4204517aea66939e7106cc1c",
+          "result": "valid"
+        },
+        {
+          "tcId": 126,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04513609657f902924e921dab1411685316b41d2bfc0be53d1de49db9c1ca78e55141d36501aac4b47dbf24fad43e47bac111596c05f66ef69258ddf0227e8e7ad",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "27347a05a945862499ce29fa7f6e4b2c496b6984b3936db3da2a5b82c4fe6302",
+          "result": "valid"
+        },
+        {
+          "tcId": 127,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0493ebaf5ecc0aa486e7e735130611ab5b165fe395a4f1ea8f82097ce422f44202ae855c1eb4c334f53b87e426801a0376837db2c86137522894ef6d9d69520163",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "4f04382598f2288f95fda3657d5e517b5f8885f2257d12b3efabb624ad5d2626",
+          "result": "valid"
+        },
+        {
+          "tcId": 128,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0411fd00b18efc4efa07e87878b5df2e7a596f93b950e50e9adda40d4e6ac854c0cc47edcf533fe03a614c03a709c9d0c0cf8dbfd4e2140b5b2df23848b49548c2",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "3b50f822d5c9311735fdb358e8c6fb2e4aa695656d75f84f151cbbdc40f7f259",
+          "result": "valid"
+        },
+        {
+          "tcId": 129,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04501a72044f83c517316628b0bc9d89ab82131bc12df36c7a42b952d5bc23c85182ba2906e104dd0a7eed7b0b1772e12b3b3b7f40a2df049174fab09a02a1a5bf",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "ac45cd4afa8a5e4e4a0e3f60e7bfea0b759875781aa7722750022e02b66e1303",
+          "result": "valid"
+        },
+        {
+          "tcId": 130,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "041f3d7d05b846eab4dac4db695a441f194c226821f5429f66aba4ae0e6ba5b90400334b91fd4073d1b7c354bd62f6bced7cdbbbd7c2d392b03ac1fe52df084069",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "8682d123138dbb4dc40451478b078596e5b19c8b1b5c68c2a8a3b046873bfe6e",
+          "result": "valid"
+        },
+        {
+          "tcId": 131,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0411ccde06e8de88d192897fd0f7bb5896553a524df319e4594a55623bc76462e122a170de0b9442314a947fbf5e035880b562ef88e3ac98594f48abc63741337b",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "246a119990f295924b62b290e591f428054c2d34314c54ee50dd3d85ed5516be",
+          "result": "valid"
+        },
+        {
+          "tcId": 132,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04594b085272f89fae6813fd3944baddbb9f2b18236273cdabf3e607a73714a252956035b2531b98fdafa63ee7e72752ef03caa9ebbb1697a18e6d31e149485e5d",
+          "private": "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared": "343c4a2c74e9416b07c855c2ec5ab053e11b51c47389d8455d6175e24f513717",
+          "result": "valid"
+        },
+        {
+          "tcId": 133,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "048238f048c292e08d49bdb5dab1f08da6d39cdbefb1d75e03e76048b903d6baf9c761b25afbf041e0e65eb9e013c336fbfc364134355fd10a86c258de3e19a857",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "81fa8ca50ac155200de410dfdfd8093037674baba7ca102828a5d0026f24f0f5",
+          "result": "valid"
+        },
+        {
+          "tcId": 134,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "042d08cf1230463b7102e8a54185986a62a3f2520c0c151ace12f5d073a40cbb2fecb8c2ed0a722185e987cf7c32acc42133f6ddb7230ea48dc0f7c6b5a43a4c0f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "151411c3b8e6d25c515186c1d9b9c6e1a05da5a7f09cd4ea8844e0916846ba48",
+          "result": "valid"
+        },
+        {
+          "tcId": 135,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04bcd1f2a75eee0baf7e0f55bbb1c876966d9d5d21f02a145ac9668491e4ca5e511c5be74b4082596f2c6cdbdb6cc9083895f333cee8075c2650963e7e727906e6",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "f72d64d6b5e38ae223c77ad3467818f8b03b9535011400157a5f426c4a512fa1",
+          "result": "valid"
+        },
+        {
+          "tcId": 136,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "044700bc548e9d6256ece382112b93f8780fd2e427f690c35bf31f682284119c725ea408d7fc6599bd2b0e754f9de166ea47a4e48b14925fa7bb635ef09642af05",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "108a89a0bc8e1b85981fe4853a86a42648ccbe6855dda1079136db8c59fc2065",
+          "result": "valid"
+        },
+        {
+          "tcId": 137,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04a0b351864a8c47ba445634bc107fed06451f97391c55921db61e74ca527a6a45fab27b1896d52df4611f627414c48ba7a131766002d5523ff883a499769a422b",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "7d362a6e1f00e525fbf012fcc9da98e09ddc281c143f1e023fac6a6b6303341f",
+          "result": "valid"
+        },
+        {
+          "tcId": 138,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "041350cac374bb076ee89eb8af43d076afc7312021006431fd909d22df064f6637244f236a65e7c1c778f6cac2d9b4ec3bd999ac185797a227cf00552d6aa5163a",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "1de1656d961de1f584a2f7179bd3be3b4a282cbd3248f29e74b73a812cad8d90",
+          "result": "valid"
+        },
+        {
+          "tcId": 139,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04c185508f464f67aacc24fa859e744fe57c3ecef2fa911c16dd2cbd073b308aaa8fef47dcef6b0fba6205f0b7e23d17758f1df5401cd9a39de42b07b92d153625",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "56ae038f61abb293f43328a5e6e40bdf73f9e7d5868e5bf1af3b03fafa559e86",
+          "result": "valid"
+        },
+        {
+          "tcId": 140,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04dccff194a9d307b5900a13f2d7a192f6e82845af1007c951b5b9720bff98d0a028fb8ba9238ad537e0d7f31444086611430abaea547913a0591dd908ecd864b5",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "c75eb0a2cd617f0117f1d9adc1056a0252a0cca0b64b373bb30d5231380415ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 141,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "040cb05cb7a4b01db1382620ca756285e1a7c6846bbb595cbbac9f89e0a62489cca88829c95f6b2e8187d2e1c3a744f41d3ebc98fa01748b1248462b350256a5e8",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "010385fdf7f4c6402ae432e4b2f11f2f861c75c4dd27b4f35b7f1efa94bbeecf",
+          "result": "valid"
+        },
+        {
+          "tcId": 142,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f95894cfe4f14ccc483adf9cdf106709e3eca5ceb20e7c145d3bf18b6aeaa8039c42c0c8c3db57e0bbb2593ebe088771ebd0e2857fc2a877c3748adacd038542",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "af116b172237915370625d3ca7360a6b6d651c573031ac33c0ce4b72a9427a7c",
+          "result": "valid"
+        },
+        {
+          "tcId": 143,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0416a8b93a6b9529b5920566131a792c554ac421af3a4bfc341408d14ddc8971c5f60ea4663449bf3ec747481d730c4d97a1565b5bb207e27e55aec88969f2023e",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "10c3a41e0a1d0018444bbc3bcf76b2893f66b69cfb046255c82a17ffa3413246",
+          "result": "valid"
+        },
+        {
+          "tcId": 144,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "047d9c0f7a011de080da8e6e225f7211e729c29425c9dc9a289d5cf8a0f63589aa129b3bfcb433ff084409e32f73741e592913003367123b3e6ec4b7fc398d1b29",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "2695b4e4a5c648ec17905e69286b6d4935a21772f5ded1e55136cf17331de9d5",
+          "result": "valid"
+        },
+        {
+          "tcId": 145,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04fea54580f4096299c17c281a3fcf6738226b636c85e8efd360a4413848b07881fd47181ae8c3ad8948f65d8c845a863b2f86a6ce8aa37a5e5c20d3e96fc9c884",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "a6f648ff3373f9433a21a38829a5667ccc2b1bcd3de13516537d6d9b77c04044",
+          "result": "valid"
+        },
+        {
+          "tcId": 146,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0408beacc04ac27e3839ce74d515d238aa98e1aa1b5e580fc5fae0116e520d880cba0585f723c44f243813b07e2d7626605ee5861523d1ac075479da773efe026e",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e1db68841b6000deba2e9a666ab2cd227fd9f33f69187b611dafec0d6c9b6e7e",
+          "result": "valid"
+        },
+        {
+          "tcId": 147,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "048cc2807089ccab7bdfbf1697f153d4eea63f3043ce63135f6b906f8235f76bf99ebdb2c26b09f49b122d1ac73a8ba37ce9c385c0269c4e40ac3a9c20314a4437",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "36648fd5e125abe08ae21199d08eb78eb7e345a1fb3b26e5fd25d3c1e96e3bb5",
+          "result": "valid"
+        },
+        {
+          "tcId": 148,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04e854fed884e6c76277af9d8dc83df66b81478a8ffff2c313f22abf0f8d4442f50f57244419b2075ce2b282440944213d87c50f58b9e7b71765d45fcad152b333",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "418df7a1a6315f55104b5b9f96da454725f59992c588a531e80a4744b8d7d4b8",
+          "result": "valid"
+        },
+        {
+          "tcId": 149,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04c1f319279a7bae9f3dc527c42308a7a6255763cccd6f24d266e75f88eb4d022f6b3a3cf14ed3b5e6915ff322b705b175da07223cff4e9ad4520dec7028e1e396",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "32dda9876dcac25c58543304a2cf6c1b31fdabf3c89e43d6eee628a02422b19c",
+          "result": "valid"
+        },
+        {
+          "tcId": 150,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "044753ee2e3ac201e9a4bf25e31513a45365b5d0526dcb2e0a88736fc8ae2681c1cc49b1e868d4de224593ec7e00e9f2c209f3b935428d3bfa978f74869af889e2",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "4c54d63b14b8ff10b653f663f3230c1827d682c833ead1f44ad6ae8e7df35e2d",
+          "result": "valid"
+        },
+        {
+          "tcId": 151,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0429c1e774c9d3a8930df8a663fadc8b9a6092d8054ff37adf598edd78d0a3ffc57173a3594be68b7ad191e0ff27d79eb4e7bb22f1090873cf307cd073b27368fc",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "4df3a98474884b1c3c78b6c81e4f90d53d8bb4daba4227c411a5747e6aac8cb8",
+          "result": "valid"
+        },
+        {
+          "tcId": 152,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04893cb0c308aaa2092d9af93e0f02cd951ec386e866480eece443cc89e672733ff6c6f43caa1e1d168ba3ead9ea041cf4f227d76b90e9e25f497f2ece8935512b",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "d2aa087051fbdc35051d21ff415f934ab5698629abde5d4b39f2f6a76e3992cf",
+          "result": "valid"
+        },
+        {
+          "tcId": 153,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04c5a2dc340e0983aad4f895bf54be9d9e176d6ba1ba6c859ca0851889a97b7dc5c90dab79207b861fd996429639cd8f31be0298b63f4934923a483a9e6f7c5ab9",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "ac7c60651653a4f3d4478ebb9aec4381183ffe1b152b6643c07c47c0b2a489cd",
+          "result": "valid"
+        },
+        {
+          "tcId": 154,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04e9db2cf8037505fd8a8044f4b3f80f67f9688815c69c788ddb26fcb3c84cb8adf02e121e4020424c6d8f1d269c00f2a7f23a59237fb48a5ba17ee57c1c264282",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "509d06dc43813dba9114c13c337bdc0bccc2c7dfa7a7d8960e5593c52849c855",
+          "result": "valid"
+        },
+        {
+          "tcId": 155,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04776aef1acb82b628e132cc29440988f0a15d4cc2b4f328aecb063c9b86e5018e91bb2038fbbb05573b1c943de8bae0853d6a934d4d164429aa145d68e9c2e0cb",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "28a88b6b258f233020ba6fa9c00d1d72831f4515b86966a9782f521315e18aa7",
+          "result": "valid"
+        },
+        {
+          "tcId": 156,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "049ec06b0b08662c0e1dd9111696a63a1601cc83cee20695778adf84d43064fc90ea9ffe0e7b32c3e30e5f7809d9acc49a8da7b77742c2a3d3660f1cee1dd4be19",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "c4ff865ff3dc4953ea78d92a02f3345a53bdb6050cfd8f41baa4395ecb6acab8",
+          "result": "valid"
+        },
+        {
+          "tcId": 157,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04fa51d128adc2000f09ff12c6fd8e25aa08556d708bf6b0ffff9e8eaad4783f0d1dd40ad51ae91e0ab471f2f6067052b1afe96a57cf5e4ddf899a6258f81c332f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "de1069f051637e10166559cef44688afc809341855261215c4f381d9d7da76ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 158,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04614dcfbea4789a3f3eb4a8e2f111c887f0248d9316b99d0864c927a045d69417ac5f8c4001f7b6e67faf5b2692f745b86f51e725c1080f15330a631ef6a503ab",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "4207bf4159faa0e50ed238b9c0ff46194a539a1ba03a5a4c8d68f369aecd31a5",
+          "result": "valid"
+        },
+        {
+          "tcId": 159,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "048321763f5533310a4779e83a58ff110480394690f7c2f65fc229c1a58ffbddc86d170141a108fc92f2bb96ddcea0652cb650c5e863af9289d37ae87a29022d9f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "7c8e29caa01e9f325e1e70d71a59850749239adf4e1b8fa5d6d0abd70c83afb7",
+          "result": "valid"
+        },
+        {
+          "tcId": 160,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04aa42c977da1ed42e52041c0af2c090f244b22ae354cc9b10781e44c89eebe336f7100a0eac8b55513ce57a8d0c195adcf50d1b05fd35b0576cd92805cbab4c1f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "98afbf6e00eb004c79657b40b7105f8526b5205942af2218f453bc26337306be",
+          "result": "valid"
+        },
+        {
+          "tcId": 161,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "040730d77d9114d5610d49a98dc196ca9e1e8fd2abe007da96b574f736bf1939258c8814055a774f7e79f7b4fb9cfb03d839566afc6059311f3d55d49ca4ddab31",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "c537409021ad95646fbccf9232ea47fa764d12db7595f436a65ad5b13cdd19f8",
+          "result": "valid"
+        },
+        {
+          "tcId": 162,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0485a82fabb60c7664e2500c59d0f24eac1aab0060c07b49828c55009fd27aa49647b85f72b467bfa2fe1b13258feb121aee75a3155b30e8b4b566b610f13b6dc5",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "ad60146b1cf2d9661884b9ef867cbb09e42466563936b03174efd8517ca8c6e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 163,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04833f2a6e5c76c3ddd13a106cee4aa8b2a9dc32e0bd7bbe2a6322abe0ab4110a2ab93845403808a7cc8e8b65fa42da414327ec3a19d539fc033ba8d8aae7cb23f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "f677a03d68570cf6083a1ba415b40b5f7ffdace4eeb804983cbd03b979d939b2",
+          "result": "valid"
+        },
+        {
+          "tcId": 164,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04cf8116ba0901b0b95308bc686fed90ceba0e5d424c8ec206cab8d7cffe93fba2d5e7a62cdeab84a20fce37b5b0ac168ca2a85a1d18cb04ee48deb250b54691aa",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "30c9fb67a3db93a4b3a54135d265171a14a2a0a79cd715e13515510793d8d081",
+          "result": "valid"
+        },
+        {
+          "tcId": 165,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04e754cdf8e56944d5bd36d025b1c0f5fb2754a2eee0fb5200bd169cdfc83f07c38f2b7881de647c2c66294e1adf767e515adda742d3a863f0cdd6665b964e60a3",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "8451f3414247058c32b53be128cffd2f2887434ab902b67b05fbbe7aeed8cbd1",
+          "result": "valid"
+        },
+        {
+          "tcId": 166,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0474f1feb9a641fd87a49e16fbb1be363297ef971213bc7d36b6abbf29d0e88ac34b6c246b313be6c3c9f33defd4ade947af547168f7c22278df8cb7b06a8018c5",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "dd6bf055a9e431479707e64590fc58f97ad3238d063ce8f66d5d37b2e3475638",
+          "result": "valid"
+        },
+        {
+          "tcId": 167,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "049368066a0748867a7b870244f5c9f82ea8bd51552959dd550bb7394497159a5dbf89b521e51db372c0bcd11fee41682cecf8e702f5956f1274efee4dfcb2f65f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "4529f4b631c9984ab216a6801281fc4fd8731a58b65ca8d07bff07811116371f",
+          "result": "valid"
+        },
+        {
+          "tcId": 168,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0464e5d7b0f7fcf4c9c16156cb8745c43995f823e7e10954131e61f9fa09059e2c2f7a39dd0dc6e8a9bb7cc79d821e7c749963dd97c7070129db638c0dd1ba053a",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "12aeb42630e4885a93cac090c66479d011a1fdfaa46c0db33e0fd51e1e573cd8",
+          "result": "valid"
+        },
+        {
+          "tcId": 169,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "043da0655a52e3d6857a39faef864cee42f1816bd8d83af8c657990846821f00228f76d10162e295fd7737d0d22fafbab24d5db0ff432b51354030e1fb09273c51",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "ad8deae400ae52dfc8d5ecd3518d78c789b3ec88cc1ec7719081a066def26c4e",
+          "result": "valid"
+        },
+        {
+          "tcId": 170,
+          "comment": "edge case for computation of y with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0442e831d5dfd2b9f5387263cd686ee03dfa235cbc07f6f3a87a7e8150556362b32be47f8e3011572855ca487ffb594f7722ef9fc3292902a23146c19bbf6da76a",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e6d3991eecb1a4b78aa700ea56934a38785b3662c59766e2ee5b157f77ecbb7c",
+          "result": "valid"
+        },
+        {
+          "tcId": 171,
+          "comment": "edge case for computation of y with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "041321838efd80e1dd8e4d0d95d17895c7dc60303a5c234182b592d9d21ef14752a44eaf3394c63708763f3b97b2d2863fd3b77ebda44862c7c23daaa437d5fe59",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "99bfe73eaba2599e79307488047236de003e9fd26f5ff1dbef62b3fec75fd612",
+          "result": "valid"
+        },
+        {
+          "tcId": 172,
+          "comment": "edge case for computation of y with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "042407bb2cef161472cc799db14e703183676f312c571e9f3df137f55df9442c4077bf00500aa7bece8c1f762ff08a0ec71bfdadfaf13380704e6202de62c5f22f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "faedeb03f8b5178db58604ab69b10b176e92c5deccf4249a9d60010dcd16a635",
+          "result": "valid"
+        },
+        {
+          "tcId": 173,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "042477b9ec12029a86f50cd95dda6cead7a34f1c2360f39e3d1159793c8ee663a6bcfed85bd19d4ed3855807267e39156413b41e39a701d8d17a23ac685fe5360c",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "47e5858af99e4e916054897807d685c8cb8b0f1692ba782bec2290a58248c683",
+          "result": "valid"
+        },
+        {
+          "tcId": 174,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04c829d3a99bb47e4256fcc63210c13282ab59e7aae90877b1797bd699d672a38b8696a03730704204894aa967273c120b57cbb71f9fca62c64f692e7f49598d2b",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "ade4ff3437df254696fb2b19f5154108d88e775e57d345bbf57a02b2abb3f07a",
+          "result": "valid"
+        },
+        {
+          "tcId": 175,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04fd61ec5552fbb24b575ebdc9d4a443e156bfc0d13c9dc611149e21d79c48c444b7b73a8dbb83a5e2267a8bcd398b10af0843474c750265e9d48d04ac4ab60405",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "598922a353fe1add65ac8f66fd225e826fa8ce493470322593735fc6627e6f2f",
+          "result": "valid"
+        },
+        {
+          "tcId": 176,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "049cd9e0f17c11a10f8aaa1f47ea7141f6399f40b079b07b14cd388f3b6b0a47a8efc86998f717a83e53c8e58ad23c71d0ecc8bc841bc16ff232a5e326844cd4c9",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "923cca706deb11de7c17f8dc089dadcee15042d5619732d9ea537f7dd993fc31",
+          "result": "valid"
+        },
+        {
+          "tcId": 177,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "043846b407782243fdf3b04042990b16e2abdb325ba098532879d14e16e914c274de571bc4ce2edd7d2d37df5593959b5c7ab59ac8fe5e06c44bbae6960b6c2510",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "bf6234cf4de2040548dd0ea2a99310389db48fe6c0eb81395ab2d42484f841ae",
+          "result": "valid"
+        },
+        {
+          "tcId": 178,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04d3a07a4b6f9b660d92b3fe937e2ebf91dda8005a7ffd0292dad91d0592f1a89ed7209513bde00287b8234e280c00b3c59dc5e333c8c56864bb6cfb364e3f2d85",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "da223bd733d403e2f2f9f59ff712230b0ab7feafc87dc7021644569e3d513795",
+          "result": "valid"
+        },
+        {
+          "tcId": 179,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "042ad9550728f65b142ed676438bafe80e365cff4eb557526560e4adfd696da778f0f01da8e947628346614ed7fefe24901f9eee79de6dc06d85d563722ec77961",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "fb888df1c34b3ff15620b94a20726954eb7989e6f8a266ee4902f45e7e86e21a",
+          "result": "valid"
+        },
+        {
+          "tcId": 180,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0419f5f0b4edd6124e340adbcce791b06d14054c7eb1f9914b44245c51d6c1101d82304d117f729ef06d97eb56aeb99a6222dc3de5e30c071956fd73ee8cdbeb81",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "c656a27fc48053f9bcfa3a240f904be76954cc8b8cb3f4790613e618c5069ddb",
+          "result": "valid"
+        },
+        {
+          "tcId": 181,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "044485dc2fbc68079c357a04daa6d5306cc78827b0fa64935747b98123009b26605258c4a5608315007db08c27ba86c8971bddc529d1c14e66478ef7fd92b33ae0",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "59e168701d9676742fd203e9ff357dfafbbe51eccb2797f7bb416d4ae21bad99",
+          "result": "valid"
+        },
+        {
+          "tcId": 182,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "042f98fd0dc4b37807d9b1dd015a08a90dc90c088014d1305e49017b60d5b07e0e1e8ec878731277193c54991353d1a424a1153b87bf2cf25309c74032fdc73f95",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "7f19652f3077e73a9677fee21d0cbad29914e3bb0270fe77500c4c0a9da8eeb8",
+          "result": "valid"
+        },
+        {
+          "tcId": 183,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04df1a499387ece423215b041d19076b61902d31bec5135910b90d8819df3bd2fe9a9bffe9f1b68acab7f57f9a19ca5820389f1d73533dd73f6532d69652336fb7",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "b1c79105ffd4b5f4f92ce3a5f55624fd2aace8eee3b80f5438c8419c55051a7d",
+          "result": "valid"
+        },
+        {
+          "tcId": 184,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04b8c2c47d8c6dd3bdee17a58081cba359e86ef4e19b368d46ed5e43fbe074b08c9b3031b7756e746099d22c985e9fd6213519186acb537fe4bcdb69f5f3a01968",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e1f33be462ded1d121dd2a15d413fb8b9a105922cb90c550abe7ddf352266c75",
+          "result": "valid"
+        },
+        {
+          "tcId": 185,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0421a34eeb4e1e2ed7e4546a8144a8d1c83ed64f3318f72f7a2d786316bdb5e97412a8cfaa2fac8629fa7e20d9229f35662f5d05ea8cd38836537d16c1a64605aa",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "04b295929582f1a5273346623d9d07fa43c654e9b1564244ddf82d61793fecb8",
+          "result": "valid"
+        },
+        {
+          "tcId": 186,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "047e9906202cd1abf7147027c8647b3a5816b363266326804d6d596e875f02e1e686a981ef38871ad59f427815cedc1aead339c90d61da12b0f7275f4084761afb",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "bc33390ac64b082bb0f2ec689f239e5931a54483e7acae90442a9401c3645223",
+          "result": "valid"
+        },
+        {
+          "tcId": 187,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04bc21004d799ecb473253e3ed07b4aff2d3ca90f12943a76e9ebdcd4931c438eaa9b6e2c6834bfbe56f4c4e5e22b125814d83f2973dcd64dc7f51939574002fac",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "5a0c1a2a33176dcb56645a3548ff709e31c37067e5ef969d230c1b1927d75d62",
+          "result": "valid"
+        },
+        {
+          "tcId": 188,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04ca6b6e4eda95cccd6cc8e16c3c6c748e2acbe31b70529bcb69445c1140e63e2583cf3c33723659b2e303051c3c1e9f702f9f27421f6b3457e377356018489b46",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "7c6a5a4a5608ae11acda6292f6d3b05b7153877dd6e1ad914ff5e3550f457661",
+          "result": "valid"
+        },
+        {
+          "tcId": 189,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04884cf0d17df4ef5e488d725b47d069cd2b99940b05b26efcd55d0e5ecd205b61e3b191a7f9f920cfab05b0f9cddd02fecf857d0e405ca36f0106aa367d492460",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "d990ca49c9b414818622b9c69197fccb197c94bd1ce13c24110e94c5c321e2c9",
+          "result": "valid"
+        },
+        {
+          "tcId": 190,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04b1e5aec6272dbb856417e7ce6102bace3e0dd7c32386511e065c1a32d5688fc5c078aff94b8eac78bdb54b210bc74676d2336ab7bc7236808291540f65c82982",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "973af53e8a92e7469856265229acbbe0adb5574beb32ea6780be385b28ae8b07",
+          "result": "valid"
+        },
+        {
+          "tcId": 191,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04ff8d38f61f633c5eb570ef877e61b4466b511ecc3dc3de87e6224a8c78c0893d7153d4f87b7f9d0488b6588df56c9934ae75d1486c1ebdb49444bad832d08017",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "d9fdde34e48cadf6e63c1de84b22da7180ac644c42c055d28625b2bf11cf4951",
+          "result": "valid"
+        },
+        {
+          "tcId": 192,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "044c381ef0302e1b428f4887f7b4fde4960245920f40c4005669a091644c27482bef739bc3a3d22c6e707557f2469f504aea9e8a07591776b3324beb5c498e6f55",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "9dda17a91ad44d472304c805b350f9ee55de2d94d7327160dbc50e2eaa85e4e8",
+          "result": "valid"
+        },
+        {
+          "tcId": 193,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04245a530c56d07978f91177e8d97cb1368546bafefbf8148cef339fe7bb652ba5b27a60edd2f498ca636996a9e5e629d5c9ec203217c1b5402ff99a0d2fa97cad",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "7a69b8de61da48f9901ff440192fc90086c3a2bb56bdb224a55b89cb82c72162",
+          "result": "valid"
+        },
+        {
+          "tcId": 194,
+          "comment": "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "043cc566a230b3df272a172cd80fb481cfdb8dd1c27a84dbb7a391f11484f14ef99be9d4cfd33748ee157625f809d0fbc1a6f0317d97dbfeda4999742455fdf78e",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "76a4006db3de3e098936d004cac1f7af41d515f753b9aa4433eb2466da42acfc",
+          "result": "valid"
+        },
+        {
+          "tcId": 195,
+          "comment": "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04455fc13990663bf24cf5908c59e4c3a084fc39ee1a7b14d812c227a8dabd6f94685d00ad604b206d59b2f4d9a75442083b85a316dab78574a3bbaa6259e89a3e",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "3be92a857ffb42c5d5c128925b89aec34cfe649920dfd647f0a03f421fb20f09",
+          "result": "valid"
+        },
+        {
+          "tcId": 196,
+          "comment": "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f933578fd1938e44b271ae431ffd0df5548496945d91cb8d311ebec9dd50d036f3d88fa2aae4236cb08858158d725e1213fdb982503bc910a5b58366cd85ee0e",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "19e0d41257ccbee1c453f834fa5f349cd9bbb98a92e848354a7579dfd2c78e30",
+          "result": "valid"
+        },
+        {
+          "tcId": 197,
+          "comment": "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "045606cbf0c5b52f0f464137d0133559fea50af271a9826ff6125746636d981850d7b10dab8e64b2f8df6fafb8d5943e7b37c6500fa95bfd6680d8f2ff74c4407a",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "3a7a54996053b41361b605e73852a5a0b17d85b42b3c4a6f119c6c87ebeb9f03",
+          "result": "valid"
+        },
+        {
+          "tcId": 198,
+          "comment": "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04bf236450ef33bceffbb90e0b86f8e99deaa1337c89826363b3cb4e0a66d541030676703afc892b8059c92e24f653b9cb2a11a5f520c848303c17c2c48600c84c",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "72f042a5b276a980d50a0583483eeda72de8ac796b1d50a843b4552a151e199d",
+          "result": "valid"
+        },
+        {
+          "tcId": 199,
+          "comment": "point with coordinate x = 0",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04000000000000000000000000000000000000000000000000000000000000000066485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "40eafb850ca7e08f19ee6447f196aeabf292e27397856e106e60a6c8b48cdb27",
+          "result": "valid"
+        },
+        {
+          "tcId": 200,
+          "comment": "point with coordinate x = 0",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0481bfb55b010b1bdf08b8d9d8590087aa278e28febff3b05632eeff09011c55798cd2f199d9815d7585073034eb76c93d50799b354b0fb1e77eb75eba8bff3d58",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "b485f3364354b738dc5402729b880c90c502d9ab52ccf81e3d21602c7b9bd909",
+          "result": "valid"
+        },
+        {
+          "tcId": 201,
+          "comment": "point with coordinate x = 0",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04614dcfbea4789a3f3eb4a8e2f111c887f0248d9316b99d0864c927a045d6941753a073befe08491a8050a4d96d08ba4790ae18db3ef7f0eaccf59ce1095afc54",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "4207bf4159faa0e50ed238b9c0ff46194a539a1ba03a5a4c8d68f369aecd31a5",
+          "result": "valid"
+        },
+        {
+          "tcId": 202,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04dbfa466f12013255f9d57a6496c158ee7dd202a1ce4a5a53005b3564d509a0bbf2578007e857bdd082751ef2f3b4b9c38a0b87bab413d55ccb26a574f2b4be9d",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e2d57eeec983756c9124f885a4d118ed5b8de7d2895fd91264cf291496949a12",
+          "result": "valid"
+        },
+        {
+          "tcId": 203,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "048238f048c292e08d49bdb5dab1f08da6d39cdbefb1d75e03e76048b903d6baf9389e4da4040fbe2019a1461fec3cc90403c9becccaa02ef5793da721c1e657a8",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "81fa8ca50ac155200de410dfdfd8093037674baba7ca102828a5d0026f24f0f5",
+          "result": "valid"
+        },
+        {
+          "tcId": 204,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "042d08cf1230463b7102e8a54185986a62a3f2520c0c151ace12f5d073a40cbb2f13473d11f58dde7b16783083cd533bdecc092249dcf15b723f08394a5bc5b3f0",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "151411c3b8e6d25c515186c1d9b9c6e1a05da5a7f09cd4ea8844e0916846ba48",
+          "result": "valid"
+        },
+        {
+          "tcId": 205,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "046e8966a6013dde2bb3b2a28c6eb013c481ddb7249ef19d73b92da35cad1d6f14604bf43d798ae27621df2eddc8f5d90ee0289c54bbac82b3c5264c478761d153",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "5460bbc867f4f61b79ed491e41779e2ac8dea27ec1320b558f3cff5b6a94c224",
+          "result": "valid"
+        },
+        {
+          "tcId": 206,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "044f612e0252b8d484bd2657a9ca1bba22afe978466aae6f12bf1d9171e01683ca48f4f3c986bf941b523889a7583fae695d3d4ea4adfb57d0c82370fd82364c1e",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "a78ac266fc5a85102db78180bd9ae4b77039ec97391a211403322e4d56b59049",
+          "result": "valid"
+        },
+        {
+          "tcId": 207,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04e8b782dab2dba4db066670ae656c7eca4abc7b1a24c7976de2ce02f25b668413bda2f9991ad7aaf44437bfdd3d91c8f94178cde0f8af9833544ccc9e2d606b8e",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "f481ae23b9192191e8e1c47203f6a807e54e1ff471e6642716f07895b32f4451",
+          "result": "valid"
+        },
+        {
+          "tcId": 208,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "041350cac374bb076ee89eb8af43d076afc7312021006431fd909d22df064f6637dbb0dc949a183e398709353d264b13c4266653e8a8685dd830ffaad2955ae9c5",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "1de1656d961de1f584a2f7179bd3be3b4a282cbd3248f29e74b73a812cad8d90",
+          "result": "valid"
+        },
+        {
+          "tcId": 209,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04ec624cda95af6633088f9809e441104322ff529e0952aad4efe3286203e0c700396b89e7168b1da4dab123aa6eb7ed60069d07b241d6fff4ba04647e4fccf1a9",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "50b13920c2368b9a2e8c80a02a6f4e4a2f84af33532eaf5728da161e620a312a",
+          "result": "valid"
+        },
+        {
+          "tcId": 210,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04d80a508b155f0c733936d523201bde339794417858cd4a34b685635138ddcf67b4af7eb47f6a8491c9147b49babcdd6538e0a126547493cdcb7e8c900d48337f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e597c39fd42649418bb49eca83589645df32ff1b3f3417087ccb3ee5bf38fbf5",
+          "result": "valid"
+        },
+        {
+          "tcId": 211,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "040cb05cb7a4b01db1382620ca756285e1a7c6846bbb595cbbac9f89e0a62489cc5777d635a094d17f782d1e3c58bb0be2c1436706fe8b74edb7b9d4cafda95a17",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "010385fdf7f4c6402ae432e4b2f11f2f861c75c4dd27b4f35b7f1efa94bbeecf",
+          "result": "valid"
+        },
+        {
+          "tcId": 212,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0472aba18bcccea84909fa724888c2d1d007b11c97e02f61e44b125b402a11041a3ca1faea5f02dd5f1327d5028de70e78c81b05338a2b2e3da509f08e2bd9ea3f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "5696fa199ef1088f88c8979db25721d0a707eb7a51bfd97a1278bcfd43b38304",
+          "result": "valid"
+        },
+        {
+          "tcId": 213,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04276e45461a0e00704bee883b3e61016eec41678d8176d37eba25557a740284e05ab0fd1bf9fdac37fa83f83f5156648bb036d6ce46ff1f6ad4c72bc953214f0f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "eab63813807eec138a696be8b9e0023dd3c6cee35b7378174aac70838866c216",
+          "result": "valid"
+        },
+        {
+          "tcId": 214,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04ec90e45db57bc01f74d7d01e8783937723f8e27ba99541698e01c57cd2a39da0933bfd2d11d31af9cba4c53aeabe6a3635a0643c114afa109ada02004286aea1",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "c982c6d73a9307038bbed250369aca65a7e392bf15f440227eb9fea43cc4756e",
+          "result": "valid"
+        },
+        {
+          "tcId": 215,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0428993d7c18770eec4418c16d595987c196412f7b273da44136b19d4b516a2ac7b9ba3574a31169d3f2f7a62758d9d27a2a4fea904b24d42312a9ebfb49ae355a",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "5581a9f0971c60709ebaf53b1febd6e0d174664b82a36692656953507c0f6dc9",
+          "result": "valid"
+        },
+        {
+          "tcId": 216,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "043e4851b2b0d1463b9c90772e10fe8cf29b181463de28e9cf81b4c9604931a4dabde252d07c1061e60f4f8cbae5c2a290c034438a06a8bac67b1ece8ed551a234",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "c7df69b1bc484804a3683449c3a228ff787387d56672588140c980b1fd4765e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 217,
+          "comment": "point with coordinate x = 0 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "043cedff3609bd11397ed3aca84a0a7bffd009d48beab100719c7607ed28e56124a15f6af627e03f57a98012fba18321b1dff6c24f51d7b6415d102608b772a44e",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "973c078916ecc4c660aa00dd4ec1e1df8793cb7f8670766a5156f8344088002f",
+          "result": "valid"
+        },
+        {
+          "tcId": 218,
+          "comment": "point with coordinate x = 0 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0441e9d4cfa8efe80b895a8cbcce2568e251db7ecdfd20a7ad710d4a4bf2addc6b5ec36a8339168a03f15b8c80f2a2a828f151d38791584853ba2ff44a2a0460a1",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "b48e119d29eef7dbb76b64218e728ddbf6ec600505ec7ced6ab6fb8763308da5",
+          "result": "valid"
+        },
+        {
+          "tcId": 219,
+          "comment": "point with coordinate x = 0 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04776aef1acb82b628e132cc29440988f0a15d4cc2b4f328aecb063c9b86e5018e6e44dfc60444faa9c4e36bc217451f7ac2956cb3b2e9bbd655eba297163d1f34",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "28a88b6b258f233020ba6fa9c00d1d72831f4515b86966a9782f521315e18aa7",
+          "result": "valid"
+        },
+        {
+          "tcId": 220,
+          "comment": "point with coordinate x = 0 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "049ec06b0b08662c0e1dd9111696a63a1601cc83cee20695778adf84d43064fc90156001f084cd3c1df1a087f626533b6572584889bd3d5c2c99f0e311e22b41e6",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "c4ff865ff3dc4953ea78d92a02f3345a53bdb6050cfd8f41baa4395ecb6acab8",
+          "result": "valid"
+        },
+        {
+          "tcId": 221,
+          "comment": "point with coordinate x = 0 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04fa51d128adc2000f09ff12c6fd8e25aa08556d708bf6b0ffff9e8eaad4783f0de22bf529e516e1f64b8e0d09f98fad4e501695a930a1b22076659da707e3ccd0",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "de1069f051637e10166559cef44688afc809341855261215c4f381d9d7da76ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 222,
+          "comment": "point with coordinate x = 0 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04efe7754ed4c0b3c1dd301bc1ed69800aa2ff5d51fb85937715e60d2e7bcada8eb1581ab75fb3c797ef94a9dba3d82568c84617eaf3fa04f279fbfd898f704604",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "b5a0ec92aecc3010d27d2263d3da66e3d2f3395d23947024a3f4744454622027",
+          "result": "valid"
+        },
+        {
+          "tcId": 223,
+          "comment": "point with coordinate x = 0 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04d8e13fbd017f1f9a26be35c611d7b2299f5d10de3c8a26362273fffb85238f3ed1426b748c1f87e3afa2c1e7a0224310c980655e07399590d1494d6d6bea0396",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "d2a5bc66498c6036aecdfaad041cef732a893de190a0a5b42ff71e13f09280e7",
+          "result": "valid"
+        },
+        {
+          "tcId": 224,
+          "comment": "point with coordinate x = 0 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "045a1027666a0e372481fec0b3901e058d60107c07b1115550ceb05789b55a6d35063d4c8ee66ed45ff3e1dfdcfd73ed96a9e83193884adbcaa574b2dd118a692b",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "1f812313ddcf36bc38071d0e51a74100d630c8e20cc414326eefa42ecb1b5f8e",
+          "result": "valid"
+        },
+        {
+          "tcId": 225,
+          "comment": "point with coordinate x = 0 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "047937b9c40986dd755a0656203089782583da7d8113a44190762ab474a20bcf60efcbc1525aed5b4ad8e687cb02c2ef8887095cadca56c765b41b4a9544ff2fe8",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "f284089bddd5e2e1be3f82640efa0658468fa1f10b281963a3ca190c3982fda6",
+          "result": "valid"
+        },
+        {
+          "tcId": 226,
+          "comment": "point with coordinate x = 0 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "049368066a0748867a7b870244f5c9f82ea8bd51552959dd550bb7394497159a5d40764add1ae24c8e3f432ee011be97d3130718fe0a6a90ed8b1011b2034d09a0",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "4529f4b631c9984ab216a6801281fc4fd8731a58b65ca8d07bff07811116371f",
+          "result": "valid"
+        },
+        {
+          "tcId": 227,
+          "comment": "point with coordinate x = 0 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04981d7449bdf0013f5eeddbb7e42c442f7ccdd9427bd26d7b388755aa5e26f46a1292b88fa6bf5dffca054dd42ed3594277b593dcc402d80340fb7816e4dcab37",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "64bbc9fdd73643eb2954f4ab640381b938c5e601846a0c6b6954966e0dc73e6f",
+          "result": "valid"
+        },
+        {
+          "tcId": 228,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0409e78d4ef60d05f750f6636209092bc43cbdd6b47e11a9de20a9feb2a50bb96c0000000000000000000000000000000000000000000000000000000000000001",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "28f67757acc28b1684ba76ffd534aed42d45b8b3f10b82a5699416eff7199a74",
+          "result": "valid"
+        },
+        {
+          "tcId": 229,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "045384d6c0def78960db967b8096d35477c5a5ce30ef0c6d8879a5568ca87e979401ee56c4581722610b43f3cbfcf3862c082a6e36baa36fd6f78403c0e399faa5",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "9ee653cda46db67612760ce35bac8450bbf48dbf74451ed93abb6db408a9fe10",
+          "result": "valid"
+        },
+        {
+          "tcId": 230,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "044eca7641a4afd5eab0b214657ff3bdcbfc66f1551a53bb59493bc38ed78ff39614a0cadff14c14736edbdcdab510cba07a8924ffd0490ee514aedfaadb648b01",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "9736ad6b2a2ef17ec3f8c8dc2e35715fb1c06f28d82e4e26876f0214588165f1",
+          "result": "valid"
+        },
+        {
+          "tcId": 231,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "048d0177ebab9c6e9e10db6dd095dbac0d6375e8a97b70f611875d877f0069d2c70000000000000000000000000000000000000000000000000000000000000001",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "748fa4f5a399320382dc920026938694c41a26fe2aaa318c5e710198dd71c793",
+          "result": "valid"
+        },
+        {
+          "tcId": 232,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "045fdb7f0cffb8b5b1142d24698a4bda76bf9827d63b1a6bd85a4e2f9b59c510cfbcb35ba9c987108b6d4337ad5393f9f910ec92410c230869d66528ed88c1b98a",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "7f97db83b4d86f04fe286041ee21e80ec3d59f3ce82cdeeaf362016fc87a3e02",
+          "result": "valid"
+        },
+        {
+          "tcId": 233,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04530b2293e60c6b6f14c75c90b1ef8b9f9fa6b2151b8d9855792eb2b3dc69f07a0db42440e73fd7d6df04aed5022fbe21ceaec33c5fbade1bd6ad321ef2e10d0b",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "21794cf24f56273fa4463cc7ae4232fa34dbe0f18b73613b8ae9cbfb9c36abf0",
+          "result": "valid"
+        },
+        {
+          "tcId": 234,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "046916fac45e568b6b9e2e2ecd611b282e5fcc40a3067d601057f879ce5a8a73cc0000000000000000000000000000000000000000000000000000000000000001",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "915106d07816e879e7643f00abf6d79fb8f1cb78bf64a6a3827f91a7b0ef0f41",
+          "result": "valid"
+        },
+        {
+          "tcId": 235,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04ed9568c85bc52a6b45733618c3602107c1fdacf23b1a38e486af95978a214e2efa0d71d5e737891c4276e247581ee6139011ca1460db9b1e20b364d9275683e2",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "2fcce552310819dd775ab7ba9ff0f96a1fcadd25a0c709703cef04bb6e1a7bd7",
+          "result": "valid"
+        },
+        {
+          "tcId": 236,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "049ff7731c00f2aa88b3fc174aba907ad17595e602e768a5f1e9462a6d4b89b2d23f178a70b9bb3edce289118338a33df30c432c347f12a3de0a2b03b353878d96",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "757d926a2693bc8a3d2d8c0554a13579ef9e559186578911f37edc88b2f5e61a",
+          "result": "valid"
+        },
+        {
+          "tcId": 237,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "048270f8179d57436b34dfc0bdf7d417a5c895116b90cb51aec718614f864a635d174804e0c0e06e3d68d3149e0b956621c6aa2bde83f4d17d03d28ef8aa389fff",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "3db29ec6f978d2269e92e9c7eb5c8b5a8e56c2228a4fb9e483feca50aa3e451f",
+          "result": "valid"
+        },
+        {
+          "tcId": 238,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04c61750e98abaf20225a881dbfd3510532cfc3df971bbbca4a2bd52f91acc9c59d0fe79342097f88ae78fc79a8032245fdd2c30cc64aceaaa9fd57b0825692531",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "72c57c2e10d77318b3a796097bbf768c6366142d80f98c90a93780a841075f32",
+          "result": "valid"
+        },
+        {
+          "tcId": 239,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "049c5d3bb54650d9550e1ee2efa3ea43c14ab99d18bb049f37b42a6dac48232f0bd3a2760d83d33afe4ce6f1d1245489c509bd26b0251f308f8c996e80f7a3f8eb",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "a96b07944e9eb2b22a9a36575eff1f4f6363b4aa3a53b100b8518a67ba5405dd",
+          "result": "valid"
+        },
+        {
+          "tcId": 240,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f1724efd481ad45a55795f06126b1f5ed28e7d9bb4fee910af2ad8c1373b18ff77edbc34da6c787ec73430347f4da86810032d88f7475f6c42f15914079d179e",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "855883316b6d097ae5eab6c67e8411a1397349a09b9d7d8f096b2ba1bd03ea31",
+          "result": "valid"
+        },
+        {
+          "tcId": 241,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04fc3680af52fa89ffcd193ecc0b0714466fe5db277ee5872846c520bf4e3721d927260a0e225a3d377e6723ecb6bef8d4493c2da78a22a307fcca8f88f4527208",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "5a75bb7a0c96b8340d0842bcccf11974e1a5a2c8f4bc22b333433cce646b6a8a",
+          "result": "valid"
+        },
+        {
+          "tcId": 242,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04106b6f81e3482db18d74029291821ae448c38844ef783bf1d6999a404401f63f6a5753f0edc68a62cfd6a0b181bb2599e1f3bac5fa8824af160de79ed867c350",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "d96412e31cf4d26195920cac952fb79ea25f6c50abc79b5ed0ef8026a6e83319",
+          "result": "valid"
+        },
+        {
+          "tcId": 243,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04093cb5193a4f94cd18edaa20a973b87ff79b0c03684c79487ecfee347e5354eb04fcb5752539170777932be15cd84c97f03815ffee8b60b647c178eebb8e14d4",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "2b0eed9badc92a1068196dfec124fe8f9d3f451e294d322eb881cce02f286026",
+          "result": "valid"
+        },
+        {
+          "tcId": 244,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04d6c38f448b964e27b5b450cc38d3cf41ef9df83d8a959771eb9c21855cb36445df638aef46a2aeb13199281e1a26d12fe61b029ec7f68b90faa89f88c7a95942",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "ed0b1d8dfd27a61fce91dc6405bfc53b6d48a8c13ba541c96ef3dcf31d7cdb88",
+          "result": "valid"
+        },
+        {
+          "tcId": 245,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "048a748d61f59c3b6a29b733b0d554b2492e7f76fad7cae1c17f2ac3de9e4a65d2eedbe6c26b6fd22bfc03c1687555d2f0a38e02adee5570686171abfec6681917",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "a796dd144f21ba3318f9e10828ecefc9c0f6ef2c427ae31351c16c2fbfa3cfa6",
+          "result": "valid"
+        },
+        {
+          "tcId": 246,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f1052699d87e5677c75e26b2abe719310648d820a96e5b381fff58b392401581b1bb16ae8b68cbb76a3256870bad1ee5a30ff9fd662fd4f8d1fe5b5f1f98ff46",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "1f3a9615b0745046a972bad5d59794a0b60b032b4ac94fe85f77dfb380d1f32b",
+          "result": "valid"
+        },
+        {
+          "tcId": 247,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "041219af5230064ee9778667225f0e009cdb961330e386edb34e4fa9fddd0e5be7e2a12554227f613aaaa78938ddbbc99b923f9d181b8192dc4b816577e8f3b7e9",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "caf9141d1fca4d0f10683b5e86d2b41af5602f017991fe7348d44e8d7014115c",
+          "result": "valid"
+        },
+        {
+          "tcId": 248,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0460def130f190e6dc44f5eb8a59e12e7efb27db968c7fa6cc6d31785f066b41b1f1bb556ac4cd77033e7aa6c5ba16f47ebafb14975a7fd72dd9b7fe23116bca55",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "6539ec1c98fa75197ba07c678b26300b3da1fe407dd4c68b89457ed669082e06",
+          "result": "valid"
+        },
+        {
+          "tcId": 249,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f23f09bdb7d17289eb005975a757a39325b4df9b29e55ba2ca679b5ec0973ae918c881f3c7b6c12bed1ec54b837d08c5908e89bdcedd84b9177720378f789600",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "0b6619827cfa948d63f021e9eddb92f884fb5ce8a404bfe059e993fc23447a69",
+          "result": "valid"
+        },
+        {
+          "tcId": 250,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "045dbec098c1b7de3e3e2e73d0b62cd49c877e1a0130a1b39eb2fd4dbd4426aa4ccbeee217591a8d76cc8deaf14dde52e3f401e53b30cbb9c1807910d827d0041d",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "2a53a561acf5caec6eb0d8aa40727942881a75d136899dfbff91528236926c39",
+          "result": "valid"
+        },
+        {
+          "tcId": 251,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "041e70730dc4f39c8970182e1a29cc836b9e9d6cbd6fcaa8c0dc1062fed9a849693e7b9151f9c8a3345366f8221c8fb700e8c3a9aa7f0cc46a48864e1605592094",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "9b377716ff1d056dac8e392249eaec740d2f5aa62303f4baf6bb1b03b2a276c5",
+          "result": "valid"
+        },
+        {
+          "tcId": 252,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f428c9ae3e23eaf9c2a5b9a7e41efd1cffbf35f881bfc35694d9c05d1e312b10ef6da9023cfd2dd0cb7b9e2a77d644affe62a63fb0f29d45291c6861aa063c5c",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "0c0c6867669743082547aa94451feb362fa29fbaf228dfb3eaf375f1a5ec2fb3",
+          "result": "valid"
+        },
+        {
+          "tcId": 253,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04b9a16d9a5b85a714e2bb2aa22b086a17404c7a3ff62452732347419c99e90bdad578b462f523994304b6afcf6944a9cc5d0ad1afad956475c8f2953c06b06b97",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "d11f9e32587fd3b6f4a2354812618b4b3b4a7539b8a223b388bb7437f8d138a5",
+          "result": "valid"
+        },
+        {
+          "tcId": 254,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "048f659a163a58e9f900c1e9b34fb1cd61ffc9890267be3417c8afe79d57214da05cd5cb68a2b93da0dbe56c1cfc0dce8b6c3260e0c48379c6d2091f16b39221c0",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "4babf6368e0359b78614060241ece46facca3f52f5bbc47ac0b46a075b5dd3a0",
+          "result": "valid"
+        },
+        {
+          "tcId": 255,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04d257f133f00a079f4e6778ea4a9bf42b9f231290431b5b93d7e8b0e35b48010650d6c6b46574d1efce03510b8db4a0981ce138c5bd8fe0e54c988c40c5fc9200",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "9627cc5c8d8b72278be89c32b52210173e6f4b8e2f48e460c6429f46f9f469ae",
+          "result": "valid"
+        },
+        {
+          "tcId": 256,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "045ef2ac57c4e93cf78d8f86c35d413b98dc1902dd245affde5c16034afc7ea45547b3e9f77fbc5075bad03c418094f1aec1d03edeafa167fa6af83526552f7034",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "d2b178bc9bb16b5a91a100bb72e15a9639e050c034346061413ec20c4fcc9bbc",
+          "result": "valid"
+        },
+        {
+          "tcId": 257,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04a7b513f96266414fa6ff439a35d8f09ab615db0bb6a3b1a120c217683f724b2342007a2c9feabcd6249a0d17acecd995e2a217fb5f07bec96938016e297efa52",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "6cdca0a731aff1ccfb1904a769cef79eba965fbab1cc64d2049d0df45dccd276",
+          "result": "valid"
+        },
+        {
+          "tcId": 258,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "047743ab7248dae5f1a59ac6b0a136e9f1e51aff8bd45795ace5f8187a13edf9adbd9642078378bab5c6d484f9e1ce39675b72170bf39abc9be7942fc01fc435d7",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "bd15e97a7f49aa33e57b54140a75fffce71b788ce0faa334cf8b45623dcc818a",
+          "result": "valid"
+        },
+        {
+          "tcId": 259,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "040e3aa971bacdace350dc0957fa5bde0946324eb139939d7fc1997c701effd04a4e6c3625d9564168d3a752961221a1de8cf5f3d603752a8c2e6277ac3a918c25",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "c8b5e8e7488857a2dde62c5fc21e4525ebaba0e06b5be83ec6e7dd771e15a01a",
+          "result": "valid"
+        },
+        {
+          "tcId": 260,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "040f563e21bf9b24015a7cdbb6f000a692784ac2e4bc2715c76f684264a899c8240cab0d76e6b01cabe4f327429d11be115ed6dc0ca74f02c1b987a082f5af43a8",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "1c63a457509b148272687e6e442bde51982d41b0080d8c0c5eb714257af971e7",
+          "result": "valid"
+        },
+        {
+          "tcId": 261,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "045da49f10249e4df3dbb4e31ece0b0ee9aa073f2588195aaae63e74f6567a774810b5dd61b6bf219e9eab30ef09c13fc184b3d09ff7a4e192bca8f5111c4163c7",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "73a1ac9ece354a930dfd9c77577b4f50acc0a78964ea0d7775631d64c709c4a2",
+          "result": "valid"
+        },
+        {
+          "tcId": 262,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "046f72e6e5c6300679d3f14f0f6e590665643576ae8bbcb7c05b2f4a83e75e6ac3e712cb056ff034da340543c5da6997e65a3ab4cd39e997892bb92ee2c22b8167",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "fcaa406329bb74f995862cea7cecc7425c6bd4148ef1a9f46b5d42da5994556a",
+          "result": "valid"
+        },
+        {
+          "tcId": 263,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "046b544df9168e7787db282e2ae01dd72306d9c9bc80f5ab38ce594766c3d929e967493ff601ca60862b47d3a0785c917e44584044e36023a54424015e58be5040",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e49ff11d46b6c4b5dde528b04132d15c040e79f9b7151fbc650030988028cb87",
+          "result": "valid"
+        },
+        {
+          "tcId": 264,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "041c31385b9db9b374e92499939ab0fd7e7eda464561eba89fcd7b4769814a8638a4764cf8ce97b5d143bb8eeb9e1b27287f2b73942ecdbc6359aafb1ee7a152c2",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "fc8f64eac1c7e688c52c467185de21914e8b253056d9e4be010ed0128f92a889",
+          "result": "valid"
+        },
+        {
+          "tcId": 265,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04aabcf8b1443d6cbb1de129a0ffe09f60b23fd9d0a44b6bdf25bed7373fdbfd1db716bde7fe9f2f46de0b688e3025e029cff15244429ad4f83484f5dea4af8583",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "6b56d8a01a884319ab5fb9d890cacfc7aabd81ad938cb5eaae207c8c1aa06efb",
+          "result": "valid"
+        },
+        {
+          "tcId": 266,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04e7cd580bd957915d527056832e37793ab3b082ddfad9372412e1908e5c16bbb6208601a970d5844b780d9246e9583eb35918c42ed695c07d52244037f0e31db5",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "2f64b5c8046d41a4e1d631ff23846bff956a4925a47f8534490a20b4b1918b9c",
+          "result": "valid"
+        },
+        {
+          "tcId": 267,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "042a52db1fe246b71c79c0d0ac49a7d38de67b202995efbbd2a9cc525f6f36010368f494be27e0593e2d612f1fa10a9211437e6aa16e65d97735014072f0dcec94",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "63ac31e718b9a780a85f0670e1d3685bbe306e5f06fee282a8784700b503c124",
+          "result": "valid"
+        },
+        {
+          "tcId": 268,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "041c50dc49fef708c4cdd62e766f9b60f784d51afee17a8fe9f3701b2fae55b7a5d10f0d9639d83dce8f26a869705a6d6d38e6d328f5685581142aec0dcd1f90e7",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "555c1917b770cebe6a98337a008ae3d8d04f571565327c93debf61ef90ddddd8",
+          "result": "valid"
+        },
+        {
+          "tcId": 269,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "046d0aa1bc1cee6d07d045002c13290d0ca25ca3c8783343a525fac70472b92c62d6fba71174448b472cf172b0ca9e377f1a2603ba7ae1276d153b20c63e7d24bf",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "3a65a9200f8f96635912faa5e7859fa303a76a1c2a41ea97ef61aa39287700a9",
+          "result": "valid"
+        },
+        {
+          "tcId": 270,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f07e3d8be2ba54c6084141e1fd2b29cfd00d4e6dd6ffb115ed839b10bd8a422f42992cb9a5243897d55408e9bb556043318d87349af35dcc0975ed805c8fa2c9",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "bb7bb52da570ba58e05fd322f82d556c2d65b365db30815879f67f233b089b51",
+          "result": "valid"
+        },
+        {
+          "tcId": 271,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0443a9b90274dbd5f36dd29046fc8390008dde74513ce4c3e8892b236efff80c9dc71547152a5897dbe16957bd15d1a87d770496f814fe2921c8f33df04393c7f8",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e8cae9944233b867eedf5902fc49ecd07e4c81c46279531e89520b74ba5370b5",
+          "result": "valid"
+        },
+        {
+          "tcId": 272,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04e9af8e8c19da9d5c2f3b3c03b8e927c3cbe2d717f98f500972e56d82eb07c2b14e83fcaacadc26f8bb5e7b94741fe54f31275ebd6e1c969d7ec2fecead8a0dae",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e72ad0cdb25f4307d1d834a5f792e9af64fd1b69a47041ec8fa46d526f419e4d",
+          "result": "valid"
+        },
+        {
+          "tcId": 273,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0433d9582b567aadbe59606fa6ffc11848e4947b5179597317776317b2b4ff65d0b4d8568dc843319cc04f4bf110496dee7c9229fc68cb0958f3cbd37ecca6990f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "000197fbc260a84dbcbf88136aeaa79b03bb8949aefd2416bef63929ef789bf3",
+          "result": "valid"
+        },
+        {
+          "tcId": 274,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04e21c0282adb1b2055fda744644c68612cfb0c68a70b9812d007f21a78f1adc4849f3e7644bc6633e2773a2f3cc5214fa7208e30afb3de992f077ee321569dc48",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "cdb18bf62670a853488ca510d8f55bab2918991424925bd9b74a821d2c6e7e3c",
+          "result": "valid"
+        },
+        {
+          "tcId": 275,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04af27de0da6556e4e64588c9694afee9a84e1cbd0c388972df3a997f760bbcd903c5a02e161551f333d770559ab1af49bf8b68274896590939ce956d9913b676f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "167303505d22cf9ef78c5b9687a5418fa9fb284f2b0ff68316288ecd7f2e2e09",
+          "result": "valid"
+        },
+        {
+          "tcId": 276,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "040da41b82550b358ff474915d83104d41a83a12ef70589b9d392f0f30dc32429edc76163c8fe07a3f709cbd92da0bbfc5045f3db82aa5344cf1fd5b27fcd2f7a6",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "85600ff23c3cde26009fea9b6539664bf045056883728ab0d4498ea0a8f4a453",
+          "result": "valid"
+        },
+        {
+          "tcId": 277,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0419c844b8c7209026a0996a782983e1bd0f0de9255b86739be9bef08ea5475cc669a779ddf57747cf7d9a22f00ed8efc6e818af5827b750d665fee6d6d58a22e8",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "a3250a2bfb145ce86e706ac3ab2bf503a66486ac0b2f7522601c124b0e0f9c5b",
+          "result": "valid"
+        },
+        {
+          "tcId": 278,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04bd07bd4326cdcabf42905efa4559a30e68cb215d40c9afb60ce02d4fda617579b927b5cba02d24fb9aafe1d429351e48bae9dd92d7bc7be15e5b8a30a86be13d",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "2d70cc8c8af01366051cc8359c2fc8f258757e2601fd8f3e08422a7b23bfeff5",
+          "result": "valid"
+        },
+        {
+          "tcId": 279,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "040089dee27a60d071dabbaf58f3e56614dad3b7f9a8030769fd0463b3e6e0f03a147b4d6e7e7fd939b9b54dab458fd556ad8fdaf4da6c3909588c4e050ca74a67",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "cbe0c571d1080ea34ee20ad1bfd21ea5ecc442ead733fb4eee3c0d7b0cce9935",
+          "result": "valid"
+        },
+        {
+          "tcId": 280,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0442ede106cf85aef46df7e5dba8a8b00459317d9e766a7b77c299aa0e17dea142b6e9a86f4fc3e945d4323ba8e459f6b7b14c563a698c757a2d5f7b0bc301ede2",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "33320fc7917fe4e19280bfbfe16f223c037f7c2dc30c0fda98310740f57fe289",
+          "result": "valid"
+        },
+        {
+          "tcId": 281,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04974b4316c5e7d1348b28dbc4fd61d8d3470de744c30f5be237f85f29969dea77b5f00b58b83cfc7bc51655465b4a28abe1ed3dbec20c6b4643aec85b95a5bec6",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "35c726ead66c39414fe0c24604df7838e5725d2fc1bd0853261e1de3338ecb4f",
+          "result": "valid"
+        },
+        {
+          "tcId": 282,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0459873d7523936a121b629e9870f930419f253a5767b9d0dc49716f2c50e17bd0163b71f2bf4318fbde1ceaa585450080eec28474cd18bf7c21d2d1bfde4ff677",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "66ea42fe6fd8741b37599bbdada3ec0e6b08c0b52ea67c29a33172f72742583c",
+          "result": "valid"
+        },
+        {
+          "tcId": 283,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04bd85a79f81c4f9613e64fa347886437856c7358d1b69cf1e923d7742d82f9b6767d26918eaa8acb113a1daadaedc709742457303ebc23cdda5572613dc827703",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "2f8a502e4f440133e84fb625292cbeabe2cb79da73987c76d4fed864d1b1b762",
+          "result": "valid"
+        },
+        {
+          "tcId": 284,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "043e6a4effc47c2f5926bb6b4acf2eac48b9524c47d511f816976796778600d6c5bfce593242a5985a977590f8d7485df3f953352957f3c17c13e94583d9c0e7b9",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "06436817d8928b77b73d16c5c3b35e243ad3ef2ab59ad047142c67a6d0923c84",
+          "result": "valid"
+        },
+        {
+          "tcId": 285,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "049a4487fcfce8396688e7449e095fe803caa253d4bd7c66dbc6261cc9d9f883a50e5251bae29c5a5cdfa31bc61105671a88a018467398158d35b88829237c0bff",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "7e83fd2c3d713bc85d6d85d9078b3a0842824d410e8abde04da0fd71c7d94705",
+          "result": "valid"
+        },
+        {
+          "tcId": 286,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04fed6ce127290c1291ca5ce64acb4e0f2f8905654d1d25ba57c1f74ab52f21f42963d31671c06b802169929525c4a1fdeff5b1eafab919dc2df6c52be84dfaef3",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "0e3dfdab606ebdc6428282acd443f189c99b3b483aa101fd8d6bed38aec59e02",
+          "result": "valid"
+        },
+        {
+          "tcId": 287,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04f7cee5b55f1869f137dd707c8f8fb8965a2be5840c3149fb759695a4661b9c0d23c78c4e9647b0d6cb2f2602be73ff25cf3d09c96d892b5745fe5eca814aec91",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "f489f2bd93f76b8e41fc6b9f211bc599d49db1f17a38e95bab1d31b2a2b55829",
+          "result": "valid"
+        },
+        {
+          "tcId": 288,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "042baaaec3b3e8d54a4e18f0960b947da2535e3cfcca2cfa8b7113aad8e3b6626f72f71e7c9e96042c1d39cc8f1139d5147c6f4fe62e23cf6df364b5f4d899f842",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "cc5738b49d30d5d02cf7e0c54a3de09b5b6f3c4dea91dd0679072a3562444c37",
+          "result": "valid"
+        },
+        {
+          "tcId": 289,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04a51ab1238bc1bed25247e7d179c83a61ae2d4a9fe2288c363ae0eb7a77de432a3c6d35d82ba8017e6ca9041cc785a30703f7bc4427506e624ac5979d715421dd",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "89a11177d6907a81d47467093bf6a3cc8ba55dee05239b160a31a3000f5d807b",
+          "result": "valid"
+        },
+        {
+          "tcId": 290,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "048b5ae8a0e55f30f509061315abae79ac480f88b44655f7269a385c81526884be262974a31a0e2322126c2d77b26b108abd81f8b952c458ccc95d46fb4924c7c0",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "2cb03c30b20037a5cf4d5b33574f3abac895bfab37867eb2ebed260e0929058d",
+          "result": "valid"
+        },
+        {
+          "tcId": 291,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "045f60c77e474dd66c8135ee3dafc75ba644649824c72737542091ad469adbb685312c09c69b629d0436bf3bd6c6083ff2a87be484a73ef3a5d2c3e06b5d9b21b3",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e54d487d0c4b12fe522af3e663ce316e632ba9d63a1f02a36fc5a82bf82731a4",
+          "result": "valid"
+        },
+        {
+          "tcId": 292,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04e06eaa73f6feae45417d859bbad4bc404b2885bcd213ebace594e16f4970e0c411ed3323a3d7afc7076239884307f91849ed5f5e36b6171d309c81344c53e06d",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "ccea969d40fa42933f4fbdc4cabe2185f8a452996254c1f4e0dde5e14feeea8d",
+          "result": "valid"
+        },
+        {
+          "tcId": 293,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "040f1c1b89e9fc6fc0faefc9109fc4a1247d9f54c7497b6cc975e6a5455bef410836cb3818548ac9b41e2b8336c3eb8d97075ae47e1827fa1ff93d4341d43c0c1d",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "eaae0e188c9427bf3c8b3ded772122204c328d5941e389d808e2724638f9aff8",
+          "result": "valid"
+        },
+        {
+          "tcId": 294,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04577069e8284a95f51dcab919b0536657058971dab76217f8d3ae722a64092e26e51f68a722cc0397f4801401771e9a3d1988d4af76f14f9e2f9c36e0773e29c2",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "fea0cce1358f1ff40ffeaaffbf91b2e8d426d4e31e9627731ace3a122eab6b0d",
+          "result": "valid"
+        },
+        {
+          "tcId": 295,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "042406a2759050b925dd4f814c5033e355548f42bbf1afb791c110f0031f29f68099d5f4b005de3927f165abeff196a28c7217fab1be2b5209c324e7d62d2dd687",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "837621ea4827bba0376aaa8aa66cfe144a2ff1e359dc619a06441d3e055f9771",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04ccaac61f35a27861183621642bc573af913356fb47cf582f0b5299099d6f6c6991f7272b83b738a7a5d30447c87f126a7d98ec72fa2609d0939d18db7ea7eb3a",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "63974ce6153762e5b364523cead93e8ce8bcc77dda56365d676136169fc4e39b",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0401415917272f1984e7217a36fb311fd2904d41a6b13973f92aae3b90e85e4d56d97c822eb7b21a84d0d1be4867404a80c34867f43139dadcc3619e10b222562b",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "0a0488144bc36d690b62148ac3076047d46d48f7adbb0f34fee9a636295fe737",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04b2575d100c6fa056bcd137ab111b5315a8908c29243b84f3dc996d0e45764b9166cabeb41885588ec08b47257df58bd58f7dcd9e012e2669fa2f52e25767fc4c",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "1232165538a44268aa7c199c54d6d207c4ef3f5aa790c10c926a20752ca645ce",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04c17355ed30ccd6427f9685709021b25c11ed176e9610c479bcc4cc7552a738e61f75114761dba0ec60cd264bbab763c5d5abcc75cd8fb5651d0645179988cc6d",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "dcab5e874e4fb76bc4312528e9d76dfae56145922533089734110bf5653f4d77",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04341592390ccce485de8880f3d727f664c381914a1becec383b35586751fc81c2add71852b87016e1019cae7a9080e75ce0b0b8aac175d692d5e7b4dad088f5cc",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "4ce2701b2be63a0083a4c53f7a0bf04cf871654f5edb6f625e3ea5e7d0bdcc90",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04fa764b6b76a86c3b762120825d353a24766208c1f5cc0fe3fe7998026a2ec5c43bb2f948fd94cdaa5869b1e0e73a4d97035cc49357fb7b74d7ed0a2c5b8d54eb",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "7abef9765cca721320fbf8edcbef6d2ba25d17b70ffa1776029bc38fe677a12c",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04a71fbb617199bd585b4b66212ca33ca9e09370e6bf15c8ea0acefd9c8e945d06840f058863078e743e220ff99f23bbc1daa36835d4b1269f0a7536e63f06d853",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "5f61404dbbbc2867dff95c1f37ed44f4cb8fabcd223b03739d888308d13bc412",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0413c8292d854d39451c0c63a802b8c03e4fcb875ef01239896295ba1c0f386975f82df197086fd86032cb36b69a27876dd75a8e9679f36ffc2210edb128d4be13",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "8d673a577e35bf9d5d00676c08b2c739617c46a052188403aa06dc714af6acc1",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "040cd9df415acc0c32fd4e3d6924ce53075b0452bf919a2ab2ebe26597570f1ecd5985d8d2c5df78fc100f87efb6dfa9543757bdffecf083dfcd1ecb38de6c23f8",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "a7835ffee0f2a69dfcf70d4e798dbe3ed32ba03cfddae5ddd11d8c0ac3d74f9b",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04d2dbea4046b23fd2b233d1ce31dceddb89b25f26c0627a9d2db3c5605c9cc99535bdc8de7451c1e27e97aa91402cce3882c71269d9cbdcb5d7ac0ceb911b9b6d",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "e98ea22209cd397edb6c319648c1eb24bc4d39598ab11995571926684ce2ceca",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04888fb044fb2b6caa60366bfa662adba479b8365a6555a29887d580f587086ba8482f4ec24082a48d6402afa1622143f26e61d91b7e30d6a4b223630ee10f70fb",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "91b65733860b1bdb9541d9f55895a3dbb3f13c199251d33006b6dcf90ac349ed",
+          "result": "valid"
+        },
+        {
+          "tcId": 307,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "042e2bec134249379d57700301f3a58e4b395a4d28370d2a06e65e7ac89ed76ac697dc960bd795cdf4fbcfdd75149057b8e022331c7b5461f383ac589d764df333",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "1fdf7c5c48047a113e5e5d1b7ed593337e769231cca5c7110160e0c1b97f4256",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04c78cda7e3b9e1772ebed30b2b51dcf155a69a0fc504557836e25147cfb8127d2f8289cf38b033d3763c8f9f6c091787a3142fb83dff5719590282c6f852e0105",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "ba0abc3e71726cb51330489176357b81b8074d7690e4e82e9a3c00151e1fa318",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "041e3df4dd7fb7718cb0aa0dd72f8a25c83c4e804e7cbd48c5e965651f9e23bf4ef0ff40dd9796e4a9a5eddd2c4ca4ebd10990d8fb8918d12d53c76001afa9de7f",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "16e632f9752d36602c95ec274b32ad594f39f6ac3bd4b0b20f8637392142cef4",
+          "result": "valid"
+        },
+        {
+          "tcId": 310,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04e5c5dc3fd88d85668b3b709fd6b4232f1f80949cbccb5588363e6c217a2b3ed88dbd0d6e3cc97f3081d16602aa3d1b655ee0791c87fcb5abe6217d8c8513807e",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "9eed4b96569f604a4d3f5af97499807111fc9888c458ece2e3000e245c2c02b0",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04021c41eceec24e0fba894ad7415a9598cbcd14fa6ca46e25575268a1d8e5bbc63f846c6a185fa3f23bb92c14e7e2cba8c74047c09af766f55ef0c907c80d9451",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "21ac32013838812621dbb584965bded6fc851d3a029810679bc57b2381bb7a7d",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "048e24192cd33335a114f5070266c014cb0d8c704d16d6042e89c17597bcd4e77ebdb4c5171704c2c09275c22a310e0c4fe092e4084856da99b94abbfa9f469f48",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "fc5978da01ca83e127dddf989a0358871b3c4ce0755bfb020633db467e21a53c",
+          "result": "valid"
+        },
+        {
+          "tcId": 313,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "0431c90ae47a93d09a2352b6f3677e7975ea62aadedb56c118eb8b9f771e2dd9f5f2601fb9cca2304e594423cf48064dbed17ae40452f18be6ae018321911e8cb3",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "9f417341261aa45d396b0ccf2a3dee7a466ca47e3ce86ecd2071d9c4db08820e",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": "04d2f211cfab84e01c8e5544036234debe35ae103bb878d7abcea6825f753e03a385f7f1870e64f1262af67a25ef9880419f45608e7f9da6dee83f5f46ceb53dcb",
+          "private": "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared": "f419febb32c254611adf569c2d583b17542b1538caa0001967f0a4bc34b8b789",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "03",
+          "shared": "85a0b58519b28e70a694ec5198f72c4bfdabaa30a70f7143b5b1cd7536f716ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 316,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "shared": "a329a7d80424ea2d6c904393808e510dfbb28155092f1bac284dceda1f13afe5",
+          "result": "valid"
+        },
+        {
+          "tcId": 317,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "0100000000000000000000000000000000000000000000000000000000000000",
+          "shared": "bd26d0293e8851c51ebe0d426345683ae94026aca545282a4759faa85fde6687",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "shared": "ea9350b2490a2010c7abf43fb1a38be729a2de375ea7a6ac34ff58cc87e51b6c",
+          "result": "valid"
+        },
+        {
+          "tcId": 319,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "008000000000000000000000000000000000000000000000000000000000000000",
+          "shared": "34eed3f6673d340b6f716913f6dfa36b5ac85fa667791e2d6a217b0c0b7ba807",
+          "result": "valid"
+        },
+        {
+          "tcId": 320,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffff00000000ffffffffffffffffbce6faada7179e83f3b9cac2fc632551",
+          "shared": "1354ce6692c9df7b6fc3119d47c56338afbedccb62faa546c0fe6ed4959e41c3",
+          "result": "valid"
+        },
+        {
+          "tcId": 321,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3a9cac2fc632551",
+          "shared": "fe7496c30d534995f0bf428b5471c21585aaafc81733916f0165597a55d12cb4",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b1cac2fc632551",
+          "shared": "348bf8042e4edf1d03c8b36ab815156e77c201b764ed4562cfe2ee90638ffef5",
+          "result": "valid"
+        },
+        {
+          "tcId": 323,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac1fc632551",
+          "shared": "6e4ec5479a7c20a537501700484f6f433a8a8fe53c288f7a25c8e8c92d39e8dc",
+          "result": "valid"
+        },
+        {
+          "tcId": 324,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6324f3",
+          "shared": "f7407d61fdf581be4f564621d590ca9b7ba37f31396150f9922f1501da8c83ef",
+          "result": "valid"
+        },
+        {
+          "tcId": 325,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632533",
+          "shared": "82236fd272208693e0574555ca465c6cc512163486084fa57f5e1bd2e2ccc0b3",
+          "result": "valid"
+        },
+        {
+          "tcId": 326,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632543",
+          "shared": "06537149664dba1a9924654cb7f787ed224851b0df25ef53fcf54f8f26cd5f3f",
+          "result": "valid"
+        },
+        {
+          "tcId": 327,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254b",
+          "shared": "f2b38539bce995d443c7bfeeefadc9e42cc2c89c60bf4e86eac95d51987bd112",
+          "result": "valid"
+        },
+        {
+          "tcId": 328,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "shared": "85a0b58519b28e70a694ec5198f72c4bfdabaa30a70f7143b5b1cd7536f716ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 329,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": "0431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private": "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254f",
+          "shared": "027b013a6f166db655d69d643c127ef8ace175311e667dff2520f5b5c75b7659",
+          "result": "valid"
+        },
+        {
+          "tcId": 330,
+          "comment": "CVE-2017-8932",
+          "flags": [
+            "CVE-2017-8932"
+          ],
+          "public": "04023819813ac969847059028ea88a1f30dfbcde03fc791d3a252c6b41211882eaf93e4ae433cc12cf2a43fc0ef26400c0e125508224cdb649380f25479148a4ad",
+          "private": "2a265f8bcbdcaf94d58519141e578124cb40d64a501fba9c11847b28965bc737",
+          "shared": "4d4de80f1534850d261075997e3049321a0864082d24a917863366c0724f5ae3",
+          "result": "valid"
+        },
+        {
+          "tcId": 331,
+          "comment": "CVE-2017-8932",
+          "flags": [
+            "CVE-2017-8932"
+          ],
+          "public": "04cc11887b2d66cbae8f4d306627192522932146b42f01d3c6f92bd5c8ba739b06a2f08a029cd06b46183085bae9248b0ed15b70280c7ef13a457f5af382426031",
+          "private": "313f72ff9fe811bf573176231b286a3bdb6f1b14e05c40146590727a71c3bccd",
+          "shared": "831c3f6b5f762d2f461901577af41354ac5f228c2591f84f8a6e51e2e3f17991",
+          "result": "valid"
+        },
+        {
+          "tcId": 332,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 333,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 334,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "040000000000000000000000000000000000000000000000000000000000000000ffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 335,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "040000000000000000000000000000000000000000000000000000000000000000ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 336,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "0400000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 337,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "0400000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 338,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "040000000000000000000000000000000000000000000000000000000000000001ffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 339,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "040000000000000000000000000000000000000000000000000000000000000001ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 340,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "04ffffffff00000001000000000000000000000000fffffffffffffffffffffffe0000000000000000000000000000000000000000000000000000000000000000",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 341,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "04ffffffff00000001000000000000000000000000fffffffffffffffffffffffe0000000000000000000000000000000000000000000000000000000000000001",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 342,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "04ffffffff00000001000000000000000000000000fffffffffffffffffffffffeffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 343,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "04ffffffff00000001000000000000000000000000fffffffffffffffffffffffeffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 344,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "04ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 345,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "04ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000001",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 346,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "04ffffffff00000001000000000000000000000000ffffffffffffffffffffffffffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 347,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": "04ffffffff00000001000000000000000000000000ffffffffffffffffffffffffffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 348,
+          "comment": "",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "public": "",
+          "private": "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 349,
+          "comment": "invalid public key",
+          "flags": [
+            "InvalidCompressedPublic",
+            "CompressedPoint"
+          ],
+          "public": "02fd4bf61763b46581fd9174d623516cf3c81edd40e29ffa2777fb6cb0ae3ce535",
+          "private": "6f953faff3599e6c762d7f4cabfeed092de2add1df1bc5748c6cbb725cf35458",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 350,
+          "comment": "public key is a low order point on twist",
+          "flags": [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
+          "public": "03efdde3b32872a9effcf3b94cbf73aa7b39f9683ece9121b9852167f4e3da609b",
+          "private": "00d27edf0ff5b6b6b465753e7158370332c153b468a1be087ad0f490bdb99e5f02",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 351,
+          "comment": "public key is a low order point on twist",
+          "flags": [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
+          "public": "02efdde3b32872a9effcf3b94cbf73aa7b39f9683ece9121b9852167f4e3da609b",
+          "private": "00d27edf0ff5b6b6b465753e7158370332c153b468a1be087ad0f490bdb99e5f03",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 352,
+          "comment": "public key is a low order point on twist",
+          "flags": [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
+          "public": "02c49524b2adfd8f5f972ef554652836e2efb2d306c6d3b0689234cec93ae73db5",
+          "private": "0095ead84540c2d027aa3130ff1b47888cc1ed67e8dda46156e71ce0991791e835",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 353,
+          "comment": "public key is a low order point on twist",
+          "flags": [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
+          "public": "0318f9bae7747cd844e98525b7ccd0daf6e1d20a818b2175a9a91e4eae5343bc98",
+          "private": "00a8681ef67fb1f189647d95e8db00c52ceef6d41a85ba0a5bd74c44e8e62c8aa4",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 354,
+          "comment": "public key is a low order point on twist",
+          "flags": [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
+          "public": "0218f9bae7747cd844e98525b7ccd0daf6e1d20a818b2175a9a91e4eae5343bc98",
+          "private": "00a8681ef67fb1f189647d95e8db00c52ceef6d41a85ba0a5bd74c44e8e62c8aa5",
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 355,
+          "comment": "public key is a low order point on twist",
+          "flags": [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
+          "public": "03c49524b2adfd8f5f972ef554652836e2efb2d306c6d3b0689234cec93ae73db5",
+          "private": "0095ead84540c2d027aa3130ff1b47888cc1ed67e8dda46156e71ce0991791e834",
+          "shared": "",
+          "result": "invalid"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/testing/kats/wycheproof/ecdsa_secp256r1_sha256_test.json
+++ b/crates/testing/kats/wycheproof/ecdsa_secp256r1_sha256_test.json
@@ -1,0 +1,7203 @@
+{
+  "algorithm": "ECDSA",
+  "schema": "ecdsa_verify_schema_v1.json",
+  "numberOfTests": 482,
+  "header": [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
+  "notes": {
+    "ArithmeticError": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
+      "cves": [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature": {
+      "bugType": "BER_ENCODING",
+      "description": "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect": "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves": [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero": {
+      "bugType": "LEGACY",
+      "description": "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect": "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves": [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "ValidSignature": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx": "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy": "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "",
+          "sig": "3045022100b292a619339f6e567a305c951c0dcbcc42d16e47f219f9e98e76e09d8770b34a02200177e60492c5a8242f76f07bfe3661bde59ec2a17ce5bd2dab2abebdf89a62e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "4d7367",
+          "sig": "30450220530bd6b0c9af2d69ba897f6b5fb59695cfbf33afe66dbadcf5b8d2a2a6538e23022100d85e489cb7a161fd55ededcedbf4cc0c0987e3e3f0f242cae934c72caa3f43e9",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100a8ea150cb80125d7381c4c1f1da8e9de2711f9917060406a73d7904519e51388022100f3ab9fa68bd47973a73b2d40480c2ba50c22c9d76ec217257288293285449b86",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "sig": "3045022100986e65933ef2ed4ee5aada139f52b70539aaf63f00a91f29c69178490d57fb7102203dafedfb8da6189d372308cbf1489bbbdabf0c0217d1c0ff0f701aaa7a694b9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+        "wx": "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+        "wy": "00c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 5,
+          "comment": "signature malleability",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802204cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "Legacy: ASN encoding of s misses leading 0",
+          "flags": [
+            "MissingZero"
+          ],
+          "msg": "313233343030",
+          "sig": "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180220b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 7,
+          "comment": "valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "length of sequence [r, s] uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30814502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 9,
+          "comment": "length of sequence [r, s] contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3082004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "length of sequence [r, s] uses 70 instead of 69",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304602202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 11,
+          "comment": "length of sequence [r, s] uses 68 instead of 69",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 12,
+          "comment": "uint32 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085010000004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "uint64 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308901000000000000004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "length of sequence [r, s] = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30847fffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "length of sequence [r, s] = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30848000000002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "length of sequence [r, s] = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3084ffffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "length of sequence [r, s] = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085ffffffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "length of sequence [r, s] = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3088ffffffffffffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "incorrect length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30ff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "removing sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "lonely sequence tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "appending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "prepending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047000002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "appending unused 0's to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "appending null value to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a498177304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492500304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "appending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "including undefined tags",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304daa00bb00cd00304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d2228aa00bb00cd0002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182229aa00bb00cd00022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "truncated length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3081",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "including undefined tags to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304baa02aabb304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "using composition with indefinite length for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 36,
+          "comment": "using composition with wrong tag for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080314502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 37,
+          "comment": "Replacing sequence [r, s] with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 38,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2e4502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 39,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2f4502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 40,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "314502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 41,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "324502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 42,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "ff4502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 43,
+          "comment": "dropping value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 44,
+          "comment": "using composition for sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30493001023044202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 45,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847",
+          "result": "invalid"
+        },
+        {
+          "tcId": 46,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 47,
+          "comment": "sequence [r, s] of size 4166 to check for overflows",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3082104602202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 48,
+          "comment": "indefinite length",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 49,
+          "comment": "indefinite length with truncated delimiter",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 50,
+          "comment": "indefinite length with additional element",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db05000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 51,
+          "comment": "indefinite length with truncated element",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db060811220000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 52,
+          "comment": "indefinite length with garbage",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000fe02beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 53,
+          "comment": "indefinite length with nonempty EOC",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0002beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 54,
+          "comment": "prepend empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047300002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 55,
+          "comment": "append empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 56,
+          "comment": "append zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304802202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 57,
+          "comment": "append garbage with high tag number",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304802202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847dbbf7f00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 58,
+          "comment": "append null with explicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847dba0020500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 59,
+          "comment": "append null with implicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847dba000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 60,
+          "comment": "sequence of sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 61,
+          "comment": "truncated sequence: removed last 1 elements",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302202202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18",
+          "result": "invalid"
+        },
+        {
+          "tcId": 62,
+          "comment": "repeating element in sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "306802202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 63,
+          "comment": "flipped bit 0 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30432ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e19022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 64,
+          "comment": "flipped bit 32 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30432ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af8bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 65,
+          "comment": "flipped bit 48 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30432ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cd6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 66,
+          "comment": "flipped bit 64 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30432ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee858b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 67,
+          "comment": "length of r uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30460281202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 68,
+          "comment": "length of r contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047028200202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 69,
+          "comment": "length of r uses 33 instead of 32",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502212ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 70,
+          "comment": "length of r uses 31 instead of 32",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045021f2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 71,
+          "comment": "uint32 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a028501000000202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 72,
+          "comment": "uint64 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02890100000000000000202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 73,
+          "comment": "length of r = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902847fffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 74,
+          "comment": "length of r = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30490284800000002ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 75,
+          "comment": "length of r = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30490284ffffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 76,
+          "comment": "length of r = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a0285ffffffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 77,
+          "comment": "length of r = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d0288ffffffffffffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 78,
+          "comment": "incorrect length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502ff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 79,
+          "comment": "replaced r by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502802ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 80,
+          "comment": "removing r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3023022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 81,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 82,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802",
+          "result": "invalid"
+        },
+        {
+          "tcId": 83,
+          "comment": "appending 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702222ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 84,
+          "comment": "prepending 0's to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022200002ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 85,
+          "comment": "appending unused 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 86,
+          "comment": "appending null value to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702222ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180500022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 87,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a222549817702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 88,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492224250002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 89,
+          "comment": "appending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d222202202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180004deadbeef022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 90,
+          "comment": "truncated length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250281022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 91,
+          "comment": "including undefined tags to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b2226aa02aabb02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 92,
+          "comment": "using composition with indefinite length for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049228002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 93,
+          "comment": "using composition with wrong tag for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049228003202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 94,
+          "comment": "Replacing r with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30250500022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 95,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304500202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 96,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304501202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 97,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304503202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 98,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304504202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 99,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045ff202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 100,
+          "comment": "dropping value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250200022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 101,
+          "comment": "using composition for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049222402012b021fa3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 102,
+          "comment": "modifying first byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022029a3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 103,
+          "comment": "modifying last byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e98022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 104,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044021f2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 105,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044021fa3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 106,
+          "comment": "r of size 4129 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30821048028210212ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 107,
+          "comment": "leading ff in r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 108,
+          "comment": "replaced r by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026090180022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 109,
+          "comment": "replacing r with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 110,
+          "comment": "flipped bit 0 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1800b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847da",
+          "result": "invalid"
+        },
+        {
+          "tcId": 111,
+          "comment": "flipped bit 32 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1800b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b48156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 112,
+          "comment": "flipped bit 48 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1800b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c124b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 113,
+          "comment": "flipped bit 64 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1800b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4097c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 114,
+          "comment": "length of s uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304602202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802812100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 115,
+          "comment": "length of s contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180282002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 116,
+          "comment": "length of s uses 34 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022200b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 117,
+          "comment": "length of s uses 32 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 118,
+          "comment": "uint32 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180285010000002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 119,
+          "comment": "uint64 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18028901000000000000002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 120,
+          "comment": "length of s = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802847fffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 121,
+          "comment": "length of s = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802848000000000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 122,
+          "comment": "length of s = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180284ffffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 123,
+          "comment": "length of s = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180285ffffffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 124,
+          "comment": "length of s = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180288ffffffffffffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 125,
+          "comment": "incorrect length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802ff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 126,
+          "comment": "replaced s by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18028000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 127,
+          "comment": "appending 0's to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022300b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 128,
+          "comment": "prepending 0's to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180223000000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 129,
+          "comment": "appending null value to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022300b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 130,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182226498177022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 131,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1822252500022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 132,
+          "comment": "appending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182223022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 133,
+          "comment": "truncated length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180281",
+          "result": "invalid"
+        },
+        {
+          "tcId": 134,
+          "comment": "including undefined tags to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182227aa02aabb022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 135,
+          "comment": "using composition with indefinite length for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182280022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 136,
+          "comment": "using composition with wrong tag for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182280032100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 137,
+          "comment": "Replacing s with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 138,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 139,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18012100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 140,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18032100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 141,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18042100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 142,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18ff2100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 143,
+          "comment": "dropping value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180200",
+          "result": "invalid"
+        },
+        {
+          "tcId": 144,
+          "comment": "using composition for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1822250201000220b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 145,
+          "comment": "modifying first byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022102b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 146,
+          "comment": "modifying last byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b491568475b",
+          "result": "invalid"
+        },
+        {
+          "tcId": 147,
+          "comment": "truncated s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847",
+          "result": "invalid"
+        },
+        {
+          "tcId": 148,
+          "comment": "s of size 4130 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3082104802202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180282102200b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 149,
+          "comment": "leading ff in s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304602202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180222ff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 150,
+          "comment": "replaced s by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18090180",
+          "result": "invalid"
+        },
+        {
+          "tcId": 151,
+          "comment": "replacing s with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 152,
+          "comment": "replaced r by r + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221012ba3a8bd6b94d5ed80a6d9d1190a436ebccc0833490686deac8635bcb9bf5369022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 153,
+          "comment": "replaced r by r - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff2ba3a8bf6b94d5eb80a6d9d1190a436f42fe12d7fad749d4c512a036c0f908c7022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 154,
+          "comment": "replaced r by r + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022201002ba3a7be6b94d6ec80a6d9d1190a432be6dfbb2cb98d6d4d72972df620817f18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 155,
+          "comment": "replaced r by -r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220d45c5741946b2a137f59262ee6f5bc91001af27a5e1117a64733950642a3d1e8022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 156,
+          "comment": "replaced r by n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100d45c5740946b2a147f59262ee6f5bc90bd01ed280528b62b3aed5fc93f06f739022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 157,
+          "comment": "replaced r by -n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fed45c5742946b2a127f59262ee6f5bc914333f7ccb6f979215379ca434640ac97022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 158,
+          "comment": "replaced r by r + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221012ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 159,
+          "comment": "replaced r by r + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02290100000000000000002ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 160,
+          "comment": "replaced s by s + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101b329f478a2bbd0a6c384ee1493b1f518276e0e4a5375928d6fcd160c11cb6d2c022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 161,
+          "comment": "replaced s by s - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220b329f47aa2bbd0a4c384ee1493b1f518ada018ef05465583885980861905228a022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 162,
+          "comment": "replaced s by s + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "304702220100b329f379a2bbd1a5c384ee1493b1f4d55181c143c3fc78fc35de0e45788d98db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 163,
+          "comment": "replaced s by -s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff4cd60b865d442f5a3c7b11eb6c4e0ae79578ec6353a20bf783ecb4b6ea97b825022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 164,
+          "comment": "replaced s by -n - s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fe4cd60b875d442f593c7b11eb6c4e0ae7d891f1b5ac8a6d729032e9f3ee3492d4022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 165,
+          "comment": "replaced s by s + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 166,
+          "comment": "replaced s by s - 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 167,
+          "comment": "replaced s by s + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e0229010000000000000000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result": "invalid"
+        },
+        {
+          "tcId": 168,
+          "comment": "Signature with special case values r=0 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 169,
+          "comment": "Signature with special case values r=0 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 170,
+          "comment": "Signature with special case values r=0 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 171,
+          "comment": "Signature with special case values r=0 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 172,
+          "comment": "Signature with special case values r=0 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 173,
+          "comment": "Signature with special case values r=0 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 174,
+          "comment": "Signature with special case values r=0 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 175,
+          "comment": "Signature with special case values r=0 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 176,
+          "comment": "Signature with special case values r=1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 177,
+          "comment": "Signature with special case values r=1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 178,
+          "comment": "Signature with special case values r=1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 179,
+          "comment": "Signature with special case values r=1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 180,
+          "comment": "Signature with special case values r=1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 181,
+          "comment": "Signature with special case values r=1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 182,
+          "comment": "Signature with special case values r=1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 183,
+          "comment": "Signature with special case values r=1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 184,
+          "comment": "Signature with special case values r=-1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 185,
+          "comment": "Signature with special case values r=-1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 186,
+          "comment": "Signature with special case values r=-1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 187,
+          "comment": "Signature with special case values r=-1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 188,
+          "comment": "Signature with special case values r=-1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 189,
+          "comment": "Signature with special case values r=-1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 190,
+          "comment": "Signature with special case values r=-1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 191,
+          "comment": "Signature with special case values r=-1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 192,
+          "comment": "Signature with special case values r=n and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 193,
+          "comment": "Signature with special case values r=n and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 194,
+          "comment": "Signature with special case values r=n and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 195,
+          "comment": "Signature with special case values r=n and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 196,
+          "comment": "Signature with special case values r=n and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 197,
+          "comment": "Signature with special case values r=n and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 198,
+          "comment": "Signature with special case values r=n and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 199,
+          "comment": "Signature with special case values r=n and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 200,
+          "comment": "Signature with special case values r=n - 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 201,
+          "comment": "Signature with special case values r=n - 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 202,
+          "comment": "Signature with special case values r=n - 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325500201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 203,
+          "comment": "Signature with special case values r=n - 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 204,
+          "comment": "Signature with special case values r=n - 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 205,
+          "comment": "Signature with special case values r=n - 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 206,
+          "comment": "Signature with special case values r=n - 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 207,
+          "comment": "Signature with special case values r=n - 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 208,
+          "comment": "Signature with special case values r=n + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 209,
+          "comment": "Signature with special case values r=n + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 210,
+          "comment": "Signature with special case values r=n + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325520201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 211,
+          "comment": "Signature with special case values r=n + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 212,
+          "comment": "Signature with special case values r=n + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 213,
+          "comment": "Signature with special case values r=n + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 214,
+          "comment": "Signature with special case values r=n + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 215,
+          "comment": "Signature with special case values r=n + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 216,
+          "comment": "Signature with special case values r=p and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 217,
+          "comment": "Signature with special case values r=p and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 218,
+          "comment": "Signature with special case values r=p and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 219,
+          "comment": "Signature with special case values r=p and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 220,
+          "comment": "Signature with special case values r=p and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 221,
+          "comment": "Signature with special case values r=p and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 222,
+          "comment": "Signature with special case values r=p and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 223,
+          "comment": "Signature with special case values r=p and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 224,
+          "comment": "Signature with special case values r=p + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 225,
+          "comment": "Signature with special case values r=p + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 226,
+          "comment": "Signature with special case values r=p + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff000000010000000000000000000000010000000000000000000000000201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 227,
+          "comment": "Signature with special case values r=p + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 228,
+          "comment": "Signature with special case values r=p + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 229,
+          "comment": "Signature with special case values r=p + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 230,
+          "comment": "Signature with special case values r=p + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 231,
+          "comment": "Signature with special case values r=p + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 232,
+          "comment": "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020100090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 233,
+          "comment": "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 234,
+          "comment": "Signature encoding contains incorrect types: r=0, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 235,
+          "comment": "Signature encoding contains incorrect types: r=0, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 236,
+          "comment": "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 237,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 238,
+          "comment": "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 239,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 240,
+          "comment": "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 241,
+          "comment": "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020101090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 242,
+          "comment": "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 243,
+          "comment": "Signature encoding contains incorrect types: r=1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 244,
+          "comment": "Signature encoding contains incorrect types: r=1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 245,
+          "comment": "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 246,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 247,
+          "comment": "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 248,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201013000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 249,
+          "comment": "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201013003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 250,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 251,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 252,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 253,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 254,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 255,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 256,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 257,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 258,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 259,
+          "comment": "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 260,
+          "comment": "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 261,
+          "comment": "Signature encoding contains incorrect types: r=n, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 262,
+          "comment": "Signature encoding contains incorrect types: r=n, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 263,
+          "comment": "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 264,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 265,
+          "comment": "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 266,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325513000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 267,
+          "comment": "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325513003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 268,
+          "comment": "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 269,
+          "comment": "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 270,
+          "comment": "Signature encoding contains incorrect types: r=p, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 271,
+          "comment": "Signature encoding contains incorrect types: r=p, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 272,
+          "comment": "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 273,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 274,
+          "comment": "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 275,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 276,
+          "comment": "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 277,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a090380fe01090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 278,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 279,
+          "comment": "Signature encoding contains incorrect types: r=True, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 280,
+          "comment": "Signature encoding contains incorrect types: r=False, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 281,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300405000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 282,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30040c000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 283,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c01300c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 284,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300430003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 285,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a30030201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 286,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008090380fe01020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 287,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 288,
+          "comment": "Signature encoding contains incorrect types: r=True, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 289,
+          "comment": "Signature encoding contains incorrect types: r=False, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 290,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050500020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 291,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050c00020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 292,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c0130020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 293,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30053000020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 294,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30083003020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 295,
+          "comment": "Edge case for Shamir multiplication",
+          "flags": [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg": "3639383139",
+          "sig": "3044022064a1aab5000d0e804f3e2fc02bdee9be8ff312334e2ba16d11547c97711c898e02206af015971cc30be6d1a206d4e013e0997772a2f91d73286ffd683b9bb2cf4f1b",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343236343739373234",
+          "sig": "3044022016aea964a2f6506d6f78c81c91fc7e8bded7d397738448de1e19a0ec580bf2660220252cd762130c6667cfe8b7bc47d27d78391e8e80c578d1cd38c3ff033be928e9",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37313338363834383931",
+          "sig": "30450221009cc98be2347d469bf476dfc26b9b733df2d26d6ef524af917c665baccb23c8820220093496459effe2d8d70727b82462f61d0ec1b7847929d10ea631dacb16b56c32",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130333539333331363638",
+          "sig": "3044022073b3c90ecd390028058164524dde892703dce3dea0d53fa8093999f07ab8aa4302202f67b0b8e20636695bb7d8bf0a651c802ed25a395387b5f4188c0c4075c88634",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393439343031323135",
+          "sig": "3046022100bfab3098252847b328fadf2f89b95c851a7f0eb390763378f37e90119d5ba3dd022100bdd64e234e832b1067c2d058ccb44d978195ccebb65c2aaf1e2da9b8b4987e3b",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333434323933303739",
+          "sig": "30440220204a9784074b246d8bf8bf04a4ceb1c1f1c9aaab168b1596d17093c5cd21d2cd022051cce41670636783dc06a759c8847868a406c2506fe17975582fe648d1d88b52",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33373036323131373132",
+          "sig": "3046022100ed66dc34f551ac82f63d4aa4f81fe2cb0031a91d1314f835027bca0f1ceeaa0302210099ca123aa09b13cd194a422e18d5fda167623c3f6e5d4d6abb8953d67c0c48c7",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333433363838373132",
+          "sig": "30450220060b700bef665c68899d44f2356a578d126b062023ccc3c056bf0f60a237012b0221008d186c027832965f4fcc78a3366ca95dedbb410cbef3f26d6be5d581c11d3610",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333531353330333730",
+          "sig": "30460221009f6adfe8d5eb5b2c24d7aa7934b6cf29c93ea76cd313c9132bb0c8e38c96831d022100b26a9c9e40e55ee0890c944cf271756c906a33e66b5bd15e051593883b5e9902",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36353533323033313236",
+          "sig": "3045022100a1af03ca91677b673ad2f33615e56174a1abf6da168cebfa8868f4ba273f16b7022020aa73ffe48afa6435cd258b173d0c2377d69022e7d098d75caf24c8c5e06b1c",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353634333436363033",
+          "sig": "3045022100fdc70602766f8eed11a6c99a71c973d5659355507b843da6e327a28c11893db902203df5349688a085b137b1eacf456a9e9e0f6d15ec0078ca60a7f83f2b10d21350",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34343239353339313137",
+          "sig": "3046022100b516a314f2fce530d6537f6a6c49966c23456f63c643cf8e0dc738f7b876e675022100d39ffd033c92b6d717dd536fbc5efdf1967c4bd80954479ba66b0120cd16fff2",
+          "result": "valid"
+        },
+        {
+          "tcId": 307,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130393533323631333531",
+          "sig": "304402203b2cbf046eac45842ecb7984d475831582717bebb6492fd0a485c101e29ff0a802204c9b7b47a98b0f82de512bc9313aaf51701099cac5f76e68c8595fc1c1d99258",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35393837333530303431",
+          "sig": "3044022030c87d35e636f540841f14af54e2f9edd79d0312cfa1ab656c3fb15bfde48dcf022047c15a5a82d24b75c85a692bd6ecafeb71409ede23efd08e0db9abf6340677ed",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343633303036383738",
+          "sig": "3044022038686ff0fda2cef6bc43b58cfe6647b9e2e8176d168dec3c68ff262113760f520220067ec3b651f422669601662167fa8717e976e2db5e6a4cf7c2ddabb3fde9d67d",
+          "result": "valid"
+        },
+        {
+          "tcId": 310,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39383137333230323837",
+          "sig": "3044022044a3e23bf314f2b344fc25c7f2de8b6af3e17d27f5ee844b225985ab6e2775cf02202d48e223205e98041ddc87be532abed584f0411f5729500493c9cc3f4dd15e86",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323232303431303436",
+          "sig": "304402202ded5b7ec8e90e7bf11f967a3d95110c41b99db3b5aa8d330eb9d638781688e902207d5792c53628155e1bfc46fb1a67e3088de049c328ae1f44ec69238a009808f9",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36363636333037313034",
+          "sig": "3046022100bdae7bcb580bf335efd3bc3d31870f923eaccafcd40ec2f605976f15137d8b8f022100f6dfa12f19e525270b0106eecfe257499f373a4fb318994f24838122ce7ec3c7",
+          "result": "valid"
+        },
+        {
+          "tcId": 313,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303335393531383938",
+          "sig": "3045022050f9c4f0cd6940e162720957ffff513799209b78596956d21ece251c2401f1c6022100d7033a0a787d338e889defaaabb106b95a4355e411a59c32aa5167dfab244726",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383436353937313935",
+          "sig": "3045022100f612820687604fa01906066a378d67540982e29575d019aabe90924ead5c860d02203f9367702dd7dd4f75ea98afd20e328a1a99f4857b316525328230ce294b0fef",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313336303436313839",
+          "sig": "30460221009505e407657d6e8bc93db5da7aa6f5081f61980c1949f56b0f2f507da5782a7a022100c60d31904e3669738ffbeccab6c3656c08e0ed5cb92b3cfa5e7f71784f9c5021",
+          "result": "valid"
+        },
+        {
+          "tcId": 316,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32363633373834323534",
+          "sig": "3046022100bbd16fbbb656b6d0d83e6a7787cd691b08735aed371732723e1c68a40404517d0221009d8e35dba96028b7787d91315be675877d2d097be5e8ee34560e3e7fd25c0f00",
+          "result": "valid"
+        },
+        {
+          "tcId": 317,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363532313030353234",
+          "sig": "304402202ec9760122db98fd06ea76848d35a6da442d2ceef7559a30cf57c61e92df327e02207ab271da90859479701fccf86e462ee3393fb6814c27b760c4963625c0a19878",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35373438303831363936",
+          "sig": "3044022054e76b7683b6650baa6a7fc49b1c51eed9ba9dd463221f7a4f1005a89fe00c5902202ea076886c773eb937ec1cc8374b7915cfd11b1c1ae1166152f2f7806a31c8fd",
+          "result": "valid"
+        },
+        {
+          "tcId": 319,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36333433393133343638",
+          "sig": "304402205291deaf24659ffbbce6e3c26f6021097a74abdbb69be4fb10419c0c496c9466022065d6fcf336d27cc7cdb982bb4e4ecef5827f84742f29f10abf83469270a03dc3",
+          "result": "valid"
+        },
+        {
+          "tcId": 320,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353431313033353938",
+          "sig": "30450220207a3241812d75d947419dc58efb05e8003b33fc17eb50f9d15166a88479f107022100cdee749f2e492b213ce80b32d0574f62f1c5d70793cf55e382d5caadf7592767",
+          "result": "valid"
+        },
+        {
+          "tcId": 321,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130343738353830313238",
+          "sig": "304502206554e49f82a855204328ac94913bf01bbe84437a355a0a37c0dee3cf81aa7728022100aea00de2507ddaf5c94e1e126980d3df16250a2eaebc8be486effe7f22b4f929",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130353336323835353638",
+          "sig": "3046022100a54c5062648339d2bff06f71c88216c26c6e19b4d80a8c602990ac82707efdfc022100e99bbe7fcfafae3e69fd016777517aa01056317f467ad09aff09be73c9731b0d",
+          "result": "valid"
+        },
+        {
+          "tcId": 323,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393533393034313035",
+          "sig": "3045022100975bd7157a8d363b309f1f444012b1a1d23096593133e71b4ca8b059cff37eaf02207faa7a28b1c822baa241793f2abc930bd4c69840fe090f2aacc46786bf919622",
+          "result": "valid"
+        },
+        {
+          "tcId": 324,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393738383438303339",
+          "sig": "304402205694a6f84b8f875c276afd2ebcfe4d61de9ec90305afb1357b95b3e0da43885e02200dffad9ffd0b757d8051dec02ebdf70d8ee2dc5c7870c0823b6ccc7c679cbaa4",
+          "result": "valid"
+        },
+        {
+          "tcId": 325,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33363130363732343432",
+          "sig": "3045022100a0c30e8026fdb2b4b4968a27d16a6d08f7098f1a98d21620d7454ba9790f1ba602205e470453a8a399f15baf463f9deceb53acc5ca64459149688bd2760c65424339",
+          "result": "valid"
+        },
+        {
+          "tcId": 326,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303534323430373035",
+          "sig": "30440220614ea84acf736527dd73602cd4bb4eea1dfebebd5ad8aca52aa0228cf7b99a880220737cc85f5f2d2f60d1b8183f3ed490e4de14368e96a9482c2a4dd193195c902f",
+          "result": "valid"
+        },
+        {
+          "tcId": 327,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35313734343438313937",
+          "sig": "3045022100bead6734ebe44b810d3fb2ea00b1732945377338febfd439a8d74dfbd0f942fa02206bb18eae36616a7d3cad35919fd21a8af4bbe7a10f73b3e036a46b103ef56e2a",
+          "result": "valid"
+        },
+        {
+          "tcId": 328,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393637353631323531",
+          "sig": "30440220499625479e161dacd4db9d9ce64854c98d922cbf212703e9654fae182df9bad2022042c177cf37b8193a0131108d97819edd9439936028864ac195b64fca76d9d693",
+          "result": "valid"
+        },
+        {
+          "tcId": 329,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343437323533333433",
+          "sig": "3045022008f16b8093a8fb4d66a2c8065b541b3d31e3bfe694f6b89c50fb1aaa6ff6c9b20221009d6455e2d5d1779748573b611cb95d4a21f967410399b39b535ba3e5af81ca2e",
+          "result": "valid"
+        },
+        {
+          "tcId": 330,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333638323634333138",
+          "sig": "3046022100be26231b6191658a19dd72ddb99ed8f8c579b6938d19bce8eed8dc2b338cb5f8022100e1d9a32ee56cffed37f0f22b2dcb57d5c943c14f79694a03b9c5e96952575c89",
+          "result": "valid"
+        },
+        {
+          "tcId": 331,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323631313938363038",
+          "sig": "3045022015e76880898316b16204ac920a02d58045f36a229d4aa4f812638c455abe0443022100e74d357d3fcb5c8c5337bd6aba4178b455ca10e226e13f9638196506a1939123",
+          "result": "valid"
+        },
+        {
+          "tcId": 332,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39363738373831303934",
+          "sig": "30440220352ecb53f8df2c503a45f9846fc28d1d31e6307d3ddbffc1132315cc07f16dad02201348dfa9c482c558e1d05c5242ca1c39436726ecd28258b1899792887dd0a3c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 333,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34393538383233383233",
+          "sig": "304402204a40801a7e606ba78a0da9882ab23c7677b8642349ed3d652c5bfa5f2a9558fb02203a49b64848d682ef7f605f2832f7384bdc24ed2925825bf8ea77dc5981725782",
+          "result": "valid"
+        },
+        {
+          "tcId": 334,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "383234363337383337",
+          "sig": "3045022100eacc5e1a8304a74d2be412b078924b3bb3511bac855c05c9e5e9e44df3d61e9602207451cd8e18d6ed1885dd827714847f96ec4bb0ed4c36ce9808db8f714204f6d1",
+          "result": "valid"
+        },
+        {
+          "tcId": 335,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131303230383333373736",
+          "sig": "304502202f7a5e9e5771d424f30f67fdab61e8ce4f8cd1214882adb65f7de94c31577052022100ac4e69808345809b44acb0b2bd889175fb75dd050c5a449ab9528f8f78daa10c",
+          "result": "valid"
+        },
+        {
+          "tcId": 336,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313333383731363438",
+          "sig": "3045022100ffcda40f792ce4d93e7e0f0e95e1a2147dddd7f6487621c30a03d710b3300219022079938b55f8a17f7ed7ba9ade8f2065a1fa77618f0b67add8d58c422c2453a49a",
+          "result": "valid"
+        },
+        {
+          "tcId": 337,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333232313434313632",
+          "sig": "304602210081f2359c4faba6b53d3e8c8c3fcc16a948350f7ab3a588b28c17603a431e39a8022100cd6f6a5cc3b55ead0ff695d06c6860b509e46d99fccefb9f7f9e101857f74300",
+          "result": "valid"
+        },
+        {
+          "tcId": 338,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130363836363535353436",
+          "sig": "3045022100dfc8bf520445cbb8ee1596fb073ea283ea130251a6fdffa5c3f5f2aaf75ca8080220048e33efce147c9dd92823640e338e68bfd7d0dc7a4905b3a7ac711e577e90e7",
+          "result": "valid"
+        },
+        {
+          "tcId": 339,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3632313535323436",
+          "sig": "3046022100ad019f74c6941d20efda70b46c53db166503a0e393e932f688227688ba6a576202210093320eb7ca0710255346bdbb3102cdcf7964ef2e0988e712bc05efe16c199345",
+          "result": "valid"
+        },
+        {
+          "tcId": 340,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37303330383138373734",
+          "sig": "3046022100ac8096842e8add68c34e78ce11dd71e4b54316bd3ebf7fffdeb7bd5a3ebc1883022100f5ca2f4f23d674502d4caf85d187215d36e3ce9f0ce219709f21a3aac003b7a8",
+          "result": "valid"
+        },
+        {
+          "tcId": 341,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35393234353233373434",
+          "sig": "30440220677b2d3a59b18a5ff939b70ea002250889ddcd7b7b9d776854b4943693fb92f702206b4ba856ade7677bf30307b21f3ccda35d2f63aee81efd0bab6972cc0795db55",
+          "result": "valid"
+        },
+        {
+          "tcId": 342,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343935353836363231",
+          "sig": "30450220479e1ded14bcaed0379ba8e1b73d3115d84d31d4b7c30e1f05e1fc0d5957cfb0022100918f79e35b3d89487cf634a4f05b2e0c30857ca879f97c771e877027355b2443",
+          "result": "valid"
+        },
+        {
+          "tcId": 343,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34303035333134343036",
+          "sig": "3044022043dfccd0edb9e280d9a58f01164d55c3d711e14b12ac5cf3b64840ead512a0a302201dbe33fa8ba84533cd5c4934365b3442ca1174899b78ef9a3199f49584389772",
+          "result": "valid"
+        },
+        {
+          "tcId": 344,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33303936343537353132",
+          "sig": "304402205b09ab637bd4caf0f4c7c7e4bca592fea20e9087c259d26a38bb4085f0bbff11022045b7eb467b6748af618e9d80d6fdcd6aa24964e5a13f885bca8101de08eb0d75",
+          "result": "valid"
+        },
+        {
+          "tcId": 345,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373834303235363230",
+          "sig": "304502205e9b1c5a028070df5728c5c8af9b74e0667afa570a6cfa0114a5039ed15ee06f022100b1360907e2d9785ead362bb8d7bd661b6c29eeffd3c5037744edaeb9ad990c20",
+          "result": "valid"
+        },
+        {
+          "tcId": 346,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32363138373837343138",
+          "sig": "304502200671a0a85c2b72d54a2fb0990e34538b4890050f5a5712f6d1a7a5fb8578f32e022100db1846bab6b7361479ab9c3285ca41291808f27fd5bd4fdac720e5854713694c",
+          "result": "valid"
+        },
+        {
+          "tcId": 347,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363432363235323632",
+          "sig": "304402207673f8526748446477dbbb0590a45492c5d7d69859d301abbaedb35b2095103a02203dc70ddf9c6b524d886bed9e6af02e0e4dec0d417a414fed3807ef4422913d7c",
+          "result": "valid"
+        },
+        {
+          "tcId": 348,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36383234313839343336",
+          "sig": "304402207f085441070ecd2bb21285089ebb1aa6450d1a06c36d3ff39dfd657a796d12b50220249712012029870a2459d18d47da9aa492a5e6cb4b2d8dafa9e4c5c54a2b9a8b",
+          "result": "valid"
+        },
+        {
+          "tcId": 349,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343834323435343235",
+          "sig": "3046022100914c67fb61dd1e27c867398ea7322d5ab76df04bc5aa6683a8e0f30a5d287348022100fa07474031481dda4953e3ac1959ee8cea7e66ec412b38d6c96d28f6d37304ea",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040ad99500288d466940031d72a9f5445a4d43784640855bf0a69874d2de5fe103c5011e6ef2c42dcd50d5d3d29f99ae6eba2c80c9244f4c5422f0979ff0c3ba5e",
+        "wx": "0ad99500288d466940031d72a9f5445a4d43784640855bf0a69874d2de5fe103",
+        "wy": "00c5011e6ef2c42dcd50d5d3d29f99ae6eba2c80c9244f4c5422f0979ff0c3ba5e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040ad99500288d466940031d72a9f5445a4d43784640855bf0a69874d2de5fe103c5011e6ef2c42dcd50d5d3d29f99ae6eba2c80c9244f4c5422f0979ff0c3ba5e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECtmVACiNRmlAAx1yqfVEWk1DeEZA\nhVvwpph00t5f4QPFAR5u8sQtzVDV09Kfma5uuiyAySRPTFQi8Jef8MO6Xg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 350,
+          "comment": "k*G has a large x-coordinate",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "303502104319055358e8617b0c46353d039cdaab022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        },
+        {
+          "tcId": 351,
+          "comment": "r too large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000fffffffffffffffffffffffc022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04ab05fd9d0de26b9ce6f4819652d9fc69193d0aa398f0fba8013e09c58220455419235271228c786759095d12b75af0692dd4103f19f6a8c32f49435a1e9b8d45",
+        "wx": "00ab05fd9d0de26b9ce6f4819652d9fc69193d0aa398f0fba8013e09c582204554",
+        "wy": "19235271228c786759095d12b75af0692dd4103f19f6a8c32f49435a1e9b8d45"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004ab05fd9d0de26b9ce6f4819652d9fc69193d0aa398f0fba8013e09c58220455419235271228c786759095d12b75af0692dd4103f19f6a8c32f49435a1e9b8d45",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqwX9nQ3ia5zm9IGWUtn8aRk9CqOY\n8PuoAT4JxYIgRVQZI1JxIox4Z1kJXRK3WvBpLdQQPxn2qMMvSUNaHpuNRQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 352,
+          "comment": "r,s are large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254f022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0480984f39a1ff38a86a68aa4201b6be5dfbfecf876219710b07badf6fdd4c6c5611feb97390d9826e7a06dfb41871c940d74415ed3cac2089f1445019bb55ed95",
+        "wx": "0080984f39a1ff38a86a68aa4201b6be5dfbfecf876219710b07badf6fdd4c6c56",
+        "wy": "11feb97390d9826e7a06dfb41871c940d74415ed3cac2089f1445019bb55ed95"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000480984f39a1ff38a86a68aa4201b6be5dfbfecf876219710b07badf6fdd4c6c5611feb97390d9826e7a06dfb41871c940d74415ed3cac2089f1445019bb55ed95",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgJhPOaH/OKhqaKpCAba+Xfv+z4di\nGXELB7rfb91MbFYR/rlzkNmCbnoG37QYcclA10QV7TysIInxRFAZu1XtlQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 353,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100909135bdb6799286170f5ead2de4f6511453fe50914f3df2de54a36383df8dd4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "044201b4272944201c3294f5baa9a3232b6dd687495fcc19a70a95bc602b4f7c0595c37eba9ee8171c1bb5ac6feaf753bc36f463e3aef16629572c0c0a8fb0800e",
+        "wx": "4201b4272944201c3294f5baa9a3232b6dd687495fcc19a70a95bc602b4f7c05",
+        "wy": "0095c37eba9ee8171c1bb5ac6feaf753bc36f463e3aef16629572c0c0a8fb0800e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200044201b4272944201c3294f5baa9a3232b6dd687495fcc19a70a95bc602b4f7c0595c37eba9ee8171c1bb5ac6feaf753bc36f463e3aef16629572c0c0a8fb0800e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQgG0JylEIBwylPW6qaMjK23Wh0lf\nzBmnCpW8YCtPfAWVw366nugXHBu1rG/q91O8NvRj467xZilXLAwKj7CADg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 354,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022027b4577ca009376f71303fd5dd227dcef5deb773ad5f5a84360644669ca249a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a71af64de5126a4a4e02b7922d66ce9415ce88a4c9d25514d91082c8725ac9575d47723c8fbe580bb369fec9c2665d8e30a435b9932645482e7c9f11e872296b",
+        "wx": "00a71af64de5126a4a4e02b7922d66ce9415ce88a4c9d25514d91082c8725ac957",
+        "wy": "5d47723c8fbe580bb369fec9c2665d8e30a435b9932645482e7c9f11e872296b"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a71af64de5126a4a4e02b7922d66ce9415ce88a4c9d25514d91082c8725ac9575d47723c8fbe580bb369fec9c2665d8e30a435b9932645482e7c9f11e872296b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpxr2TeUSakpOAreSLWbOlBXOiKTJ\n0lUU2RCCyHJayVddR3I8j75YC7Np/snCZl2OMKQ1uZMmRUgufJ8R6HIpaw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 355,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020105020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "046627cec4f0731ea23fc2931f90ebe5b7572f597d20df08fc2b31ee8ef16b15726170ed77d8d0a14fc5c9c3c4c9be7f0d3ee18f709bb275eaf2073e258fe694a5",
+        "wx": "6627cec4f0731ea23fc2931f90ebe5b7572f597d20df08fc2b31ee8ef16b1572",
+        "wy": "6170ed77d8d0a14fc5c9c3c4c9be7f0d3ee18f709bb275eaf2073e258fe694a5"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200046627cec4f0731ea23fc2931f90ebe5b7572f597d20df08fc2b31ee8ef16b15726170ed77d8d0a14fc5c9c3c4c9be7f0d3ee18f709bb275eaf2073e258fe694a5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZifOxPBzHqI/wpMfkOvlt1cvWX0g\n3wj8KzHujvFrFXJhcO132NChT8XJw8TJvn8NPuGPcJuyderyBz4lj+aUpQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 356,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020105020103",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "045a7c8825e85691cce1f5e7544c54e73f14afc010cb731343262ca7ec5a77f5bfef6edf62a4497c1bd7b147fb6c3d22af3c39bfce95f30e13a16d3d7b2812f813",
+        "wx": "5a7c8825e85691cce1f5e7544c54e73f14afc010cb731343262ca7ec5a77f5bf",
+        "wy": "00ef6edf62a4497c1bd7b147fb6c3d22af3c39bfce95f30e13a16d3d7b2812f813"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200045a7c8825e85691cce1f5e7544c54e73f14afc010cb731343262ca7ec5a77f5bfef6edf62a4497c1bd7b147fb6c3d22af3c39bfce95f30e13a16d3d7b2812f813",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWnyIJehWkczh9edUTFTnPxSvwBDL\ncxNDJiyn7Fp39b/vbt9ipEl8G9exR/tsPSKvPDm/zpXzDhOhbT17KBL4Ew==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 357,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020105020105",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04cbe0c29132cd738364fedd603152990c048e5e2fff996d883fa6caca7978c73770af6a8ce44cb41224b2603606f4c04d188e80bff7cc31ad5189d4ab0d70e8c1",
+        "wx": "00cbe0c29132cd738364fedd603152990c048e5e2fff996d883fa6caca7978c737",
+        "wy": "70af6a8ce44cb41224b2603606f4c04d188e80bff7cc31ad5189d4ab0d70e8c1"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004cbe0c29132cd738364fedd603152990c048e5e2fff996d883fa6caca7978c73770af6a8ce44cb41224b2603606f4c04d188e80bff7cc31ad5189d4ab0d70e8c1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEy+DCkTLNc4Nk/t1gMVKZDASOXi//\nmW2IP6bKynl4xzdwr2qM5Ey0EiSyYDYG9MBNGI6Av/fMMa1RidSrDXDowQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 358,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020105020106",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042ef747671c97d9c7f9cb2f6a30d678c3d84757ba241ef7183d51a29f52d87c2ea8fb2ea635b761baefc1c4ded2099281b844e13e044c328553bbbafa337d8a76",
+        "wx": "2ef747671c97d9c7f9cb2f6a30d678c3d84757ba241ef7183d51a29f52d87c2e",
+        "wy": "00a8fb2ea635b761baefc1c4ded2099281b844e13e044c328553bbbafa337d8a76"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042ef747671c97d9c7f9cb2f6a30d678c3d84757ba241ef7183d51a29f52d87c2ea8fb2ea635b761baefc1c4ded2099281b844e13e044c328553bbbafa337d8a76",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELvdHZxyX2cf5yy9qMNZ4w9hHV7ok\nHvcYPVGin1LYfC6o+y6mNbdhuu/BxN7SCZKBuEThPgRMMoVTu7r6M32Kdg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 359,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020106020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04931cc49cda4d87d25b1601c56c3b83b4f45e44971998f2d3e7d3c55152214edf058dc140abbba42fc1ddbf30dab8eb9b46ee7338b3f7ee96242bf45e1df5e995",
+        "wx": "00931cc49cda4d87d25b1601c56c3b83b4f45e44971998f2d3e7d3c55152214edf",
+        "wy": "058dc140abbba42fc1ddbf30dab8eb9b46ee7338b3f7ee96242bf45e1df5e995"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004931cc49cda4d87d25b1601c56c3b83b4f45e44971998f2d3e7d3c55152214edf058dc140abbba42fc1ddbf30dab8eb9b46ee7338b3f7ee96242bf45e1df5e995",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkxzEnNpNh9JbFgHFbDuDtPReRJcZ\nmPLT59PFUVIhTt8FjcFAq7ukL8HdvzDauOubRu5zOLP37pYkK/ReHfXplQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 360,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020106020103",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04899a4af61867e3f3c190dbb48f8bc9fc74b70a467a4a1f06477b3af2f39ab8ed47ac000f9ea8a3034939bf48ad5d061a69fc8495ae4df2dbec7effa03a0062b3",
+        "wx": "00899a4af61867e3f3c190dbb48f8bc9fc74b70a467a4a1f06477b3af2f39ab8ed",
+        "wy": "47ac000f9ea8a3034939bf48ad5d061a69fc8495ae4df2dbec7effa03a0062b3"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004899a4af61867e3f3c190dbb48f8bc9fc74b70a467a4a1f06477b3af2f39ab8ed47ac000f9ea8a3034939bf48ad5d061a69fc8495ae4df2dbec7effa03a0062b3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiZpK9hhn4/PBkNu0j4vJ/HS3CkZ6\nSh8GR3s68vOauO1HrAAPnqijA0k5v0itXQYaafyEla5N8tvsfv+gOgBisw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 361,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020106020106",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d03eb09913cc20c6a8d0070f0d8d2a7f63527fafa44117fce6bd1ef2aa4ae3c46d5df3f45ac58fa334c6d102381b3120b7a2455600dcaff3d1a845514f12bf46",
+        "wx": "00d03eb09913cc20c6a8d0070f0d8d2a7f63527fafa44117fce6bd1ef2aa4ae3c4",
+        "wy": "6d5df3f45ac58fa334c6d102381b3120b7a2455600dcaff3d1a845514f12bf46"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d03eb09913cc20c6a8d0070f0d8d2a7f63527fafa44117fce6bd1ef2aa4ae3c46d5df3f45ac58fa334c6d102381b3120b7a2455600dcaff3d1a845514f12bf46",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0D6wmRPMIMao0AcPDY0qf2NSf6+k\nQRf85r0e8qpK48RtXfP0WsWPozTG0QI4GzEgt6JFVgDcr/PRqEVRTxK/Rg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 362,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020106020107",
+          "result": "valid"
+        },
+        {
+          "tcId": 363,
+          "comment": "r is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632557020107",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "043a72476291571193b4d109b2c37b59f2807e8fe9cffd804eacded903e77ca0da592dbc74fee0ca7508cc7bc282b0c51a143286ff53c60131668e7a0929e4ed04",
+        "wx": "3a72476291571193b4d109b2c37b59f2807e8fe9cffd804eacded903e77ca0da",
+        "wy": "592dbc74fee0ca7508cc7bc282b0c51a143286ff53c60131668e7a0929e4ed04"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200043a72476291571193b4d109b2c37b59f2807e8fe9cffd804eacded903e77ca0da592dbc74fee0ca7508cc7bc282b0c51a143286ff53c60131668e7a0929e4ed04",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOnJHYpFXEZO00Qmyw3tZ8oB+j+nP\n/YBOrN7ZA+d8oNpZLbx0/uDKdQjMe8KCsMUaFDKG/1PGATFmjnoJKeTtBA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 364,
+          "comment": "s is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020106022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc75fbd8",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d0f73792203716afd4be4329faa48d269f15313ebbba379d7783c97bf3e890d9971f4a3206605bec21782bf5e275c714417e8f566549e6bc68690d2363c89cc1",
+        "wx": "00d0f73792203716afd4be4329faa48d269f15313ebbba379d7783c97bf3e890d9",
+        "wy": "00971f4a3206605bec21782bf5e275c714417e8f566549e6bc68690d2363c89cc1"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d0f73792203716afd4be4329faa48d269f15313ebbba379d7783c97bf3e890d9971f4a3206605bec21782bf5e275c714417e8f566549e6bc68690d2363c89cc1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0Pc3kiA3Fq/UvkMp+qSNJp8VMT67\nujedd4PJe/PokNmXH0oyBmBb7CF4K/XidccUQX6PVmVJ5rxoaQ0jY8icwQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 365,
+          "comment": "small r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3027020201000221008f1e3c7862c58b16bb76eddbb76eddbb516af4f63f2d74d76e0d28c9bb75ea88",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "044838b2be35a6276a80ef9e228140f9d9b96ce83b7a254f71ccdebbb8054ce05ffa9cbc123c919b19e00238198d04069043bd660a828814051fcb8aac738a6c6b",
+        "wx": "4838b2be35a6276a80ef9e228140f9d9b96ce83b7a254f71ccdebbb8054ce05f",
+        "wy": "00fa9cbc123c919b19e00238198d04069043bd660a828814051fcb8aac738a6c6b"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200044838b2be35a6276a80ef9e228140f9d9b96ce83b7a254f71ccdebbb8054ce05ffa9cbc123c919b19e00238198d04069043bd660a828814051fcb8aac738a6c6b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESDiyvjWmJ2qA754igUD52bls6Dt6\nJU9xzN67uAVM4F/6nLwSPJGbGeACOBmNBAaQQ71mCoKIFAUfy4qsc4psaw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 366,
+          "comment": "smallish r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302c02072d9b4d347952d6022100ef3043e7329581dbb3974497710ab11505ee1c87ff907beebadd195a0ffe6d7a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "047393983ca30a520bbc4783dc9960746aab444ef520c0a8e771119aa4e74b0f64e9d7be1ab01a0bf626e709863e6a486dbaf32793afccf774e2c6cd27b1857526",
+        "wx": "7393983ca30a520bbc4783dc9960746aab444ef520c0a8e771119aa4e74b0f64",
+        "wy": "00e9d7be1ab01a0bf626e709863e6a486dbaf32793afccf774e2c6cd27b1857526"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200047393983ca30a520bbc4783dc9960746aab444ef520c0a8e771119aa4e74b0f64e9d7be1ab01a0bf626e709863e6a486dbaf32793afccf774e2c6cd27b1857526",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc5OYPKMKUgu8R4PcmWB0aqtETvUg\nwKjncRGapOdLD2Tp174asBoL9ibnCYY+akhtuvMnk6/M93Tixs0nsYV1Jg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 367,
+          "comment": "100-bit r and small s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3032020d1033e67e37b32b445580bf4eff0221008b748b74000000008b748b748b748b7466e769ad4a16d3dcd87129b8e91d1b4d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "045ac331a1103fe966697379f356a937f350588a05477e308851b8a502d5dfcdc5fe9993df4b57939b2b8da095bf6d794265204cfe03be995a02e65d408c871c0b",
+        "wx": "5ac331a1103fe966697379f356a937f350588a05477e308851b8a502d5dfcdc5",
+        "wy": "00fe9993df4b57939b2b8da095bf6d794265204cfe03be995a02e65d408c871c0b"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200045ac331a1103fe966697379f356a937f350588a05477e308851b8a502d5dfcdc5fe9993df4b57939b2b8da095bf6d794265204cfe03be995a02e65d408c871c0b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWsMxoRA/6WZpc3nzVqk381BYigVH\nfjCIUbilAtXfzcX+mZPfS1eTmyuNoJW/bXlCZSBM/gO+mVoC5l1AjIccCw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 368,
+          "comment": "small r and 100 bit s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302702020100022100ef9f6ba4d97c09d03178fa20b4aaad83be3cf9cb824a879fec3270fc4b81ef5b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "041d209be8de2de877095a399d3904c74cc458d926e27bb8e58e5eae5767c41509dd59e04c214f7b18dce351fc2a549893a6860e80163f38cc60a4f2c9d040d8c9",
+        "wx": "1d209be8de2de877095a399d3904c74cc458d926e27bb8e58e5eae5767c41509",
+        "wy": "00dd59e04c214f7b18dce351fc2a549893a6860e80163f38cc60a4f2c9d040d8c9"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200041d209be8de2de877095a399d3904c74cc458d926e27bb8e58e5eae5767c41509dd59e04c214f7b18dce351fc2a549893a6860e80163f38cc60a4f2c9d040d8c9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHSCb6N4t6HcJWjmdOQTHTMRY2Sbi\ne7jljl6uV2fEFQndWeBMIU97GNzjUfwqVJiTpoYOgBY/OMxgpPLJ0EDYyQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 369,
+          "comment": "100-bit r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3032020d062522bbd3ecbe7c39e93e7c25022100ef9f6ba4d97c09d03178fa20b4aaad83be3cf9cb824a879fec3270fc4b81ef5b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04083539fbee44625e3acaafa2fcb41349392cef0633a1b8fabecee0c133b10e99915c1ebe7bf00df8535196770a58047ae2a402f26326bb7d41d4d7616337911e",
+        "wx": "083539fbee44625e3acaafa2fcb41349392cef0633a1b8fabecee0c133b10e99",
+        "wy": "00915c1ebe7bf00df8535196770a58047ae2a402f26326bb7d41d4d7616337911e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004083539fbee44625e3acaafa2fcb41349392cef0633a1b8fabecee0c133b10e99915c1ebe7bf00df8535196770a58047ae2a402f26326bb7d41d4d7616337911e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECDU5++5EYl46yq+i/LQTSTks7wYz\nobj6vs7gwTOxDpmRXB6+e/AN+FNRlncKWAR64qQC8mMmu31B1NdhYzeRHg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 370,
+          "comment": "r and s^-1 are close to n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6324d50220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04e075effd9607d08d5f34e3652f64cfa3bd6d20c58d0a232f058491260ab212a4cc61760ac8b0680c1b644c03cc628ba9dc4a3c0561368489c692bd40f43aa3ca",
+        "wx": "00e075effd9607d08d5f34e3652f64cfa3bd6d20c58d0a232f058491260ab212a4",
+        "wy": "00cc61760ac8b0680c1b644c03cc628ba9dc4a3c0561368489c692bd40f43aa3ca"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004e075effd9607d08d5f34e3652f64cfa3bd6d20c58d0a232f058491260ab212a4cc61760ac8b0680c1b644c03cc628ba9dc4a3c0561368489c692bd40f43aa3ca",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4HXv/ZYH0I1fNONlL2TPo71tIMWN\nCiMvBYSRJgqyEqTMYXYKyLBoDBtkTAPMYoup3Eo8BWE2hInGkr1A9Dqjyg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 371,
+          "comment": "r and s are 64-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30160209009c44febf31c3594f020900839ed28247c2b06b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04cffb758c3073ea3c08efd9f7f17a85b6ae385c5a140c146ad5f1f5a826718bc8dfdc6bebc894144c6d418ac5d97339726ad2ae925df868426e5628e9f4e62342",
+        "wx": "00cffb758c3073ea3c08efd9f7f17a85b6ae385c5a140c146ad5f1f5a826718bc8",
+        "wy": "00dfdc6bebc894144c6d418ac5d97339726ad2ae925df868426e5628e9f4e62342"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004cffb758c3073ea3c08efd9f7f17a85b6ae385c5a140c146ad5f1f5a826718bc8dfdc6bebc894144c6d418ac5d97339726ad2ae925df868426e5628e9f4e62342",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEz/t1jDBz6jwI79n38XqFtq44XFoU\nDBRq1fH1qCZxi8jf3GvryJQUTG1BisXZczlyatKukl34aEJuVijp9OYjQg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 372,
+          "comment": "r and s are 100-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "301e020d09df8b682430beef6f5fd7c7cd020d0fd0a62e13778f4222a0d61c8a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04b98740e69e61a325d5f772e3b5c4f67fb7150b16a9afeca9ddc4afcbb6fa0549c446e814138e4ebc82dbf86a390056d4595dcf45e381fef217a4597d7bd51498",
+        "wx": "00b98740e69e61a325d5f772e3b5c4f67fb7150b16a9afeca9ddc4afcbb6fa0549",
+        "wy": "00c446e814138e4ebc82dbf86a390056d4595dcf45e381fef217a4597d7bd51498"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004b98740e69e61a325d5f772e3b5c4f67fb7150b16a9afeca9ddc4afcbb6fa0549c446e814138e4ebc82dbf86a390056d4595dcf45e381fef217a4597d7bd51498",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuYdA5p5hoyXV93LjtcT2f7cVCxap\nr+yp3cSvy7b6BUnERugUE45OvILb+Go5AFbUWV3PReOB/vIXpFl9e9UUmA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 373,
+          "comment": "r and s are 128-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30260211008a598e563a89f526c32ebec8de26367c02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0484536a270c3932bb2084732adf2c768efc6d3977e5220229ea9a44888b8f9d7b1766398cdac2fc8000017b29a7ba15a58f196037f35f7008ed4286ddff00fd46",
+        "wx": "0084536a270c3932bb2084732adf2c768efc6d3977e5220229ea9a44888b8f9d7b",
+        "wy": "1766398cdac2fc8000017b29a7ba15a58f196037f35f7008ed4286ddff00fd46"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000484536a270c3932bb2084732adf2c768efc6d3977e5220229ea9a44888b8f9d7b1766398cdac2fc8000017b29a7ba15a58f196037f35f7008ed4286ddff00fd46",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhFNqJww5MrsghHMq3yx2jvxtOXfl\nIgIp6ppEiIuPnXsXZjmM2sL8gAABeymnuhWljxlgN/NfcAjtQobd/wD9Rg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 374,
+          "comment": "r and s are 160-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0bdf021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "048aeb368a7027a4d64abdea37390c0c1d6a26f399e2d9734de1eb3d0e1937387405bd13834715e1dbae9b875cf07bd55e1b6691c7f7536aef3b19bf7a4adf576d",
+        "wx": "008aeb368a7027a4d64abdea37390c0c1d6a26f399e2d9734de1eb3d0e19373874",
+        "wy": "05bd13834715e1dbae9b875cf07bd55e1b6691c7f7536aef3b19bf7a4adf576d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200048aeb368a7027a4d64abdea37390c0c1d6a26f399e2d9734de1eb3d0e1937387405bd13834715e1dbae9b875cf07bd55e1b6691c7f7536aef3b19bf7a4adf576d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEius2inAnpNZKveo3OQwMHWom85ni\n2XNN4es9Dhk3OHQFvRODRxXh266bh1zwe9VeG2aRx/dTau87Gb96St9XbQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 375,
+          "comment": "s == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30250220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70020101",
+          "result": "valid"
+        },
+        {
+          "tcId": 376,
+          "comment": "s == 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30250220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70020100",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0461722eaba731c697c7a9ba4d0afdbb5713d8aa12b0eab601bb33dbaf792c5adc272cd993b2b663aba5b3a26c101182ff178684945e83879e71598b95fe647dfc",
+        "wx": "61722eaba731c697c7a9ba4d0afdbb5713d8aa12b0eab601bb33dbaf792c5adc",
+        "wy": "272cd993b2b663aba5b3a26c101182ff178684945e83879e71598b95fe647dfc"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000461722eaba731c697c7a9ba4d0afdbb5713d8aa12b0eab601bb33dbaf792c5adc272cd993b2b663aba5b3a26c101182ff178684945e83879e71598b95fe647dfc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYXIuq6cxxpfHqbpNCv27VxPYqhKw\n6rYBuzPbr3ksWtwnLNmTsrZjq6WzomwQEYL/F4aElF6Dh55xWYuV/mR9/A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 377,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022002f676969f451a8ccafa4c4f09791810e6d632dbd60b1d5540f3284fbe1889b0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04c4c91981e720e20d7e478ff19d09b95a98f58c0f469b72801a8ce844a347316594afcd4188182e7779889b3258d0368ece1e66797fe7c648c6f0b9e26bd71871",
+        "wx": "00c4c91981e720e20d7e478ff19d09b95a98f58c0f469b72801a8ce844a3473165",
+        "wy": "0094afcd4188182e7779889b3258d0368ece1e66797fe7c648c6f0b9e26bd71871"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004c4c91981e720e20d7e478ff19d09b95a98f58c0f469b72801a8ce844a347316594afcd4188182e7779889b3258d0368ece1e66797fe7c648c6f0b9e26bd71871",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExMkZgecg4g1+R4/xnQm5Wpj1jA9G\nm3KAGozoRKNHMWWUr81BiBgud3mImzJY0DaOzh5meX/nxkjG8Lnia9cYcQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 378,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002204e260962e33362ef0046126d2d5a4edc6947ab20e19b8ec19cf79e5908b6e628",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d58d47bf49bc8f416641f6f760fcbca80aa52a814e56a5fa40bab44fd6f6317216deaa84d45d8e0e29cc9ecf5653f8ee6444750813becae8deb42b04ba07a634",
+        "wx": "00d58d47bf49bc8f416641f6f760fcbca80aa52a814e56a5fa40bab44fd6f63172",
+        "wy": "16deaa84d45d8e0e29cc9ecf5653f8ee6444750813becae8deb42b04ba07a634"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d58d47bf49bc8f416641f6f760fcbca80aa52a814e56a5fa40bab44fd6f6317216deaa84d45d8e0e29cc9ecf5653f8ee6444750813becae8deb42b04ba07a634",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Y1Hv0m8j0FmQfb3YPy8qAqlKoFO\nVqX6QLq0T9b2MXIW3qqE1F2ODinMns9WU/juZER1CBO+yujetCsEugemNA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 379,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220077ed0d8f20f697d8fc591ac64dd5219c7932122b4f9b9ec6441e44a0092cf21",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0491e305822e5e44f3fdb616e2ef42cd98f241b86e9f68815bc4dba6a945e4eefb3c5937e2ac1d9466f6d65e49b35fc8d75ffc22e1fe2f32af42f5fa3c26f9b4b0",
+        "wx": "0091e305822e5e44f3fdb616e2ef42cd98f241b86e9f68815bc4dba6a945e4eefb",
+        "wy": "3c5937e2ac1d9466f6d65e49b35fc8d75ffc22e1fe2f32af42f5fa3c26f9b4b0"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000491e305822e5e44f3fdb616e2ef42cd98f241b86e9f68815bc4dba6a945e4eefb3c5937e2ac1d9466f6d65e49b35fc8d75ffc22e1fe2f32af42f5fa3c26f9b4b0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkeMFgi5eRPP9thbi70LNmPJBuG6f\naIFbxNumqUXk7vs8WTfirB2UZvbWXkmzX8jXX/wi4f4vMq9C9fo8Jvm0sA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 380,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002203e0292a67e181c6c0105ee35e956e78e9bdd033c6e71ae57884039a245e4175f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0424a0bc4d16dbbd40d2fd81a7c3f8d8ec741607d5bb406a0611cc60d0e683bd46b575cad039c15f7f3dffcfc007b4b0f743c871ecc76a504a32672fd84526d861",
+        "wx": "24a0bc4d16dbbd40d2fd81a7c3f8d8ec741607d5bb406a0611cc60d0e683bd46",
+        "wy": "00b575cad039c15f7f3dffcfc007b4b0f743c871ecc76a504a32672fd84526d861"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000424a0bc4d16dbbd40d2fd81a7c3f8d8ec741607d5bb406a0611cc60d0e683bd46b575cad039c15f7f3dffcfc007b4b0f743c871ecc76a504a32672fd84526d861",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJKC8TRbbvUDS/YGnw/jY7HQWB9W7\nQGoGEcxg0OaDvUa1dcrQOcFffz3/z8AHtLD3Q8hx7MdqUEoyZy/YRSbYYQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 381,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022013d22b06d6b8f5d97e0c64962b4a3bae30f668ca6217ef5b35d799f159e23ebe",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d24dd06745cafb39186d22a92aa0e58169a79ab69488628a9da5ed3ef747269b7e9209d98faeb95355948adae61d5291c6015d3ee9513486d886fb05cbd25c6a",
+        "wx": "00d24dd06745cafb39186d22a92aa0e58169a79ab69488628a9da5ed3ef747269b",
+        "wy": "7e9209d98faeb95355948adae61d5291c6015d3ee9513486d886fb05cbd25c6a"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d24dd06745cafb39186d22a92aa0e58169a79ab69488628a9da5ed3ef747269b7e9209d98faeb95355948adae61d5291c6015d3ee9513486d886fb05cbd25c6a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0k3QZ0XK+zkYbSKpKqDlgWmnmraU\niGKKnaXtPvdHJpt+kgnZj665U1WUitrmHVKRxgFdPulRNIbYhvsFy9Jcag==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 382,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002204523ce342e4994bb8968bf6613f60c06c86111f15a3a389309e72cd447d5dd99",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "048200f148e7eab1581bcd1e23946f8a9b8191d9641f9560341721f9d3fec3d63ece795669e0481e035de8623d716a6984d0a4809d6c65519443ee55260f7f3dcb",
+        "wx": "008200f148e7eab1581bcd1e23946f8a9b8191d9641f9560341721f9d3fec3d63e",
+        "wy": "00ce795669e0481e035de8623d716a6984d0a4809d6c65519443ee55260f7f3dcb"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200048200f148e7eab1581bcd1e23946f8a9b8191d9641f9560341721f9d3fec3d63ece795669e0481e035de8623d716a6984d0a4809d6c65519443ee55260f7f3dcb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEggDxSOfqsVgbzR4jlG+Km4GR2WQf\nlWA0FyH50/7D1j7OeVZp4EgeA13oYj1xammE0KSAnWxlUZRD7lUmD389yw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 383,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022037d765be3c9c78189ad30edb5097a4db670de11686d01420e37039d4677f4809",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a8a69c5ed33b150ce8d37ac197070ed894c05d47258a80c9041d92486622024de85997c9666b60a393568efede8f4ca0167c1e10f626e62fc1b8c8e9c6ba6ed7",
+        "wx": "00a8a69c5ed33b150ce8d37ac197070ed894c05d47258a80c9041d92486622024d",
+        "wy": "00e85997c9666b60a393568efede8f4ca0167c1e10f626e62fc1b8c8e9c6ba6ed7"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a8a69c5ed33b150ce8d37ac197070ed894c05d47258a80c9041d92486622024de85997c9666b60a393568efede8f4ca0167c1e10f626e62fc1b8c8e9c6ba6ed7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqKacXtM7FQzo03rBlwcO2JTAXUcl\nioDJBB2SSGYiAk3oWZfJZmtgo5NWjv7ej0ygFnweEPYm5i/BuMjpxrpu1w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 384,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022044237823b54e0c74c2bf5f759d9ac5f8cb897d537ffa92effd4f0bb6c9acd860",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04ed0587e75b3b9a1dd0794f41d1729fcd432b2436cbf51c230d8bc7273273181735a57f09c7873d3964aa8102c9e25fa53070cd924cb7e3a459174740b8b71c34",
+        "wx": "00ed0587e75b3b9a1dd0794f41d1729fcd432b2436cbf51c230d8bc72732731817",
+        "wy": "35a57f09c7873d3964aa8102c9e25fa53070cd924cb7e3a459174740b8b71c34"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004ed0587e75b3b9a1dd0794f41d1729fcd432b2436cbf51c230d8bc7273273181735a57f09c7873d3964aa8102c9e25fa53070cd924cb7e3a459174740b8b71c34",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7QWH51s7mh3QeU9B0XKfzUMrJDbL\n9RwjDYvHJzJzGBc1pX8Jx4c9OWSqgQLJ4l+lMHDNkky346RZF0dAuLccNA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 385,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220266d30a485385906054ca86d46f5f2b17e7f4646a3092092ad92877126538111",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04077091d99004a99ee08224e59a46a70495e6fba4eff681c3ce42127e588681ef4f1c16c77dfa440dde18245c9de76243d8f2fd9dea3f2782d6c04974d02f25dc",
+        "wx": "077091d99004a99ee08224e59a46a70495e6fba4eff681c3ce42127e588681ef",
+        "wy": "4f1c16c77dfa440dde18245c9de76243d8f2fd9dea3f2782d6c04974d02f25dc"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004077091d99004a99ee08224e59a46a70495e6fba4eff681c3ce42127e588681ef4f1c16c77dfa440dde18245c9de76243d8f2fd9dea3f2782d6c04974d02f25dc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEB3CR2ZAEqZ7ggiTlmkanBJXm+6Tv\n9oHDzkISfliGge9PHBbHffpEDd4YJFyd52JD2PL9neo/J4LWwEl00C8l3A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 386,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220538c7b3798e84d0ce90340165806348971ed44db8f0c674f5f215968390f92ee",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04616a8b8e57d82c11678f5827911024cd23a16cb52a65f230fb554a7b110c35a5bb466660be5cab3e4b587c12b45bd998bd56c7d66c2f94d03a1a6d2028d8a154",
+        "wx": "616a8b8e57d82c11678f5827911024cd23a16cb52a65f230fb554a7b110c35a5",
+        "wy": "00bb466660be5cab3e4b587c12b45bd998bd56c7d66c2f94d03a1a6d2028d8a154"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004616a8b8e57d82c11678f5827911024cd23a16cb52a65f230fb554a7b110c35a5bb466660be5cab3e4b587c12b45bd998bd56c7d66c2f94d03a1a6d2028d8a154",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYWqLjlfYLBFnj1gnkRAkzSOhbLUq\nZfIw+1VKexEMNaW7RmZgvlyrPktYfBK0W9mYvVbH1mwvlNA6Gm0gKNihVA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 387,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206fef0ef15d1688e15e704c4e6bb8bb7f40d52d3af5c661bb78c4ed9b408699b3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0471dc92b2b1baa7612c4a53427a0d2dfe548fa9cf829bb6b248f736a5eb30b513f91c7dff1144cb36057c2b859f35bd666a7961833b06de0f45159fbae208e326",
+        "wx": "71dc92b2b1baa7612c4a53427a0d2dfe548fa9cf829bb6b248f736a5eb30b513",
+        "wy": "00f91c7dff1144cb36057c2b859f35bd666a7961833b06de0f45159fbae208e326"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000471dc92b2b1baa7612c4a53427a0d2dfe548fa9cf829bb6b248f736a5eb30b513f91c7dff1144cb36057c2b859f35bd666a7961833b06de0f45159fbae208e326",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcdySsrG6p2EsSlNCeg0t/lSPqc+C\nm7aySPc2peswtRP5HH3/EUTLNgV8K4WfNb1manlhgzsG3g9FFZ+64gjjJg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 388,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206f44275e9aeb1331efcb8d58f35c0252791427e403ad84daad51d247cc2a64c6",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04662f43ae614bd9c90ff3fcded25cf0ef186b6967a47aa6aa7ae7f396594df931f5f94a525edd50d3738f7a28d03d7a2a70095c8f89de9bb2c645fea8d8bac9e0",
+        "wx": "662f43ae614bd9c90ff3fcded25cf0ef186b6967a47aa6aa7ae7f396594df931",
+        "wy": "00f5f94a525edd50d3738f7a28d03d7a2a70095c8f89de9bb2c645fea8d8bac9e0"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004662f43ae614bd9c90ff3fcded25cf0ef186b6967a47aa6aa7ae7f396594df931f5f94a525edd50d3738f7a28d03d7a2a70095c8f89de9bb2c645fea8d8bac9e0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZi9DrmFL2ckP8/ze0lzw7xhraWek\neqaqeufzlllN+TH1+UpSXt1Q03OPeijQPXoqcAlcj4nem7LGRf6o2LrJ4A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 389,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022021323755b103d2f9da6ab83eccab9ad8598bcf625652f10e7a3eeee3c3945fb3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04dff107959bd2f7386497a5624430a0ab35e552c1a4e4dc9c298caeb96353170dcb5065d7947a676c76287ca8e430324f8a534b0ba6f21200e033c4b88852a3cc",
+        "wx": "00dff107959bd2f7386497a5624430a0ab35e552c1a4e4dc9c298caeb96353170d",
+        "wy": "00cb5065d7947a676c76287ca8e430324f8a534b0ba6f21200e033c4b88852a3cc"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004dff107959bd2f7386497a5624430a0ab35e552c1a4e4dc9c298caeb96353170dcb5065d7947a676c76287ca8e430324f8a534b0ba6f21200e033c4b88852a3cc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3/EHlZvS9zhkl6ViRDCgqzXlUsGk\n5NycKYyuuWNTFw3LUGXXlHpnbHYofKjkMDJPilNLC6byEgDgM8S4iFKjzA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 390,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206c50acfe76de1289e7a5edb240f1c2a7879db6873d5d931f3c6ac467a6eac171",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04bd0862b0bfba85036922e06f5458754aafc3075b603a814b3ac75659bf24d7528258a607ffca2cfe05a300cb4c3c4e1963bbb1bc54d320e16969f85aad243385",
+        "wx": "00bd0862b0bfba85036922e06f5458754aafc3075b603a814b3ac75659bf24d752",
+        "wy": "008258a607ffca2cfe05a300cb4c3c4e1963bbb1bc54d320e16969f85aad243385"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004bd0862b0bfba85036922e06f5458754aafc3075b603a814b3ac75659bf24d7528258a607ffca2cfe05a300cb4c3c4e1963bbb1bc54d320e16969f85aad243385",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvQhisL+6hQNpIuBvVFh1Sq/DB1tg\nOoFLOsdWWb8k11KCWKYH/8os/gWjAMtMPE4ZY7uxvFTTIOFpafharSQzhQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 391,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220755b7fffb0b17ad57dca50fcefb7fe297b029df25e5ccb5069e8e70c2742c2a6",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04b533d4695dd5b8c5e07757e55e6e516f7e2c88fa0239e23f60e8ec07dd70f2871b134ee58cc583278456863f33c3a85d881f7d4a39850143e29d4eaf009afe47",
+        "wx": "00b533d4695dd5b8c5e07757e55e6e516f7e2c88fa0239e23f60e8ec07dd70f287",
+        "wy": "1b134ee58cc583278456863f33c3a85d881f7d4a39850143e29d4eaf009afe47"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004b533d4695dd5b8c5e07757e55e6e516f7e2c88fa0239e23f60e8ec07dd70f2871b134ee58cc583278456863f33c3a85d881f7d4a39850143e29d4eaf009afe47",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtTPUaV3VuMXgd1flXm5Rb34siPoC\nOeI/YOjsB91w8ocbE07ljMWDJ4RWhj8zw6hdiB99SjmFAUPinU6vAJr+Rw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 392,
+          "comment": "point at infinity during verify",
+          "flags": [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a80220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04f50d371b91bfb1d7d14e1323523bc3aa8cbf2c57f9e284de628c8b4536787b86f94ad887ac94d527247cd2e7d0c8b1291c553c9730405380b14cbb209f5fa2dd",
+        "wx": "00f50d371b91bfb1d7d14e1323523bc3aa8cbf2c57f9e284de628c8b4536787b86",
+        "wy": "00f94ad887ac94d527247cd2e7d0c8b1291c553c9730405380b14cbb209f5fa2dd"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004f50d371b91bfb1d7d14e1323523bc3aa8cbf2c57f9e284de628c8b4536787b86f94ad887ac94d527247cd2e7d0c8b1291c553c9730405380b14cbb209f5fa2dd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9Q03G5G/sdfRThMjUjvDqoy/LFf5\n4oTeYoyLRTZ4e4b5StiHrJTVJyR80ufQyLEpHFU8lzBAU4CxTLsgn1+i3Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 393,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a902207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a8",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0468ec6e298eafe16539156ce57a14b04a7047c221bafc3a582eaeb0d857c4d94697bed1af17850117fdb39b2324f220a5698ed16c426a27335bb385ac8ca6fb30",
+        "wx": "68ec6e298eafe16539156ce57a14b04a7047c221bafc3a582eaeb0d857c4d946",
+        "wy": "0097bed1af17850117fdb39b2324f220a5698ed16c426a27335bb385ac8ca6fb30"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000468ec6e298eafe16539156ce57a14b04a7047c221bafc3a582eaeb0d857c4d94697bed1af17850117fdb39b2324f220a5698ed16c426a27335bb385ac8ca6fb30",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaOxuKY6v4WU5FWzlehSwSnBHwiG6\n/DpYLq6w2FfE2UaXvtGvF4UBF/2zmyMk8iClaY7RbEJqJzNbs4WsjKb7MA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 394,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a902207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0469da0364734d2e530fece94019265fefb781a0f1b08f6c8897bdf6557927c8b866d2d3c7dcd518b23d726960f069ad71a933d86ef8abbcce8b20f71e2a847002",
+        "wx": "69da0364734d2e530fece94019265fefb781a0f1b08f6c8897bdf6557927c8b8",
+        "wy": "66d2d3c7dcd518b23d726960f069ad71a933d86ef8abbcce8b20f71e2a847002"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000469da0364734d2e530fece94019265fefb781a0f1b08f6c8897bdf6557927c8b866d2d3c7dcd518b23d726960f069ad71a933d86ef8abbcce8b20f71e2a847002",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEadoDZHNNLlMP7OlAGSZf77eBoPGw\nj2yIl732VXknyLhm0tPH3NUYsj1yaWDwaa1xqTPYbvirvM6LIPceKoRwAg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 395,
+          "comment": "u1 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022100bb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca605023",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d8adc00023a8edc02576e2b63e3e30621a471e2b2320620187bf067a1ac1ff3233e2b50ec09807accb36131fff95ed12a09a86b4ea9690aa32861576ba2362e1",
+        "wx": "00d8adc00023a8edc02576e2b63e3e30621a471e2b2320620187bf067a1ac1ff32",
+        "wy": "33e2b50ec09807accb36131fff95ed12a09a86b4ea9690aa32861576ba2362e1"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d8adc00023a8edc02576e2b63e3e30621a471e2b2320620187bf067a1ac1ff3233e2b50ec09807accb36131fff95ed12a09a86b4ea9690aa32861576ba2362e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2K3AACOo7cAlduK2Pj4wYhpHHisj\nIGIBh78GehrB/zIz4rUOwJgHrMs2Ex//le0SoJqGtOqWkKoyhhV2uiNi4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 396,
+          "comment": "u1 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022044a5ad0ad0636d9f12bc9e0a6bdd5e1cbcb012ea7bf091fcec15b0c43202d52e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "043623ac973ced0a56fa6d882f03a7d5c7edca02cfc7b2401fab3690dbe75ab7858db06908e64b28613da7257e737f39793da8e713ba0643b92e9bb3252be7f8fe",
+        "wx": "3623ac973ced0a56fa6d882f03a7d5c7edca02cfc7b2401fab3690dbe75ab785",
+        "wy": "008db06908e64b28613da7257e737f39793da8e713ba0643b92e9bb3252be7f8fe"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200043623ac973ced0a56fa6d882f03a7d5c7edca02cfc7b2401fab3690dbe75ab7858db06908e64b28613da7257e737f39793da8e713ba0643b92e9bb3252be7f8fe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENiOslzztClb6bYgvA6fVx+3KAs/H\nskAfqzaQ2+dat4WNsGkI5ksoYT2nJX5zfzl5PajnE7oGQ7kum7MlK+f4/g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 397,
+          "comment": "u2 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04cf04ea77e9622523d894b93ff52dc3027b31959503b6fa3890e5e04263f922f1e8528fb7c006b3983c8b8400e57b4ed71740c2f3975438821199bedeaecab2e9",
+        "wx": "00cf04ea77e9622523d894b93ff52dc3027b31959503b6fa3890e5e04263f922f1",
+        "wy": "00e8528fb7c006b3983c8b8400e57b4ed71740c2f3975438821199bedeaecab2e9"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004cf04ea77e9622523d894b93ff52dc3027b31959503b6fa3890e5e04263f922f1e8528fb7c006b3983c8b8400e57b4ed71740c2f3975438821199bedeaecab2e9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzwTqd+liJSPYlLk/9S3DAnsxlZUD\ntvo4kOXgQmP5IvHoUo+3wAazmDyLhADle07XF0DC85dUOIIRmb7ersqy6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 398,
+          "comment": "u2 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022100aaaaaaaa00000000aaaaaaaaaaaaaaaa7def51c91a0fbf034d26872ca84218e1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04db7a2c8a1ab573e5929dc24077b508d7e683d49227996bda3e9f78dbeff773504f417f3bc9a88075c2e0aadd5a13311730cf7cc76a82f11a36eaf08a6c99a206",
+        "wx": "00db7a2c8a1ab573e5929dc24077b508d7e683d49227996bda3e9f78dbeff77350",
+        "wy": "4f417f3bc9a88075c2e0aadd5a13311730cf7cc76a82f11a36eaf08a6c99a206"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004db7a2c8a1ab573e5929dc24077b508d7e683d49227996bda3e9f78dbeff773504f417f3bc9a88075c2e0aadd5a13311730cf7cc76a82f11a36eaf08a6c99a206",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE23osihq1c+WSncJAd7UI1+aD1JIn\nmWvaPp942+/3c1BPQX87yaiAdcLgqt1aEzEXMM98x2qC8Ro26vCKbJmiBg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 399,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100e91e1ba60fdedb76a46bcb51dc0b8b4b7e019f0a28721885fa5d3a8196623397",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04dead11c7a5b396862f21974dc4752fadeff994efe9bbd05ab413765ea80b6e1f1de3f0640e8ac6edcf89cff53c40e265bb94078a343736df07aa0318fc7fe1ff",
+        "wx": "00dead11c7a5b396862f21974dc4752fadeff994efe9bbd05ab413765ea80b6e1f",
+        "wy": "1de3f0640e8ac6edcf89cff53c40e265bb94078a343736df07aa0318fc7fe1ff"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004dead11c7a5b396862f21974dc4752fadeff994efe9bbd05ab413765ea80b6e1f1de3f0640e8ac6edcf89cff53c40e265bb94078a343736df07aa0318fc7fe1ff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3q0Rx6WzloYvIZdNxHUvre/5lO/p\nu9BatBN2XqgLbh8d4/BkDorG7c+Jz/U8QOJlu5QHijQ3Nt8HqgMY/H/h/w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 400,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100fdea5843ffeb73af94313ba4831b53fe24f799e525b1e8e8c87b59b95b430ad9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d0bc472e0d7c81ebaed3a6ef96c18613bb1fea6f994326fbe80e00dfde67c7e9986c723ea4843d48389b946f64ad56c83ad70ff17ba85335667d1bb9fa619efd",
+        "wx": "00d0bc472e0d7c81ebaed3a6ef96c18613bb1fea6f994326fbe80e00dfde67c7e9",
+        "wy": "00986c723ea4843d48389b946f64ad56c83ad70ff17ba85335667d1bb9fa619efd"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d0bc472e0d7c81ebaed3a6ef96c18613bb1fea6f994326fbe80e00dfde67c7e9986c723ea4843d48389b946f64ad56c83ad70ff17ba85335667d1bb9fa619efd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0LxHLg18geuu06bvlsGGE7sf6m+Z\nQyb76A4A395nx+mYbHI+pIQ9SDiblG9krVbIOtcP8XuoUzVmfRu5+mGe/Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 401,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022003ffcabf2f1b4d2a65190db1680d62bb994e41c5251cd73b3c3dfc5e5bafc035",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a0a44ca947d66a2acb736008b9c08d1ab2ad03776e02640f78495d458dd51c326337fe5cf8c4604b1f1c409dc2d872d4294a4762420df43a30a2392e40426add",
+        "wx": "00a0a44ca947d66a2acb736008b9c08d1ab2ad03776e02640f78495d458dd51c32",
+        "wy": "6337fe5cf8c4604b1f1c409dc2d872d4294a4762420df43a30a2392e40426add"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a0a44ca947d66a2acb736008b9c08d1ab2ad03776e02640f78495d458dd51c326337fe5cf8c4604b1f1c409dc2d872d4294a4762420df43a30a2392e40426add",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoKRMqUfWairLc2AIucCNGrKtA3du\nAmQPeEldRY3VHDJjN/5c+MRgSx8cQJ3C2HLUKUpHYkIN9DowojkuQEJq3Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 402,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02204dfbc401f971cd304b33dfdb17d0fed0fe4c1a88ae648e0d2847f74977534989",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04c9c2115290d008b45fb65fad0f602389298c25420b775019d42b62c3ce8a96b73877d25a8080dc02d987ca730f0405c2c9dbefac46f9e601cc3f06e9713973fd",
+        "wx": "00c9c2115290d008b45fb65fad0f602389298c25420b775019d42b62c3ce8a96b7",
+        "wy": "3877d25a8080dc02d987ca730f0405c2c9dbefac46f9e601cc3f06e9713973fd"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004c9c2115290d008b45fb65fad0f602389298c25420b775019d42b62c3ce8a96b73877d25a8080dc02d987ca730f0405c2c9dbefac46f9e601cc3f06e9713973fd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEycIRUpDQCLRftl+tD2AjiSmMJUIL\nd1AZ1Ctiw86Klrc4d9JagIDcAtmHynMPBAXCydvvrEb55gHMPwbpcTlz/Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 403,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bc4024761cd2ffd43dfdb17d0fed112b988977055cd3a8e54971eba9cda5ca71",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "045eca1ef4c287dddc66b8bccf1b88e8a24c0018962f3c5e7efa83bc1a5ff6033e5e79c4cb2c245b8c45abdce8a8e4da758d92a607c32cd407ecaef22f1c934a71",
+        "wx": "5eca1ef4c287dddc66b8bccf1b88e8a24c0018962f3c5e7efa83bc1a5ff6033e",
+        "wy": "5e79c4cb2c245b8c45abdce8a8e4da758d92a607c32cd407ecaef22f1c934a71"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200045eca1ef4c287dddc66b8bccf1b88e8a24c0018962f3c5e7efa83bc1a5ff6033e5e79c4cb2c245b8c45abdce8a8e4da758d92a607c32cd407ecaef22f1c934a71",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXsoe9MKH3dxmuLzPG4jookwAGJYv\nPF5++oO8Gl/2Az5eecTLLCRbjEWr3Oio5Np1jZKmB8Ms1AfsrvIvHJNKcQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 404,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220788048ed39a5ffa77bfb62fa1fda2257742bf35d128fb3459f2a0c909ee86f91",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "045caaa030e7fdf0e4936bc7ab5a96353e0a01e4130c3f8bf22d473e317029a47adeb6adc462f7058f2a20d371e9702254e9b201642005b3ceda926b42b178bef9",
+        "wx": "5caaa030e7fdf0e4936bc7ab5a96353e0a01e4130c3f8bf22d473e317029a47a",
+        "wy": "00deb6adc462f7058f2a20d371e9702254e9b201642005b3ceda926b42b178bef9"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200045caaa030e7fdf0e4936bc7ab5a96353e0a01e4130c3f8bf22d473e317029a47adeb6adc462f7058f2a20d371e9702254e9b201642005b3ceda926b42b178bef9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXKqgMOf98OSTa8erWpY1PgoB5BMM\nP4vyLUc+MXAppHretq3EYvcFjyog03HpcCJU6bIBZCAFs87akmtCsXi++Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 405,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220476d9131fd381bd917d0fed112bc9e0a5924b5ed5b11167edd8b23582b3cb15e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04c2fd20bac06e555bb8ac0ce69eb1ea20f83a1fc3501c8a66469b1a31f619b0986237050779f52b615bd7b8d76a25fc95ca2ed32525c75f27ffc87ac397e6cbaf",
+        "wx": "00c2fd20bac06e555bb8ac0ce69eb1ea20f83a1fc3501c8a66469b1a31f619b098",
+        "wy": "6237050779f52b615bd7b8d76a25fc95ca2ed32525c75f27ffc87ac397e6cbaf"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004c2fd20bac06e555bb8ac0ce69eb1ea20f83a1fc3501c8a66469b1a31f619b0986237050779f52b615bd7b8d76a25fc95ca2ed32525c75f27ffc87ac397e6cbaf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwv0gusBuVVu4rAzmnrHqIPg6H8NQ\nHIpmRpsaMfYZsJhiNwUHefUrYVvXuNdqJfyVyi7TJSXHXyf/yHrDl+bLrw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 406,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0221008374253e3e21bd154448d0a8f640fe46fafa8b19ce78d538f6cc0a19662d3601",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "043fd6a1ca7f77fb3b0bbe726c372010068426e11ea6ae78ce17bedae4bba86ced03ce5516406bf8cfaab8745eac1cd69018ad6f50b5461872ddfc56e0db3c8ff4",
+        "wx": "3fd6a1ca7f77fb3b0bbe726c372010068426e11ea6ae78ce17bedae4bba86ced",
+        "wy": "03ce5516406bf8cfaab8745eac1cd69018ad6f50b5461872ddfc56e0db3c8ff4"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200043fd6a1ca7f77fb3b0bbe726c372010068426e11ea6ae78ce17bedae4bba86ced03ce5516406bf8cfaab8745eac1cd69018ad6f50b5461872ddfc56e0db3c8ff4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEP9ahyn93+zsLvnJsNyAQBoQm4R6m\nrnjOF77a5LuobO0DzlUWQGv4z6q4dF6sHNaQGK1vULVGGHLd/Fbg2zyP9A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 407,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220357cfd3be4d01d413c5b9ede36cba5452c11ee7fe14879e749ae6a2d897a52d6",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "049cb8e51e27a5ae3b624a60d6dc32734e4989db20e9bca3ede1edf7b086911114b4c104ab3c677e4b36d6556e8ad5f523410a19f2e277aa895fc57322b4427544",
+        "wx": "009cb8e51e27a5ae3b624a60d6dc32734e4989db20e9bca3ede1edf7b086911114",
+        "wy": "00b4c104ab3c677e4b36d6556e8ad5f523410a19f2e277aa895fc57322b4427544"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200049cb8e51e27a5ae3b624a60d6dc32734e4989db20e9bca3ede1edf7b086911114b4c104ab3c677e4b36d6556e8ad5f523410a19f2e277aa895fc57322b4427544",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnLjlHielrjtiSmDW3DJzTkmJ2yDp\nvKPt4e33sIaRERS0wQSrPGd+SzbWVW6K1fUjQQoZ8uJ3qolfxXMitEJ1RA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 408,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022029798c5c0ee287d4a5e8e6b799fd86b8df5225298e6ffc807cd2f2bc27a0a6d8",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a3e52c156dcaf10502620b7955bc2b40bc78ef3d569e1223c262512d8f49602a4a2039f31c1097024ad3cc86e57321de032355463486164cf192944977df147f",
+        "wx": "00a3e52c156dcaf10502620b7955bc2b40bc78ef3d569e1223c262512d8f49602a",
+        "wy": "4a2039f31c1097024ad3cc86e57321de032355463486164cf192944977df147f"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a3e52c156dcaf10502620b7955bc2b40bc78ef3d569e1223c262512d8f49602a4a2039f31c1097024ad3cc86e57321de032355463486164cf192944977df147f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEo+UsFW3K8QUCYgt5VbwrQLx47z1W\nnhIjwmJRLY9JYCpKIDnzHBCXAkrTzIblcyHeAyNVRjSGFkzxkpRJd98Ufw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 409,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02200b70f22c781092452dca1a5711fa3a5a1f72add1bf52c2ff7cae4820b30078dd",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04f19b78928720d5bee8e670fb90010fb15c37bf91b58a5157c3f3c059b2655e88cf701ec962fb4a11dcf273f5dc357e58468560c7cfeb942d074abd4329260509",
+        "wx": "00f19b78928720d5bee8e670fb90010fb15c37bf91b58a5157c3f3c059b2655e88",
+        "wy": "00cf701ec962fb4a11dcf273f5dc357e58468560c7cfeb942d074abd4329260509"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004f19b78928720d5bee8e670fb90010fb15c37bf91b58a5157c3f3c059b2655e88cf701ec962fb4a11dcf273f5dc357e58468560c7cfeb942d074abd4329260509",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8Zt4kocg1b7o5nD7kAEPsVw3v5G1\nilFXw/PAWbJlXojPcB7JYvtKEdzyc/XcNX5YRoVgx8/rlC0HSr1DKSYFCQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 410,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022016e1e458f021248a5b9434ae23f474b43ee55ba37ea585fef95c90416600f1ba",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0483a744459ecdfb01a5cf52b27a05bb7337482d242f235d7b4cb89345545c90a8c05d49337b9649813287de9ffe90355fd905df5f3c32945828121f37cc50de6e",
+        "wx": "0083a744459ecdfb01a5cf52b27a05bb7337482d242f235d7b4cb89345545c90a8",
+        "wy": "00c05d49337b9649813287de9ffe90355fd905df5f3c32945828121f37cc50de6e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000483a744459ecdfb01a5cf52b27a05bb7337482d242f235d7b4cb89345545c90a8c05d49337b9649813287de9ffe90355fd905df5f3c32945828121f37cc50de6e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEg6dERZ7N+wGlz1KyegW7czdILSQv\nI117TLiTRVRckKjAXUkze5ZJgTKH3p/+kDVf2QXfXzwylFgoEh83zFDebg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 411,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02202252d6856831b6cf895e4f0535eeaf0e5e5809753df848fe760ad86219016a97",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04dd13c6b34c56982ddae124f039dfd23f4b19bbe88cee8e528ae51e5d6f3a21d7bfad4c2e6f263fe5eb59ca974d039fc0e4c3345692fb5320bdae4bd3b42a45ff",
+        "wx": "00dd13c6b34c56982ddae124f039dfd23f4b19bbe88cee8e528ae51e5d6f3a21d7",
+        "wy": "00bfad4c2e6f263fe5eb59ca974d039fc0e4c3345692fb5320bdae4bd3b42a45ff"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004dd13c6b34c56982ddae124f039dfd23f4b19bbe88cee8e528ae51e5d6f3a21d7bfad4c2e6f263fe5eb59ca974d039fc0e4c3345692fb5320bdae4bd3b42a45ff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3RPGs0xWmC3a4STwOd/SP0sZu+iM\n7o5SiuUeXW86Ide/rUwubyY/5etZypdNA5/A5MM0VpL7UyC9rkvTtCpF/w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 412,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02210081ffe55f178da695b28c86d8b406b15dab1a9e39661a3ae017fbe390ac0972c3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0467e6f659cdde869a2f65f094e94e5b4dfad636bbf95192feeed01b0f3deb7460a37e0a51f258b7aeb51dfe592f5cfd5685bbe58712c8d9233c62886437c38ba0",
+        "wx": "67e6f659cdde869a2f65f094e94e5b4dfad636bbf95192feeed01b0f3deb7460",
+        "wy": "00a37e0a51f258b7aeb51dfe592f5cfd5685bbe58712c8d9233c62886437c38ba0"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000467e6f659cdde869a2f65f094e94e5b4dfad636bbf95192feeed01b0f3deb7460a37e0a51f258b7aeb51dfe592f5cfd5685bbe58712c8d9233c62886437c38ba0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZ+b2Wc3ehpovZfCU6U5bTfrWNrv5\nUZL+7tAbDz3rdGCjfgpR8li3rrUd/lkvXP1WhbvlhxLI2SM8YohkN8OLoA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 413,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02207fffffffaaaaaaaaffffffffffffffffe9a2538f37b28a2c513dee40fecbb71a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042eb6412505aec05c6545f029932087e490d05511e8ec1f599617bb367f9ecaaf805f51efcc4803403f9b1ae0124890f06a43fedcddb31830f6669af292895cb0",
+        "wx": "2eb6412505aec05c6545f029932087e490d05511e8ec1f599617bb367f9ecaaf",
+        "wy": "00805f51efcc4803403f9b1ae0124890f06a43fedcddb31830f6669af292895cb0"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042eb6412505aec05c6545f029932087e490d05511e8ec1f599617bb367f9ecaaf805f51efcc4803403f9b1ae0124890f06a43fedcddb31830f6669af292895cb0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELrZBJQWuwFxlRfApkyCH5JDQVRHo\n7B9Zlhe7Nn+eyq+AX1HvzEgDQD+bGuASSJDwakP+3N2zGDD2ZprykolcsA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 414,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100b62f26b5f2a2b26f6de86d42ad8a13da3ab3cccd0459b201de009e526adf21f2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0484db645868eab35e3a9fd80e056e2e855435e3a6b68d75a50a854625fe0d7f356d2589ac655edc9a11ef3e075eddda9abf92e72171570ef7bf43a2ee39338cfe",
+        "wx": "0084db645868eab35e3a9fd80e056e2e855435e3a6b68d75a50a854625fe0d7f35",
+        "wy": "6d2589ac655edc9a11ef3e075eddda9abf92e72171570ef7bf43a2ee39338cfe"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000484db645868eab35e3a9fd80e056e2e855435e3a6b68d75a50a854625fe0d7f356d2589ac655edc9a11ef3e075eddda9abf92e72171570ef7bf43a2ee39338cfe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhNtkWGjqs146n9gOBW4uhVQ146a2\njXWlCoVGJf4NfzVtJYmsZV7cmhHvPgde3dqav5LnIXFXDve/Q6LuOTOM/g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 415,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bb1d9ac949dd748cd02bbbe749bd351cd57b38bb61403d700686aa7b4c90851e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0491b9e47c56278662d75c0983b22ca8ea6aa5059b7a2ff7637eb2975e386ad66349aa8ff283d0f77c18d6d11dc062165fd13c3c0310679c1408302a16854ecfbd",
+        "wx": "0091b9e47c56278662d75c0983b22ca8ea6aa5059b7a2ff7637eb2975e386ad663",
+        "wy": "49aa8ff283d0f77c18d6d11dc062165fd13c3c0310679c1408302a16854ecfbd"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000491b9e47c56278662d75c0983b22ca8ea6aa5059b7a2ff7637eb2975e386ad66349aa8ff283d0f77c18d6d11dc062165fd13c3c0310679c1408302a16854ecfbd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkbnkfFYnhmLXXAmDsiyo6mqlBZt6\nL/djfrKXXjhq1mNJqo/yg9D3fBjW0R3AYhZf0Tw8AxBnnBQIMCoWhU7PvQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 416,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022066755a00638cdaec1c732513ca0234ece52545dac11f816e818f725b4f60aaf2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04f3ec2f13caf04d0192b47fb4c5311fb6d4dc6b0a9e802e5327f7ec5ee8e4834df97e3e468b7d0db867d6ecfe81e2b0f9531df87efdb47c1338ac321fefe5a432",
+        "wx": "00f3ec2f13caf04d0192b47fb4c5311fb6d4dc6b0a9e802e5327f7ec5ee8e4834d",
+        "wy": "00f97e3e468b7d0db867d6ecfe81e2b0f9531df87efdb47c1338ac321fefe5a432"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004f3ec2f13caf04d0192b47fb4c5311fb6d4dc6b0a9e802e5327f7ec5ee8e4834df97e3e468b7d0db867d6ecfe81e2b0f9531df87efdb47c1338ac321fefe5a432",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8+wvE8rwTQGStH+0xTEfttTcawqe\ngC5TJ/fsXujkg035fj5Gi30NuGfW7P6B4rD5Ux34fv20fBM4rDIf7+WkMg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 417,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022055a00c9fcdaebb6032513ca0234ecfffe98ebe492fdf02e48ca48e982beb3669",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d92b200aefcab6ac7dafd9acaf2fa10b3180235b8f46b4503e4693c670fccc885ef2f3aebf5b317475336256768f7c19efb7352d27e4cccadc85b6b8ab922c72",
+        "wx": "00d92b200aefcab6ac7dafd9acaf2fa10b3180235b8f46b4503e4693c670fccc88",
+        "wy": "5ef2f3aebf5b317475336256768f7c19efb7352d27e4cccadc85b6b8ab922c72"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d92b200aefcab6ac7dafd9acaf2fa10b3180235b8f46b4503e4693c670fccc885ef2f3aebf5b317475336256768f7c19efb7352d27e4cccadc85b6b8ab922c72",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2SsgCu/Ktqx9r9msry+hCzGAI1uP\nRrRQPkaTxnD8zIhe8vOuv1sxdHUzYlZ2j3wZ77c1LSfkzMrchba4q5Iscg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 418,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100ab40193f9b5d76c064a27940469d9fffd31d7c925fbe05c919491d3057d66cd2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040a88361eb92ecca2625b38e5f98bbabb96bf179b3d76fc48140a3bcd881523cde6bdf56033f84a5054035597375d90866aa2c96b86a41ccf6edebf47298ad489",
+        "wx": "0a88361eb92ecca2625b38e5f98bbabb96bf179b3d76fc48140a3bcd881523cd",
+        "wy": "00e6bdf56033f84a5054035597375d90866aa2c96b86a41ccf6edebf47298ad489"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040a88361eb92ecca2625b38e5f98bbabb96bf179b3d76fc48140a3bcd881523cde6bdf56033f84a5054035597375d90866aa2c96b86a41ccf6edebf47298ad489",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECog2HrkuzKJiWzjl+Yu6u5a/F5s9\ndvxIFAo7zYgVI83mvfVgM/hKUFQDVZc3XZCGaqLJa4akHM9u3r9HKYrUiQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 419,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100ca0234ebb5fdcb13ca0234ecffffffffcb0dadbbc7f549f8a26b4408d0dc8600",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d0fb17ccd8fafe827e0c1afc5d8d80366e2b20e7f14a563a2ba50469d84375e868612569d39e2bb9f554355564646de99ac602cc6349cf8c1e236a7de7637d93",
+        "wx": "00d0fb17ccd8fafe827e0c1afc5d8d80366e2b20e7f14a563a2ba50469d84375e8",
+        "wy": "68612569d39e2bb9f554355564646de99ac602cc6349cf8c1e236a7de7637d93"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d0fb17ccd8fafe827e0c1afc5d8d80366e2b20e7f14a563a2ba50469d84375e868612569d39e2bb9f554355564646de99ac602cc6349cf8c1e236a7de7637d93",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0PsXzNj6/oJ+DBr8XY2ANm4rIOfx\nSlY6K6UEadhDdehoYSVp054rufVUNVVkZG3pmsYCzGNJz4weI2p952N9kw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 420,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff3ea3677e082b9310572620ae19933a9e65b285598711c77298815ad3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04836f33bbc1dc0d3d3abbcef0d91f11e2ac4181076c9af0a22b1e4309d3edb2769ab443ff6f901e30c773867582997c2bec2b0cb8120d760236f3a95bbe881f75",
+        "wx": "00836f33bbc1dc0d3d3abbcef0d91f11e2ac4181076c9af0a22b1e4309d3edb276",
+        "wy": "009ab443ff6f901e30c773867582997c2bec2b0cb8120d760236f3a95bbe881f75"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004836f33bbc1dc0d3d3abbcef0d91f11e2ac4181076c9af0a22b1e4309d3edb2769ab443ff6f901e30c773867582997c2bec2b0cb8120d760236f3a95bbe881f75",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEg28zu8HcDT06u87w2R8R4qxBgQds\nmvCiKx5DCdPtsnaatEP/b5AeMMdzhnWCmXwr7CsMuBINdgI286lbvogfdQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 421,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220266666663bbbbbbbe6666666666666665b37902e023fab7c8f055d86e5cc41f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0492f99fbe973ed4a299719baee4b432741237034dec8d72ba5103cb33e55feeb8033dd0e91134c734174889f3ebcf1b7a1ac05767289280ee7a794cebd6e69697",
+        "wx": "0092f99fbe973ed4a299719baee4b432741237034dec8d72ba5103cb33e55feeb8",
+        "wy": "033dd0e91134c734174889f3ebcf1b7a1ac05767289280ee7a794cebd6e69697"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000492f99fbe973ed4a299719baee4b432741237034dec8d72ba5103cb33e55feeb8033dd0e91134c734174889f3ebcf1b7a1ac05767289280ee7a794cebd6e69697",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkvmfvpc+1KKZcZuu5LQydBI3A03s\njXK6UQPLM+Vf7rgDPdDpETTHNBdIifPrzxt6GsBXZyiSgO56eUzr1uaWlw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 422,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff36db6db7a492492492492492146c573f4c6dfc8d08a443e258970b09",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d35ba58da30197d378e618ec0fa7e2e2d12cffd73ebbb2049d130bba434af09eff83986e6875e41ea432b7585a49b3a6c77cbb3c47919f8e82874c794635c1d2",
+        "wx": "00d35ba58da30197d378e618ec0fa7e2e2d12cffd73ebbb2049d130bba434af09e",
+        "wy": "00ff83986e6875e41ea432b7585a49b3a6c77cbb3c47919f8e82874c794635c1d2"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d35ba58da30197d378e618ec0fa7e2e2d12cffd73ebbb2049d130bba434af09eff83986e6875e41ea432b7585a49b3a6c77cbb3c47919f8e82874c794635c1d2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE01uljaMBl9N45hjsD6fi4tEs/9c+\nu7IEnRMLukNK8J7/g5huaHXkHqQyt1haSbOmx3y7PEeRn46Ch0x5RjXB0g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 423,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff2aaaaaab7fffffffffffffffc815d0e60b3e596ecb1ad3a27cfd49c4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "048651ce490f1b46d73f3ff475149be29136697334a519d7ddab0725c8d0793224e11c65bd8ca92dc8bc9ae82911f0b52751ce21dd9003ae60900bd825f590cc28",
+        "wx": "008651ce490f1b46d73f3ff475149be29136697334a519d7ddab0725c8d0793224",
+        "wy": "00e11c65bd8ca92dc8bc9ae82911f0b52751ce21dd9003ae60900bd825f590cc28"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200048651ce490f1b46d73f3ff475149be29136697334a519d7ddab0725c8d0793224e11c65bd8ca92dc8bc9ae82911f0b52751ce21dd9003ae60900bd825f590cc28",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhlHOSQ8bRtc/P/R1FJvikTZpczSl\nGdfdqwclyNB5MiThHGW9jKktyLya6CkR8LUnUc4h3ZADrmCQC9gl9ZDMKA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 424,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02207fffffff55555555ffffffffffffffffd344a71e6f651458a27bdc81fd976e37",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "046d8e1b12c831a0da8795650ff95f101ed921d9e2f72b15b1cdaca9826b9cfc6def6d63e2bc5c089570394a4bc9f892d5e6c7a6a637b20469a58c106ad486bf37",
+        "wx": "6d8e1b12c831a0da8795650ff95f101ed921d9e2f72b15b1cdaca9826b9cfc6d",
+        "wy": "00ef6d63e2bc5c089570394a4bc9f892d5e6c7a6a637b20469a58c106ad486bf37"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200046d8e1b12c831a0da8795650ff95f101ed921d9e2f72b15b1cdaca9826b9cfc6def6d63e2bc5c089570394a4bc9f892d5e6c7a6a637b20469a58c106ad486bf37",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbY4bEsgxoNqHlWUP+V8QHtkh2eL3\nKxWxzaypgmuc/G3vbWPivFwIlXA5SkvJ+JLV5sempjeyBGmljBBq1Ia/Nw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 425,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02203fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192aa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040ae580bae933b4ef2997cbdbb0922328ca9a410f627a0f7dff24cb4d920e15428911e7f8cc365a8a88eb81421a361ccc2b99e309d8dcd9a98ba83c3949d893e3",
+        "wx": "0ae580bae933b4ef2997cbdbb0922328ca9a410f627a0f7dff24cb4d920e1542",
+        "wy": "008911e7f8cc365a8a88eb81421a361ccc2b99e309d8dcd9a98ba83c3949d893e3"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040ae580bae933b4ef2997cbdbb0922328ca9a410f627a0f7dff24cb4d920e15428911e7f8cc365a8a88eb81421a361ccc2b99e309d8dcd9a98ba83c3949d893e3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECuWAuukztO8pl8vbsJIjKMqaQQ9i\neg99/yTLTZIOFUKJEef4zDZaiojrgUIaNhzMK5njCdjc2amLqDw5SdiT4w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 426,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02205d8ecd64a4eeba466815ddf3a4de9a8e6abd9c5db0a01eb80343553da648428f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "045b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc46963838a40f2a36092e9004e92d8d940cf5638550ce672ce8b8d4e15eba5499249e9",
+        "wx": "5b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc46963",
+        "wy": "00838a40f2a36092e9004e92d8d940cf5638550ce672ce8b8d4e15eba5499249e9"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200045b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc46963838a40f2a36092e9004e92d8d940cf5638550ce672ce8b8d4e15eba5499249e9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEW4Ev1SGq+mmDWoSczm+962mDtELS\nRE/nDhNMAn/EaWODikDyo2CS6QBOktjZQM9WOFUM5nLOi41OFeulSZJJ6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 427,
+          "comment": "point duplication during verification",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100bb726660235793aa9957a61e76e00c2c435109cf9a15dd624d53f4301047856b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "045b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc469637c75bf0c5c9f6d17ffb16d2726bf30a9c7aaf31a8d317472b1ea145ab66db616",
+        "wx": "5b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc46963",
+        "wy": "7c75bf0c5c9f6d17ffb16d2726bf30a9c7aaf31a8d317472b1ea145ab66db616"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200045b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc469637c75bf0c5c9f6d17ffb16d2726bf30a9c7aaf31a8d317472b1ea145ab66db616",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEW4Ev1SGq+mmDWoSczm+962mDtELS\nRE/nDhNMAn/EaWN8db8MXJ9tF/+xbScmvzCpx6rzGo0xdHKx6hRatm22Fg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 428,
+          "comment": "duplication bug",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100bb726660235793aa9957a61e76e00c2c435109cf9a15dd624d53f4301047856b",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "046adda82b90261b0f319faa0d878665a6b6da497f09c903176222c34acfef72a647e6f50dcc40ad5d9b59f7602bb222fad71a41bf5e1f9df4959a364c62e488d9",
+        "wx": "6adda82b90261b0f319faa0d878665a6b6da497f09c903176222c34acfef72a6",
+        "wy": "47e6f50dcc40ad5d9b59f7602bb222fad71a41bf5e1f9df4959a364c62e488d9"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200046adda82b90261b0f319faa0d878665a6b6da497f09c903176222c34acfef72a647e6f50dcc40ad5d9b59f7602bb222fad71a41bf5e1f9df4959a364c62e488d9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEat2oK5AmGw8xn6oNh4ZlprbaSX8J\nyQMXYiLDSs/vcqZH5vUNzECtXZtZ92ArsiL61xpBv14fnfSVmjZMYuSI2Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 429,
+          "comment": "point with x-coordinate 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30250201010220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042fca0d0a47914de77ed56e7eccc3276a601120c6df0069c825c8f6a01c9f382065f3450a1d17c6b24989a39beb1c7decfca8384fbdc294418e5d807b3c6ed7de",
+        "wx": "2fca0d0a47914de77ed56e7eccc3276a601120c6df0069c825c8f6a01c9f3820",
+        "wy": "65f3450a1d17c6b24989a39beb1c7decfca8384fbdc294418e5d807b3c6ed7de"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042fca0d0a47914de77ed56e7eccc3276a601120c6df0069c825c8f6a01c9f382065f3450a1d17c6b24989a39beb1c7decfca8384fbdc294418e5d807b3c6ed7de",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEL8oNCkeRTed+1W5+zMMnamARIMbf\nAGnIJcj2oByfOCBl80UKHRfGskmJo5vrHH3s/Kg4T73ClEGOXYB7PG7X3g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 430,
+          "comment": "point with x-coordinate 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022101000000000000000000000000000000000000000000000000000000000000000002203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aa9",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04dd86d3b5f4a13e8511083b78002081c53ff467f11ebd98a51a633db76665d25045d5c8200c89f2fa10d849349226d21d8dfaed6ff8d5cb3e1b7e17474ebc18f7",
+        "wx": "00dd86d3b5f4a13e8511083b78002081c53ff467f11ebd98a51a633db76665d250",
+        "wy": "45d5c8200c89f2fa10d849349226d21d8dfaed6ff8d5cb3e1b7e17474ebc18f7"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004dd86d3b5f4a13e8511083b78002081c53ff467f11ebd98a51a633db76665d25045d5c8200c89f2fa10d849349226d21d8dfaed6ff8d5cb3e1b7e17474ebc18f7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3YbTtfShPoURCDt4ACCBxT/0Z/Ee\nvZilGmM9t2Zl0lBF1cggDIny+hDYSTSSJtIdjfrtb/jVyz4bfhdHTrwY9w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 431,
+          "comment": "comparison with point at infinity ",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aa9",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "044fea55b32cb32aca0c12c4cd0abfb4e64b0f5a516e578c016591a93f5a0fbcc5d7d3fd10b2be668c547b212f6bb14c88f0fecd38a8a4b2c785ed3be62ce4b280",
+        "wx": "4fea55b32cb32aca0c12c4cd0abfb4e64b0f5a516e578c016591a93f5a0fbcc5",
+        "wy": "00d7d3fd10b2be668c547b212f6bb14c88f0fecd38a8a4b2c785ed3be62ce4b280"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200044fea55b32cb32aca0c12c4cd0abfb4e64b0f5a516e578c016591a93f5a0fbcc5d7d3fd10b2be668c547b212f6bb14c88f0fecd38a8a4b2c785ed3be62ce4b280",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAET+pVsyyzKsoMEsTNCr+05ksPWlFu\nV4wBZZGpP1oPvMXX0/0Qsr5mjFR7IS9rsUyI8P7NOKiksseF7TvmLOSygA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 432,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc476699780220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04c6a771527024227792170a6f8eee735bf32b7f98af669ead299802e32d7c3107bc3b4b5e65ab887bbd343572b3e5619261fe3a073e2ffd78412f726867db589e",
+        "wx": "00c6a771527024227792170a6f8eee735bf32b7f98af669ead299802e32d7c3107",
+        "wy": "00bc3b4b5e65ab887bbd343572b3e5619261fe3a073e2ffd78412f726867db589e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004c6a771527024227792170a6f8eee735bf32b7f98af669ead299802e32d7c3107bc3b4b5e65ab887bbd343572b3e5619261fe3a073e2ffd78412f726867db589e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExqdxUnAkIneSFwpvju5zW/Mrf5iv\nZp6tKZgC4y18MQe8O0teZauIe700NXKz5WGSYf46Bz4v/XhBL3JoZ9tYng==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 433,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022100b6db6db6249249254924924924924924625bd7a09bec4ca81bcdd9f8fd6b63cc",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04851c2bbad08e54ec7a9af99f49f03644d6ec6d59b207fec98de85a7d15b956efcee9960283045075684b410be8d0f7494b91aa2379f60727319f10ddeb0fe9d6",
+        "wx": "00851c2bbad08e54ec7a9af99f49f03644d6ec6d59b207fec98de85a7d15b956ef",
+        "wy": "00cee9960283045075684b410be8d0f7494b91aa2379f60727319f10ddeb0fe9d6"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004851c2bbad08e54ec7a9af99f49f03644d6ec6d59b207fec98de85a7d15b956efcee9960283045075684b410be8d0f7494b91aa2379f60727319f10ddeb0fe9d6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhRwrutCOVOx6mvmfSfA2RNbsbVmy\nB/7JjehafRW5Vu/O6ZYCgwRQdWhLQQvo0PdJS5GqI3n2BycxnxDd6w/p1g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 434,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022100cccccccc00000000cccccccccccccccc971f2ef152794b9d8fc7d568c9e8eaa7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04f6417c8a670584e388676949e53da7fc55911ff68318d1bf3061205acb19c48f8f2b743df34ad0f72674acb7505929784779cd9ac916c3669ead43026ab6d43f",
+        "wx": "00f6417c8a670584e388676949e53da7fc55911ff68318d1bf3061205acb19c48f",
+        "wy": "008f2b743df34ad0f72674acb7505929784779cd9ac916c3669ead43026ab6d43f"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004f6417c8a670584e388676949e53da7fc55911ff68318d1bf3061205acb19c48f8f2b743df34ad0f72674acb7505929784779cd9ac916c3669ead43026ab6d43f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9kF8imcFhOOIZ2lJ5T2n/FWRH/aD\nGNG/MGEgWssZxI+PK3Q980rQ9yZ0rLdQWSl4R3nNmskWw2aerUMCarbUPw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 435,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997802203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aaa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04501421277be45a5eefec6c639930d636032565af420cf3373f557faa7f8a06438673d6cb6076e1cfcdc7dfe7384c8e5cac08d74501f2ae6e89cad195d0aa1371",
+        "wx": "501421277be45a5eefec6c639930d636032565af420cf3373f557faa7f8a0643",
+        "wy": "008673d6cb6076e1cfcdc7dfe7384c8e5cac08d74501f2ae6e89cad195d0aa1371"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004501421277be45a5eefec6c639930d636032565af420cf3373f557faa7f8a06438673d6cb6076e1cfcdc7dfe7384c8e5cac08d74501f2ae6e89cad195d0aa1371",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUBQhJ3vkWl7v7GxjmTDWNgMlZa9C\nDPM3P1V/qn+KBkOGc9bLYHbhz83H3+c4TI5crAjXRQHyrm6JytGV0KoTcQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 436,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022049249248db6db6dbb6db6db6db6db6db5a8b230d0b2b51dcd7ebf0c9fef7c185",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040d935bf9ffc115a527735f729ca8a4ca23ee01a4894adf0e3415ac84e808bb343195a3762fea29ed38912bd9ea6c4fde70c3050893a4375850ce61d82eba33c5",
+        "wx": "0d935bf9ffc115a527735f729ca8a4ca23ee01a4894adf0e3415ac84e808bb34",
+        "wy": "3195a3762fea29ed38912bd9ea6c4fde70c3050893a4375850ce61d82eba33c5"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040d935bf9ffc115a527735f729ca8a4ca23ee01a4894adf0e3415ac84e808bb343195a3762fea29ed38912bd9ea6c4fde70c3050893a4375850ce61d82eba33c5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDZNb+f/BFaUnc19ynKikyiPuAaSJ\nSt8ONBWshOgIuzQxlaN2L+op7TiRK9nqbE/ecMMFCJOkN1hQzmHYLrozxQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 437,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022016a4502e2781e11ac82cbc9d1edd8c981584d13e18411e2f6e0478c34416e3bb",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "045e59f50708646be8a589355014308e60b668fb670196206c41e748e64e4dca215de37fee5c97bcaf7144d5b459982f52eeeafbdf03aacbafef38e213624a01de",
+        "wx": "5e59f50708646be8a589355014308e60b668fb670196206c41e748e64e4dca21",
+        "wy": "5de37fee5c97bcaf7144d5b459982f52eeeafbdf03aacbafef38e213624a01de"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200045e59f50708646be8a589355014308e60b668fb670196206c41e748e64e4dca215de37fee5c97bcaf7144d5b459982f52eeeafbdf03aacbafef38e213624a01de",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXln1Bwhka+iliTVQFDCOYLZo+2cB\nliBsQedI5k5NyiFd43/uXJe8r3FE1bRZmC9S7ur73wOqy6/vOOITYkoB3g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 438,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2960220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04169fb797325843faff2f7a5b5445da9e2fd6226f7ef90ef0bfe924104b02db8e7bbb8de662c7b9b1cf9b22f7a2e582bd46d581d68878efb2b861b131d8a1d667",
+        "wx": "169fb797325843faff2f7a5b5445da9e2fd6226f7ef90ef0bfe924104b02db8e",
+        "wy": "7bbb8de662c7b9b1cf9b22f7a2e582bd46d581d68878efb2b861b131d8a1d667"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004169fb797325843faff2f7a5b5445da9e2fd6226f7ef90ef0bfe924104b02db8e7bbb8de662c7b9b1cf9b22f7a2e582bd46d581d68878efb2b861b131d8a1d667",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFp+3lzJYQ/r/L3pbVEXani/WIm9+\n+Q7wv+kkEEsC2457u43mYse5sc+bIvei5YK9RtWB1oh477K4YbEx2KHWZw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 439,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022100b6db6db6249249254924924924924924625bd7a09bec4ca81bcdd9f8fd6b63cc",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04271cd89c000143096b62d4e9e4ca885aef2f7023d18affdaf8b7b548981487540a1c6e954e32108435b55fa385b0f76481a609b9149ccb4b02b2ca47fe8e4da5",
+        "wx": "271cd89c000143096b62d4e9e4ca885aef2f7023d18affdaf8b7b54898148754",
+        "wy": "0a1c6e954e32108435b55fa385b0f76481a609b9149ccb4b02b2ca47fe8e4da5"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004271cd89c000143096b62d4e9e4ca885aef2f7023d18affdaf8b7b548981487540a1c6e954e32108435b55fa385b0f76481a609b9149ccb4b02b2ca47fe8e4da5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJxzYnAABQwlrYtTp5MqIWu8vcCPR\niv/a+Le1SJgUh1QKHG6VTjIQhDW1X6OFsPdkgaYJuRScy0sCsspH/o5NpQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 440,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022100cccccccc00000000cccccccccccccccc971f2ef152794b9d8fc7d568c9e8eaa7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "043d0bc7ed8f09d2cb7ddb46ebc1ed799ab1563a9ab84bf524587a220afe499c12e22dc3b3c103824a4f378d96adb0a408abf19ce7d68aa6244f78cb216fa3f8df",
+        "wx": "3d0bc7ed8f09d2cb7ddb46ebc1ed799ab1563a9ab84bf524587a220afe499c12",
+        "wy": "00e22dc3b3c103824a4f378d96adb0a408abf19ce7d68aa6244f78cb216fa3f8df"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200043d0bc7ed8f09d2cb7ddb46ebc1ed799ab1563a9ab84bf524587a220afe499c12e22dc3b3c103824a4f378d96adb0a408abf19ce7d68aa6244f78cb216fa3f8df",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPQvH7Y8J0st920brwe15mrFWOpq4\nS/UkWHoiCv5JnBLiLcOzwQOCSk83jZatsKQIq/Gc59aKpiRPeMshb6P43w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 441,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c29602203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aaa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a6c885ade1a4c566f9bb010d066974abb281797fa701288c721bcbd23663a9b72e424b690957168d193a6096fc77a2b004a9c7d467e007e1f2058458f98af316",
+        "wx": "00a6c885ade1a4c566f9bb010d066974abb281797fa701288c721bcbd23663a9b7",
+        "wy": "2e424b690957168d193a6096fc77a2b004a9c7d467e007e1f2058458f98af316"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a6c885ade1a4c566f9bb010d066974abb281797fa701288c721bcbd23663a9b72e424b690957168d193a6096fc77a2b004a9c7d467e007e1f2058458f98af316",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpsiFreGkxWb5uwENBml0q7KBeX+n\nASiMchvL0jZjqbcuQktpCVcWjRk6YJb8d6KwBKnH1GfgB+HyBYRY+YrzFg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 442,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022049249248db6db6dbb6db6db6db6db6db5a8b230d0b2b51dcd7ebf0c9fef7c185",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "048d3c2c2c3b765ba8289e6ac3812572a25bf75df62d87ab7330c3bdbad9ebfa5c4c6845442d66935b238578d43aec54f7caa1621d1af241d4632e0b780c423f5d",
+        "wx": "008d3c2c2c3b765ba8289e6ac3812572a25bf75df62d87ab7330c3bdbad9ebfa5c",
+        "wy": "4c6845442d66935b238578d43aec54f7caa1621d1af241d4632e0b780c423f5d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200048d3c2c2c3b765ba8289e6ac3812572a25bf75df62d87ab7330c3bdbad9ebfa5c4c6845442d66935b238578d43aec54f7caa1621d1af241d4632e0b780c423f5d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjTwsLDt2W6gonmrDgSVyolv3XfYt\nh6tzMMO9utnr+lxMaEVELWaTWyOFeNQ67FT3yqFiHRryQdRjLgt4DEI/XQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 443,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022016a4502e2781e11ac82cbc9d1edd8c981584d13e18411e2f6e0478c34416e3bb",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+        "wx": "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
+        "wy": "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpZP40Li/hp/m47n60p8D54WK84zV2sxXs7LtkBoN79R9Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 444,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100bb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca6050230220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 445,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022044a5ad0ad0636d9f12bc9e0a6bdd5e1cbcb012ea7bf091fcec15b0c43202d52e0220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a",
+        "wx": "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
+        "wy": "00b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpawHL0cAeWAZXEYFLWD8GHp1DHMqZTOoTE0Sb+XyECuCg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 446,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100bb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca6050230220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 447,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022044a5ad0ad0636d9f12bc9e0a6bdd5e1cbcb012ea7bf091fcec15b0c43202d52e0220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "044f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685",
+        "wx": "4f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000",
+        "wy": "00ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200044f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETzN8z9Z3JqgF5PFgCuKEnfOAfsoR\nc4Ajn72BaQAAAADtneoSTMjDlkFkEemIww9CfrUEr0OjFGzV336mBmbWhQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 448,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100d434e262a49eab7781e353a3565e482550dd0fd5defa013c7f29745eff3569f10221009b0c0a93f267fb6052fd8077be769c2b98953195d7bc10de844218305c6ba17a",
+          "result": "valid"
+        },
+        {
+          "tcId": 449,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402200fe774355c04d060f76d79fd7a772e421463489221bf0a33add0be9b1979110b0220500dcba1c69a8fbd43fa4f57f743ce124ca8b91a1f325f3fac6181175df55737",
+          "result": "valid"
+        },
+        {
+          "tcId": 450,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100bb40bf217bed3fb3950c7d39f03d36dc8e3b2cd79693f125bfd06595ee1135e30220541bf3532351ebb032710bdb6a1bf1bfc89a1e291ac692b3fa4780745bb55677",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f49726500493584fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000",
+        "wx": "3cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f497265004935",
+        "wy": "0084fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f49726500493584fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTWE+hdNeRxyvyzjiAqJYN0qfHoTOKgvhanlnNvegAAAAA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 451,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30440220664eb7ee6db84a34df3c86ea31389a5405badd5ca99231ff556d3e75a233e73a022059f3c752e52eca46137642490a51560ce0badc678754b8f72e51a2901426a1bd",
+          "result": "valid"
+        },
+        {
+          "tcId": 452,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502204cd0429bbabd2827009d6fcd843d4ce39c3e42e2d1631fd001985a79d1fd8b430221009638bf12dd682f60be7ef1d0e0d98f08b7bca77a1a2b869ae466189d2acdabe3",
+          "result": "valid"
+        },
+        {
+          "tcId": 453,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100e56c6ea2d1b017091c44d8b6cb62b9f460e3ce9aed5e5fd41e8added97c56c04022100a308ec31f281e955be20b457e463440b4fcf2b80258078207fc1378180f89b55",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f4972650049357b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff",
+        "wx": "3cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f497265004935",
+        "wy": "7b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f4972650049357b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTV7BeixhuONQdMcd/V2nyLVg4XsyFfQelYaYyQhf////w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 454,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402201158a08d291500b4cabed3346d891eee57c176356a2624fb011f8fbbf34668300220228a8c486a736006e082325b85290c5bc91f378b75d487dda46798c18f285519",
+          "result": "valid"
+        },
+        {
+          "tcId": 455,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100b1db9289649f59410ea36b0c0fc8d6aa2687b29176939dd23e0dde56d309fa9d02203e1535e4280559015b0dbd987366dcf43a6d1af5c23c7d584e1c3f48a1251336",
+          "result": "valid"
+        },
+        {
+          "tcId": 456,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100b7b16e762286cb96446aa8d4e6e7578b0a341a79f2dd1a220ac6f0ca4e24ed86022100ddc60a700a139b04661c547d07bbb0721780146df799ccf55e55234ecb8f12bc",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffffa01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e",
+        "wx": "2829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffff",
+        "wy": "00a01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffffa01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKCnDH6ouQA40TtlLyj/NBUWVbrz+\nitD236X/jv////+gGq+vAA5SWFhVr6dnat4oQRMJkFLfV+frO9N+vrkiLg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 457,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100d82a7c2717261187c8e00d8df963ff35d796edad36bc6e6bd1c91c670d9105b402203dcabddaf8fcaa61f4603e7cbac0f3c0351ecd5988efb23f680d07debd139929",
+          "result": "valid"
+        },
+        {
+          "tcId": 458,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402205eb9c8845de68eb13d5befe719f462d77787802baff30ce96a5cba063254af7802202c026ae9be2e2a5e7ca0ff9bbd92fb6e44972186228ee9a62b87ddbe2ef66fb5",
+          "result": "valid"
+        },
+        {
+          "tcId": 459,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304602210096843dd03c22abd2f3b782b170239f90f277921becc117d0404a8e4e36230c28022100f2be378f526f74a543f67165976de9ed9a31214eb4d7e6db19e1ede123dd991d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f55a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73",
+        "wx": "00fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f5",
+        "wy": "5a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f55a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE////+UgIHmoEWN2PnnOPJmX/kFmt\naqwHCDGMTKmnpPVairy6LdqEdDEe5UFJuXPK4MD7iVV60L945lKaFmO9cw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 460,
+          "comment": "x-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30440220766456dce1857c906f9996af729339464d27e9d98edc2d0e3b760297067421f60220402385ecadae0d8081dccaf5d19037ec4e55376eced699e93646bfbbf19d0b41",
+          "result": "valid"
+        },
+        {
+          "tcId": 461,
+          "comment": "x-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100c605c4b2edeab20419e6518a11b2dbc2b97ed8b07cced0b19c34f777de7b9fd9022100edf0f612c5f46e03c719647bc8af1b29b2cde2eda700fb1cff5e159d47326dba",
+          "result": "valid"
+        },
+        {
+          "tcId": 462,
+          "comment": "x-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100d48b68e6cabfe03cf6141c9ac54141f210e64485d9929ad7b732bfe3b7eb8a84022100feedae50c61bd00e19dc26f9b7e2265e4508c389109ad2f208f0772315b6c941",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0400000003fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71",
+        "wx": "03fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e",
+        "wy": "1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000003fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAAAAA/oV+WOUnV8DpvXH+G+eABXu\nsjrrv/EXOTe6dI4QmYcgcOjofFVfoTZZzKXX+tz8sAI+qIlUjKSK8rp+cQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 463,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100b7c81457d4aeb6aa65957098569f0479710ad7f6595d5874c35a93d12a5dd4c7022100b7961a0b652878c2d568069a432ca18a1a9199f2ca574dad4b9e3a05c0a1cdb3",
+          "result": "valid"
+        },
+        {
+          "tcId": 464,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402206b01332ddb6edfa9a30a1321d5858e1ee3cf97e263e669f8de5e9652e76ff3f702205939545fced457309a6a04ace2bd0f70139c8f7d86b02cb1cc58f9e69e96cd5a",
+          "result": "valid"
+        },
+        {
+          "tcId": 465,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100efdb884720eaeadc349f9fc356b6c0344101cd2fd8436b7d0e6a4fb93f106361022100f24bee6ad5dc05f7613975473aadf3aacba9e77de7d69b6ce48cb60d8113385d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015000000001352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2",
+        "wx": "00bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
+        "wy": "1352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015000000001352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BUAAAAAE1K7Sg+i6kzOuatj3WhK3loRJ7zzAKaYpxk7wg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 466,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3044022031230428405560dcb88fb5a646836aea9b23a23dd973dcbe8014c87b8b20eb0702200f9344d6e812ce166646747694a41b0aaf97374e19f3c5fb8bd7ae3d9bd0beff",
+          "result": "valid"
+        },
+        {
+          "tcId": 467,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100caa797da65b320ab0d5c470cda0b36b294359c7db9841d679174db34c4855743022100cf543a62f23e212745391aaf7505f345123d2685ee3b941d3de6d9b36242e5a0",
+          "result": "valid"
+        },
+        {
+          "tcId": 468,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502207e5f0ab5d900d3d3d7867657e5d6d36519bc54084536e7d21c336ed8001859450221009450c07f201faec94b82dfb322e5ac676688294aad35aa72e727ff0b19b646aa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d",
+        "wx": "00bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
+        "wy": "00fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BX////+7K1EtvBdFbMxRlScIpe1IqXu2EMM/1lnWObEPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 469,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100d7d70c581ae9e3f66dc6a480bf037ae23f8a1e4a2136fe4b03aa69f0ca25b35602210089c460f8a5a5c2bbba962c8a3ee833a413e85658e62a59e2af41d9127cc47224",
+          "result": "valid"
+        },
+        {
+          "tcId": 470,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30440220341c1b9ff3c83dd5e0dfa0bf68bcdf4bb7aa20c625975e5eeee34bb396266b34022072b69f061b750fd5121b22b11366fad549c634e77765a017902a67099e0a4469",
+          "result": "valid"
+        },
+        {
+          "tcId": 471,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022070bebe684cdcb5ca72a42f0d873879359bd1781a591809947628d313a3814f67022100aec03aca8f5587a4d535fa31027bbe9cc0e464b1c3577f4c2dcde6b2094798a9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-non-minimal-tag",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx": "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy": "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 472,
+          "comment": "signature with non-minimal SEQUENCE tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "3f1045022100b292a619339f6e567a305c951c0dcbcc42d16e47f219f9e98e76e09d8770b34a02200177e60492c5a8242f76f07bfe3661bde59ec2a17ce5bd2dab2abebdf89a62e2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 473,
+          "comment": "signature with non-minimal INTEGER tag on r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "30461f022100b292a619339f6e567a305c951c0dcbcc42d16e47f219f9e98e76e09d8770b34a02200177e60492c5a8242f76f07bfe3661bde59ec2a17ce5bd2dab2abebdf89a62e2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 474,
+          "comment": "signature with non-minimal INTEGER tag on s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "3046022100b292a619339f6e567a305c951c0dcbcc42d16e47f219f9e98e76e09d8770b34a1f02200177e60492c5a8242f76f07bfe3661bde59ec2a17ce5bd2dab2abebdf89a62e2",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64",
+        "wx": "264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9",
+        "wy": "cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJk15ag2rmzdtNO6m/il93hx7c+U5\nRLyWyPHopoULtsnPUwgCDu1GDGSd2uYdTvi7eZWBE/EGvvr08Yh20SpeZA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 475,
+          "comment": "r = 5, x = 5 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020105022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04add76677e54a92e79bbee36a70e1754838273ec4b39295e4018a587290a7fc73f240d625642c943e610d80d953c5c6b8a12760a624ba3b90a0b7902755e1ae79",
+        "wx": "add76677e54a92e79bbee36a70e1754838273ec4b39295e4018a587290a7fc73",
+        "wy": "f240d625642c943e610d80d953c5c6b8a12760a624ba3b90a0b7902755e1ae79"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004add76677e54a92e79bbee36a70e1754838273ec4b39295e4018a587290a7fc73f240d625642c943e610d80d953c5c6b8a12760a624ba3b90a0b7902755e1ae79",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErddmd+VKkuebvuNqcOF1SDgnPsSz\nkpXkAYpYcpCn/HPyQNYlZCyUPmENgNlTxca4oSdgpiS6O5Cgt5AnVeGueQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 476,
+          "comment": "r = 6, x = 5 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020106022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64",
+        "wx": "264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9",
+        "wy": "cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJk15ag2rmzdtNO6m/il93hx7c+U5\nRLyWyPHopoULtsnPUwgCDu1GDGSd2uYdTvi7eZWBE/EGvvr08Yh20SpeZA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 477,
+          "comment": "r = 5 + n, x = 5 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632556022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04e7e49dd82812432744fefe723f7f69663214ad1b85c02b2650b4ca0354743a325223c51c415f457aec69cb019bbe3d27585b38f8b79c39dfea6c27c2f0d8146a",
+        "wx": "e7e49dd82812432744fefe723f7f69663214ad1b85c02b2650b4ca0354743a32",
+        "wy": "5223c51c415f457aec69cb019bbe3d27585b38f8b79c39dfea6c27c2f0d8146a"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004e7e49dd82812432744fefe723f7f69663214ad1b85c02b2650b4ca0354743a325223c51c415f457aec69cb019bbe3d27585b38f8b79c39dfea6c27c2f0d8146a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5+Sd2CgSQydE/v5yP39pZjIUrRuF\nwCsmULTKA1R0OjJSI8UcQV9FeuxpywGbvj0nWFs4+LecOd/qbCfC8NgUag==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 478,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04ce24c99032d52ac6ead23c0ae3ec68ef41e51a281fd457808c83136d7dcce90e8f7a154b551e9f39c59279357aa491b2a62bdebc2bb78613883fc72936c057e0",
+        "wx": "ce24c99032d52ac6ead23c0ae3ec68ef41e51a281fd457808c83136d7dcce90e",
+        "wy": "8f7a154b551e9f39c59279357aa491b2a62bdebc2bb78613883fc72936c057e0"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004ce24c99032d52ac6ead23c0ae3ec68ef41e51a281fd457808c83136d7dcce90e8f7a154b551e9f39c59279357aa491b2a62bdebc2bb78613883fc72936c057e0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEziTJkDLVKsbq0jwK4+xo70HlGigf\n1FeAjIMTbX3M6Q6PehVLVR6fOcWSeTV6pJGypivevCu3hhOIP8cpNsBX4A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 479,
+          "comment": "r = 3, x = n + 3 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020103022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04c981c75ddfd3910387eb147098fe5658c43aaaa34c681cd6d514b6ad5b6baa6d14fbddb53a6e6db18e90602bc60f2e736d625765f7f2cca4be76f4eeccf12c18",
+        "wx": "c981c75ddfd3910387eb147098fe5658c43aaaa34c681cd6d514b6ad5b6baa6d",
+        "wy": "14fbddb53a6e6db18e90602bc60f2e736d625765f7f2cca4be76f4eeccf12c18"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004c981c75ddfd3910387eb147098fe5658c43aaaa34c681cd6d514b6ad5b6baa6d14fbddb53a6e6db18e90602bc60f2e736d625765f7f2cca4be76f4eeccf12c18",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyYHHXd/TkQOH6xRwmP5WWMQ6qqNM\naBzW1RS2rVtrqm0U+921Om5tsY6QYCvGDy5zbWJXZffyzKS+dvTuzPEsGA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 480,
+          "comment": "r = 4, x = n + 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020104022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040ec505bc19b14a43e05678cccf07a443d3e871a2e19b68a4da91859a0650f32477300e4f64e9982d94dff5d294428bb37cc9be66117cae9c389d2d495f68b987",
+        "wx": "0ec505bc19b14a43e05678cccf07a443d3e871a2e19b68a4da91859a0650f324",
+        "wy": "77300e4f64e9982d94dff5d294428bb37cc9be66117cae9c389d2d495f68b987"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040ec505bc19b14a43e05678cccf07a443d3e871a2e19b68a4da91859a0650f32477300e4f64e9982d94dff5d294428bb37cc9be66117cae9c389d2d495f68b987",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDsUFvBmxSkPgVnjMzwekQ9PocaLh\nm2ik2pGFmgZQ8yR3MA5PZOmYLZTf9dKUQouzfMm+ZhF8rpw4nS1JX2i5hw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 481,
+          "comment": "r = p - n + 5, x = 5 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303502104319055358e8617b0c46353d039cdab3022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d42ce21e730f3d2a84e949828574b4dceeb77d4f89556735f34fba03028ee3ed32daf8bfd3f0a7a0821170840f4e032056722386b35d9bdd4f4f450696f4fb52",
+        "wx": "d42ce21e730f3d2a84e949828574b4dceeb77d4f89556735f34fba03028ee3ed",
+        "wy": "32daf8bfd3f0a7a0821170840f4e032056722386b35d9bdd4f4f450696f4fb52"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d42ce21e730f3d2a84e949828574b4dceeb77d4f89556735f34fba03028ee3ed32daf8bfd3f0a7a0821170840f4e032056722386b35d9bdd4f4f450696f4fb52",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1CziHnMPPSqE6UmChXS03O63fU+J\nVWc180+6AwKO4+0y2vi/0/CnoIIRcIQPTgMgVnIjhrNdm91PT0UGlvT7Ug==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 482,
+          "comment": "r = 2^256 - n + 5, x = 5 is invalid; r + n is too large to compare r + n with x, and overflows 2^256 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3042021d00ffffffff00000000000000004319055258e8617b0c46353d039cdab4022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/testing/kats/wycheproof/ecdsa_secp256r1_sha512_test.json
+++ b/crates/testing/kats/wycheproof/ecdsa_secp256r1_sha512_test.json
@@ -1,0 +1,7907 @@
+{
+  "algorithm": "ECDSA",
+  "schema": "ecdsa_verify_schema_v1.json",
+  "numberOfTests": 552,
+  "header": [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
+  "notes": {
+    "ArithmeticError": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
+      "cves": [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature": {
+      "bugType": "BER_ENCODING",
+      "description": "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect": "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves": [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero": {
+      "bugType": "LEGACY",
+      "description": "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect": "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves": [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "Untruncatedhash": {
+      "bugType": "MISSING_STEP",
+      "description": "If the size of the digest is longer than the size of the underlying order of the multiplicative subgroup then the hash digest must be truncated during signature generation and verification. This test vector contains a signature where this step has been omitted."
+    },
+    "ValidSignature": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx": "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy": "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "",
+          "sig": "30440220093f3825c0cf820cced816a3a67446c85606a6d529e43857643fccc11e1f705f0220769782888c63058630f97a5891c8700e82979e4f233586bfc5042fa73cb70a4e",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "4d7367",
+          "sig": "3046022100e8564e3e515a09f9f35258442b99e162d27e10975fcb7963d3c26319dc093f84022100c3af01ed0fd0148749ca323364846c862fc6f4beb682b7ead3b2d89b9da8bad4",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502201412254f8c1dd2742a00ddee5192e7baa288741026871f3057ad9f983b5ab114022100bcdf878fa156f37040922698ad6fb6928601ddc26c40448ea660e67c25eda090",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "sig": "30450221009e0676048381839bb0a4703a0ae38facfe1e2c61bd25950c896aa975cd6ec86902206ea0cedf96f11fff0e746941183492f4d17272c92449afd20e34041a6894ee82",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+        "wx": "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+        "wy": "00c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 5,
+          "comment": "signature malleability",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002205f85a63a5be977ad714cea16b10035f07cadf7513ae8cca86f35b7692aafd69f",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "Legacy: ASN encoding of s misses leading 0",
+          "flags": [
+            "MissingZero"
+          ],
+          "msg": "313233343030",
+          "sig": "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00220a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 7,
+          "comment": "valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "length of sequence [r, s] uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30814502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 9,
+          "comment": "length of sequence [r, s] contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3082004502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "length of sequence [r, s] uses 70 instead of 69",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304602202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 11,
+          "comment": "length of sequence [r, s] uses 68 instead of 69",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 12,
+          "comment": "uint32 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085010000004502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "uint64 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308901000000000000004502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "length of sequence [r, s] = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30847fffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "length of sequence [r, s] = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30848000000002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "length of sequence [r, s] = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3084ffffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "length of sequence [r, s] = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085ffffffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "length of sequence [r, s] = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3088ffffffffffffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "incorrect length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30ff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "removing sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "lonely sequence tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "appending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "prepending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047000002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "appending unused 0's to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "appending null value to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a498177304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492500304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "appending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "including undefined tags",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304daa00bb00cd00304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d2228aa00bb00cd0002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02229aa00bb00cd00022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "truncated length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3081",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "including undefined tags to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304baa02aabb304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "using composition with indefinite length for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 36,
+          "comment": "using composition with wrong tag for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080314502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 37,
+          "comment": "Replacing sequence [r, s] with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 38,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2e4502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 39,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2f4502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 40,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "314502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 41,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "324502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 42,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "ff4502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 43,
+          "comment": "dropping value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 44,
+          "comment": "using composition for sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30493001023044202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 45,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34e",
+          "result": "invalid"
+        },
+        {
+          "tcId": 46,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 47,
+          "comment": "sequence [r, s] of size 4166 to check for overflows",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3082104602202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 48,
+          "comment": "indefinite length",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 49,
+          "comment": "indefinite length with truncated delimiter",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb200",
+          "result": "invalid"
+        },
+        {
+          "tcId": 50,
+          "comment": "indefinite length with additional element",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb205000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 51,
+          "comment": "indefinite length with truncated element",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2060811220000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 52,
+          "comment": "indefinite length with garbage",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000fe02beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 53,
+          "comment": "indefinite length with nonempty EOC",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20002beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 54,
+          "comment": "prepend empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047300002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 55,
+          "comment": "append empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb23000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 56,
+          "comment": "append zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304802202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 57,
+          "comment": "append garbage with high tag number",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304802202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2bf7f00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 58,
+          "comment": "append null with explicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2a0020500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 59,
+          "comment": "append null with implicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2a000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 60,
+          "comment": "sequence of sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 61,
+          "comment": "truncated sequence: removed last 1 elements",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302202202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 62,
+          "comment": "repeating element in sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "306802202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 63,
+          "comment": "flipped bit 0 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30432478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c1022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 64,
+          "comment": "flipped bit 32 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30432478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42a98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 65,
+          "comment": "flipped bit 48 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30432478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c67f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 66,
+          "comment": "flipped bit 64 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30432478f1d049f6d857ac900a7af1772226a4c59b345fbb90603c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 67,
+          "comment": "length of r uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30460281202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 68,
+          "comment": "length of r contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047028200202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 69,
+          "comment": "length of r uses 33 instead of 32",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502212478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 70,
+          "comment": "length of r uses 31 instead of 32",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045021f2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 71,
+          "comment": "uint32 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a028501000000202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 72,
+          "comment": "uint64 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02890100000000000000202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 73,
+          "comment": "length of r = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902847fffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 74,
+          "comment": "length of r = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30490284800000002478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 75,
+          "comment": "length of r = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30490284ffffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 76,
+          "comment": "length of r = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a0285ffffffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 77,
+          "comment": "length of r = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d0288ffffffffffffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 78,
+          "comment": "incorrect length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502ff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 79,
+          "comment": "replaced r by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502802478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 80,
+          "comment": "removing r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3023022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 81,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 82,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002",
+          "result": "invalid"
+        },
+        {
+          "tcId": 83,
+          "comment": "appending 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702222478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 84,
+          "comment": "prepending 0's to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022200002478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 85,
+          "comment": "appending unused 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 86,
+          "comment": "appending null value to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702222478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00500022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 87,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a222549817702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 88,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492224250002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 89,
+          "comment": "appending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d222202202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00004deadbeef022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 90,
+          "comment": "truncated length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250281022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 91,
+          "comment": "including undefined tags to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b2226aa02aabb02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 92,
+          "comment": "using composition with indefinite length for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049228002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 93,
+          "comment": "using composition with wrong tag for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049228003202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 94,
+          "comment": "Replacing r with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30250500022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 95,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304500202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 96,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304501202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 97,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304503202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 98,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304504202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 99,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045ff202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 100,
+          "comment": "dropping value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250200022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 101,
+          "comment": "using composition for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492224020124021f78f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 102,
+          "comment": "modifying first byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202678f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 103,
+          "comment": "modifying last byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f98140022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 104,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044021f2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 105,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044021f78f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 106,
+          "comment": "r of size 4129 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30821048028210212478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 107,
+          "comment": "leading ff in r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 108,
+          "comment": "replaced r by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026090180022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 109,
+          "comment": "replacing r with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 110,
+          "comment": "flipped bit 0 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb3",
+          "result": "invalid"
+        },
+        {
+          "tcId": 111,
+          "comment": "flipped bit 32 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841358d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 112,
+          "comment": "flipped bit 48 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84851359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 113,
+          "comment": "flipped bit 64 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dd84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 114,
+          "comment": "length of s uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304602202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002812100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 115,
+          "comment": "length of s contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00282002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 116,
+          "comment": "length of s uses 34 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022200a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 117,
+          "comment": "length of s uses 32 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 118,
+          "comment": "uint32 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00285010000002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 119,
+          "comment": "uint64 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0028901000000000000002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 120,
+          "comment": "length of s = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002847fffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 121,
+          "comment": "length of s = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002848000000000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 122,
+          "comment": "length of s = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00284ffffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 123,
+          "comment": "length of s = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00285ffffffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 124,
+          "comment": "length of s = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00288ffffffffffffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 125,
+          "comment": "incorrect length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002ff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 126,
+          "comment": "replaced s by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0028000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 127,
+          "comment": "appending 0's to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022300a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 128,
+          "comment": "prepending 0's to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00223000000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 129,
+          "comment": "appending null value to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022300a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 130,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02226498177022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 131,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c022252500022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 132,
+          "comment": "appending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02223022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 133,
+          "comment": "truncated length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00281",
+          "result": "invalid"
+        },
+        {
+          "tcId": 134,
+          "comment": "including undefined tags to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02227aa02aabb022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 135,
+          "comment": "using composition with indefinite length for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02280022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 136,
+          "comment": "using composition with wrong tag for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02280032100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 137,
+          "comment": "Replacing s with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 138,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 139,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0012100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 140,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0032100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 141,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0042100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 142,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0ff2100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 143,
+          "comment": "dropping value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00200",
+          "result": "invalid"
+        },
+        {
+          "tcId": 144,
+          "comment": "using composition for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c022250201000220a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 145,
+          "comment": "modifying first byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022102a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 146,
+          "comment": "modifying last byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34e32",
+          "result": "invalid"
+        },
+        {
+          "tcId": 147,
+          "comment": "truncated s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34e",
+          "result": "invalid"
+        },
+        {
+          "tcId": 148,
+          "comment": "s of size 4130 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3082104802202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00282102200a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 149,
+          "comment": "leading ff in s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304602202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00222ff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 150,
+          "comment": "replaced s by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0090180",
+          "result": "invalid"
+        },
+        {
+          "tcId": 151,
+          "comment": "replacing s with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 152,
+          "comment": "replaced r by r + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221012478f1cf49f6d858ac900a7af177222661ac95e206d32ee63020beee955ca711022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 153,
+          "comment": "replaced r by r - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff2478f1d149f6d856ac900a7af1772226e7dea086b8a3f1dc48ad29689c965c6f022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 154,
+          "comment": "replaced r by r + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022201002478f0d049f6d957ac900a7af17721e38bc048db775a1554f631b727fc1ed2c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 155,
+          "comment": "replaced r by -r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220db870e2fb60927a8536ff5850e88ddd95b3a64cba0446f9ec3990bd467067e40022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 156,
+          "comment": "replaced r by n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100db870e2eb60927a9536ff5850e88ddd918215f79475c0e23b752d6976369a391022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 157,
+          "comment": "replaced r by -n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fedb870e30b60927a7536ff5850e88ddd99e536a1df92cd119cfdf41116aa358ef022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 158,
+          "comment": "replaced r by r + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221012478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 159,
+          "comment": "replaced r by r + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02290100000000000000002478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 160,
+          "comment": "replaced s by s + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101a07a59c3a41688548eb315e94effca0efd1ffe0a13467061783dde1cce167403022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 161,
+          "comment": "replaced s by s - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220a07a59c5a41688528eb315e94effca0f835208aec517335790ca4896d5502961022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 162,
+          "comment": "replaced s by s + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "304702220100a07a58c4a41689538eb315e94effc9cc2733b10383cd56d03e4ed65634d89fb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 163,
+          "comment": "replaced s by -s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff5f85a63b5be977ac714cea16b10035f0bfc6fca393d12e237b7beca62e4cb14e022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 164,
+          "comment": "replaced s by -n - s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fe5f85a63c5be977ab714cea16b10035f102e001f5ecb98f9e87c221e331e98bfd022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 165,
+          "comment": "replaced s by s + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 166,
+          "comment": "replaced s by s - 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 167,
+          "comment": "replaced s by s + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e0229010000000000000000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 168,
+          "comment": "Signature with special case values r=0 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 169,
+          "comment": "Signature with special case values r=0 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 170,
+          "comment": "Signature with special case values r=0 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 171,
+          "comment": "Signature with special case values r=0 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 172,
+          "comment": "Signature with special case values r=0 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 173,
+          "comment": "Signature with special case values r=0 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 174,
+          "comment": "Signature with special case values r=0 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 175,
+          "comment": "Signature with special case values r=0 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 176,
+          "comment": "Signature with special case values r=1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 177,
+          "comment": "Signature with special case values r=1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 178,
+          "comment": "Signature with special case values r=1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 179,
+          "comment": "Signature with special case values r=1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 180,
+          "comment": "Signature with special case values r=1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 181,
+          "comment": "Signature with special case values r=1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 182,
+          "comment": "Signature with special case values r=1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 183,
+          "comment": "Signature with special case values r=1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 184,
+          "comment": "Signature with special case values r=-1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 185,
+          "comment": "Signature with special case values r=-1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 186,
+          "comment": "Signature with special case values r=-1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 187,
+          "comment": "Signature with special case values r=-1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 188,
+          "comment": "Signature with special case values r=-1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 189,
+          "comment": "Signature with special case values r=-1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 190,
+          "comment": "Signature with special case values r=-1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 191,
+          "comment": "Signature with special case values r=-1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 192,
+          "comment": "Signature with special case values r=n and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 193,
+          "comment": "Signature with special case values r=n and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 194,
+          "comment": "Signature with special case values r=n and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 195,
+          "comment": "Signature with special case values r=n and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 196,
+          "comment": "Signature with special case values r=n and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 197,
+          "comment": "Signature with special case values r=n and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 198,
+          "comment": "Signature with special case values r=n and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 199,
+          "comment": "Signature with special case values r=n and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 200,
+          "comment": "Signature with special case values r=n - 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 201,
+          "comment": "Signature with special case values r=n - 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 202,
+          "comment": "Signature with special case values r=n - 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325500201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 203,
+          "comment": "Signature with special case values r=n - 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 204,
+          "comment": "Signature with special case values r=n - 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 205,
+          "comment": "Signature with special case values r=n - 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 206,
+          "comment": "Signature with special case values r=n - 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 207,
+          "comment": "Signature with special case values r=n - 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 208,
+          "comment": "Signature with special case values r=n + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 209,
+          "comment": "Signature with special case values r=n + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 210,
+          "comment": "Signature with special case values r=n + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325520201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 211,
+          "comment": "Signature with special case values r=n + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 212,
+          "comment": "Signature with special case values r=n + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 213,
+          "comment": "Signature with special case values r=n + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 214,
+          "comment": "Signature with special case values r=n + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 215,
+          "comment": "Signature with special case values r=n + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 216,
+          "comment": "Signature with special case values r=p and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 217,
+          "comment": "Signature with special case values r=p and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 218,
+          "comment": "Signature with special case values r=p and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 219,
+          "comment": "Signature with special case values r=p and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 220,
+          "comment": "Signature with special case values r=p and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 221,
+          "comment": "Signature with special case values r=p and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 222,
+          "comment": "Signature with special case values r=p and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 223,
+          "comment": "Signature with special case values r=p and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 224,
+          "comment": "Signature with special case values r=p + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 225,
+          "comment": "Signature with special case values r=p + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 226,
+          "comment": "Signature with special case values r=p + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff000000010000000000000000000000010000000000000000000000000201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 227,
+          "comment": "Signature with special case values r=p + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result": "invalid"
+        },
+        {
+          "tcId": 228,
+          "comment": "Signature with special case values r=p + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result": "invalid"
+        },
+        {
+          "tcId": 229,
+          "comment": "Signature with special case values r=p + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result": "invalid"
+        },
+        {
+          "tcId": 230,
+          "comment": "Signature with special case values r=p + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 231,
+          "comment": "Signature with special case values r=p + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 232,
+          "comment": "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020100090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 233,
+          "comment": "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 234,
+          "comment": "Signature encoding contains incorrect types: r=0, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 235,
+          "comment": "Signature encoding contains incorrect types: r=0, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 236,
+          "comment": "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 237,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 238,
+          "comment": "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 239,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 240,
+          "comment": "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 241,
+          "comment": "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020101090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 242,
+          "comment": "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 243,
+          "comment": "Signature encoding contains incorrect types: r=1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 244,
+          "comment": "Signature encoding contains incorrect types: r=1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 245,
+          "comment": "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 246,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 247,
+          "comment": "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 248,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201013000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 249,
+          "comment": "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201013003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 250,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 251,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 252,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 253,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 254,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 255,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 256,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 257,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 258,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 259,
+          "comment": "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 260,
+          "comment": "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 261,
+          "comment": "Signature encoding contains incorrect types: r=n, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 262,
+          "comment": "Signature encoding contains incorrect types: r=n, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 263,
+          "comment": "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 264,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 265,
+          "comment": "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 266,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325513000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 267,
+          "comment": "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325513003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 268,
+          "comment": "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 269,
+          "comment": "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 270,
+          "comment": "Signature encoding contains incorrect types: r=p, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 271,
+          "comment": "Signature encoding contains incorrect types: r=p, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 272,
+          "comment": "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 273,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 274,
+          "comment": "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 275,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 276,
+          "comment": "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 277,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a090380fe01090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 278,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 279,
+          "comment": "Signature encoding contains incorrect types: r=True, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 280,
+          "comment": "Signature encoding contains incorrect types: r=False, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 281,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300405000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 282,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30040c000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 283,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c01300c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 284,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300430003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 285,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a30030201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 286,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008090380fe01020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 287,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 288,
+          "comment": "Signature encoding contains incorrect types: r=True, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 289,
+          "comment": "Signature encoding contains incorrect types: r=False, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 290,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050500020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 291,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050c00020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 292,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c0130020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 293,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30053000020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 294,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30083003020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 295,
+          "comment": "Edge case for Shamir multiplication",
+          "flags": [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg": "3932323038",
+          "sig": "3044022064a1aab5000d0e804f3e2fc02bdee9be8ff312334e2ba16d11547c97711c898e02203c623e7f7598376825fa8bc09e727c75794cbb4ee8716ae15c31cd1cbe9ca3ee",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393439313934313732",
+          "sig": "304402203a4f61f7f8c4546e3580f7848411786fee1229a07a6ecf5fb84870869188215d022018c5ce44354e2274eadb8fea319f8d6f60944532dbaae86bfd8105f253041bcb",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35333637363431383737",
+          "sig": "304502203fa9975fb2b08b7b6e33f3843099da3f43f1dcfe9b171a60cafd5489ca9c5328022100985a86825a0cc728f5d9dac2a513b49127a06100f0fc4b8b1f200903e0df9ed2",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363731343831303935",
+          "sig": "304402204d66e7ee5edd02ab96db25954050079ef8de1d0f02f34d4d75112eaf3f73124002206292d1563140013c589be40e599862bdd6bda2103809928928a119b43851a2ce",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131323037313732393039",
+          "sig": "3046022100a9228305f7b486f568eb65d44e49ba007e3f14b8f23c689c952e4ced1e6cf91e022100b73c74d28bd1268002bed784a6b06c40a90ee5938ea6d08f272d027e0f96a72c",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131323938303334323336",
+          "sig": "304402203fa39842bfab6c38afa7963c60beb09484d4579fc75ef09efff44e91bc62ca8302205612add1924f0285ace5b158828e2b32ab2b6e7f10ee68dca1cc54591fee1fec",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39383736303239363833",
+          "sig": "3045022006c04b02edfeecd8620f035ea4f449bd924593e86e5288a6f22d1923b0e2e8a9022100f666718e6fefb515bb9339d29cc0e58cfba89d605ca0066bca87f6a3f08ebcfa",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3230323034323936353139",
+          "sig": "304402201ddd953c32a5f84109cd4d9ec8c364dd318376ff5d228211a367483077d638800220563dba4845de762baf04910618d587e0dd0c97dd1c9785c24ffdf2f8a660abf2",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343531363639313830",
+          "sig": "30460221009fe4ec4831ef4945f100d5d35a2e6312411ca5df6c900ca60690f2985d553482022100c674ad5e1bead2f767c9248e444452a4a8530dd47246cbbc968da865bdf212b6",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303933363835393531",
+          "sig": "3046022100e8703d6b16a79fc2ab3653cece29d06f65dd6f2c230cb08ee30c5517407d75db0221008cfeb87b8e95ddacd638b37d315393c5005f3ab8bba0cc1cd1a050829b775bfb",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36323139353630323031",
+          "sig": "3046022100def608caf1f277d71403009f209c1d7eef11aaa7920397fbf429b8146181aece022100f3b8f2aa5b3df9a8b37313ea66ad5b74673f3e8614ff471b1eb6773217511fb0",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363832343734333033",
+          "sig": "304402204f5d08e8d936ce831d02d6b23fb8fce0e0750101af3ab9c3b28636b95a5e24ad02206f034480553bcecac221f8be8288163c55492e2e56a88f4d0341b61436a0a6c0",
+          "result": "valid"
+        },
+        {
+          "tcId": 307,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33373336353331373836",
+          "sig": "3045022100bdd822bfe3733d9f4b88764fe091db2e8f8af366e4c44d876bf82e62bd48c7ee02207fbf7750c5dc849a2c55dbdd067806f869652a7b3a57baa4733781d3128f02de",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373935393033373932",
+          "sig": "304402201c4fc02961b7f4245566b410bf08f447502ea4f75b15690344681efa2edf7b4b02207d63eef119dc88bc4a1b2c43ac21cd53892443661f8c3a97d558bf888c29f769",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39333939363131303037",
+          "sig": "304402206406f2d249ab1264e175476ca3300efd049fcad569dff40b922082b41cc7b7ce0220461872b803383f785077714a9566c4d652e87b2cad90dd4f4cc84bc55004c530",
+          "result": "valid"
+        },
+        {
+          "tcId": 310,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303837343931313835",
+          "sig": "30450220415c924b9ba1902b340058117d90623602d48b8280583fb231dc93823b83a153022100f18be8cdc2063a26ab030504d3397dc6e9c6b6c56f4e3a59832c0e4643c0263c",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323336363738353030",
+          "sig": "3045022100d12e96c7d2f177b7cf6d8a1ede060a2b174dc993d43f5fe60f75604824b64fef02200c97d87035fcca0a5f47fe6461bb30cbaf05b37e4211ec3fcd51fc71a12239ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343438393937373033",
+          "sig": "304502207df72a64c7e982c88f83b3a22802690098147e0e42ef4371ef069910858c0646022100adbaa7b10c6a3f995ed5f83d7bda4ba626b355f34a72bf92ff788300b70e72d0",
+          "result": "valid"
+        },
+        {
+          "tcId": 313,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35373134363332383037",
+          "sig": "30440220047c4306f8d30e425ae70e0bee9e0b94faa4ef18a9c6d7f2c95de0fe6e2a323702207a4d0d0a596bd9ea3fe9850e9c8c77322594344623c0b46ac2a8c95948aefd98",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323236343837343932",
+          "sig": "3044022057d603a367e23af39c95dd418c0176da8b211d50b1be82bf5ef621a2640204f702205dc3f285ad015c4d71157bd11e5b8df6a89e4b267393b08b5ad5013bdae544b1",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35333533343439343739",
+          "sig": "3044022011df6741021ec8cc567584aea16817c540859c4e5011551c00b097fcfc2337e50220668551919d43206ac0571fc5ad3ac0efb489bea599e7bf99fe4c7468d6c2c5e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 316,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373837333033383830",
+          "sig": "304402207451ffede471bd370406533436fc42a89daa0af4903d087cbc062fe7e54dbf700220590895398f22b48ce72cbf7c3d3ee1dd7fb0ee645edb0b1b1de35f370e5bf5ee",
+          "result": "valid"
+        },
+        {
+          "tcId": 317,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323332313935383233",
+          "sig": "3045022100fc4c4d81da6f687a6426263193c1a680b67734a1b180647b8c76407cc4f0a9c6022056f775d372c9bee685374085be676c9cf31cf1f978a5e6ccb04e4a0761159cc7",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130373339333931393137",
+          "sig": "3045022100feb978ca33c46ffba47eb63bb40de7833e43d5654575b54de1fea3d1de3c8ad50220108078ba997bfa064521baf342c97b0c64bd25240c8fd0fd7533ae2d03081b70",
+          "result": "valid"
+        },
+        {
+          "tcId": 319,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383831303237333135",
+          "sig": "3046022100cc61729698467ba53da199ff481fe7433f194fc96367907e8dc5e1d9f42b1e2102210083dd9ef156e7c1f9c09b3bf86a4f1c88e5dd20cd74d997858e600797dbe74ad2",
+          "result": "valid"
+        },
+        {
+          "tcId": 320,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36303631363933393037",
+          "sig": "3045022100d47f616303ff0eb813eac32e760ba30ad445e0af7dc57e70756104823f6a895f0220047f2217b399c46a426b936a124980a6011f0896f51dbe07632828a72d7173f1",
+          "result": "valid"
+        },
+        {
+          "tcId": 321,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38383935323237303934",
+          "sig": "3046022100cff73dfa2bac67ce1340b25c885abb3e7979ef7f840f15d5f19e86640cdd40a3022100c7d1210802796c4f251049ee08a2c29f5c71064033d17010c65bf2e94499381e",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353830323334303934",
+          "sig": "3044022010acaf9c485ab1220355b95be269f124e12eb252f2224b0fc50785eb2ee3df45022032443b557efc6896347fa778e1fcf33cbb769c9a7da896b20d93fea7c2791ea4",
+          "result": "valid"
+        },
+        {
+          "tcId": 323,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393635393931353132",
+          "sig": "3046022100f919da0651abc2bff994a879d2778fa5195d57400e003e8dd6adb3fc7a0cc4cc0221009b945d06bd119665b278a59bd24fdd2350817d0be87997bee57b70c479d64a2d",
+          "result": "valid"
+        },
+        {
+          "tcId": 324,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323838373332313938",
+          "sig": "3045022100cc38e7a018f6d70b2d9b49120cc9b4a169f2f72238821a86b81f553b6225d24e0220276efd8bf06ccce07c7aae35eaac3bd1c374dcf0cf0588d5e0e4171936688636",
+          "result": "valid"
+        },
+        {
+          "tcId": 325,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323330383837333139",
+          "sig": "3045022100ff85ad66621991c318b85cef73c576cb2a8d43c568c1aafc85b40ef2a9a6b41c0220732a79e6837ebf8434fea6e7fefa948f506ae455c1a3eb36a030185a23037d96",
+          "result": "valid"
+        },
+        {
+          "tcId": 326,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313239303536393337",
+          "sig": "3044022033f016e51eef9b1136380cb8b84c6b38b107e24c6731bd07cb1c7f4a29f33a83022036b177bb8be94c8be67ff3a41fcc4d22b5c9eb377da713eb014ae01c64ca6dd7",
+          "result": "valid"
+        },
+        {
+          "tcId": 327,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373438363536343338",
+          "sig": "3045022100929413ee91f27454d74e91370a10a86fc98ac7305c8ab4ca59752bda3a7bfc370220483b47a26a0d7d2e6bd37d351d9ee37c5ec2a4686d884d78b6beb7f6b08c50f9",
+          "result": "valid"
+        },
+        {
+          "tcId": 328,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37353833353032363034",
+          "sig": "30450220578202c7d0abac93ca43dde3cb44414e5601c1eb557604cb9adb4bde0a12633b022100fb9a7412e307aee95ef4b53540571a21559414e5306794ab5182cfb229dab3e9",
+          "result": "valid"
+        },
+        {
+          "tcId": 329,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333237373534323739",
+          "sig": "3045022046d45ad0bb75b8639d0e91d8450fc31887c211328a5784fc83b4cb7f5b962c1b022100d6751d13ede2079b7aa1d822bdb32d7f3cf00273a1ff03df90c0ec7c62a47568",
+          "result": "valid"
+        },
+        {
+          "tcId": 330,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373735353038353834",
+          "sig": "3046022100abe84c941783d5ced284fea56341ecc68d6bdd3196d318fbd074641f8c885bd5022100bdea3c44d48e01aa40935c1c9723ff733199563440f26b4ecf0b444b0418d9f5",
+          "result": "valid"
+        },
+        {
+          "tcId": 331,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3137393832363438333832",
+          "sig": "3045022005277cdbf491e336fe81be24e393a161a4fb89112c9ffed1ee6649c406713408022100ab6934332e68e108bb0484d21c457dcf381a620c3a4712fdbfeb658a3fafd60c",
+          "result": "valid"
+        },
+        {
+          "tcId": 332,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333936373737333635",
+          "sig": "30450220293825737c8c14430ed10dbadd7da337275f9b61d1d26377f778ffaa00c139de022100cdddec267a8678c96829bf6c1d6f38322e119937cfd2fee01e9dc9525f43ed6b",
+          "result": "valid"
+        },
+        {
+          "tcId": 333,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35393938313035383031",
+          "sig": "304402202041fdd6111c45dfd29e750e082dcdadc9a584a8a2be46580fb0ba3b3dc658620220421824fe987e4172a0f8bbcb7bcd9e1b073b7742ed9f9df98f2a1a37cd374ce3",
+          "result": "valid"
+        },
+        {
+          "tcId": 334,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3136363737383237303537",
+          "sig": "30450220267941db660e046ab14e795669e002b852f7788447c53ebef46a2056978b5574022100d00183bcaf75bc11e37653f952f6a6537151c3aa0a1b9e4e41b004a29185395b",
+          "result": "valid"
+        },
+        {
+          "tcId": 335,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323036323134333632",
+          "sig": "304402205dcd7f6814739d47f80a363b9414e6cbfb5f0846223888510abd5b3903d7ae09022043418f138bb3c857c0ad750ca8389ebcf3719cb389634ac54a91de9f18fd7238",
+          "result": "valid"
+        },
+        {
+          "tcId": 336,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36383432343936303435",
+          "sig": "304502205e0e8cc0280409a0ce252da02b2424d2de3a52b406c3778932dbc60cb86c356702210093d25e929c5b00e950d89585ec6c01b6589ae0ec0af8a79c04df9e5b27b58bc5",
+          "result": "valid"
+        },
+        {
+          "tcId": 337,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323639383937333231",
+          "sig": "304502204fcf9c9d9ffbf4e0b98268c087071bffe0673bb8dcb32aa667f8a639c364ea47022100820db0730bee8227fc831643fcb8e2ef9c0f7059ce42da45cf74828effa8d772",
+          "result": "valid"
+        },
+        {
+          "tcId": 338,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333837333234363932",
+          "sig": "3046022100c60cd2e08248d58d1639b123633643c63f89aff611f998937ccb08c9113bcdca022100ac4bb470ce0164616dada7a173364ed3f9d16fd32c686136f904c99266fda17e",
+          "result": "valid"
+        },
+        {
+          "tcId": 339,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313138383837353336",
+          "sig": "304502207cfdaf6f22c1c7668d7b6f56f8a7be3fdeeb17a7863539555bbfa899dd70c5f1022100cee151adc71e68483b95a7857a862ae0c5a6eee478d93d40ccc7d40a31dcbd90",
+          "result": "valid"
+        },
+        {
+          "tcId": 340,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393838363036353435",
+          "sig": "304402202270be7ee033a706b59746eab34816be7e15c8784061d5281060707a0abe0a7d022056a163341ee95e7e3c04294a57f5f7d24bf3c3c6f13ef2f161077c47bd27665d",
+          "result": "valid"
+        },
+        {
+          "tcId": 341,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343739313135383435",
+          "sig": "3044022016b5d2bfcaba21167a69f7433d0c476b21ded37d84dc74ca401a3ecddb2752a8022062852cf97d89adfb0ebbe6f398ee641bfea8a2271580aac8a3d8326d8c6e0ef9",
+          "result": "valid"
+        },
+        {
+          "tcId": 342,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35303736383837333637",
+          "sig": "3046022100d907eefa664115848b90c3d5baa0236f08eafaf81c0d52bb9d0f8acb57490847022100fd91bc45a76e31cdc58c4bfb3df27f6470d20b19f0fba6a77b6c8846650ed8a6",
+          "result": "valid"
+        },
+        {
+          "tcId": 343,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393838353036393637",
+          "sig": "30450220048337b34f427e8774b3bf7c8ff4b1ae65d132ac8af94829bb2d32944579bb31022100bd6f8eab82213ccf80764644204bb6bf16c668729cdd31dd8596286c15686e8e",
+          "result": "valid"
+        },
+        {
+          "tcId": 344,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373231333036313331",
+          "sig": "3046022100b2bc46b7c44293557ab7ebeb0264924277193f87a25d94c924df1518ba7c7260022100abf1f6238ff696aaafaf4f0cbbe152c3d771c5bfc43f36d7e5f5235819d02c1a",
+          "result": "valid"
+        },
+        {
+          "tcId": 345,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323034313031363535",
+          "sig": "3045022040d4b38a61232e654ffd08b91e18609851f4189f7bf8a425ad59d9cbb1b54c990221009e775a7bd0d934c3ed886037f5d3b356f60eda41191690566e99677d7aaf64f3",
+          "result": "valid"
+        },
+        {
+          "tcId": 346,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313530363830393530",
+          "sig": "3046022100ac8f64d7df8d9fea005744e3ac4af70aa3a38e5a0f3d069d85806a4f29710339022100c014e96decfef3857cc174f2c46ad0882bef0c4c8a17ce09441961e4ae8d2df3",
+          "result": "valid"
+        },
+        {
+          "tcId": 347,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373237343630313033",
+          "sig": "3044022041b3766f41a673a01e2c0cab5ceedbcec8d82530a393f884d72aa4e6685dea0a0220073a55dca2da577cafb40e12dd20bf8529a13a6acdf9a1c7d4b2048d60876cb3",
+          "result": "valid"
+        },
+        {
+          "tcId": 348,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134353731343631323235",
+          "sig": "304502201942755aa8128382cd8e35a4350c22cc45ba5704d99e8a240970df11956ad866022100f64cf1e0816cf7ac5044f73ba938e142ef3305cb09becb80a0a5b9ad7ba3eb07",
+          "result": "valid"
+        },
+        {
+          "tcId": 349,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313739353136303930",
+          "sig": "3045022051aba4ff1c7ddf17e0632ab71684d8de6dc700219ef346cb28ce9dafc3565b3b022100b6aaebe1af0ad01f07a68bf1cf57f9d6040b43c14b7eb8238542760e32ce3b0c",
+          "result": "valid"
+        },
+        {
+          "tcId": 350,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35383932373133303534",
+          "sig": "304502210091efbfcc731650e9f004c38b71db146c17bf871c82c4e87716f7ff2f7f9e51d00220089ea631a7c5f05311c521d21ba798b5174881f0fd8095fb3a77515913efb6e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 351,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33383936313832323937",
+          "sig": "304502204a7e47bd281ea09b9e3a32934c7a969e1f788f978b41585989f4689e804663fb022100e65f6bd702403cbbed7f8ad0045f331d4a96fbf8c43f71f11615b7d1b9153b7f",
+          "result": "valid"
+        },
+        {
+          "tcId": 352,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38323833333436373332",
+          "sig": "3046022100c795f5da86e10a604d4f94bf7cac381c73edad1461d66929e53aa57ca294e89f022100bae784ab6c7b58332ee05e7d54169edf55ce45f030e71ae8df63969fb327a10c",
+          "result": "valid"
+        },
+        {
+          "tcId": 353,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33333636393734383931",
+          "sig": "3046022100ea68b24843b225f505e01c0e608b20b4d93e8faf6b9cf70cf8f9134a80e7b668022100a3abc044b4728f80fe414bdc66f032b262356720547bec7729fad94151c6adc7",
+          "result": "valid"
+        },
+        {
+          "tcId": 354,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313939313533323239",
+          "sig": "3046022100bfe7502140c57a24a77edc3d9b3c4bc11d21bdb0b196977b7f2b13ac973ad697022100947a01da9731849d72b67ef7bc40b012480fd389895aad1f6b1cdbeab3b93b8d",
+          "result": "valid"
+        },
+        {
+          "tcId": 355,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363030333136383232",
+          "sig": "304402203434ee1142740a0ab8623b97fc8dc2567eda45dadf6039b45c448819e840cf3002203c0fac0487841997202c29f3bf2df540b115b29dc619160d52203d4a1fd4b9f7",
+          "result": "valid"
+        },
+        {
+          "tcId": 356,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "383639363531363935",
+          "sig": "304502205338500e23ba96a0adc6ef84932e25fbad7435d9f70eb7f476c6912de12e33c8022100a002f5583ea8c0d7fb17136d0ee0415acf629879ce6b01ac52e3ecd7772a3704",
+          "result": "valid"
+        },
+        {
+          "tcId": 357,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36353833393236333732",
+          "sig": "304402204ff2d4e31f4180de6901d2d20341d12387c9c55f4cf003a742f049b84af6fe0502200312f38771414555fa5ed2817dcc629a8c7cf69d306300e87bc167278ec3ef37",
+          "result": "valid"
+        },
+        {
+          "tcId": 358,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3133323035303135373235",
+          "sig": "3044022051d665bad5f2d6306c6bbfe1f27555887670061d4df36ec9f4ce6cdfaf9ea7ac02202905e43f6207ee93df35a2e9fb9bc8098c448ae98a14e4ad1ebaea5d56b6e493",
+          "result": "valid"
+        },
+        {
+          "tcId": 359,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35303835333330373931",
+          "sig": "3046022100b804e0235f135aba7b7531b6831f26cc9fb77d3f83854957431be20706b813690221009d317fd08e4e0467617db819cde1d7d4d74da489b2bce4db055ea01eccfafcf2",
+          "result": "valid"
+        },
+        {
+          "tcId": 360,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37383636383133313139",
+          "sig": "30450221008ab50ef3660ccb6af34c78e795ded6b256ffca5c94f249f3d907fb65235ef680022049d5aaeae5a6d0c15b286e428b5e720cf37a822ede445baa143ffae69aba91b8",
+          "result": "valid"
+        },
+        {
+          "tcId": 361,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303832353339343239",
+          "sig": "30440220571b9c46a47c5cc53a574c196c3fb07f3510c0f4443b9f2fe781252c24d343de022068a9aebd50ff165c89b5b9cb6c1754191958f360b4d2851a481a3e1106ee7809",
+          "result": "valid"
+        },
+        {
+          "tcId": 362,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130303635393536363937",
+          "sig": "304502204cb7817b04dc73be60d3711803bc10687a6e3f4ab79c4c1a4e9d63a73174d4eb022100ce398d2d6602d2af58a64042f830bf774aee18209d6fb5c743b6a6e437826b98",
+          "result": "valid"
+        },
+        {
+          "tcId": 363,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33303234313831363034",
+          "sig": "30450220684399c6cd6ebb1c5d5efb0d78dce40ebd48d9d944eb6548c9ce68d7fdc82229022100cf25c8e427fae359bfe60fa02964f4c9b8d6db54612e05c78c341f0a8c52d0b5",
+          "result": "valid"
+        },
+        {
+          "tcId": 364,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37373637383532383734",
+          "sig": "3045022020b7b36d5bc76fa182ca27152a99a956e6a0880000694296e31af98a7312d04b022100eeeabc5521f9856e920eb7d29ed7e4042f178ff706dff8eeb24b429e3b63402a",
+          "result": "valid"
+        },
+        {
+          "tcId": 365,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353434313939393734",
+          "sig": "304402206b65c95e8e121d2e6ee506cfd62cb88e0bfb3589da40876898ef66c43982aca9022009642c05ad619b4402fd297eb57e29cca5c2eb6823931ba82de32d7c652ba73e",
+          "result": "valid"
+        },
+        {
+          "tcId": 366,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35383433343830333931",
+          "sig": "3044022067c74cbf5ea4b777bf521ace099f4f094d8f58900e15e67e1b4bd399056629ed02203d2884655c49b8b5f64e802a054e7bf09b0fc80ca18ebf927b82e58bb4a00400",
+          "result": "valid"
+        },
+        {
+          "tcId": 367,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373138383932363239",
+          "sig": "3045022079a5e40da5cf34c4c39adf7dfc5d454995a250314ebd212b5c8e3f4e6f875feb022100b268920e403ba17828ff271938a6558a5b2dd000229f8edb4a9d9f9b6ac1b472",
+          "result": "valid"
+        },
+        {
+          "tcId": 368,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373433323233343433",
+          "sig": "3045022100c8b13006c3a51a322fff9321761b01de134f526be582b22e19693c443fc9fe46022034e7f60179c6162ab980fcd58f173b0e6c30b524d35c67921677522dcef843a1",
+          "result": "valid"
+        },
+        {
+          "tcId": 369,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343036303035393336",
+          "sig": "304502203513db745489a487c88a6cedf8795b640f8f71578397bdabd6cc586c25bd66ad02210099a72cd3f0ca6c799149283ca0af37f86b88200d0c905bd3c9f1b859e55b1659",
+          "result": "valid"
+        },
+        {
+          "tcId": 370,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363134303336393838",
+          "sig": "304402203a6386afb08f7ff8140b5a270f764e8706ef2830fb177446f7b4eeb8a25aac6402204b70854b38c29245b2b980eba10ea936c68a38c1da5255ce2386db23afc7c06a",
+          "result": "valid"
+        },
+        {
+          "tcId": 371,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303935343235363835",
+          "sig": "3046022100b8fc54a8a6be3c55e99c06f99ccdcce7af5c18a3c5829726a870cc1068458f64022100cc7237c39c8e6a4a1c8c62f5f88636549c7410798b89684c502c3adfe5fb7ad2",
+          "result": "valid"
+        },
+        {
+          "tcId": 372,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303038303938393833",
+          "sig": "3045022047b460851e5607f2021626635c565a63f78f558795e1b330d09115970dbbb8ab022100a6a9f4f213e08d3c736d3e1c44a35140cb107619f265a5b13608ed729fd6d894",
+          "result": "valid"
+        },
+        {
+          "tcId": 373,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353734313437393237",
+          "sig": "30450221008cfda4f7a65864ebbea3144863da9b075c07b5b42cb4569643ddfd70dd753b190220595784b1ab217874b82b9585521f8090b9f6322884ab7a620464f51cf846c5b7",
+          "result": "valid"
+        },
+        {
+          "tcId": 374,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383636373731353232",
+          "sig": "304402204cd6a45bd7c8bf0edbdf073dbf1f746234cbbca31ec20b526b077c9f480096e702207cf97ae0d33f50b73a5d7adf8aa4eeeb6ff10f89a8794efe1d874e23299c1b3d",
+          "result": "valid"
+        },
+        {
+          "tcId": 375,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363934323830373837",
+          "sig": "304402202e233f4df8ffebeaec64842b23cce161c80d303b016eca562429b227ae2b58ec022046b6b56adec82f82b54daa6a5fca286740a1704828052072a5f0bc8c7b884242",
+          "result": "valid"
+        },
+        {
+          "tcId": 376,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39393231363932353638",
+          "sig": "30440220549f658d4a3f98233a2c93bd5b1a52d64af10815ae60becb4139cac822b579c3022027bdddf0dbcf374a2aec8accc47a8ac897f8d1823dda8eb2052590970b39ce2a",
+          "result": "valid"
+        },
+        {
+          "tcId": 377,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131363039343339373938",
+          "sig": "30450221009fabcc1e5fd965226902f594559e231369e584453974e74f49d7d762e134fb9d0220293cccc510793bac45ce5da2bb6c9e906437f59435ca206655f74b625df07c7c",
+          "result": "valid"
+        },
+        {
+          "tcId": 378,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37313836313632313030",
+          "sig": "304502202e5c140fd6f5f823addc8088ffaae967e7f4897274316769561dfb31435825d9022100eda47327d7cfae1daa344ff5582a467bd18eb9f01caeab9c6da3c0cc89df6713",
+          "result": "valid"
+        },
+        {
+          "tcId": 379,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323934333437313737",
+          "sig": "304402204c11e3b7efbe3908ad2118e54d7d34d6c6eb4570bf7fdb11a7679fe93afa254c0220712e90f421836e542dac49d10bb39db4a98b2735b6336d8a3c392f3b90e60bbe",
+          "result": "valid"
+        },
+        {
+          "tcId": 380,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3138353134343535313230",
+          "sig": "3045022100dfb4619303f4ff689563d2275069fac44d63ea3c3b18f4fb1ac805d7df3d12ec022068e37b846583901db256329f9cf64f40c416fba50dcb9be333a3e29c76ae32db",
+          "result": "valid"
+        },
+        {
+          "tcId": 381,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343736303433393330",
+          "sig": "3045022100e70e8e17bd758ff0c48f91cb2c53d293f0f5ae82eb9dfe76ab98f9b064278635022021dde32cb0389cad7bdf676d9b9b7d25bb034ad25a55ea71ee7ee26a18359dd2",
+          "result": "valid"
+        },
+        {
+          "tcId": 382,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353637333738373431",
+          "sig": "30440220421397ecae30617a5a6081ad1badf6ce9d9d4cb2afdabf1f900e7fdb7fb0af5a022057ca89dc22801c75fdbefdaeca65c675625f94de7d635062b08ed308df5762cc",
+          "result": "valid"
+        },
+        {
+          "tcId": 383,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35373339393334393935",
+          "sig": "304502200610c08076909bb722fba105c23eac8f66b4db1d58f66a882fc90d59acdec8e0022100af59e8d570761cac589d49f11c884007f7ac1eea1a44c6f3fdad1d542187d25e",
+          "result": "valid"
+        },
+        {
+          "tcId": 384,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343738333636313339",
+          "sig": "3045022059a1181cab0ee8ce94ab2b5ab4f4b13a422e38efe69f634bf947485a5b9ea49c0221009b3c913d98a4ab15f6a39f1802b8f2d28559aa1f8d03a3a88df00c89dc293a97",
+          "result": "valid"
+        },
+        {
+          "tcId": 385,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363439303532363032",
+          "sig": "30460221008cae6c4dfbf901bd66ab82541011fa15c8e90e2c18c01bd881acaa2b63cb587b022100a86acf943f29cef91d1b66a7de5547df6cdfc45dd7bef816dcb8de9f5a425d2d",
+          "result": "valid"
+        },
+        {
+          "tcId": 386,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373633383837343936",
+          "sig": "30450221008b00c74b86474d782eac9974aea606d8f7ee78c79597e15687021f5991e86acd0220309dfe3686648eae104e87b3e9b5616a3ad479ca4f0b558ae4f1e5ab3115346a",
+          "result": "valid"
+        },
+        {
+          "tcId": 387,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353739303230303830",
+          "sig": "30450220433a915504c977809634a36fcf4480e4c8069fc127d201d30dfdb1f423c95fd4022100bcb1b89aafd50a1766b09741fc6a9a96e744ae9826d839bf85ffb50a91981773",
+          "result": "valid"
+        },
+        {
+          "tcId": 388,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35333434373837383438",
+          "sig": "304502204b69abd2b39840a545cdd4a72d384234580e2fd938b7091d0ecdb562780857db022100fdab9957119e0a4092af82f6cc29f3c8a692671ec86efb0a03c1112a0a1e0467",
+          "result": "valid"
+        },
+        {
+          "tcId": 389,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3139323636343130393230",
+          "sig": "3045022100dab9d3686c28363ad017b4a2b36d35bf2eb80633613d44deb9501d42a3efbd3802201392a562d79f9ab19014e4f7e2f2668259f3720a76c120d4a3c3964e880f7679",
+          "result": "valid"
+        },
+        {
+          "tcId": 390,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33373033393135373035",
+          "sig": "3045022023f94e47b440ce379b74c9311232b19a64e3e7c9b90da34b0c1c3f3d7af28105022100e1425903b1479c2ce18b108a6d1ec8b7a4f0f657dedb00de3a3ceea7fdeee9be",
+          "result": "valid"
+        },
+        {
+          "tcId": 391,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3831353435373730",
+          "sig": "30450221009d706a8fa85d15bd0c3492c6672dfe529f4073b217b3947b5b2cfd61f87ccb7102206aaaaf369f82a0e542f72ded7d7eb90c8314ffa613a0ea81da1c8393dbae2bac",
+          "result": "valid"
+        },
+        {
+          "tcId": 392,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313935353330333737",
+          "sig": "3046022100ac77918c4085c8a7ce5020b00c315629aee053a445cb4661eb50f6b62a47da29022100df2aea2b9c11a6ce39d3cd9e1faf4a53057e0b1b2e48a324be9e773203fe9fbb",
+          "result": "valid"
+        },
+        {
+          "tcId": 393,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323637383130393033",
+          "sig": "30460221009db2dbd2935f147fae7f6a95c8e2307bd8537c3d96eb732ad6d5ebdd89bc754e02210093a9ab99d2de9d08fe0a61e26c8fe1ebbf88726e4b69d551b57d15f0ae16df5a",
+          "result": "valid"
+        },
+        {
+          "tcId": 394,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131313830373230383135",
+          "sig": "30440220769f70093939afbd1fa15873decfa803ca523ace8040280ba78cf833497722bc0220369875aba5e1ced5a4ca8444ec9399a38038b00e153a0ae34d9b3c9781447eea",
+          "result": "valid"
+        },
+        {
+          "tcId": 395,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38333831383639323930",
+          "sig": "3045022026e5182b9822550ad52f46ad80781d6bef3d110a204db5e58a0746f796982200022100a9418e76029ced0cf78a571a9e59ad04086e91f70e6813981bb33c1dee891165",
+          "result": "valid"
+        },
+        {
+          "tcId": 396,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313331323837323737",
+          "sig": "3046022100e7bd6aefcf7b27e1f3fadbe713f9adb3d23398e88200cd2e94989c9d12e921770221009583e0de3b76f8d4b1e634a81cbc34af54e2f8599f3684ce48d372760c8204c4",
+          "result": "valid"
+        },
+        {
+          "tcId": 397,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134333331393236353338",
+          "sig": "30450221008638ed7eaa83609a01a6af9c52ec9bfddda90442b1e6031d61cfa22e48b2e1e2022020c284d596f71c6c8df732f5a5a2006302301e1a792e2b39663d93a9760762d2",
+          "result": "valid"
+        },
+        {
+          "tcId": 398,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333434393038323336",
+          "sig": "3044022061d924307a96180b06383608ba91674e15c3ea06ff2534412b93a587dde649c1022059b84aa2115b2547edac88088ca6313e9fbe1ca6a361c7e57938f9dde3f4349c",
+          "result": "valid"
+        },
+        {
+          "tcId": 399,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36383239383335393239",
+          "sig": "30450220424fcfc3fd63d128c2eb125e88c7fe5d283b63470a786b82783edbb8a0b7a6d7022100b11548c2cd7fce9d44e795ca51af0b2f6a5180e9c9be0314007ed9e7f4bbe5e9",
+          "result": "valid"
+        },
+        {
+          "tcId": 400,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343435313538303233",
+          "sig": "3045022100a5f747ae6290fa9582c6ce8d5608621d495f061551bc4531bacba586a563b184022062faf8f92291e12812835b3f1d43c967bceb885b110bd06e5a68e2d74781ae2b",
+          "result": "valid"
+        },
+        {
+          "tcId": 401,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3132363937393837363434",
+          "sig": "3045022100b731dc0d92c2cc7a605d78233f7814699bdf1cab2df297b6844eec4015af8ea0022039b1a0cc88eb85bcdc356b3620c51f1298c60aec5306b107e900ffdba049dd6f",
+          "result": "valid"
+        },
+        {
+          "tcId": 402,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333939323432353533",
+          "sig": "3046022100ef73c4fa322da39fb6503bab6b66b64d241056afbcd6908f84b61ccbbe890433022100f1ef85413e5764aa58a3128ccfcf388324fe5340e5edf8d0135ae76786ce415b",
+          "result": "valid"
+        },
+        {
+          "tcId": 403,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363031393737393737",
+          "sig": "30450220694cd30e2ad0182579331474b271ee2d48723bc8415dc6513873586ce705b76b022100c5ac0c0ed5a4017d110cb45d63aa955dc7dc5ce23e7965c5397c3ff46a884636",
+          "result": "valid"
+        },
+        {
+          "tcId": 404,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130383738373535313435",
+          "sig": "3046022100f38b2236be3024e10b894ffb1cc68d0bb8d4cf0fcd2cfc1779f8883765d3cd96022100da69cd0b74c25566d60a486edd559fc39d569fb2751445a4798df8a36891802c",
+          "result": "valid"
+        },
+        {
+          "tcId": 405,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37303034323532393939",
+          "sig": "3046022100a881732c205a0b4b95669c00756fd91973450109a46f17d5a9d971b5e92b9aa40221008acefdca4e06c16b47ccad1c57c05912637e107096ba230c92b97187db79e19e",
+          "result": "valid"
+        },
+        {
+          "tcId": 406,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353635333235323833",
+          "sig": "3044022004452f554bae819b42effb84ef44a9f1cb7e2d75b4ba9ff9b9cfffaddde3fd1b022061a3fbc5e73c350f2e3d85a7452cd231a3f3375fc11f5fe153b185f53b09c1d0",
+          "result": "valid"
+        },
+        {
+          "tcId": 407,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3233383236333432333530",
+          "sig": "3045022005814f57f58efc7cb490119e584e635e6f0ad1c19fb5dc2edafda075bb55f98e0221009dd5c6e39009d67d965903ecffe08a851775cc1248cc19c0b77798282131b8f6",
+          "result": "valid"
+        },
+        {
+          "tcId": 408,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343437383437303635",
+          "sig": "3045022100dc1c4a46085e198843b1f01980cd5e4a1ff6f8e8ff7014397f0afd5b247fb0a0022038a13dc723ed90b30251d742b14733a03292ff26530a1ebcaf3d10862a6eff82",
+          "result": "valid"
+        },
+        {
+          "tcId": 409,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134323630323035353434",
+          "sig": "304502201067667bf525734ca7f2510e36348fd9c2c9bccf032dfd571de6d45abd49361a022100fa762568d3a19e5a1d8ea65e00202a5b16f9afae56733a01f86e35378c558da4",
+          "result": "valid"
+        },
+        {
+          "tcId": 410,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393933383335323835",
+          "sig": "3046022100e58d69dc56bc1031644847e3e046e2ea845a515d969d07ea1aa53aea5bd92fa1022100bfe50b80f7c512f5ab521fe7e1a131045fde78d4de826c91573baaba1e35ca97",
+          "result": "valid"
+        },
+        {
+          "tcId": 411,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34323932313533353233",
+          "sig": "3046022100fe79c6b8c14d0f23d426e3d157f1b541f6bb91bf29957ef97c55949c9ba48a350221009da112c4a4cf4b1ff490c426f6c8ff122183964a0de56f7336ab382dc9d10285",
+          "result": "valid"
+        },
+        {
+          "tcId": 412,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34343539393031343936",
+          "sig": "3045022045d4ed7e9edacb5a730944ab0037fba0a136ed9d0d26b2f4d4058554f148fa6f022100f136f15fd30cfe5e5548b3f4965c16a66a7c12904686abe12da777619212ae8c",
+          "result": "valid"
+        },
+        {
+          "tcId": 413,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333933393731313731",
+          "sig": "304402204fb7c1727e40bae272f6143a50001b54b536f90233157896dbf845e263f2486302206fea5c924dca17519f6e502ef67efa08d39eb5cc3381266f0216864d2bd00a62",
+          "result": "valid"
+        },
+        {
+          "tcId": 414,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333930363936343935",
+          "sig": "30450220779aac665dd988054b04f2e9d483ca79179b3372b58ca00fe43520f44fcb4c32022100b4eca1182cd51f0abd3ea2268dcda49a807ad4116a583102047498aa863653f5",
+          "result": "valid"
+        },
+        {
+          "tcId": 415,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131343436303536323634",
+          "sig": "3046022100db7ac6f65fb1c38d80064fd11861631237a09924b4eeca4e1569fa4b7d80ad24022100a38d178d37e13e1afa07a9d03da025d594461938a62a6c6744f5c8f7d7b7bb81",
+          "result": "valid"
+        },
+        {
+          "tcId": 416,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363835303034373530",
+          "sig": "3046022100c90043b4aadf795d870ac223f33acdbd1948c31afff059054dc99528c6503fa6022100829f67b312bb134f6954a23c611a7f7b5b2a69efced9c48db589ac0b4d3da827",
+          "result": "valid"
+        },
+        {
+          "tcId": 417,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3232323035333630363139",
+          "sig": "3045022100fa16c0125b6615b90e81f7499804308a90179bf3fcff6a4b2695271c68b23ded02200d6cda5ce041dc5a5f319ad9c0de4927d0cf5e89e37b79216194413d42976d54",
+          "result": "valid"
+        },
+        {
+          "tcId": 418,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36323135363635313234",
+          "sig": "304502201a4b5bd0f806549f46a3e71bfe412d6d89206017640ded66f3d0b2d9b26bec45022100aac5f74e3130264e01428570ee82ee47e245d160ed812ae252dedffd82e1ec2c",
+          "result": "valid"
+        },
+        {
+          "tcId": 419,
+          "comment": "Signature generated without truncating the hash",
+          "flags": [
+            "Untruncatedhash"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100f8e272234b51475ec4c6f327562a6e5c9080a96225e88b2e5f72a8eecbd41ab40220516b91617fc39e3141b3bc769f6a3b2e468e687f50bdc29e19088af62d203f4b",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04b6e08b1bcc89e7fb0b84d7497e310553495be4877eccc4b3d6d79f7c68a0573431760fa1bcea4972759174ac1103bc6011985ccee251918d0573fbcb78969116",
+        "wx": "00b6e08b1bcc89e7fb0b84d7497e310553495be4877eccc4b3d6d79f7c68a05734",
+        "wy": "31760fa1bcea4972759174ac1103bc6011985ccee251918d0573fbcb78969116"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004b6e08b1bcc89e7fb0b84d7497e310553495be4877eccc4b3d6d79f7c68a0573431760fa1bcea4972759174ac1103bc6011985ccee251918d0573fbcb78969116",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtuCLG8yJ5/sLhNdJfjEFU0lb5Id+\nzMSz1teffGigVzQxdg+hvOpJcnWRdKwRA7xgEZhczuJRkY0Fc/vLeJaRFg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 420,
+          "comment": "k*G has a large x-coordinate",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "303502104319055358e8617b0c46353d039cdaab022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        },
+        {
+          "tcId": 421,
+          "comment": "r too large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000001000000000000000000000000fffffffffffffffffffffffc022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "043590c6a10353d669bc94d8e2ff9e14bbeed4a7f45b887255ab7e37b676387bb615fc6f97ce39a3874c2b34cc571889abfa0a706c2cfb0e5a4750cc25690696f8",
+        "wx": "3590c6a10353d669bc94d8e2ff9e14bbeed4a7f45b887255ab7e37b676387bb6",
+        "wy": "15fc6f97ce39a3874c2b34cc571889abfa0a706c2cfb0e5a4750cc25690696f8"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200043590c6a10353d669bc94d8e2ff9e14bbeed4a7f45b887255ab7e37b676387bb615fc6f97ce39a3874c2b34cc571889abfa0a706c2cfb0e5a4750cc25690696f8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENZDGoQNT1mm8lNji/54Uu+7Up/Rb\niHJVq343tnY4e7YV/G+Xzjmjh0wrNMxXGImr+gpwbCz7DlpHUMwlaQaW+A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 422,
+          "comment": "r,s are large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254f022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04369e96402f2cfd1a37b3acbdecfc562862dbca944a0f12d7aaacb8d325d7650aa723621922be2bdac9186290fdcdda028d94437966507d93f2fc1f5c887fdedb",
+        "wx": "369e96402f2cfd1a37b3acbdecfc562862dbca944a0f12d7aaacb8d325d7650a",
+        "wy": "00a723621922be2bdac9186290fdcdda028d94437966507d93f2fc1f5c887fdedb"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004369e96402f2cfd1a37b3acbdecfc562862dbca944a0f12d7aaacb8d325d7650aa723621922be2bdac9186290fdcdda028d94437966507d93f2fc1f5c887fdedb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENp6WQC8s/Ro3s6y97PxWKGLbypRK\nDxLXqqy40yXXZQqnI2IZIr4r2skYYpD9zdoCjZRDeWZQfZPy/B9ciH/e2w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 423,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100909135bdb6799286170f5ead2de4f6511453fe50914f3df2de54a36383df8dd4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0427a0a80ea2e1aa798ea9bcc3aedbf01ab78e49c9ec2ad0e08a0429a0e1db4d0d32a8ee7bee9d0a40014e484f34a92bd6f33fe63624ea9579657441ac79666e7f",
+        "wx": "27a0a80ea2e1aa798ea9bcc3aedbf01ab78e49c9ec2ad0e08a0429a0e1db4d0d",
+        "wy": "32a8ee7bee9d0a40014e484f34a92bd6f33fe63624ea9579657441ac79666e7f"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000427a0a80ea2e1aa798ea9bcc3aedbf01ab78e49c9ec2ad0e08a0429a0e1db4d0d32a8ee7bee9d0a40014e484f34a92bd6f33fe63624ea9579657441ac79666e7f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJ6CoDqLhqnmOqbzDrtvwGreOScns\nKtDgigQpoOHbTQ0yqO577p0KQAFOSE80qSvW8z/mNiTqlXlldEGseWZufw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 424,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022027b4577ca009376f71303fd5dd227dcef5deb773ad5f5a84360644669ca249a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "049cff61712d4bc5b3638341e6e0a576a8098c9c6d3f198d389c4669f398dc0867f3b9e09f567f3dfd9c4d2c1163e82beadf16c76e8f9d7a64673800ea76fa1e59",
+        "wx": "009cff61712d4bc5b3638341e6e0a576a8098c9c6d3f198d389c4669f398dc0867",
+        "wy": "00f3b9e09f567f3dfd9c4d2c1163e82beadf16c76e8f9d7a64673800ea76fa1e59"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200049cff61712d4bc5b3638341e6e0a576a8098c9c6d3f198d389c4669f398dc0867f3b9e09f567f3dfd9c4d2c1163e82beadf16c76e8f9d7a64673800ea76fa1e59",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnP9hcS1LxbNjg0Hm4KV2qAmMnG0/\nGY04nEZp85jcCGfzueCfVn89/ZxNLBFj6Cvq3xbHbo+demRnOADqdvoeWQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 425,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020105020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d9117cae81295e82682fa387991e668e1570e0e90100bf4e63964822460561bc19f96b1787ed15769929978ba3dd7f68c97adf5c16f671e756cd8f08c49456ca",
+        "wx": "00d9117cae81295e82682fa387991e668e1570e0e90100bf4e63964822460561bc",
+        "wy": "19f96b1787ed15769929978ba3dd7f68c97adf5c16f671e756cd8f08c49456ca"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d9117cae81295e82682fa387991e668e1570e0e90100bf4e63964822460561bc19f96b1787ed15769929978ba3dd7f68c97adf5c16f671e756cd8f08c49456ca",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2RF8roEpXoJoL6OHmR5mjhVw4OkB\nAL9OY5ZIIkYFYbwZ+WsXh+0Vdpkpl4uj3X9oyXrfXBb2cedWzY8IxJRWyg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 426,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020105020103",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "048cfcbad3524c22b992529f943e3ce0b2d126085501d6e3edd4f1dbf74bdca21eafb259b1ba179cac09e8e43a88c8a09e7339910a7c941932e44b8be56f1fccde",
+        "wx": "008cfcbad3524c22b992529f943e3ce0b2d126085501d6e3edd4f1dbf74bdca21e",
+        "wy": "00afb259b1ba179cac09e8e43a88c8a09e7339910a7c941932e44b8be56f1fccde"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200048cfcbad3524c22b992529f943e3ce0b2d126085501d6e3edd4f1dbf74bdca21eafb259b1ba179cac09e8e43a88c8a09e7339910a7c941932e44b8be56f1fccde",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjPy601JMIrmSUp+UPjzgstEmCFUB\n1uPt1PHb90vcoh6vslmxuhecrAno5DqIyKCeczmRCnyUGTLkS4vlbx/M3g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 427,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020105020105",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04fbb51127e1f1b6a38e9fe9a2544614edb8e43ad7cd8c56f14b3235dda3bc11179abd9753a9e647e9340c395fb2b91384d6d33fcb6456214350b6f3fa00f4364c",
+        "wx": "00fbb51127e1f1b6a38e9fe9a2544614edb8e43ad7cd8c56f14b3235dda3bc1117",
+        "wy": "009abd9753a9e647e9340c395fb2b91384d6d33fcb6456214350b6f3fa00f4364c"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004fbb51127e1f1b6a38e9fe9a2544614edb8e43ad7cd8c56f14b3235dda3bc11179abd9753a9e647e9340c395fb2b91384d6d33fcb6456214350b6f3fa00f4364c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+7URJ+HxtqOOn+miVEYU7bjkOtfN\njFbxSzI13aO8EReavZdTqeZH6TQMOV+yuROE1tM/y2RWIUNQtvP6APQ2TA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 428,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020105020106",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04cba74b6b024a29a173df9abb9593294a6b8e83efd7f48d67311dcfb557ca80b8e68417e9afb0494417a568129701137effb2174b5c50bb8adf716a4a5ca95d0c",
+        "wx": "00cba74b6b024a29a173df9abb9593294a6b8e83efd7f48d67311dcfb557ca80b8",
+        "wy": "00e68417e9afb0494417a568129701137effb2174b5c50bb8adf716a4a5ca95d0c"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004cba74b6b024a29a173df9abb9593294a6b8e83efd7f48d67311dcfb557ca80b8e68417e9afb0494417a568129701137effb2174b5c50bb8adf716a4a5ca95d0c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEy6dLawJKKaFz35q7lZMpSmuOg+/X\n9I1nMR3PtVfKgLjmhBfpr7BJRBelaBKXARN+/7IXS1xQu4rfcWpKXKldDA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 429,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020106020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04ea4518f4df8b277eb5ad16cb6bf851e841cedccd99c95c28f681c18a643d15ce4077c637f77b4da58ac8c9ab59523ebb0619d97dca2df1cb8a457b160af1adb9",
+        "wx": "00ea4518f4df8b277eb5ad16cb6bf851e841cedccd99c95c28f681c18a643d15ce",
+        "wy": "4077c637f77b4da58ac8c9ab59523ebb0619d97dca2df1cb8a457b160af1adb9"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004ea4518f4df8b277eb5ad16cb6bf851e841cedccd99c95c28f681c18a643d15ce4077c637f77b4da58ac8c9ab59523ebb0619d97dca2df1cb8a457b160af1adb9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6kUY9N+LJ361rRbLa/hR6EHO3M2Z\nyVwo9oHBimQ9Fc5Ad8Y393tNpYrIyatZUj67BhnZfcot8cuKRXsWCvGtuQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 430,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020106020103",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04e148d9966e5b9b536380927de72e59a6655e7070091b25b47b44fdb2a8bd390f35259cd39d6f6ed62340d12152b0fdc1702be5ebdb8f0061d6607b05ca3d7b1b",
+        "wx": "00e148d9966e5b9b536380927de72e59a6655e7070091b25b47b44fdb2a8bd390f",
+        "wy": "35259cd39d6f6ed62340d12152b0fdc1702be5ebdb8f0061d6607b05ca3d7b1b"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004e148d9966e5b9b536380927de72e59a6655e7070091b25b47b44fdb2a8bd390f35259cd39d6f6ed62340d12152b0fdc1702be5ebdb8f0061d6607b05ca3d7b1b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4UjZlm5bm1NjgJJ95y5ZpmVecHAJ\nGyW0e0T9sqi9OQ81JZzTnW9u1iNA0SFSsP3BcCvl69uPAGHWYHsFyj17Gw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 431,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020106020106",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a61edf1f6e011a27b9fb4e43ca2ef58c1dd6a7f5cf9e89a678d87b2f9a6d8a80b6e5624c5ef144000bde93ccec7ec58b3c646b42e3d92806b281f35c62c39ccf",
+        "wx": "00a61edf1f6e011a27b9fb4e43ca2ef58c1dd6a7f5cf9e89a678d87b2f9a6d8a80",
+        "wy": "00b6e5624c5ef144000bde93ccec7ec58b3c646b42e3d92806b281f35c62c39ccf"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a61edf1f6e011a27b9fb4e43ca2ef58c1dd6a7f5cf9e89a678d87b2f9a6d8a80b6e5624c5ef144000bde93ccec7ec58b3c646b42e3d92806b281f35c62c39ccf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEph7fH24BGie5+05Dyi71jB3Wp/XP\nnommeNh7L5ptioC25WJMXvFEAAvek8zsfsWLPGRrQuPZKAaygfNcYsOczw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 432,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020106020107",
+          "result": "valid"
+        },
+        {
+          "tcId": 433,
+          "comment": "r is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632557020107",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a1ff55a03cd061f2408c0ada1ae9f7197f53ef84190564fd3dace78839bc6420178e94a5d6028186997cd36f3c8d2631a272d7936b2cfb3d62730f8c0fe80983",
+        "wx": "00a1ff55a03cd061f2408c0ada1ae9f7197f53ef84190564fd3dace78839bc6420",
+        "wy": "178e94a5d6028186997cd36f3c8d2631a272d7936b2cfb3d62730f8c0fe80983"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a1ff55a03cd061f2408c0ada1ae9f7197f53ef84190564fd3dace78839bc6420178e94a5d6028186997cd36f3c8d2631a272d7936b2cfb3d62730f8c0fe80983",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEof9VoDzQYfJAjAraGun3GX9T74QZ\nBWT9PazniDm8ZCAXjpSl1gKBhpl80288jSYxonLXk2ss+z1icw+MD+gJgw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 434,
+          "comment": "s is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020106022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc75fbd8",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "041b824a11eed94fbcd9b722d06613bbcf7eca00b9136f2652642178f37b1a920ee900de495d9ef56fa6d19f3dd1e0edb23d23835ac8c2d3d13c0227e852e503eb",
+        "wx": "1b824a11eed94fbcd9b722d06613bbcf7eca00b9136f2652642178f37b1a920e",
+        "wy": "00e900de495d9ef56fa6d19f3dd1e0edb23d23835ac8c2d3d13c0227e852e503eb"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200041b824a11eed94fbcd9b722d06613bbcf7eca00b9136f2652642178f37b1a920ee900de495d9ef56fa6d19f3dd1e0edb23d23835ac8c2d3d13c0227e852e503eb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEG4JKEe7ZT7zZtyLQZhO7z37KALkT\nbyZSZCF483sakg7pAN5JXZ71b6bRnz3R4O2yPSODWsjC09E8AifoUuUD6w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 435,
+          "comment": "small r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3027020201000221008f1e3c7862c58b16bb76eddbb76eddbb516af4f63f2d74d76e0d28c9bb75ea88",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042914b30c4c784696ffc3dddcec05f36cb1488bc342b9f529d5387acb9e48cb8d3dbd30d0d5d6d6a39108863c2d6a6e8571cd3261fb9eb98ce46125bd8f139136",
+        "wx": "2914b30c4c784696ffc3dddcec05f36cb1488bc342b9f529d5387acb9e48cb8d",
+        "wy": "3dbd30d0d5d6d6a39108863c2d6a6e8571cd3261fb9eb98ce46125bd8f139136"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042914b30c4c784696ffc3dddcec05f36cb1488bc342b9f529d5387acb9e48cb8d3dbd30d0d5d6d6a39108863c2d6a6e8571cd3261fb9eb98ce46125bd8f139136",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKRSzDEx4Rpb/w93c7AXzbLFIi8NC\nufUp1Th6y55Iy409vTDQ1dbWo5EIhjwtam6Fcc0yYfueuYzkYSW9jxORNg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 436,
+          "comment": "smallish r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302c02072d9b4d347952d6022100ef3043e7329581dbb3974497710ab11505ee1c87ff907beebadd195a0ffe6d7a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042579f546fe2f2aeb5f822feb28f2f8371618d04815455a7e903c10024a17da415528e951147f76bee1314e65a49c6ec70686e62d38fbc23472f96e3d3b33fd1f",
+        "wx": "2579f546fe2f2aeb5f822feb28f2f8371618d04815455a7e903c10024a17da41",
+        "wy": "5528e951147f76bee1314e65a49c6ec70686e62d38fbc23472f96e3d3b33fd1f"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042579f546fe2f2aeb5f822feb28f2f8371618d04815455a7e903c10024a17da415528e951147f76bee1314e65a49c6ec70686e62d38fbc23472f96e3d3b33fd1f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJXn1Rv4vKutfgi/rKPL4NxYY0EgV\nRVp+kDwQAkoX2kFVKOlRFH92vuExTmWknG7HBobmLTj7wjRy+W49OzP9Hw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 437,
+          "comment": "100-bit r and small s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3032020d1033e67e37b32b445580bf4eff0221008b748b74000000008b748b748b748b7466e769ad4a16d3dcd87129b8e91d1b4d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04b102196bf455ee5aafc6f895504d3c3b6b2d37c35f8669bd0f0b694795fbd992f777b6f829b9628ac35db0ef43f6a89f0a42812614e4c15924d8d47ebe45bae5",
+        "wx": "00b102196bf455ee5aafc6f895504d3c3b6b2d37c35f8669bd0f0b694795fbd992",
+        "wy": "00f777b6f829b9628ac35db0ef43f6a89f0a42812614e4c15924d8d47ebe45bae5"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004b102196bf455ee5aafc6f895504d3c3b6b2d37c35f8669bd0f0b694795fbd992f777b6f829b9628ac35db0ef43f6a89f0a42812614e4c15924d8d47ebe45bae5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsQIZa/RV7lqvxviVUE08O2stN8Nf\nhmm9DwtpR5X72ZL3d7b4KbliisNdsO9D9qifCkKBJhTkwVkk2NR+vkW65Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 438,
+          "comment": "small r and 100 bit s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302702020100022100ef9f6ba4d97c09d03178fa20b4aaad83be3cf9cb824a879fec3270fc4b81ef5b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "044d056ab2ff57662fd6eebbe23930fef5cd08083e24146190cd01960b1fcd3749fe7ec5847651c857898be0f09efd6e0116a5dbe327f6f3080a65fc966bf64d91",
+        "wx": "4d056ab2ff57662fd6eebbe23930fef5cd08083e24146190cd01960b1fcd3749",
+        "wy": "00fe7ec5847651c857898be0f09efd6e0116a5dbe327f6f3080a65fc966bf64d91"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200044d056ab2ff57662fd6eebbe23930fef5cd08083e24146190cd01960b1fcd3749fe7ec5847651c857898be0f09efd6e0116a5dbe327f6f3080a65fc966bf64d91",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETQVqsv9XZi/W7rviOTD+9c0ICD4k\nFGGQzQGWCx/NN0n+fsWEdlHIV4mL4PCe/W4BFqXb4yf28wgKZfyWa/ZNkQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 439,
+          "comment": "100-bit r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3032020d062522bbd3ecbe7c39e93e7c25022100ef9f6ba4d97c09d03178fa20b4aaad83be3cf9cb824a879fec3270fc4b81ef5b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04361c4a62cd867613138dfe24ccebc4b7df1b55fc7410f4995ee2b6b9ab2220584f116c6c84e53d262fd13a5f5de6b57e7a1981de4ecdffdf3323b4e91d80649c",
+        "wx": "361c4a62cd867613138dfe24ccebc4b7df1b55fc7410f4995ee2b6b9ab222058",
+        "wy": "4f116c6c84e53d262fd13a5f5de6b57e7a1981de4ecdffdf3323b4e91d80649c"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004361c4a62cd867613138dfe24ccebc4b7df1b55fc7410f4995ee2b6b9ab2220584f116c6c84e53d262fd13a5f5de6b57e7a1981de4ecdffdf3323b4e91d80649c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENhxKYs2GdhMTjf4kzOvEt98bVfx0\nEPSZXuK2uasiIFhPEWxshOU9Ji/ROl9d5rV+ehmB3k7N/98zI7TpHYBknA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 440,
+          "comment": "r and s^-1 are close to n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6324d50220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "048156a2127c4c46a1ecf24c0522b85fabe94e6c8b9d962420b2acc9e2b6291af05235bf5dc5ccdd1bd333bce846197de363ba0dc158ef0f0174d714a09e76a66f",
+        "wx": "008156a2127c4c46a1ecf24c0522b85fabe94e6c8b9d962420b2acc9e2b6291af0",
+        "wy": "5235bf5dc5ccdd1bd333bce846197de363ba0dc158ef0f0174d714a09e76a66f"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200048156a2127c4c46a1ecf24c0522b85fabe94e6c8b9d962420b2acc9e2b6291af05235bf5dc5ccdd1bd333bce846197de363ba0dc158ef0f0174d714a09e76a66f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgVaiEnxMRqHs8kwFIrhfq+lObIud\nliQgsqzJ4rYpGvBSNb9dxczdG9MzvOhGGX3jY7oNwVjvDwF01xSgnnambw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 441,
+          "comment": "r and s are 64-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30160209009c44febf31c3594f020900839ed28247c2b06b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04cb180dda5ed44ca0f78cc19c6659c88451b4d0084a4a904cb2dc770f78318613fae0bd290165858bd670788f5f78ad7806b49a2b932409e3dfb7195ccafaad0d",
+        "wx": "00cb180dda5ed44ca0f78cc19c6659c88451b4d0084a4a904cb2dc770f78318613",
+        "wy": "00fae0bd290165858bd670788f5f78ad7806b49a2b932409e3dfb7195ccafaad0d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004cb180dda5ed44ca0f78cc19c6659c88451b4d0084a4a904cb2dc770f78318613fae0bd290165858bd670788f5f78ad7806b49a2b932409e3dfb7195ccafaad0d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyxgN2l7UTKD3jMGcZlnIhFG00AhK\nSpBMstx3D3gxhhP64L0pAWWFi9ZweI9feK14BrSaK5MkCePftxlcyvqtDQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 442,
+          "comment": "r and s are 100-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "301e020d09df8b682430beef6f5fd7c7cd020d0fd0a62e13778f4222a0d61c8a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0417e9a8ed4d6141f99dcc7794468576b16a9404c82a1969b91db0ca7534a5e00bbc4edd49e6dcf0476bd986551c3adccd4ddcdcdee6eb567cb68d925b4674113d",
+        "wx": "17e9a8ed4d6141f99dcc7794468576b16a9404c82a1969b91db0ca7534a5e00b",
+        "wy": "00bc4edd49e6dcf0476bd986551c3adccd4ddcdcdee6eb567cb68d925b4674113d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000417e9a8ed4d6141f99dcc7794468576b16a9404c82a1969b91db0ca7534a5e00bbc4edd49e6dcf0476bd986551c3adccd4ddcdcdee6eb567cb68d925b4674113d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEF+mo7U1hQfmdzHeURoV2sWqUBMgq\nGWm5HbDKdTSl4Au8Tt1J5tzwR2vZhlUcOtzNTdzc3ubrVny2jZJbRnQRPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 443,
+          "comment": "r and s are 128-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30260211008a598e563a89f526c32ebec8de26367c02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04f123d6999fec34a68c99539d2c9d50268fcdfafa99215d900c93c0c59bd34d933095156ba887f0f965804af24995cf5572553e6adb04da368a90419e523185ce",
+        "wx": "00f123d6999fec34a68c99539d2c9d50268fcdfafa99215d900c93c0c59bd34d93",
+        "wy": "3095156ba887f0f965804af24995cf5572553e6adb04da368a90419e523185ce"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004f123d6999fec34a68c99539d2c9d50268fcdfafa99215d900c93c0c59bd34d933095156ba887f0f965804af24995cf5572553e6adb04da368a90419e523185ce",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8SPWmZ/sNKaMmVOdLJ1QJo/N+vqZ\nIV2QDJPAxZvTTZMwlRVrqIfw+WWASvJJlc9VclU+atsE2jaKkEGeUjGFzg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 444,
+          "comment": "r and s are 160-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0bdf021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04db9d5c5113f00822a146c9cda2e75cb6634cd0dff54aff6e22875171f57a0dad1c424cdd83eb01c02f6f8d36f42c6dc7e39db74358da8ac9bc9dc5890d46f667",
+        "wx": "00db9d5c5113f00822a146c9cda2e75cb6634cd0dff54aff6e22875171f57a0dad",
+        "wy": "1c424cdd83eb01c02f6f8d36f42c6dc7e39db74358da8ac9bc9dc5890d46f667"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004db9d5c5113f00822a146c9cda2e75cb6634cd0dff54aff6e22875171f57a0dad1c424cdd83eb01c02f6f8d36f42c6dc7e39db74358da8ac9bc9dc5890d46f667",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE251cURPwCCKhRsnNoudctmNM0N/1\nSv9uIodRcfV6Da0cQkzdg+sBwC9vjTb0LG3H4523Q1jaism8ncWJDUb2Zw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 445,
+          "comment": "s == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30250220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70020101",
+          "result": "valid"
+        },
+        {
+          "tcId": 446,
+          "comment": "s == 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30250220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70020100",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "044d9cddf6b4ff05cdf5f557a32db1712e49ab45ae53ade49b9469e665ffa2db773ead4c88e83f38cd16d61dda97645355424279e5132dfec14421cabfc1203a6b",
+        "wx": "4d9cddf6b4ff05cdf5f557a32db1712e49ab45ae53ade49b9469e665ffa2db77",
+        "wy": "3ead4c88e83f38cd16d61dda97645355424279e5132dfec14421cabfc1203a6b"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200044d9cddf6b4ff05cdf5f557a32db1712e49ab45ae53ade49b9469e665ffa2db773ead4c88e83f38cd16d61dda97645355424279e5132dfec14421cabfc1203a6b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETZzd9rT/Bc319VejLbFxLkmrRa5T\nreSblGnmZf+i23c+rUyI6D84zRbWHdqXZFNVQkJ55RMt/sFEIcq/wSA6aw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 447,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022002f676969f451a8ccafa4c4f09791810e6d632dbd60b1d5540f3284fbe1889b0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "045eb0559c2fde581a0df6207f3b2872d8e80a1ec8f6d542bf0319ec254c1c23ea272a1ab985cdfab8573a797ed554e137bda258ae3c841ccbf6559187b3471233",
+        "wx": "5eb0559c2fde581a0df6207f3b2872d8e80a1ec8f6d542bf0319ec254c1c23ea",
+        "wy": "272a1ab985cdfab8573a797ed554e137bda258ae3c841ccbf6559187b3471233"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200045eb0559c2fde581a0df6207f3b2872d8e80a1ec8f6d542bf0319ec254c1c23ea272a1ab985cdfab8573a797ed554e137bda258ae3c841ccbf6559187b3471233",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXrBVnC/eWBoN9iB/Oyhy2OgKHsj2\n1UK/AxnsJUwcI+onKhq5hc36uFc6eX7VVOE3vaJYrjyEHMv2VZGHs0cSMw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 448,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002204e260962e33362ef0046126d2d5a4edc6947ab20e19b8ec19cf79e5908b6e628",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042cb4debf57562b9aa191e38d101c51d8bd3eedf242a1123cd3c6060526c4dd2bdc6abd94d54374aede721d0c78193e9b999508a9f2a9ae8737f87a5fc7e0c673",
+        "wx": "2cb4debf57562b9aa191e38d101c51d8bd3eedf242a1123cd3c6060526c4dd2b",
+        "wy": "00dc6abd94d54374aede721d0c78193e9b999508a9f2a9ae8737f87a5fc7e0c673"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042cb4debf57562b9aa191e38d101c51d8bd3eedf242a1123cd3c6060526c4dd2bdc6abd94d54374aede721d0c78193e9b999508a9f2a9ae8737f87a5fc7e0c673",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELLTev1dWK5qhkeONEBxR2L0+7fJC\noRI808YGBSbE3Svcar2U1UN0rt5yHQx4GT6bmZUIqfKproc3+Hpfx+DGcw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 449,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220077ed0d8f20f697d8fc591ac64dd5219c7932122b4f9b9ec6441e44a0092cf21",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0463d556714900ed08e751f58c1978c1a673c9a9bf975fc4b8af32c2e7944f21d4c2cdf2e7b72fcffe3e8767dc769856ef9fec98ef0139b22f87166300a3781599",
+        "wx": "63d556714900ed08e751f58c1978c1a673c9a9bf975fc4b8af32c2e7944f21d4",
+        "wy": "00c2cdf2e7b72fcffe3e8767dc769856ef9fec98ef0139b22f87166300a3781599"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000463d556714900ed08e751f58c1978c1a673c9a9bf975fc4b8af32c2e7944f21d4c2cdf2e7b72fcffe3e8767dc769856ef9fec98ef0139b22f87166300a3781599",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY9VWcUkA7QjnUfWMGXjBpnPJqb+X\nX8S4rzLC55RPIdTCzfLnty/P/j6HZ9x2mFbvn+yY7wE5si+HFmMAo3gVmQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 450,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002203e0292a67e181c6c0105ee35e956e78e9bdd033c6e71ae57884039a245e4175f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040d09be47824c5c23f727bfb550c6dbbdf90abb35d3623013f1c6d7d31be03d95845fede0a0f580dff795e7d5b278a2c78bfa5c4facd1fccfe190ec8eef206778",
+        "wx": "0d09be47824c5c23f727bfb550c6dbbdf90abb35d3623013f1c6d7d31be03d95",
+        "wy": "00845fede0a0f580dff795e7d5b278a2c78bfa5c4facd1fccfe190ec8eef206778"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040d09be47824c5c23f727bfb550c6dbbdf90abb35d3623013f1c6d7d31be03d95845fede0a0f580dff795e7d5b278a2c78bfa5c4facd1fccfe190ec8eef206778",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDQm+R4JMXCP3J7+1UMbbvfkKuzXT\nYjAT8cbX0xvgPZWEX+3goPWA3/eV59WyeKLHi/pcT6zR/M/hkOyO7yBneA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 451,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022013d22b06d6b8f5d97e0c64962b4a3bae30f668ca6217ef5b35d799f159e23ebe",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0435b75a83731a5b56325add4f28a09742039e0e62f75728e896783fd957400d5be3f3fa5269577faa7089e9c8e9d9f732ef78d433e4be382820323c197c5bbc39",
+        "wx": "35b75a83731a5b56325add4f28a09742039e0e62f75728e896783fd957400d5b",
+        "wy": "00e3f3fa5269577faa7089e9c8e9d9f732ef78d433e4be382820323c197c5bbc39"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000435b75a83731a5b56325add4f28a09742039e0e62f75728e896783fd957400d5be3f3fa5269577faa7089e9c8e9d9f732ef78d433e4be382820323c197c5bbc39",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENbdag3MaW1YyWt1PKKCXQgOeDmL3\nVyjolng/2VdADVvj8/pSaVd/qnCJ6cjp2fcy73jUM+S+OCggMjwZfFu8OQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 452,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002204523ce342e4994bb8968bf6613f60c06c86111f15a3a389309e72cd447d5dd99",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04fdd28d47e3d60ed4c7fd48e68003f48c5346354ecae2e4b1b4ff43ecd6058fcb010d7e9f008ae48f88a90640999a931ee47d77b2cfb442c614b14054af2c9ddf",
+        "wx": "00fdd28d47e3d60ed4c7fd48e68003f48c5346354ecae2e4b1b4ff43ecd6058fcb",
+        "wy": "010d7e9f008ae48f88a90640999a931ee47d77b2cfb442c614b14054af2c9ddf"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004fdd28d47e3d60ed4c7fd48e68003f48c5346354ecae2e4b1b4ff43ecd6058fcb010d7e9f008ae48f88a90640999a931ee47d77b2cfb442c614b14054af2c9ddf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/dKNR+PWDtTH/UjmgAP0jFNGNU7K\n4uSxtP9D7NYFj8sBDX6fAIrkj4ipBkCZmpMe5H13ss+0QsYUsUBUryyd3w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 453,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022037d765be3c9c78189ad30edb5097a4db670de11686d01420e37039d4677f4809",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0473d914dde798f430d51de4e43b3cc5aa557fc4797d9a1820813509979efe3753089ffa286ba30505e3a9ae5c9587854ddb3de2a04ee7a0dbed0dfb087e2d190b",
+        "wx": "73d914dde798f430d51de4e43b3cc5aa557fc4797d9a1820813509979efe3753",
+        "wy": "089ffa286ba30505e3a9ae5c9587854ddb3de2a04ee7a0dbed0dfb087e2d190b"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000473d914dde798f430d51de4e43b3cc5aa557fc4797d9a1820813509979efe3753089ffa286ba30505e3a9ae5c9587854ddb3de2a04ee7a0dbed0dfb087e2d190b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc9kU3eeY9DDVHeTkOzzFqlV/xHl9\nmhgggTUJl57+N1MIn/ooa6MFBeOprlyVh4VN2z3ioE7noNvtDfsIfi0ZCw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 454,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022044237823b54e0c74c2bf5f759d9ac5f8cb897d537ffa92effd4f0bb6c9acd860",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0424861819b9fb20fb1fcc75eb7a44b2abbb36047812429119ba5b232dfc1ad3c244ec4740e65634fae7d692ea166cb4640201486845c2fb96d4f49beaecc3289a",
+        "wx": "24861819b9fb20fb1fcc75eb7a44b2abbb36047812429119ba5b232dfc1ad3c2",
+        "wy": "44ec4740e65634fae7d692ea166cb4640201486845c2fb96d4f49beaecc3289a"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000424861819b9fb20fb1fcc75eb7a44b2abbb36047812429119ba5b232dfc1ad3c244ec4740e65634fae7d692ea166cb4640201486845c2fb96d4f49beaecc3289a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJIYYGbn7IPsfzHXrekSyq7s2BHgS\nQpEZulsjLfwa08JE7EdA5lY0+ufWkuoWbLRkAgFIaEXC+5bU9Jvq7MMomg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 455,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220266d30a485385906054ca86d46f5f2b17e7f4646a3092092ad92877126538111",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04de056c8c24eb527ad5021ddcf3b16b099b668a03f7da03075f410a0770347bde01880d2a7b162491221c0b370fe81f28924422a4c70117682b898bc325791ce4",
+        "wx": "00de056c8c24eb527ad5021ddcf3b16b099b668a03f7da03075f410a0770347bde",
+        "wy": "01880d2a7b162491221c0b370fe81f28924422a4c70117682b898bc325791ce4"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004de056c8c24eb527ad5021ddcf3b16b099b668a03f7da03075f410a0770347bde01880d2a7b162491221c0b370fe81f28924422a4c70117682b898bc325791ce4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3gVsjCTrUnrVAh3c87FrCZtmigP3\n2gMHX0EKB3A0e94BiA0qexYkkSIcCzcP6B8okkQipMcBF2griYvDJXkc5A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 456,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220538c7b3798e84d0ce90340165806348971ed44db8f0c674f5f215968390f92ee",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04cf2de76812f62ecd4e7d8e674d1b79dddbdca18677c8ba338a71b65134d0429fad6d87d6d6592ba1130b81198f6fbe39719cb872d30fc1757af2ae86307b3f9e",
+        "wx": "00cf2de76812f62ecd4e7d8e674d1b79dddbdca18677c8ba338a71b65134d0429f",
+        "wy": "00ad6d87d6d6592ba1130b81198f6fbe39719cb872d30fc1757af2ae86307b3f9e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004cf2de76812f62ecd4e7d8e674d1b79dddbdca18677c8ba338a71b65134d0429fad6d87d6d6592ba1130b81198f6fbe39719cb872d30fc1757af2ae86307b3f9e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzy3naBL2Ls1OfY5nTRt53dvcoYZ3\nyLozinG2UTTQQp+tbYfW1lkroRMLgRmPb745cZy4ctMPwXV68q6GMHs/ng==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 457,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206fef0ef15d1688e15e704c4e6bb8bb7f40d52d3af5c661bb78c4ed9b408699b3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0428d9b9fe0d3c2471f224476eb89c13fa68b433213c31b6376b16226abfeae1c636fef52918dd106cd21958f1f379b09278051472309731ea1192121b3b78f873",
+        "wx": "28d9b9fe0d3c2471f224476eb89c13fa68b433213c31b6376b16226abfeae1c6",
+        "wy": "36fef52918dd106cd21958f1f379b09278051472309731ea1192121b3b78f873"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000428d9b9fe0d3c2471f224476eb89c13fa68b433213c31b6376b16226abfeae1c636fef52918dd106cd21958f1f379b09278051472309731ea1192121b3b78f873",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKNm5/g08JHHyJEduuJwT+mi0MyE8\nMbY3axYiar/q4cY2/vUpGN0QbNIZWPHzebCSeAUUcjCXMeoRkhIbO3j4cw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 458,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206f44275e9aeb1331efcb8d58f35c0252791427e403ad84daad51d247cc2a64c6",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04334ddf8629f0b980796f255e650e247598f6f71e90c501dd11fcb58ea1e6c0a39215c31a4741e4b28657fc7ddb490c0e2a21c7b770460301344dbdd67e85f30d",
+        "wx": "334ddf8629f0b980796f255e650e247598f6f71e90c501dd11fcb58ea1e6c0a3",
+        "wy": "009215c31a4741e4b28657fc7ddb490c0e2a21c7b770460301344dbdd67e85f30d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004334ddf8629f0b980796f255e650e247598f6f71e90c501dd11fcb58ea1e6c0a39215c31a4741e4b28657fc7ddb490c0e2a21c7b770460301344dbdd67e85f30d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM03fhinwuYB5byVeZQ4kdZj29x6Q\nxQHdEfy1jqHmwKOSFcMaR0HksoZX/H3bSQwOKiHHt3BGAwE0Tb3WfoXzDQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 459,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022021323755b103d2f9da6ab83eccab9ad8598bcf625652f10e7a3eeee3c3945fb3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "048e889d0a2530f73421ad2e08302651f41ddeb1ae5083ce7e313e06d6928c375afeca9b4490f6aa5e8d45d187ec8d3ab699f29c0cc77386c56f93f2f39e0f2874",
+        "wx": "008e889d0a2530f73421ad2e08302651f41ddeb1ae5083ce7e313e06d6928c375a",
+        "wy": "00feca9b4490f6aa5e8d45d187ec8d3ab699f29c0cc77386c56f93f2f39e0f2874"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200048e889d0a2530f73421ad2e08302651f41ddeb1ae5083ce7e313e06d6928c375afeca9b4490f6aa5e8d45d187ec8d3ab699f29c0cc77386c56f93f2f39e0f2874",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjoidCiUw9zQhrS4IMCZR9B3esa5Q\ng85+MT4G1pKMN1r+yptEkPaqXo1F0YfsjTq2mfKcDMdzhsVvk/Lzng8odA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 460,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206c50acfe76de1289e7a5edb240f1c2a7879db6873d5d931f3c6ac467a6eac171",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04297ef19b14f0dfb7c4a294732096ed4304bc5e2eeb86581e0014ddb6e14920878bf2260ecb396e33383c4898bd954dd3c6e7bcdd7810ad0a649f97722bad0095",
+        "wx": "297ef19b14f0dfb7c4a294732096ed4304bc5e2eeb86581e0014ddb6e1492087",
+        "wy": "008bf2260ecb396e33383c4898bd954dd3c6e7bcdd7810ad0a649f97722bad0095"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004297ef19b14f0dfb7c4a294732096ed4304bc5e2eeb86581e0014ddb6e14920878bf2260ecb396e33383c4898bd954dd3c6e7bcdd7810ad0a649f97722bad0095",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKX7xmxTw37fEopRzIJbtQwS8Xi7r\nhlgeABTdtuFJIIeL8iYOyzluMzg8SJi9lU3Txue83XgQrQpkn5dyK60AlQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 461,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220755b7fffb0b17ad57dca50fcefb7fe297b029df25e5ccb5069e8e70c2742c2a6",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0499f19f07b33e03caf4703e04b930d57d6d9baa44460c596a2d3064e0b63ea41286a74c4612a812ee348d2b43f80de627c11c75d81511e22a199c32119b792c6a",
+        "wx": "0099f19f07b33e03caf4703e04b930d57d6d9baa44460c596a2d3064e0b63ea412",
+        "wy": "0086a74c4612a812ee348d2b43f80de627c11c75d81511e22a199c32119b792c6a"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000499f19f07b33e03caf4703e04b930d57d6d9baa44460c596a2d3064e0b63ea41286a74c4612a812ee348d2b43f80de627c11c75d81511e22a199c32119b792c6a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmfGfB7M+A8r0cD4EuTDVfW2bqkRG\nDFlqLTBk4LY+pBKGp0xGEqgS7jSNK0P4DeYnwRx12BUR4ioZnDIRm3ksag==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 462,
+          "comment": "point at infinity during verify",
+          "flags": [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a80220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04313f3309b236484c6eb4ea381e007854467a617343a2e97d845801c01a632cfe33f231854bba89a8ca3f802a2764d3bf6c3233c811a31e5e8028a0b862cb1977",
+        "wx": "313f3309b236484c6eb4ea381e007854467a617343a2e97d845801c01a632cfe",
+        "wy": "33f231854bba89a8ca3f802a2764d3bf6c3233c811a31e5e8028a0b862cb1977"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004313f3309b236484c6eb4ea381e007854467a617343a2e97d845801c01a632cfe33f231854bba89a8ca3f802a2764d3bf6c3233c811a31e5e8028a0b862cb1977",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMT8zCbI2SExutOo4HgB4VEZ6YXND\noul9hFgBwBpjLP4z8jGFS7qJqMo/gConZNO/bDIzyBGjHl6AKKC4YssZdw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 463,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a902207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a8",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d3aa01fe59bad92cffe3db59e1385391fafd7af4e4ce462e8aac157274cc8a05c7a7e603e18538aac15f89610beacc21e39898e6c5f7680a81c5bd7bd744a989",
+        "wx": "00d3aa01fe59bad92cffe3db59e1385391fafd7af4e4ce462e8aac157274cc8a05",
+        "wy": "00c7a7e603e18538aac15f89610beacc21e39898e6c5f7680a81c5bd7bd744a989"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d3aa01fe59bad92cffe3db59e1385391fafd7af4e4ce462e8aac157274cc8a05c7a7e603e18538aac15f89610beacc21e39898e6c5f7680a81c5bd7bd744a989",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE06oB/lm62Sz/49tZ4ThTkfr9evTk\nzkYuiqwVcnTMigXHp+YD4YU4qsFfiWEL6swh45iY5sX3aAqBxb1710SpiQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 464,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a902207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "045e31eccd4704ebf7a4247ea57f9351abadff63679f2276e2a3b05009ebc1b8df648465a925010db823b2a5f3a6072343a6cc9961a9c482399d0d82051c2e3232",
+        "wx": "5e31eccd4704ebf7a4247ea57f9351abadff63679f2276e2a3b05009ebc1b8df",
+        "wy": "648465a925010db823b2a5f3a6072343a6cc9961a9c482399d0d82051c2e3232"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200045e31eccd4704ebf7a4247ea57f9351abadff63679f2276e2a3b05009ebc1b8df648465a925010db823b2a5f3a6072343a6cc9961a9c482399d0d82051c2e3232",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXjHszUcE6/ekJH6lf5NRq63/Y2ef\nInbio7BQCevBuN9khGWpJQENuCOypfOmByNDpsyZYanEgjmdDYIFHC4yMg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 465,
+          "comment": "u1 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b023210281",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04ce0a47f881fd7315a733c4317848fa33c72e38de0b8fda36b61aa9a164f5808a85b05d25115ea4097ddf63f878c8e83657e66de136a8f9e62ed81a58bf117ff9",
+        "wx": "00ce0a47f881fd7315a733c4317848fa33c72e38de0b8fda36b61aa9a164f5808a",
+        "wy": "0085b05d25115ea4097ddf63f878c8e83657e66de136a8f9e62ed81a58bf117ff9"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004ce0a47f881fd7315a733c4317848fa33c72e38de0b8fda36b61aa9a164f5808a85b05d25115ea4097ddf63f878c8e83657e66de136a8f9e62ed81a58bf117ff9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzgpH+IH9cxWnM8QxeEj6M8cuON4L\nj9o2thqpoWT1gIqFsF0lEV6kCX3fY/h4yOg2V+Zt4Tao+eYu2BpYvxF/+Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 466,
+          "comment": "u1 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022100bc07ff031506dc74a75086a43252fb43731975a16dca6b025e867412d94222d0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04cd6f487b47f36c0dea8f4b04c4e6ac637c76b725929c611f48addcf3d2f65941b50ea8f3a491190ee0b20cfb6efd113608e7c7c127577500e7f5c4a4e490fd60",
+        "wx": "00cd6f487b47f36c0dea8f4b04c4e6ac637c76b725929c611f48addcf3d2f65941",
+        "wy": "00b50ea8f3a491190ee0b20cfb6efd113608e7c7c127577500e7f5c4a4e490fd60"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004cd6f487b47f36c0dea8f4b04c4e6ac637c76b725929c611f48addcf3d2f65941b50ea8f3a491190ee0b20cfb6efd113608e7c7c127577500e7f5c4a4e490fd60",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzW9Ie0fzbA3qj0sExOasY3x2tyWS\nnGEfSK3c89L2WUG1DqjzpJEZDuCyDPtu/RE2COfHwSdXdQDn9cSk5JD9YA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 467,
+          "comment": "u2 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04456e5f8067d68a1b0a2e8fe2b28acad5755687154a0f167734ebabbdc059070d720dbe96659a66ef0cf27a73e7b3f3f145a60e0ad29f1e21dcc2bb42f0d82c1e",
+        "wx": "456e5f8067d68a1b0a2e8fe2b28acad5755687154a0f167734ebabbdc059070d",
+        "wy": "720dbe96659a66ef0cf27a73e7b3f3f145a60e0ad29f1e21dcc2bb42f0d82c1e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004456e5f8067d68a1b0a2e8fe2b28acad5755687154a0f167734ebabbdc059070d720dbe96659a66ef0cf27a73e7b3f3f145a60e0ad29f1e21dcc2bb42f0d82c1e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERW5fgGfWihsKLo/isorK1XVWhxVK\nDxZ3NOurvcBZBw1yDb6WZZpm7wzyenPns/PxRaYOCtKfHiHcwrtC8NgsHg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 468,
+          "comment": "u2 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022100aaaaaaaa00000000aaaaaaaaaaaaaaaa7def51c91a0fbf034d26872ca84218e1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0442bf0c0ac1e3850baf5515748a878e34249f71035e20a9f54ed468ec273cb0fc5b3138500230055c71f12d53f5c7d0e3d8aa54a94c668cb311e20d195fc71abb",
+        "wx": "42bf0c0ac1e3850baf5515748a878e34249f71035e20a9f54ed468ec273cb0fc",
+        "wy": "5b3138500230055c71f12d53f5c7d0e3d8aa54a94c668cb311e20d195fc71abb"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000442bf0c0ac1e3850baf5515748a878e34249f71035e20a9f54ed468ec273cb0fc5b3138500230055c71f12d53f5c7d0e3d8aa54a94c668cb311e20d195fc71abb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQr8MCsHjhQuvVRV0ioeONCSfcQNe\nIKn1TtRo7Cc8sPxbMThQAjAFXHHxLVP1x9Dj2KpUqUxmjLMR4g0ZX8cauw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 469,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02206bfd55a8f8fdb68472e52873ef39ac3eace6d53df576f0ad2da4607bb52c0d46",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04ffdd48da63d3af67223f16c51eb7e95600eb0b0e8b964f4fcd8c534face3c2c2b4e009ab2a76829480e69c9e43b2f1fe076cfafb3fa8d27dd4d6bab4d6c3db54",
+        "wx": "00ffdd48da63d3af67223f16c51eb7e95600eb0b0e8b964f4fcd8c534face3c2c2",
+        "wy": "00b4e009ab2a76829480e69c9e43b2f1fe076cfafb3fa8d27dd4d6bab4d6c3db54"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffdd48da63d3af67223f16c51eb7e95600eb0b0e8b964f4fcd8c534face3c2c2b4e009ab2a76829480e69c9e43b2f1fe076cfafb3fa8d27dd4d6bab4d6c3db54",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/91I2mPTr2ciPxbFHrfpVgDrCw6L\nlk9PzYxTT6zjwsK04AmrKnaClIDmnJ5DsvH+B2z6+z+o0n3U1rq01sPbVA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 470,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220654937791db0686f712ff9b453eeadb0026c9b058bba49199ca3e8fac03c094f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04793cbfce6f335dcfede7c6898ea1c537d7661ed6a8c9d308d64a2560d21c6e2c483d23a5ff05da00eaf9d52cf5362be9b53b95316c6a32e9ebe68d9ac35c2fd6",
+        "wx": "793cbfce6f335dcfede7c6898ea1c537d7661ed6a8c9d308d64a2560d21c6e2c",
+        "wy": "483d23a5ff05da00eaf9d52cf5362be9b53b95316c6a32e9ebe68d9ac35c2fd6"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004793cbfce6f335dcfede7c6898ea1c537d7661ed6a8c9d308d64a2560d21c6e2c483d23a5ff05da00eaf9d52cf5362be9b53b95316c6a32e9ebe68d9ac35c2fd6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeTy/zm8zXc/t58aJjqHFN9dmHtao\nydMI1kolYNIcbixIPSOl/wXaAOr51Sz1NivptTuVMWxqMunr5o2aw1wv1g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 471,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100c51bbee23a95437abe5c978f8fe596a31c858ac8d55be9786aa5d36a5ac74e97",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a9f7023f559d4bb6c9f4bc3643e2824aff5451d929479ec3ea5eb30bad2c36ac6a7c77e8dd21f4ad49b103e67da9d3cda62b653dd194fad2ba8d1dd37bb0ea9b",
+        "wx": "00a9f7023f559d4bb6c9f4bc3643e2824aff5451d929479ec3ea5eb30bad2c36ac",
+        "wy": "6a7c77e8dd21f4ad49b103e67da9d3cda62b653dd194fad2ba8d1dd37bb0ea9b"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a9f7023f559d4bb6c9f4bc3643e2824aff5451d929479ec3ea5eb30bad2c36ac6a7c77e8dd21f4ad49b103e67da9d3cda62b653dd194fad2ba8d1dd37bb0ea9b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqfcCP1WdS7bJ9Lw2Q+KCSv9UUdkp\nR57D6l6zC60sNqxqfHfo3SH0rUmxA+Z9qdPNpitlPdGU+tK6jR3Te7Dqmw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 472,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0221008ba4c3da7154ba564ab344ae12005aa482b6c1639ea191f8568afb6e47163c45",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04df79ee082b2fc77e9ce4633471f569bbcb5ce53856e3067774f37e8a64a2c7ffaa488a6c34d499df76f427de3609bfcfd9feae67ffe0b0de594463c453b0ab16",
+        "wx": "00df79ee082b2fc77e9ce4633471f569bbcb5ce53856e3067774f37e8a64a2c7ff",
+        "wy": "00aa488a6c34d499df76f427de3609bfcfd9feae67ffe0b0de594463c453b0ab16"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004df79ee082b2fc77e9ce4633471f569bbcb5ce53856e3067774f37e8a64a2c7ffaa488a6c34d499df76f427de3609bfcfd9feae67ffe0b0de594463c453b0ab16",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE33nuCCsvx36c5GM0cfVpu8tc5ThW\n4wZ3dPN+imSix/+qSIpsNNSZ33b0J942Cb/P2f6uZ//gsN5ZRGPEU7CrFg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 473,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02204c3dafcf4ba55bf1344ae12005aa4a74f46eaa85f5023131cc637ae2ea90ab26",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "044cc3bf65e32e00284adfca00f40df755415c485091ac0489ae9a337103a5f8f0123ab86dd433b933b4f2063c002144df3cfeba78dad0ed89c0377541532908c2",
+        "wx": "4cc3bf65e32e00284adfca00f40df755415c485091ac0489ae9a337103a5f8f0",
+        "wy": "123ab86dd433b933b4f2063c002144df3cfeba78dad0ed89c0377541532908c2"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200044cc3bf65e32e00284adfca00f40df755415c485091ac0489ae9a337103a5f8f0123ab86dd433b933b4f2063c002144df3cfeba78dad0ed89c0377541532908c2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETMO/ZeMuAChK38oA9A33VUFcSFCR\nrASJrpozcQOl+PASOrht1DO5M7TyBjwAIUTfPP66eNrQ7YnAN3VBUykIwg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 474,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100987b5f9e974ab7e26895c2400b5494e9e8dd550bea04626398c6f5c5d521564c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04264a7ad439a4828a9dc97ecf837155355f99ae0b65975f851b541ad3a0e032f067268b7298c73e581866fbcbd161689b16b81cf262e007ce68e25a28c83ef041",
+        "wx": "264a7ad439a4828a9dc97ecf837155355f99ae0b65975f851b541ad3a0e032f0",
+        "wy": "67268b7298c73e581866fbcbd161689b16b81cf262e007ce68e25a28c83ef041"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004264a7ad439a4828a9dc97ecf837155355f99ae0b65975f851b541ad3a0e032f067268b7298c73e581866fbcbd161689b16b81cf262e007ce68e25a28c83ef041",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJkp61DmkgoqdyX7Pg3FVNV+Zrgtl\nl1+FG1Qa06DgMvBnJotymMc+WBhm+8vRYWibFrgc8mLgB85o4looyD7wQQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 475,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100fcf97e2fbf0e80d412005aa4a75086a3f004f59d512cb47271798733ab418606",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "041d7ff4d3a41206c8143635f12876e0ea0875ea5e4a5a249250d0eda33daa211f56e89c0beaf910ac934ca12380455600d0fd85b56a7035cb171b3f1c72a15569",
+        "wx": "1d7ff4d3a41206c8143635f12876e0ea0875ea5e4a5a249250d0eda33daa211f",
+        "wy": "56e89c0beaf910ac934ca12380455600d0fd85b56a7035cb171b3f1c72a15569"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200041d7ff4d3a41206c8143635f12876e0ea0875ea5e4a5a249250d0eda33daa211f56e89c0beaf910ac934ca12380455600d0fd85b56a7035cb171b3f1c72a15569",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHX/006QSBsgUNjXxKHbg6gh16l5K\nWiSSUNDtoz2qIR9W6JwL6vkQrJNMoSOARVYA0P2FtWpwNcsXGz8ccqFVaQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 476,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022079d482b60864d6c5cb4fd5db9e7e28ccd9a5948c316c8740fb429c0f37169a02",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04b09685f338dceb421778a1458d52bed734c236242da2baa280d6f6b7b86e4f117fe6a34146b422d7aebd1a51b20948d7872a514c4cfd7686dc436b70733d6473",
+        "wx": "00b09685f338dceb421778a1458d52bed734c236242da2baa280d6f6b7b86e4f11",
+        "wy": "7fe6a34146b422d7aebd1a51b20948d7872a514c4cfd7686dc436b70733d6473"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004b09685f338dceb421778a1458d52bed734c236242da2baa280d6f6b7b86e4f117fe6a34146b422d7aebd1a51b20948d7872a514c4cfd7686dc436b70733d6473",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsJaF8zjc60IXeKFFjVK+1zTCNiQt\norqigNb2t7huTxF/5qNBRrQi1669GlGyCUjXhypRTEz9dobcQ2twcz1kcw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 477,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0221008ecd11081a4d0759c14f7bf46813d52cc6738115321be0a4da78a3356bb71510",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04dd811f2c0f5e9d4fbb2ef31818c1cd807247bc14fcd1170bef00e2c71dc037b443a15cdf8f3fbdc87e06250c0720d261d2b8d087fa7bf9548f6293f0ce5ae899",
+        "wx": "00dd811f2c0f5e9d4fbb2ef31818c1cd807247bc14fcd1170bef00e2c71dc037b4",
+        "wy": "43a15cdf8f3fbdc87e06250c0720d261d2b8d087fa7bf9548f6293f0ce5ae899"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004dd811f2c0f5e9d4fbb2ef31818c1cd807247bc14fcd1170bef00e2c71dc037b443a15cdf8f3fbdc87e06250c0720d261d2b8d087fa7bf9548f6293f0ce5ae899",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3YEfLA9enU+7LvMYGMHNgHJHvBT8\n0RcL7wDixx3AN7RDoVzfjz+9yH4GJQwHINJh0rjQh/p7+VSPYpPwzlromQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 478,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100e8dbffed13c9a2093085c079714f11f24eb583d73ba2b416b3169183e7d9b4c2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0469d60ae1f39e1da95809d408894707ad2134f4943a1db089bebf815a391f18db32b401d98bf894d3b6d59e6eb45573285642e358ad687b7d7bf9600b1987809e",
+        "wx": "69d60ae1f39e1da95809d408894707ad2134f4943a1db089bebf815a391f18db",
+        "wy": "32b401d98bf894d3b6d59e6eb45573285642e358ad687b7d7bf9600b1987809e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000469d60ae1f39e1da95809d408894707ad2134f4943a1db089bebf815a391f18db32b401d98bf894d3b6d59e6eb45573285642e358ad687b7d7bf9600b1987809e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEadYK4fOeHalYCdQIiUcHrSE09JQ6\nHbCJvr+BWjkfGNsytAHZi/iU07bVnm60VXMoVkLjWK1oe317+WALGYeAng==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 479,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100ca01552a838124bec68d6bc6086329e06673900eac5c262e5ce79a8521cd1eae",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a658553a0620c95e987b5c3163bcfea68c52065f53c9d553f2a924d8b3ed511f79f0dfec4536b65aa5fb31297e96f6b464aa669b9268b3156c43d4612978a577",
+        "wx": "00a658553a0620c95e987b5c3163bcfea68c52065f53c9d553f2a924d8b3ed511f",
+        "wy": "79f0dfec4536b65aa5fb31297e96f6b464aa669b9268b3156c43d4612978a577"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a658553a0620c95e987b5c3163bcfea68c52065f53c9d553f2a924d8b3ed511f79f0dfec4536b65aa5fb31297e96f6b464aa669b9268b3156c43d4612978a577",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEplhVOgYgyV6Ye1wxY7z+poxSBl9T\nydVT8qkk2LPtUR958N/sRTa2WqX7MSl+lva0ZKpmm5JosxVsQ9RhKXildw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 480,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0221009402aa560702497c8d1ad78c10c653c11000256fb1a0add7c6156a474737180b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04bc4d3354a6a973dd8088919cc181194e879ed7920db30d0d1278edf74413b7b92450d162b26dcb25fbbd53ea4044189981d737055925bd2e86bfb0374b09f3ca",
+        "wx": "00bc4d3354a6a973dd8088919cc181194e879ed7920db30d0d1278edf74413b7b9",
+        "wy": "2450d162b26dcb25fbbd53ea4044189981d737055925bd2e86bfb0374b09f3ca"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004bc4d3354a6a973dd8088919cc181194e879ed7920db30d0d1278edf74413b7b92450d162b26dcb25fbbd53ea4044189981d737055925bd2e86bfb0374b09f3ca",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvE0zVKapc92AiJGcwYEZToee15IN\nsw0NEnjt90QTt7kkUNFism3LJfu9U+pARBiZgdc3BVklvS6Gv7A3Swnzyg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 481,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02205e03ff818a836e3a53a8435219297da1b98cbad0b6e535812f433a096ca11168",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040eb628724fce764c687d874ade7b8e0aa4abf20ee6e3610fac9fe3e72f97ab5aed09f4843660eb1daf015d397a7c1073d7ae43bda0ba3e117008785abfffa00f",
+        "wx": "0eb628724fce764c687d874ade7b8e0aa4abf20ee6e3610fac9fe3e72f97ab5a",
+        "wy": "00ed09f4843660eb1daf015d397a7c1073d7ae43bda0ba3e117008785abfffa00f"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040eb628724fce764c687d874ade7b8e0aa4abf20ee6e3610fac9fe3e72f97ab5aed09f4843660eb1daf015d397a7c1073d7ae43bda0ba3e117008785abfffa00f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDrYock/OdkxofYdK3nuOCqSr8g7m\n42EPrJ/j5y+Xq1rtCfSENmDrHa8BXTl6fBBz165DvaC6PhFwCHhav/+gDw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 482,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100e28ddf709d4aa1bddf2e4bc7c7f2cb516cb642bb3e39c3feaf2fcf16ab9539f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04e7ac5cc7f296912f703f59fe88e49b521da245e12e6eee161ee6b3b1127611a77b3bedd2a773cf58b0629b936dd85dad2d0c39676306ed63e1a9bcd0e08bccc2",
+        "wx": "00e7ac5cc7f296912f703f59fe88e49b521da245e12e6eee161ee6b3b1127611a7",
+        "wy": "7b3bedd2a773cf58b0629b936dd85dad2d0c39676306ed63e1a9bcd0e08bccc2"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004e7ac5cc7f296912f703f59fe88e49b521da245e12e6eee161ee6b3b1127611a77b3bedd2a773cf58b0629b936dd85dad2d0c39676306ed63e1a9bcd0e08bccc2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE56xcx/KWkS9wP1n+iOSbUh2iReEu\nbu4WHuazsRJ2Ead7O+3Sp3PPWLBim5Nt2F2tLQw5Z2MG7WPhqbzQ4IvMwg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 483,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02207fffffffaaaaaaaaffffffffffffffffe9a2538f37b28a2c513dee40fecbb71a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042407b60abf3ee5edaf92ed505a11d0ddce0ea33eca58a031bb2f162c512f4062fb81bff36bf967e834e3d5d468730dcd70440022ab60061a62fac53350fe259f",
+        "wx": "2407b60abf3ee5edaf92ed505a11d0ddce0ea33eca58a031bb2f162c512f4062",
+        "wy": "00fb81bff36bf967e834e3d5d468730dcd70440022ab60061a62fac53350fe259f"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042407b60abf3ee5edaf92ed505a11d0ddce0ea33eca58a031bb2f162c512f4062fb81bff36bf967e834e3d5d468730dcd70440022ab60061a62fac53350fe259f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJAe2Cr8+5e2vku1QWhHQ3c4Ooz7K\nWKAxuy8WLFEvQGL7gb/za/ln6DTj1dRocw3NcEQAIqtgBhpi+sUzUP4lnw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 484,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100b62f26b5f2a2b26f6de86d42ad8a13da3ab3cccd0459b201de009e526adf21f2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0447b2ad96dfc2f23fe5926809f38042b2c801962bd7394cefbf4aacb2554b7b0bdf2b937a16a7d96a2a0682cd164428890208597f2cdcc734fda73600b5cf6c59",
+        "wx": "47b2ad96dfc2f23fe5926809f38042b2c801962bd7394cefbf4aacb2554b7b0b",
+        "wy": "00df2b937a16a7d96a2a0682cd164428890208597f2cdcc734fda73600b5cf6c59"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000447b2ad96dfc2f23fe5926809f38042b2c801962bd7394cefbf4aacb2554b7b0bdf2b937a16a7d96a2a0682cd164428890208597f2cdcc734fda73600b5cf6c59",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAER7Ktlt/C8j/lkmgJ84BCssgBlivX\nOUzvv0qsslVLewvfK5N6FqfZaioGgs0WRCiJAghZfyzcxzT9pzYAtc9sWQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 485,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bb1d9ac949dd748cd02bbbe749bd351cd57b38bb61403d700686aa7b4c90851e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0469a65b75f31ae7b4930292f90902461befcee5d1606939c28e01b652a7fbc498cf68619e5860128f56cecf53eba2ffe82889a9bb04a5fa4c8b722bc91d55978a",
+        "wx": "69a65b75f31ae7b4930292f90902461befcee5d1606939c28e01b652a7fbc498",
+        "wy": "00cf68619e5860128f56cecf53eba2ffe82889a9bb04a5fa4c8b722bc91d55978a"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000469a65b75f31ae7b4930292f90902461befcee5d1606939c28e01b652a7fbc498cf68619e5860128f56cecf53eba2ffe82889a9bb04a5fa4c8b722bc91d55978a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaaZbdfMa57STApL5CQJGG+/O5dFg\naTnCjgG2Uqf7xJjPaGGeWGASj1bOz1Prov/oKImpuwSl+kyLcivJHVWXig==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 486,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022066755a00638cdaec1c732513ca0234ece52545dac11f816e818f725b4f60aaf2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04b2037176c84db04a6c773e32f9ed1d6b25ef4c303c6725c6932ec2cc2788bcbb9361505e6b771691adb41598f292d6521722404bf183241b195738b77abd6cfe",
+        "wx": "00b2037176c84db04a6c773e32f9ed1d6b25ef4c303c6725c6932ec2cc2788bcbb",
+        "wy": "009361505e6b771691adb41598f292d6521722404bf183241b195738b77abd6cfe"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004b2037176c84db04a6c773e32f9ed1d6b25ef4c303c6725c6932ec2cc2788bcbb9361505e6b771691adb41598f292d6521722404bf183241b195738b77abd6cfe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsgNxdshNsEpsdz4y+e0dayXvTDA8\nZyXGky7CzCeIvLuTYVBea3cWka20FZjyktZSFyJAS/GDJBsZVzi3er1s/g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 487,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022055a00c9fcdaebb6032513ca0234ecfffe98ebe492fdf02e48ca48e982beb3669",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "041eef95aef71f793afd50bb2604064d63e88bef7404a4d0e206446245ae2e7834c96e86dd040f9794b63712d90e719576b8b92c406ab0f288ad9b327bd124454f",
+        "wx": "1eef95aef71f793afd50bb2604064d63e88bef7404a4d0e206446245ae2e7834",
+        "wy": "00c96e86dd040f9794b63712d90e719576b8b92c406ab0f288ad9b327bd124454f"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200041eef95aef71f793afd50bb2604064d63e88bef7404a4d0e206446245ae2e7834c96e86dd040f9794b63712d90e719576b8b92c406ab0f288ad9b327bd124454f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHu+VrvcfeTr9ULsmBAZNY+iL73QE\npNDiBkRiRa4ueDTJbobdBA+XlLY3EtkOcZV2uLksQGqw8oitmzJ70SRFTw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 488,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100ab40193f9b5d76c064a27940469d9fffd31d7c925fbe05c919491d3057d66cd2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a9734899c954e5b7adbca8f783428b5fbcbdfd3d2813f8d2f95b31a78ab107567667abf8c02ce4951bc59b2564130c27d7b64cdbc5cad95ca42d5bbb7cd4e793",
+        "wx": "00a9734899c954e5b7adbca8f783428b5fbcbdfd3d2813f8d2f95b31a78ab10756",
+        "wy": "7667abf8c02ce4951bc59b2564130c27d7b64cdbc5cad95ca42d5bbb7cd4e793"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a9734899c954e5b7adbca8f783428b5fbcbdfd3d2813f8d2f95b31a78ab107567667abf8c02ce4951bc59b2564130c27d7b64cdbc5cad95ca42d5bbb7cd4e793",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqXNImclU5betvKj3g0KLX7y9/T0o\nE/jS+Vsxp4qxB1Z2Z6v4wCzklRvFmyVkEwwn17ZM28XK2VykLVu7fNTnkw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 489,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100ca0234ebb5fdcb13ca0234ecffffffffcb0dadbbc7f549f8a26b4408d0dc8600",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "041ae51662331a1dbfab0751d30dfab2273a04a239e055a537b16ab595f9612396434f21c2bfe6555c9fc4a8e82dab1fa5631881b016e0831d9e1bbf5799fcf32e",
+        "wx": "1ae51662331a1dbfab0751d30dfab2273a04a239e055a537b16ab595f9612396",
+        "wy": "434f21c2bfe6555c9fc4a8e82dab1fa5631881b016e0831d9e1bbf5799fcf32e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200041ae51662331a1dbfab0751d30dfab2273a04a239e055a537b16ab595f9612396434f21c2bfe6555c9fc4a8e82dab1fa5631881b016e0831d9e1bbf5799fcf32e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGuUWYjMaHb+rB1HTDfqyJzoEojng\nVaU3sWq1lflhI5ZDTyHCv+ZVXJ/EqOgtqx+lYxiBsBbggx2eG79XmfzzLg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 490,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff3ea3677e082b9310572620ae19933a9e65b285598711c77298815ad3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0453c90cdd8b0dadd21c44ad557b327f4dbf57144aaf06597deb3f94125206a6c14603475bd79b30e36340cd09b0b59e6cd46ce90150e9ffe5c8a0172b2c9898e3",
+        "wx": "53c90cdd8b0dadd21c44ad557b327f4dbf57144aaf06597deb3f94125206a6c1",
+        "wy": "4603475bd79b30e36340cd09b0b59e6cd46ce90150e9ffe5c8a0172b2c9898e3"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000453c90cdd8b0dadd21c44ad557b327f4dbf57144aaf06597deb3f94125206a6c14603475bd79b30e36340cd09b0b59e6cd46ce90150e9ffe5c8a0172b2c9898e3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEU8kM3YsNrdIcRK1VezJ/Tb9XFEqv\nBll96z+UElIGpsFGA0db15sw42NAzQmwtZ5s1GzpAVDp/+XIoBcrLJiY4w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 491,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220266666663bbbbbbbe6666666666666665b37902e023fab7c8f055d86e5cc41f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0433797539515c51f429967b8e36930d9fdda1edb13aecec9771f7cde5f6f2e74eba51d0b6456bb902dba1f3ea436f96ad2355da454dc9b32c503c4bc6cfd6d410",
+        "wx": "33797539515c51f429967b8e36930d9fdda1edb13aecec9771f7cde5f6f2e74e",
+        "wy": "00ba51d0b6456bb902dba1f3ea436f96ad2355da454dc9b32c503c4bc6cfd6d410"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000433797539515c51f429967b8e36930d9fdda1edb13aecec9771f7cde5f6f2e74eba51d0b6456bb902dba1f3ea436f96ad2355da454dc9b32c503c4bc6cfd6d410",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM3l1OVFcUfQplnuONpMNn92h7bE6\n7OyXcffN5fby5066UdC2RWu5Atuh8+pDb5atI1XaRU3JsyxQPEvGz9bUEA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 492,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff36db6db7a492492492492492146c573f4c6dfc8d08a443e258970b09",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040a8f5f1d5bbd2783fa7f37c86879057fb2fcf25383aafb86d03d6bafb41a17b3eaf6da715fe950349fd5736117b08e15e32cf1d2fdc003e510009f1b4ba1e648",
+        "wx": "0a8f5f1d5bbd2783fa7f37c86879057fb2fcf25383aafb86d03d6bafb41a17b3",
+        "wy": "00eaf6da715fe950349fd5736117b08e15e32cf1d2fdc003e510009f1b4ba1e648"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040a8f5f1d5bbd2783fa7f37c86879057fb2fcf25383aafb86d03d6bafb41a17b3eaf6da715fe950349fd5736117b08e15e32cf1d2fdc003e510009f1b4ba1e648",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECo9fHVu9J4P6fzfIaHkFf7L88lOD\nqvuG0D1rr7QaF7Pq9tpxX+lQNJ/Vc2EXsI4V4yzx0v3AA+UQAJ8bS6HmSA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 493,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff2aaaaaab7fffffffffffffffc815d0e60b3e596ecb1ad3a27cfd49c4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "041dbc94e96c056b9d2cb6773bb24b69ed473851badf927a29955aff290ef3675a65e587561122aa8226facb95df08308cadf01c8351a1569176d917821113aa7c",
+        "wx": "1dbc94e96c056b9d2cb6773bb24b69ed473851badf927a29955aff290ef3675a",
+        "wy": "65e587561122aa8226facb95df08308cadf01c8351a1569176d917821113aa7c"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200041dbc94e96c056b9d2cb6773bb24b69ed473851badf927a29955aff290ef3675a65e587561122aa8226facb95df08308cadf01c8351a1569176d917821113aa7c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHbyU6WwFa50stnc7sktp7Uc4Ubrf\nknoplVr/KQ7zZ1pl5YdWESKqgib6y5XfCDCMrfAcg1GhVpF22ReCEROqfA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 494,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02207fffffff55555555ffffffffffffffffd344a71e6f651458a27bdc81fd976e37",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04084ab885dbff7f12e6cdadb59d456e500797779425c7518c259c83718289e6e991c345d3a093e86670605bbc2ff4c69d0ed694fd433ec6b6ba1bf7d56c3e6b51",
+        "wx": "084ab885dbff7f12e6cdadb59d456e500797779425c7518c259c83718289e6e9",
+        "wy": "0091c345d3a093e86670605bbc2ff4c69d0ed694fd433ec6b6ba1bf7d56c3e6b51"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004084ab885dbff7f12e6cdadb59d456e500797779425c7518c259c83718289e6e991c345d3a093e86670605bbc2ff4c69d0ed694fd433ec6b6ba1bf7d56c3e6b51",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECEq4hdv/fxLmza21nUVuUAeXd5Ql\nx1GMJZyDcYKJ5umRw0XToJPoZnBgW7wv9MadDtaU/UM+xra6G/fVbD5rUQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 495,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02203fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192aa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04003adfa4c620a207096cd18ee8fd2a90e20106cf824a0c63d6dec727a9fe7f509430d26bdd5f71e819d12b70069901461ae083cc809122d4fb86b5c475244e5a",
+        "wx": "3adfa4c620a207096cd18ee8fd2a90e20106cf824a0c63d6dec727a9fe7f50",
+        "wy": "009430d26bdd5f71e819d12b70069901461ae083cc809122d4fb86b5c475244e5a"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004003adfa4c620a207096cd18ee8fd2a90e20106cf824a0c63d6dec727a9fe7f509430d26bdd5f71e819d12b70069901461ae083cc809122d4fb86b5c475244e5a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADrfpMYgogcJbNGO6P0qkOIBBs+C\nSgxj1t7HJ6n+f1CUMNJr3V9x6BnRK3AGmQFGGuCDzICRItT7hrXEdSROWg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 496,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02205d8ecd64a4eeba466815ddf3a4de9a8e6abd9c5db0a01eb80343553da648428f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "047c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c58848d5ca99b350bd7d10ab5ee6fcfe46623fdc03e9f828158f4d4cc08ad1ff83de4",
+        "wx": "7c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c5884",
+        "wy": "008d5ca99b350bd7d10ab5ee6fcfe46623fdc03e9f828158f4d4cc08ad1ff83de4"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200047c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c58848d5ca99b350bd7d10ab5ee6fcfe46623fdc03e9f828158f4d4cc08ad1ff83de4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfJiy1H60M8DRjlM8+8iQnWb3t51Z\nJcyxfszsnRBcWISNXKmbNQvX0Qq17m/P5GYj/cA+n4KBWPTUzAitH/g95A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 497,
+          "comment": "point duplication during verification",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100b4cfa1996ec1d24cdbc8fa17fcabc3a5d4b2b36cf4b50a7b775ab78785710746",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "047c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c588472a35663caf4282ff54a1190301b99dc023fc1617d7ea70b2b33f752e007c21b",
+        "wx": "7c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c5884",
+        "wy": "72a35663caf4282ff54a1190301b99dc023fc1617d7ea70b2b33f752e007c21b"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200047c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c588472a35663caf4282ff54a1190301b99dc023fc1617d7ea70b2b33f752e007c21b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfJiy1H60M8DRjlM8+8iQnWb3t51Z\nJcyxfszsnRBcWIRyo1ZjyvQoL/VKEZAwG5ncAj/BYX1+pwsrM/dS4AfCGw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 498,
+          "comment": "duplication bug",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100b4cfa1996ec1d24cdbc8fa17fcabc3a5d4b2b36cf4b50a7b775ab78785710746",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04b7a90e21e7547d73267940033cea05042c50f7c9fa5eaeb471cd6260c685f2e38bb7309d0c3bab249faaf3e44179d6dd5302375c580fd0570a788c6be3680c67",
+        "wx": "00b7a90e21e7547d73267940033cea05042c50f7c9fa5eaeb471cd6260c685f2e3",
+        "wy": "008bb7309d0c3bab249faaf3e44179d6dd5302375c580fd0570a788c6be3680c67"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004b7a90e21e7547d73267940033cea05042c50f7c9fa5eaeb471cd6260c685f2e38bb7309d0c3bab249faaf3e44179d6dd5302375c580fd0570a788c6be3680c67",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEt6kOIedUfXMmeUADPOoFBCxQ98n6\nXq60cc1iYMaF8uOLtzCdDDurJJ+q8+RBedbdUwI3XFgP0FcKeIxr42gMZw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 499,
+          "comment": "point with x-coordinate 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30250201010220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "041550a173373b2d594374f0642cd73de06a045c09c7a4f388c731e8cd8971adfc9a3a9843583a86c0e1c62cbde67165f40a926b1028ba38aa3895e188ebbc7066",
+        "wx": "1550a173373b2d594374f0642cd73de06a045c09c7a4f388c731e8cd8971adfc",
+        "wy": "009a3a9843583a86c0e1c62cbde67165f40a926b1028ba38aa3895e188ebbc7066"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200041550a173373b2d594374f0642cd73de06a045c09c7a4f388c731e8cd8971adfc9a3a9843583a86c0e1c62cbde67165f40a926b1028ba38aa3895e188ebbc7066",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFVChczc7LVlDdPBkLNc94GoEXAnH\npPOIxzHozYlxrfyaOphDWDqGwOHGLL3mcWX0CpJrECi6OKo4leGI67xwZg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 500,
+          "comment": "point with x-coordinate 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022101000000000000000000000000000000000000000000000000000000000000000002203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aa9",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04313447778195daa1791a6530cd0697ae34bf9d8d225984394f72eef3505971110996a8fbdd1a70ecd64cb00b595afe1669bfef80d91756a62d84c1d83e0f22ab",
+        "wx": "313447778195daa1791a6530cd0697ae34bf9d8d225984394f72eef350597111",
+        "wy": "0996a8fbdd1a70ecd64cb00b595afe1669bfef80d91756a62d84c1d83e0f22ab"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004313447778195daa1791a6530cd0697ae34bf9d8d225984394f72eef3505971110996a8fbdd1a70ecd64cb00b595afe1669bfef80d91756a62d84c1d83e0f22ab",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMTRHd4GV2qF5GmUwzQaXrjS/nY0i\nWYQ5T3Lu81BZcREJlqj73Rpw7NZMsAtZWv4Wab/vgNkXVqYthMHYPg8iqw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 501,
+          "comment": "comparison with point at infinity ",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aa9",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "044ada634941476ca63c2c5803eec2f33b2d17920f798a5be6275f5a54cd2e7639b1a04bead5c7314c427492db21b9544d81caa8159587e41aa023aa967f31aaa1",
+        "wx": "4ada634941476ca63c2c5803eec2f33b2d17920f798a5be6275f5a54cd2e7639",
+        "wy": "00b1a04bead5c7314c427492db21b9544d81caa8159587e41aa023aa967f31aaa1"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200044ada634941476ca63c2c5803eec2f33b2d17920f798a5be6275f5a54cd2e7639b1a04bead5c7314c427492db21b9544d81caa8159587e41aa023aa967f31aaa1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEStpjSUFHbKY8LFgD7sLzOy0Xkg95\nilvmJ19aVM0udjmxoEvq1ccxTEJ0ktshuVRNgcqoFZWH5BqgI6qWfzGqoQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 502,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc476699780220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04aacce093270fa59ad412b5459a08e490743b97086c781ac3c8d54030b41a31193bece4956172d56befb7011d684e772905e48d2115444a75ac7a325a3f25f4b1",
+        "wx": "00aacce093270fa59ad412b5459a08e490743b97086c781ac3c8d54030b41a3119",
+        "wy": "3bece4956172d56befb7011d684e772905e48d2115444a75ac7a325a3f25f4b1"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004aacce093270fa59ad412b5459a08e490743b97086c781ac3c8d54030b41a31193bece4956172d56befb7011d684e772905e48d2115444a75ac7a325a3f25f4b1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqszgkycPpZrUErVFmgjkkHQ7lwhs\neBrDyNVAMLQaMRk77OSVYXLVa++3AR1oTncpBeSNIRVESnWsejJaPyX0sQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 503,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022100b6db6db6249249254924924924924924625bd7a09bec4ca81bcdd9f8fd6b63cc",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04f62b8d7feeff5a847ab79212269e55e62fa87ebe930821747b57a511a5ea99f0439ee057bb27898582a683c3fdb7f95404d41d42f276803751a316eb3aab7ebf",
+        "wx": "00f62b8d7feeff5a847ab79212269e55e62fa87ebe930821747b57a511a5ea99f0",
+        "wy": "439ee057bb27898582a683c3fdb7f95404d41d42f276803751a316eb3aab7ebf"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004f62b8d7feeff5a847ab79212269e55e62fa87ebe930821747b57a511a5ea99f0439ee057bb27898582a683c3fdb7f95404d41d42f276803751a316eb3aab7ebf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9iuNf+7/WoR6t5ISJp5V5i+ofr6T\nCCF0e1elEaXqmfBDnuBXuyeJhYKmg8P9t/lUBNQdQvJ2gDdRoxbrOqt+vw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 504,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022100cccccccc00000000cccccccccccccccc971f2ef152794b9d8fc7d568c9e8eaa7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "044baa07ff6e7bb9aa223d1c61932005fe98fe78b787fdab4bd3619bc8833072a2bcacd63802c56af82607953e72a0f5d3c23bd265544e020951824ea485555d33",
+        "wx": "4baa07ff6e7bb9aa223d1c61932005fe98fe78b787fdab4bd3619bc8833072a2",
+        "wy": "00bcacd63802c56af82607953e72a0f5d3c23bd265544e020951824ea485555d33"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200044baa07ff6e7bb9aa223d1c61932005fe98fe78b787fdab4bd3619bc8833072a2bcacd63802c56af82607953e72a0f5d3c23bd265544e020951824ea485555d33",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES6oH/257uaoiPRxhkyAF/pj+eLeH\n/atL02GbyIMwcqK8rNY4AsVq+CYHlT5yoPXTwjvSZVROAglRgk6khVVdMw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 505,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997802203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aaa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040c753ed1ba92f766800fdd0ae1c0d7f8f4cd8305fd803d8bca881397b5937e2db568509b1faf3cf251de6db9810e8b8caed235da10eeddbed62775c8e5c9460a",
+        "wx": "0c753ed1ba92f766800fdd0ae1c0d7f8f4cd8305fd803d8bca881397b5937e2d",
+        "wy": "00b568509b1faf3cf251de6db9810e8b8caed235da10eeddbed62775c8e5c9460a"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040c753ed1ba92f766800fdd0ae1c0d7f8f4cd8305fd803d8bca881397b5937e2db568509b1faf3cf251de6db9810e8b8caed235da10eeddbed62775c8e5c9460a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDHU+0bqS92aAD90K4cDX+PTNgwX9\ngD2LyogTl7WTfi21aFCbH6888lHebbmBDouMrtI12hDu3b7WJ3XI5clGCg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 506,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022049249248db6db6dbb6db6db6db6db6db5a8b230d0b2b51dcd7ebf0c9fef7c185",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04030fdcae6541f22c5bab254e4f1a285c507d1cefea03bf90cf19daf3cb62df695ff2c94d588f2c2b2b0a12bebc011bcee4fa1b54506ec07d0a29d24a0891193c",
+        "wx": "030fdcae6541f22c5bab254e4f1a285c507d1cefea03bf90cf19daf3cb62df69",
+        "wy": "5ff2c94d588f2c2b2b0a12bebc011bcee4fa1b54506ec07d0a29d24a0891193c"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004030fdcae6541f22c5bab254e4f1a285c507d1cefea03bf90cf19daf3cb62df695ff2c94d588f2c2b2b0a12bebc011bcee4fa1b54506ec07d0a29d24a0891193c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAw/crmVB8ixbqyVOTxooXFB9HO/q\nA7+Qzxna88ti32lf8slNWI8sKysKEr68ARvO5PobVFBuwH0KKdJKCJEZPA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 507,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022016a4502e2781e11ac82cbc9d1edd8c981584d13e18411e2f6e0478c34416e3bb",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0403fc621eaf90c23d8f9fa125d2c59b8728ebccb30ca3e3db879a06ca90f20cdcae58d3f0c6aef0e805be10ea54e23cf6f0397f9addddc2b09088855316b0ef44",
+        "wx": "03fc621eaf90c23d8f9fa125d2c59b8728ebccb30ca3e3db879a06ca90f20cdc",
+        "wy": "00ae58d3f0c6aef0e805be10ea54e23cf6f0397f9addddc2b09088855316b0ef44"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000403fc621eaf90c23d8f9fa125d2c59b8728ebccb30ca3e3db879a06ca90f20cdcae58d3f0c6aef0e805be10ea54e23cf6f0397f9addddc2b09088855316b0ef44",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEA/xiHq+Qwj2Pn6El0sWbhyjrzLMM\no+Pbh5oGypDyDNyuWNPwxq7w6AW+EOpU4jz28Dl/mt3dwrCQiIVTFrDvRA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 508,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2960220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0470f2ce24dc62923bb09cc92d74329bbd0d2e6b0e354c0be2383d24acdccb9e4cd42d1f973466f5e5462a939084a294ebfc7a45629c70ee5def46de9536ea7bf7",
+        "wx": "70f2ce24dc62923bb09cc92d74329bbd0d2e6b0e354c0be2383d24acdccb9e4c",
+        "wy": "00d42d1f973466f5e5462a939084a294ebfc7a45629c70ee5def46de9536ea7bf7"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000470f2ce24dc62923bb09cc92d74329bbd0d2e6b0e354c0be2383d24acdccb9e4cd42d1f973466f5e5462a939084a294ebfc7a45629c70ee5def46de9536ea7bf7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcPLOJNxikjuwnMktdDKbvQ0uaw41\nTAviOD0krNzLnkzULR+XNGb15UYqk5CEopTr/HpFYpxw7l3vRt6VNup79w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 509,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022100b6db6db6249249254924924924924924625bd7a09bec4ca81bcdd9f8fd6b63cc",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04732b8ac0c30fe44307431235271cb5d6e5f677a19ce3f058b939a7bf19349d3c858cc735af8577468275847cf5ec19972e6c20738276e2708b23c595bfc4433d",
+        "wx": "732b8ac0c30fe44307431235271cb5d6e5f677a19ce3f058b939a7bf19349d3c",
+        "wy": "00858cc735af8577468275847cf5ec19972e6c20738276e2708b23c595bfc4433d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004732b8ac0c30fe44307431235271cb5d6e5f677a19ce3f058b939a7bf19349d3c858cc735af8577468275847cf5ec19972e6c20738276e2708b23c595bfc4433d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcyuKwMMP5EMHQxI1Jxy11uX2d6Gc\n4/BYuTmnvxk0nTyFjMc1r4V3RoJ1hHz17BmXLmwgc4J24nCLI8WVv8RDPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 510,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022100cccccccc00000000cccccccccccccccc971f2ef152794b9d8fc7d568c9e8eaa7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0447aff9501825a166782bb58a5b459006eacdbce5e5323addad34ec1b6444cdce9199c31502ad4277c73ddd0c807b72634c45762404837d9814a5d4b5a7c3f398",
+        "wx": "47aff9501825a166782bb58a5b459006eacdbce5e5323addad34ec1b6444cdce",
+        "wy": "009199c31502ad4277c73ddd0c807b72634c45762404837d9814a5d4b5a7c3f398"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000447aff9501825a166782bb58a5b459006eacdbce5e5323addad34ec1b6444cdce9199c31502ad4277c73ddd0c807b72634c45762404837d9814a5d4b5a7c3f398",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAER6/5UBgloWZ4K7WKW0WQBurNvOXl\nMjrdrTTsG2REzc6RmcMVAq1Cd8c93QyAe3JjTEV2JASDfZgUpdS1p8PzmA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 511,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c29602203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aaa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04aed8eeff77644bf83b9222f8f57173fa8217ec7e0763ee7d7171fb6092fba5c06486a86d94f48834ba5adbaf349687f9cee400389642b828e68207b147ca2c46",
+        "wx": "00aed8eeff77644bf83b9222f8f57173fa8217ec7e0763ee7d7171fb6092fba5c0",
+        "wy": "6486a86d94f48834ba5adbaf349687f9cee400389642b828e68207b147ca2c46"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004aed8eeff77644bf83b9222f8f57173fa8217ec7e0763ee7d7171fb6092fba5c06486a86d94f48834ba5adbaf349687f9cee400389642b828e68207b147ca2c46",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErtju/3dkS/g7kiL49XFz+oIX7H4H\nY+59cXH7YJL7pcBkhqhtlPSINLpa2680lof5zuQAOJZCuCjmggexR8osRg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 512,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022049249248db6db6dbb6db6db6db6db6db5a8b230d0b2b51dcd7ebf0c9fef7c185",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04f7c54a585a904300d05b53ef3b854e71999a344b89adc0caaa28e254db9bc7c7c161a79f38ff446051303577e40638fb020329940a63c241bb32c2205eb57b7d",
+        "wx": "00f7c54a585a904300d05b53ef3b854e71999a344b89adc0caaa28e254db9bc7c7",
+        "wy": "00c161a79f38ff446051303577e40638fb020329940a63c241bb32c2205eb57b7d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004f7c54a585a904300d05b53ef3b854e71999a344b89adc0caaa28e254db9bc7c7c161a79f38ff446051303577e40638fb020329940a63c241bb32c2205eb57b7d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE98VKWFqQQwDQW1PvO4VOcZmaNEuJ\nrcDKqijiVNubx8fBYaefOP9EYFEwNXfkBjj7AgMplApjwkG7MsIgXrV7fQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 513,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022016a4502e2781e11ac82cbc9d1edd8c981584d13e18411e2f6e0478c34416e3bb",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+        "wx": "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
+        "wy": "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpZP40Li/hp/m47n60p8D54WK84zV2sxXs7LtkBoN79R9Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 514,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b0232102810220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 515,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100bc07ff031506dc74a75086a43252fb43731975a16dca6b025e867412d94222d00220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a",
+        "wx": "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
+        "wy": "00b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpawHL0cAeWAZXEYFLWD8GHp1DHMqZTOoTE0Sb+XyECuCg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 516,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b0232102810220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
+          "result": "invalid"
+        },
+        {
+          "tcId": 517,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100bc07ff031506dc74a75086a43252fb43731975a16dca6b025e867412d94222d00220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "044f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685",
+        "wx": "4f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000",
+        "wy": "00ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200044f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETzN8z9Z3JqgF5PFgCuKEnfOAfsoR\nc4Ajn72BaQAAAADtneoSTMjDlkFkEemIww9CfrUEr0OjFGzV336mBmbWhQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 518,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30440220554482404173a5582884b0d168a32ef8033d7eb780936c390e8eedf720c7f56402200a15413f9ed0d454b92ab901119e7251a4d444ba1421ba639fa57e0d8cf6b313",
+          "result": "valid"
+        },
+        {
+          "tcId": 519,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502200b1d838dd54a462745e2c8d5f32637f26fb16dde20a385e45f8a20a8a1f8370e022100ae855e0a10ef087075fda0ed84e2bc5786a681172ea9834e53351316df332bbd",
+          "result": "valid"
+        },
+        {
+          "tcId": 520,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100af89e4f2b03e5d1f0352e258ef71493040c17d70c36cfd044128302df2ed5e4a0220420f04148c3e6f06561bd448362d6c6fa3f9aeeb7e42843b4674e7ddfd0ba901",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f49726500493584fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000",
+        "wx": "3cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f497265004935",
+        "wy": "0084fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f49726500493584fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTWE+hdNeRxyvyzjiAqJYN0qfHoTOKgvhanlnNvegAAAAA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 521,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402206c1581f1485ccc4e657606fa1a38cf227e3870dc9f41e26b84e28483635e321b02201b3e3c22af23e919b30330f8710f6ef3760c0e2237a9a9f5cf30a1d9f5bbd464",
+          "result": "valid"
+        },
+        {
+          "tcId": 522,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100dc83bf97ca28db0e04104a16fe3de694311a6cd9f230a300504ae71d8ec755b1022064a83af0ab3e6037003a1f4240dffd8a342afdee50604ed1afa416fd009e4668",
+          "result": "valid"
+        },
+        {
+          "tcId": 523,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450220575b70b4375684291b95d81e3c820ed9bde9e5b7343036e4951f3c46894a6d9d022100f10d716efbfeba953701b603fc9ef6ff6e47edef38c9eeef2d55e6486bc4d6e6",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f4972650049357b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff",
+        "wx": "3cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f497265004935",
+        "wy": "7b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f4972650049357b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTV7BeixhuONQdMcd/V2nyLVg4XsyFfQelYaYyQhf////w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 524,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450221008d4f113189dfd3d3239e331f76d3fca9cef86fcd5dc9b4ab2ca38aeba56c178b022078389c3cf11dcff6d6c7f5efd277d480060691144b568a6f090c8902557bfc61",
+          "result": "valid"
+        },
+        {
+          "tcId": 525,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100834d10ec2d2d50eeebfecd6328f03fafbb488fc043c362cbc67880ec0ebd04b302210094c026feaf6e68759146fe5b6fd52eaa3c3c5552d83719d2cb900615e2a634db",
+          "result": "valid"
+        },
+        {
+          "tcId": 526,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502206894de495e7bb5566807d475d96a0d414a94f4f02c3ab7c2edc2916deafc1e1f022100a603642c20fabc07182867fcc6923d35be23ad3f97a5f93c6ec5b9cce8239569",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "042829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffffa01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e",
+        "wx": "2829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffff",
+        "wy": "00a01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200042829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffffa01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKCnDH6ouQA40TtlLyj/NBUWVbrz+\nitD236X/jv////+gGq+vAA5SWFhVr6dnat4oQRMJkFLfV+frO9N+vrkiLg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 527,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100e500c086fedd59e090ce7bfb615751ed9abe4c09b839ee8f05320245b9796f3e022100807b1d0638c86ef6113fff0d63497800e1b848b5a303a54c748e45ca8f35d7d7",
+          "result": "valid"
+        },
+        {
+          "tcId": 528,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100b922c1abe1a8309c0acf90e586c6de8c33e37057673390a97ff098f71680b32b022100f86d92b051b7923d82555c205e21b54eab869766c716209648c3e6cc2629057d",
+          "result": "valid"
+        },
+        {
+          "tcId": 529,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100823c37e46c74ec8497d89245fde3bf53ddb462c00d840e983dcb1b72bbf8bf27022100c4552f2425d14f0f0fa988778403d60a58962e7c548715af83b2edabbb24a49f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f55a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73",
+        "wx": "00fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f5",
+        "wy": "5a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f55a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE////+UgIHmoEWN2PnnOPJmX/kFmt\naqwHCDGMTKmnpPVairy6LdqEdDEe5UFJuXPK4MD7iVV60L945lKaFmO9cw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 530,
+          "comment": "x-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450220577a08a95db6dcda9985109942d3786630f640190f920b95bd4d5d84e0f163ef022100d762286e92925973fd38b67ef944a99c0ec5b499b7175cbb4369e053c1fcbb10",
+          "result": "valid"
+        },
+        {
+          "tcId": 531,
+          "comment": "x-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402207ba458cfe952326922c7aa2854bdc673ce3daaf65d464dfb9f700701503056b102200df8821c92d20546fa741fb426bf56728a53182691964225c9b380b56b22ee6d",
+          "result": "valid"
+        },
+        {
+          "tcId": 532,
+          "comment": "x-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402205cd60c3b021b4be116f06f1d447f65e458329a8bbae1d9b5977d18cf5618486102204c635cd7aa9aebb5716d5ae09e57f8c481a741a029b40f71ec47344ef883e86e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0400000003fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71",
+        "wx": "03fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e",
+        "wy": "1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000003fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAAAAA/oV+WOUnV8DpvXH+G+eABXu\nsjrrv/EXOTe6dI4QmYcgcOjofFVfoTZZzKXX+tz8sAI+qIlUjKSK8rp+cQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 533,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402204b50e1e8cf830e04c17e7472caf60da8150ffa568e2c64498cc972a379e542e502202e3adaa5afab89cca91693609555f40543578852cde29c21cb037c0c0b78478e",
+          "result": "valid"
+        },
+        {
+          "tcId": 534,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402205aea930c7d8fffcd5c6df2c9430ef76f8b5ed58a8b9c95847288abf8f09a1ac202207ddfef7688a6053ce4eeeeefd6f1a9d71381b7548925f6682aa0a9d05cf5a3a3",
+          "result": "valid"
+        },
+        {
+          "tcId": 535,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304602210098b092c2d14b5b14a23e9368e0ce1be744dfae9f9a5cdaba51e7872099df96f202210090d3e4f87bd7bc94589f8150b6b01045cd8759a00af78b24d7de771887610df5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015000000001352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2",
+        "wx": "00bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
+        "wy": "1352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015000000001352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BUAAAAAE1K7Sg+i6kzOuatj3WhK3loRJ7zzAKaYpxk7wg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 536,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30460221009e95f2856a9fff9a172b07817c8c60fe185cd3ce9582678f8cc4b02bc444621a022100c54ca51d8117d904f0d3773911cb2792348fae21c2da7dad25f990d122376e4c",
+          "result": "valid"
+        },
+        {
+          "tcId": 537,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100e77df8f9782696344c33de29ebdc9f8d3fcf463d950cdbe256fd4fc2fd44877e02210087028850c962cf2fb450ffe6b983981e499dc498fbd654fa454c9e07c8cb5ca8",
+          "result": "valid"
+        },
+        {
+          "tcId": 538,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100bd2dd6f5026d2b5ad7ead74bdf52b8cbcabc08facee0a1c8584658a85ed0c5dc02203e8543e819bdae47d872e29a85ba38addf3eaeaad8786d79c3fb027f6f1ff4bf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d",
+        "wx": "00bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
+        "wy": "00fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BX////+7K1EtvBdFbMxRlScIpe1IqXu2EMM/1lnWObEPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 539,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100bd5c0294acc28c15c5d1ebc7274c9ca21a081c8a67da430a34a7fff1a564fabb02207ec103a2385b4ff38b47d306434e9091de24dc9f1a25967ee06f8a0a53ac0181",
+          "result": "valid"
+        },
+        {
+          "tcId": 540,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402203c7dbfb43dd80379ee2c23ad5472873a22c8a0179ac8f381ad9e0f193231dc1f02207cf8e07530ade503b3d43a84b75a2a76fc40763daed4e9734e745c58c9ae72d3",
+          "result": "valid"
+        },
+        {
+          "tcId": 541,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100b38ca4dac6d949be5e5f969860269f0eedff2eb92f45bfc02470300cc96dd52602201c7b22992bb13749cc0c5bc25330a17446e40db734203f9035172725fc70f863",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-non-minimal-tag",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx": "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy": "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 542,
+          "comment": "signature with non-minimal SEQUENCE tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "3f10440220093f3825c0cf820cced816a3a67446c85606a6d529e43857643fccc11e1f705f0220769782888c63058630f97a5891c8700e82979e4f233586bfc5042fa73cb70a4e",
+          "result": "invalid"
+        },
+        {
+          "tcId": 543,
+          "comment": "signature with non-minimal INTEGER tag on r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "30451f0220093f3825c0cf820cced816a3a67446c85606a6d529e43857643fccc11e1f705f0220769782888c63058630f97a5891c8700e82979e4f233586bfc5042fa73cb70a4e",
+          "result": "invalid"
+        },
+        {
+          "tcId": 544,
+          "comment": "signature with non-minimal INTEGER tag on s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "30450220093f3825c0cf820cced816a3a67446c85606a6d529e43857643fccc11e1f705f1f0220769782888c63058630f97a5891c8700e82979e4f233586bfc5042fa73cb70a4e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0486bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe",
+        "wx": "86bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981",
+        "wy": "cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000486bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhr3OOpLFZHD7pQLW5pcTPa/4haDv\nTQvQVgM180DCCYHLxgiSmtvlAo452HZvSyyGhdl6L+DtKP7eT5j7D3cMvg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 545,
+          "comment": "r = 5, x = 5 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020105022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "048936f32d1479a4e39b857e082d34f8a6c33a0a0d6fe21f156419b484b3ebedf8f9869ef53c92a87fe002a14668b307f8a7a020e7ec2fb36e76d53447faf02b12",
+        "wx": "8936f32d1479a4e39b857e082d34f8a6c33a0a0d6fe21f156419b484b3ebedf8",
+        "wy": "f9869ef53c92a87fe002a14668b307f8a7a020e7ec2fb36e76d53447faf02b12"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200048936f32d1479a4e39b857e082d34f8a6c33a0a0d6fe21f156419b484b3ebedf8f9869ef53c92a87fe002a14668b307f8a7a020e7ec2fb36e76d53447faf02b12",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiTbzLRR5pOObhX4ILTT4psM6Cg1v\n4h8VZBm0hLPr7fj5hp71PJKof+ACoUZoswf4p6Ag5+wvs2521TRH+vArEg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 546,
+          "comment": "r = 6, x = 5 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020106022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0486bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe",
+        "wx": "86bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981",
+        "wy": "cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000486bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhr3OOpLFZHD7pQLW5pcTPa/4haDv\nTQvQVgM180DCCYHLxgiSmtvlAo452HZvSyyGhdl6L+DtKP7eT5j7D3cMvg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 547,
+          "comment": "r = 5 + n, x = 5 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632556022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04fbfa53e8658bce3e1325b118d39b046aa55d6775cbf42dd4fd9dada7b42b5ec2c848f72bc2f7049196d56b6690472f4d23569a0648510cb8feec9d34f4f7f226",
+        "wx": "fbfa53e8658bce3e1325b118d39b046aa55d6775cbf42dd4fd9dada7b42b5ec2",
+        "wy": "c848f72bc2f7049196d56b6690472f4d23569a0648510cb8feec9d34f4f7f226"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004fbfa53e8658bce3e1325b118d39b046aa55d6775cbf42dd4fd9dada7b42b5ec2c848f72bc2f7049196d56b6690472f4d23569a0648510cb8feec9d34f4f7f226",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+/pT6GWLzj4TJbEY05sEaqVdZ3XL\n9C3U/Z2tp7QrXsLISPcrwvcEkZbVa2aQRy9NI1aaBkhRDLj+7J009PfyJg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 548,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04249ab0e745b4a2aae5cd92a3b4cdc68d00795dcf2721b9b1d749a83c5c346ceb33e51922356e3281799e327ed0627c6c5588ff3b2663ee389d7616522dadfcdf",
+        "wx": "249ab0e745b4a2aae5cd92a3b4cdc68d00795dcf2721b9b1d749a83c5c346ceb",
+        "wy": "33e51922356e3281799e327ed0627c6c5588ff3b2663ee389d7616522dadfcdf"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004249ab0e745b4a2aae5cd92a3b4cdc68d00795dcf2721b9b1d749a83c5c346ceb33e51922356e3281799e327ed0627c6c5588ff3b2663ee389d7616522dadfcdf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJJqw50W0oqrlzZKjtM3GjQB5Xc8n\nIbmx10moPFw0bOsz5RkiNW4ygXmeMn7QYnxsVYj/OyZj7jiddhZSLa383w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 549,
+          "comment": "r = 3, x = n + 3 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020103022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a495c3752b645eef19d87471511393559dcf399d50ddbcc14b5264b06e9d0de3074805c963f45a35db08d2349f2f1893db3a219512342c1160c2c307deac8c02",
+        "wx": "a495c3752b645eef19d87471511393559dcf399d50ddbcc14b5264b06e9d0de3",
+        "wy": "074805c963f45a35db08d2349f2f1893db3a219512342c1160c2c307deac8c02"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a495c3752b645eef19d87471511393559dcf399d50ddbcc14b5264b06e9d0de3074805c963f45a35db08d2349f2f1893db3a219512342c1160c2c307deac8c02",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpJXDdStkXu8Z2HRxUROTVZ3POZ1Q\n3bzBS1JksG6dDeMHSAXJY/RaNdsI0jSfLxiT2zohlRI0LBFgwsMH3qyMAg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 550,
+          "comment": "r = 4, x = n + 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020104022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04ed141e3d790add9e090cc9cb6a4866854a2fe3e5c9c09cc74e2cb32f1cae182d21124d25d8f62f890e3e45bb66c09b3331cef82e1dcd6a0615fad74c5464686d",
+        "wx": "ed141e3d790add9e090cc9cb6a4866854a2fe3e5c9c09cc74e2cb32f1cae182d",
+        "wy": "21124d25d8f62f890e3e45bb66c09b3331cef82e1dcd6a0615fad74c5464686d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004ed141e3d790add9e090cc9cb6a4866854a2fe3e5c9c09cc74e2cb32f1cae182d21124d25d8f62f890e3e45bb66c09b3331cef82e1dcd6a0615fad74c5464686d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7RQePXkK3Z4JDMnLakhmhUov4+XJ\nwJzHTiyzLxyuGC0hEk0l2PYviQ4+RbtmwJszMc74Lh3NagYV+tdMVGRobQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 551,
+          "comment": "r = p - n + 5, x = 5 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303502104319055358e8617b0c46353d039cdab3022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040997e2769537eff2ec78b27d716a5efd50a0737bc66bf7fec8fdb04e709544bde69d8aaa401b4a81ed474bc124db119b3555f60cae696790c77d64d994abc2d6",
+        "wx": "0997e2769537eff2ec78b27d716a5efd50a0737bc66bf7fec8fdb04e709544bd",
+        "wy": "e69d8aaa401b4a81ed474bc124db119b3555f60cae696790c77d64d994abc2d6"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040997e2769537eff2ec78b27d716a5efd50a0737bc66bf7fec8fdb04e709544bde69d8aaa401b4a81ed474bc124db119b3555f60cae696790c77d64d994abc2d6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECZfidpU37/LseLJ9cWpe/VCgc3vG\na/f+yP2wTnCVRL3mnYqqQBtKge1HS8Ek2xGbNVX2DK5pZ5DHfWTZlKvC1g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 552,
+          "comment": "r = 2^256 - n + 5, x = 5 is invalid; r + n is too large to compare r + n with x, and overflows 2^256 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3042021d00ffffffff00000000000000004319055258e8617b0c46353d039cdab4022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
First commit adds the [ecdh_secp256r1_ecpoint_test.json](https://github.com/cryspen/libcrux/compare/robin/kats-p256-add-test-vector?expand=1#diff-4523de4043484f45365838081d13a988789e01bf5042a7807819f987b6b320a4) wycheproof test vector file and accompanying parsing code in libcrux-kats (based on #1373).

The second commit adds a test in `crates/algorithms/p256` that evaluates the test vectors against the libcrux-p256 ECDH implementation.

The tested crate also contains an ECDSA implementation which is not tested as part of this PR.
@jschneider-bensch Should this be done in a follow-up or should I include it here?

closes #1416 

[skip changelog]
