### PR TITLE
[workspace] Prepare additional pre-releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.4-rc.1] (2026-05-11)
+## [0.0.4-rc.2] (2026-05-12)
 
 ### Fixed
 
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-ed25519`, `libcrux-ml-kem`, `libcrux-kem`, `libcrux-aesgcm`, `libcrux-blake2`, `libcrux-chacha20poly1305`, `libcrux-p256`, `libcrux-curve25519`, `libcrux-sha3`, `libcrux-sha2`, `libcrux-hmac`, `libcrux-hkdf`, `libcrux-rsa`, `libcrux-ecdsa`, `libcrux-ecdh`, `libcrux-digest`, `libcrux-psq`, `libcrux-ml-dsa`, `libcrux-aead`
 - [#1412](https://github.com/cryspen/libcrux/pull/1412): Update dependencies: `libcrux-aead`, `libcrux-aesgcm`, `libcrux-chacha20poly1305`, `libcrux-ecdsa`, `libcrux-hkdf`, `libcrux-hmac`, `libcrux-kem`, `libcrux-ml-dsa`, `libcrux-psq`, `libcrux-ecdh`, `libcrux-hpke-rs`
 - (libcrux-ecdh) [#1385](https://github.com/cryspen/libcrux/pull/1385): Update RNG trait bounds on key generation functions from rand v0.9 `Rng` trait to rand v0.10 `Rng` trait
 - (libcrux-ecdsa) [#1385](https://github.com/cryspen/libcrux/pull/1385): Dropped `Rng` bounds on `rand` feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.4-rc.1"
+version = "0.0.4-rc.2"
 authors = ["Cryspen"]
 license = "Apache-2.0"
 homepage = "https://github.com/cryspen/libcrux"
@@ -89,33 +89,33 @@ allow-branch = ["main"]
 [workspace.dependencies]
 cavp = { path = "cavp" }
 hax-lib = { version = "=0.3.6" }
-libcrux-aead = { version = "=0.0.8-rc.1", path = "crates/primitives/aead" }
-libcrux-aesgcm = { version = "=0.0.8-rc.1", path = "crates/algorithms/aesgcm" }
-libcrux-blake2 = { version = "=0.0.6", path = "crates/algorithms/blake2" }
-libcrux-chacha20poly1305 = { version = "=0.0.8-rc.1", path = "crates/algorithms/chacha20poly1305" }
+libcrux-aead = { version = "=0.0.8-rc.2", path = "crates/primitives/aead" }
+libcrux-aesgcm = { version = "=0.0.8-rc.2", path = "crates/algorithms/aesgcm" }
+libcrux-blake2 = { version = "=0.0.7-rc.1", path = "crates/algorithms/blake2" }
+libcrux-chacha20poly1305 = { version = "=0.0.8-rc.2", path = "crates/algorithms/chacha20poly1305" }
 libcrux-poly1305 = { version = "=0.0.5", path = "crates/algorithms/poly1305" }
-libcrux-ecdsa = { version = "=0.0.7-rc.1", path = "crates/algorithms/ecdsa" }
-libcrux-ed25519 = { version = "=0.0.7", path = "crates/algorithms/ed25519" }
+libcrux-ecdsa = { version = "=0.0.7-rc.2", path = "crates/algorithms/ecdsa" }
+libcrux-ed25519 = { version = "=0.0.8-rc.1", path = "crates/algorithms/ed25519" }
 libcrux-hacl-rs = { version = "=0.0.4", path = "crates/utils/hacl-rs" }
-libcrux-hkdf = { version = "=0.0.7-rc.1", path = "crates/algorithms/hkdf" }
-libcrux-hmac = { version = "=0.0.7-rc.1", path = "crates/algorithms/hmac" }
+libcrux-hkdf = { version = "=0.0.7-rc.2", path = "crates/algorithms/hkdf" }
+libcrux-hmac = { version = "=0.0.7-rc.2", path = "crates/algorithms/hmac" }
 libcrux-intrinsics = { version = "=0.0.6", path = "crates/utils/intrinsics" }
-libcrux-digest = { version = "=0.0.7", path = "crates/primitives/digest" }
-libcrux-rsa = { version = "=0.0.6", path = "crates/algorithms/rsa" }
-libcrux-sha2 = { version = "=0.0.6", path = "crates/algorithms/sha2" }
-libcrux-sha3 = { version = "=0.0.8", path = "crates/algorithms/sha3" }
-libcrux-traits = { version = "=0.0.6", path = "traits" }
-libcrux-kem = { version = "=0.0.8-rc.1", path = "libcrux-kem" }
-libcrux-ml-dsa = { version = "=0.0.9-rc.1", path = "libcrux-ml-dsa" }
+libcrux-digest = { version = "=0.0.8-rc.1", path = "crates/primitives/digest" }
+libcrux-rsa = { version = "=0.0.7-rc.1", path = "crates/algorithms/rsa" }
+libcrux-sha2 = { version = "=0.0.7-rc.1", path = "crates/algorithms/sha2" }
+libcrux-sha3 = { version = "=0.0.9-rc.1", path = "crates/algorithms/sha3" }
+libcrux-traits = { version = "=0.0.7-rc.1", path = "traits" }
+libcrux-kem = { version = "=0.0.8-rc.2", path = "libcrux-kem" }
+libcrux-ml-dsa = { version = "=0.0.9-rc.2", path = "libcrux-ml-dsa" }
 libcrux-platform = { version = "=0.0.3", path = "crates/sys/platform" }
-libcrux-psq = { version = "=0.0.9-rc.1", path = "libcrux-psq" }
+libcrux-psq = { version = "=0.0.9-rc.2", path = "libcrux-psq" }
 
 # For the crates below it is necessary to set `default-features = true`
 # in workspace crates that depend on the default feature set.
-libcrux-ecdh = { version = "=0.0.7-rc.1", path = "libcrux-ecdh", default-features = false }
-libcrux-curve25519 = { version = "=0.0.6", path = "crates/algorithms/curve25519", default-features = false }
-libcrux-ml-kem = { version = "=0.0.8", path = "libcrux-ml-kem", default-features = false }
-libcrux-p256 = { version = "=0.0.6", path = "crates/algorithms/p256", default-features = false }
+libcrux-ecdh = { version = "=0.0.7-rc.2", path = "libcrux-ecdh", default-features = false }
+libcrux-curve25519 = { version = "=0.0.7-rc.1", path = "crates/algorithms/curve25519", default-features = false }
+libcrux-ml-kem = { version = "=0.0.9-rc.1", path = "libcrux-ml-kem", default-features = false }
+libcrux-p256 = { version = "=0.0.7-rc.1", path = "crates/algorithms/p256", default-features = false }
 
 # Test utilities
 libcrux-kats = { path = "crates/testing/kats" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -71,7 +71,7 @@ pqcrypto-kyber = { version = "0.8.0" }
 openssl = "0.10"
 
 [target.'cfg(all(not(target_os = "windows"), target_arch = "x86_64"))'.dev-dependencies]
-libjade-sys = { version = "=0.0.4-rc.1", path = "../crates/sys/libjade" }
+libjade-sys = { version = "=0.0.4-rc.2", path = "../crates/sys/libjade" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crypto_lib25519)'] }

--- a/crates/algorithms/aesgcm/CHANGELOG.md
+++ b/crates/algorithms/aesgcm/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.8-rc.1] (2026-05-11)
+## [0.0.8-rc.2] (2026-05-12)
+
+### Changed
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
 
 ### Removed
 

--- a/crates/algorithms/aesgcm/Cargo.toml
+++ b/crates/algorithms/aesgcm/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 name = "libcrux-aesgcm"
 readme = "README.md"
 repository.workspace = true
-version = "0.0.8-rc.1"
+version = "0.0.8-rc.2"
 
 [lib]
 bench = false # so libtest doesn't eat the arguments to criterion

--- a/crates/algorithms/blake2/CHANGELOG.md
+++ b/crates/algorithms/blake2/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7-rc.1] (2026-05-12)
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
+
 ## [0.0.6] (2026-02-12)
 
 ### Changed

--- a/crates/algorithms/blake2/Cargo.toml
+++ b/crates/algorithms/blake2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-blake2"
 description = "Formally verified blake2 hash library"
-version = "0.0.6"
+version = "0.0.7-rc.1"
 readme = "Readme.md"
 
 authors.workspace = true

--- a/crates/algorithms/chacha20poly1305/CHANGELOG.md
+++ b/crates/algorithms/chacha20poly1305/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.8-rc.1] (2026-05-11)
+## [0.0.8-rc.2] (2026-05-12)
 
 ### Fixed
 
 - [#1386](https://github.com/cryspen/libcrux/pull/1386): Fix potential panic in `libcrux_chacha20poly1305::encrypt` (reported by @fg0x0)
+
+## Changed
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
 
 ## [0.0.7] (2026-03-19)
 

--- a/crates/algorithms/chacha20poly1305/Cargo.toml
+++ b/crates/algorithms/chacha20poly1305/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-chacha20poly1305"
 description = "Formally verified ChaCha20-Poly1305 AEAD library"
-version = "0.0.8-rc.1"
+version = "0.0.8-rc.2"
 readme = "Readme.md"
 
 authors.workspace = true

--- a/crates/algorithms/curve25519/CHANGELOG.md
+++ b/crates/algorithms/curve25519/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7-rc.1] (2026-05-12)
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
+
 ## [0.0.6] (2026-02-12)
 
 ### Added

--- a/crates/algorithms/curve25519/Cargo.toml
+++ b/crates/algorithms/curve25519/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-curve25519"
 description = "Formally verified curve25519 ECDH library"
-version = "0.0.6"
+version = "0.0.7-rc.1"
 readme = "Readme.md"
 
 authors.workspace = true

--- a/crates/algorithms/ecdsa/CHANGELOG.md
+++ b/crates/algorithms/ecdsa/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.7-rc.1] (2026-05-11)
+## [0.0.7-rc.2] (2026-05-12)
 
 ### Changed
 
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-sha2`
 - [#1385](https://github.com/cryspen/libcrux/pull/1385): Dropped `Rng` bounds on `rand` feature
 
 ## [0.0.6] (2026-02-12)

--- a/crates/algorithms/ecdsa/Cargo.toml
+++ b/crates/algorithms/ecdsa/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcrux-ecdsa"
 description = "Formally verified ECDSA signature library"
 readme = "Readme.md"
-version = "0.0.7-rc.1"
+version = "0.0.7-rc.2"
 
 authors.workspace = true
 license.workspace = true

--- a/crates/algorithms/ed25519/CHANGELOG.md
+++ b/crates/algorithms/ed25519/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.8-rc.1] (2026-05-12)
+
+### Changed
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-sha2`
+- [#1385](https://github.com/cryspen/libcrux/pull/1385): Update trait bounds to use `rand` version 0.10
+
 ## [0.0.7] (2026-03-19)
 
 ### Fixed

--- a/crates/algorithms/ed25519/Cargo.toml
+++ b/crates/algorithms/ed25519/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-ed25519"
 description = "Formally verified ed25519 signature library"
-version = "0.0.7"
+version = "0.0.8-rc.1"
 readme = "Readme.md"
 
 authors.workspace = true

--- a/crates/algorithms/hkdf/CHANGELOG.md
+++ b/crates/algorithms/hkdf/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.7-rc.1] (2026-05-11)
+## [0.0.7-rc.2] (2026-05-12)
 
 ### Changed
 
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-hmac`
 - [#1412](https://github.com/cryspen/libcrux/pull/1412): Update dependencies: `libcrux-hmac`
 
 ## [0.0.6] (2026-02-12)

--- a/crates/algorithms/hkdf/Cargo.toml
+++ b/crates/algorithms/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-hkdf"
-version = "0.0.7-rc.1"
+version = "0.0.7-rc.2"
 description = "Libcrux HKDF implementation"
 readme = "Readme.md"
 

--- a/crates/algorithms/hmac/CHANGELOG.md
+++ b/crates/algorithms/hmac/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.7-rc.1] (2026-05-11)
+## [0.0.7-rc.2] (2026-05-12)
 
 ### Removed
 
 - [#1391](https://github.com/cryspen/libcrux/pull/1391): Remove support for HMAC-SHA1
+
+### Changed
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-sha2`
 
 ## [0.0.6] (2026-02-12)
 

--- a/crates/algorithms/hmac/Cargo.toml
+++ b/crates/algorithms/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-hmac"
-version = "0.0.7-rc.1"
+version = "0.0.7-rc.2"
 description = "Libcrux HMAC implementation"
 readme = "Readme.md"
 

--- a/crates/algorithms/p256/CHANGELOG.md
+++ b/crates/algorithms/p256/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7-rc.1]
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-sha2`
+
 ## [0.0.6] (2026-02-12)
 
 ### Changed

--- a/crates/algorithms/p256/Cargo.toml
+++ b/crates/algorithms/p256/Cargo.toml
@@ -3,7 +3,7 @@ name = "libcrux-p256"
 description = "Formally verified P-256 implementation"
 readme = "Readme.md"
 
-version = "0.0.6"
+version = "0.0.7-rc.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/algorithms/rsa/CHANGELOG.md
+++ b/crates/algorithms/rsa/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7-rc.1] (2026-05-12)
+
+### Changed
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-sha2`
+
 ## [0.0.6] (2026-02-12)
 
 ### Changed

--- a/crates/algorithms/rsa/Cargo.toml
+++ b/crates/algorithms/rsa/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-rsa"
 description = "Formally verified RSA signature library"
-version = "0.0.6"
+version = "0.0.7-rc.1"
 readme = "Readme.md"
 
 authors.workspace = true

--- a/crates/algorithms/sha2/CHANGELOG.md
+++ b/crates/algorithms/sha2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7-rc.1]
+
+### Changed
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
+
 ## [0.0.6] (2026-02-12)
 
 ### Changed

--- a/crates/algorithms/sha2/Cargo.toml
+++ b/crates/algorithms/sha2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-sha2"
 description = "Formally verified SHA2 hash library"
-version = "0.0.6"
+version = "0.0.7-rc.1"
 readme = "Readme.md"
 
 authors.workspace = true

--- a/crates/algorithms/sha3/CHANGELOG.md
+++ b/crates/algorithms/sha3/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9-rc.1] (2026-05-12)
+
+### Changed
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
+
 ## [0.0.8] (2026-03-19)
 
 ### Fixed

--- a/crates/algorithms/sha3/Cargo.toml
+++ b/crates/algorithms/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-sha3"
-version = "0.0.8"
+version = "0.0.9-rc.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/primitives/aead/CHANGELOG.md
+++ b/crates/primitives/aead/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.8-rc.1] (2026-05-11)
+## [0.0.8-rc.2] (2026-05-12)
 
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-aesgcm`, `libcrux-chacha20poly1305`
 - [#1412](https://github.com/cryspen/libcrux/pull/1412): Update dependencies: `libcrux-chacha20poly1305`, `libcrux-aesgcm`
 
 ## [0.0.7] (2026-03-19)

--- a/crates/primitives/aead/Cargo.toml
+++ b/crates/primitives/aead/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Formally verified AEAD library"
 name = "libcrux-aead"
 readme = "Readme.md"
-version = "0.0.8-rc.1"
+version = "0.0.8-rc.2"
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/primitives/digest/CHANGELOG.md
+++ b/crates/primitives/digest/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.8-rc.1] (2026-05-12)
+
+### Changed
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-blake2`, `libcrux-sha3`, `libcrux-sha2`
+
 ## [0.0.7] (2026-03-19)
 
 ### Changed

--- a/crates/primitives/digest/Cargo.toml
+++ b/crates/primitives/digest/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Digest library"
 name = "libcrux-digest"
 readme = "Readme.md"
-version = "0.0.7"
+version = "0.0.8-rc.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/libcrux-ecdh/CHANGELOG.md
+++ b/libcrux-ecdh/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.7-rc.1] (2026-05-11)
+## [0.0.7-rc.2] (2026-05-12)
 
 ### Changed
 
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-p256`, `libcrux-curve25519`
 - [#1385](https://github.com/cryspen/libcrux/pull/1385): Update RNG trait bounds on key generation functions from rand v0.9 `Rng` trait to rand v0.10 `Rng` trait
 
 ## [0.0.6] (2026-02-12)

--- a/libcrux-ecdh/Cargo.toml
+++ b/libcrux-ecdh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-ecdh"
-version = "0.0.7-rc.1"
+version = "0.0.7-rc.2"
 description = "Libcrux ECDH implementation"
 readme = "Readme.md"
 

--- a/libcrux-kem/CHANGELOG.md
+++ b/libcrux-kem/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.8-rc.1] (2026-05-11)
+## [0.0.8-rc.2] (2026-05-12)
 
 ### Changed
 
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-ml-kem`, `libcrux-p256`, `libcrux-curve25519`, `libcrux-sha3`, `libcrux-ecdh`
 - [#1412](https://github.com/cryspen/libcrux/pull/1412): Update dependencies: `libcrux-ecdh`
+- [#1385](https://github.com/cryspen/libcrux/pull/1385): Update trait bounds to use `rand` version 0.10
 
 ## [0.0.7] (2026-03-19)
 

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-kem"
-version = "0.0.8-rc.1"
+version = "0.0.8-rc.2"
 description = "Libcrux KEM implementation"
 readme = "README.md"
 

--- a/libcrux-ml-dsa/CHANGELOG.md
+++ b/libcrux-ml-dsa/CHANGELOG.md
@@ -5,12 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.9-rc.1] (2026-05-11)
+## [0.0.9-rc.2] (2026-05-12)
 
 ### Fixed
 
 - [#1398](https://github.com/cryspen/libcrux/pull/1398): Fix incorrect AVX2 use_hint implementation
 - [#1395](https://github.com/cryspen/libcrux/pull/1395): Fully reduce iNTT inputs on AVX2
+
+### Changed
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-sha3`
 
 ## [0.0.8] (2026-03-19)
 

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-ml-dsa"
 description = "Libcrux ML-DSA implementation"
-version = "0.0.9-rc.1"
+version = "0.0.9-rc.2"
 readme = "README.md"
 
 authors.workspace = true

--- a/libcrux-ml-kem/CHANGELOG.md
+++ b/libcrux-ml-kem/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9-rc.1] (2026-05-12)
+
+### Changed
+
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-sha3`
+- [#1385](https://github.com/cryspen/libcrux/pull/1385): Update trait bounds to use `rand` version 0.10
+
 ## [0.0.8] (2026-03-19)
 
 ### Changed

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-ml-kem"
-version = "0.0.8"
+version = "0.0.9-rc.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/libcrux-psq/CHANGELOG.md
+++ b/libcrux-psq/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.9-rc.1] (2026-05-11)
+## [0.0.9-rc.2] (2026-05-12)
 
 ### Changed
 
+- [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-ed25519`, `libcrux-ml-kem`, `libcrux-kem`, `libcrux-aesgcm`, `libcrux-chacha20poly1305`, `libcrux-sha2`, `libcrux-hmac`, `libcrux-hkdf`, `libcrux-ecdh`, `libcrux-ml-dsa`
 - [#1412](https://github.com/cryspen/libcrux/pull/1412): Update dependencies: `libcrux-chacha20poly1305`, `libcrux-hmac`, `libcrux-aesgcm`, `libcrux-ecdh`, `libcrux-ml-dsa`
 
 ## Removed

--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-psq"
 description = "Libcrux Pre-Shared post-Quantum key establishement protocol"
-version = "0.0.9-rc.1"
+version = "0.0.9-rc.2"
 readme = "README.md"
 
 authors.workspace = true

--- a/specs/kyber/Cargo.toml
+++ b/specs/kyber/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libcrux = { version = "=0.0.3", path = "../../" }
+libcrux = { version = "=0.0.4-rc.2", path = "../../" }
 hacspec-lib = { version = "0.0.1", path = "../hacspec-lib" }
 
 [dev-dependencies]
-libcrux-kem = { version = "=0.0.7", path = "../../libcrux-kem", features = [
+libcrux-kem = { version = "=0.0.8-rc.2", path = "../../libcrux-kem", features = [
     "tests",
 ] }
 hex = { version = "0.4.3", features = ["serde"] }

--- a/traits/CHANGELOG.md
+++ b/traits/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7-rc.1] (2026-05-12)
+
+### Changed
+
+- [#1385](https://github.com/cryspen/libcrux/pull/1385): Update trait bounds to use `rand` version 0.10
+
 ## [0.0.6] (2026-02-12)
 
 ### Changed

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-traits"
 description = "Traits for cryptographic algorithms"
-version = "0.0.6"
+version = "0.0.7-rc.1"
 
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This PR prepares more crate pre-releases in addition to the ones from #1412:

- `libcrux-blake`
- `libcrux-ed25519`
- `libcrux-digest`
- `libcrux-rsa`
- `libcrux-sha2`
- `libcrux-sha3`
- `libcrux-traits`
- `libcrux-curve25519`
- `libcrux-ml-kem`
- `libcrux-p256`

These are all crates that also had the `rand` version bump, or depend on a crate that had the rand version bump. In addition to these new pre-releases there are more pre-releases of crates from #1412, since their workspace dependencies include one of the above crates.