### PR TITLE
[workspace] More pre-releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`, `libcrux-poly1305`, `libcrux-curve25519`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-ed25519`, `libcrux-ml-kem`, `libcrux-kem`, `libcrux-aesgcm`, `libcrux-blake2`, `libcrux-chacha20poly1305`, `libcrux-p256`, `libcrux-curve25519`, `libcrux-sha3`, `libcrux-sha2`, `libcrux-hmac`, `libcrux-hkdf`, `libcrux-rsa`, `libcrux-ecdsa`, `libcrux-ecdh`, `libcrux-digest`, `libcrux-psq`, `libcrux-ml-dsa`, `libcrux-aead`
 - [#1412](https://github.com/cryspen/libcrux/pull/1412): Update dependencies: `libcrux-aead`, `libcrux-aesgcm`, `libcrux-chacha20poly1305`, `libcrux-ecdsa`, `libcrux-hkdf`, `libcrux-hmac`, `libcrux-kem`, `libcrux-ml-dsa`, `libcrux-psq`, `libcrux-ecdh`, `libcrux-hpke-rs`
 - (libcrux-ecdh) [#1385](https://github.com/cryspen/libcrux/pull/1385): Update RNG trait bounds on key generation functions from rand v0.9 `Rng` trait to rand v0.10 `Rng` trait

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,13 +93,13 @@ libcrux-aead = { version = "=0.0.8-rc.2", path = "crates/primitives/aead" }
 libcrux-aesgcm = { version = "=0.0.8-rc.2", path = "crates/algorithms/aesgcm" }
 libcrux-blake2 = { version = "=0.0.7-rc.1", path = "crates/algorithms/blake2" }
 libcrux-chacha20poly1305 = { version = "=0.0.8-rc.2", path = "crates/algorithms/chacha20poly1305" }
-libcrux-poly1305 = { version = "=0.0.5", path = "crates/algorithms/poly1305" }
+libcrux-poly1305 = { version = "=0.0.6-rc.1", path = "crates/algorithms/poly1305" }
 libcrux-ecdsa = { version = "=0.0.7-rc.2", path = "crates/algorithms/ecdsa" }
 libcrux-ed25519 = { version = "=0.0.8-rc.1", path = "crates/algorithms/ed25519" }
-libcrux-hacl-rs = { version = "=0.0.4", path = "crates/utils/hacl-rs" }
+libcrux-hacl-rs = { version = "=0.0.5-rc.1", path = "crates/utils/hacl-rs" }
 libcrux-hkdf = { version = "=0.0.7-rc.2", path = "crates/algorithms/hkdf" }
 libcrux-hmac = { version = "=0.0.7-rc.2", path = "crates/algorithms/hmac" }
-libcrux-intrinsics = { version = "=0.0.6", path = "crates/utils/intrinsics" }
+libcrux-intrinsics = { version = "=0.0.7-rc.1", path = "crates/utils/intrinsics" }
 libcrux-digest = { version = "=0.0.8-rc.1", path = "crates/primitives/digest" }
 libcrux-rsa = { version = "=0.0.7-rc.1", path = "crates/algorithms/rsa" }
 libcrux-sha2 = { version = "=0.0.7-rc.1", path = "crates/algorithms/sha2" }
@@ -113,7 +113,7 @@ libcrux-psq = { version = "=0.0.9-rc.2", path = "libcrux-psq" }
 # For the crates below it is necessary to set `default-features = true`
 # in workspace crates that depend on the default feature set.
 libcrux-ecdh = { version = "=0.0.7-rc.2", path = "libcrux-ecdh", default-features = false }
-libcrux-curve25519 = { version = "=0.0.7-rc.1", path = "crates/algorithms/curve25519", default-features = false }
+libcrux-curve25519 = { version = "=0.0.7-rc.2", path = "crates/algorithms/curve25519", default-features = false }
 libcrux-ml-kem = { version = "=0.0.9-rc.1", path = "libcrux-ml-kem", default-features = false }
 libcrux-p256 = { version = "=0.0.7-rc.1", path = "crates/algorithms/p256", default-features = false }
 

--- a/crates/algorithms/aesgcm/CHANGELOG.md
+++ b/crates/algorithms/aesgcm/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-intrinsics`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
 
 ### Removed

--- a/crates/algorithms/blake2/CHANGELOG.md
+++ b/crates/algorithms/blake2/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.7-rc.1] (2026-05-12)
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
 
 ## [0.0.6] (2026-02-12)

--- a/crates/algorithms/chacha20poly1305/CHANGELOG.md
+++ b/crates/algorithms/chacha20poly1305/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`, `libcrux-poly1305`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
 
 ## [0.0.7] (2026-03-19)

--- a/crates/algorithms/chacha20poly1305/Cargo.toml
+++ b/crates/algorithms/chacha20poly1305/Cargo.toml
@@ -11,10 +11,10 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-libcrux-poly1305 = { version = "=0.0.5", path = "../poly1305/", features = [
+libcrux-poly1305 = { version = "=0.0.6-rc.1", path = "../poly1305/", features = [
     "expose-hacl",
 ] }
-libcrux-hacl-rs = { version = "=0.0.4", path = "../../utils/hacl-rs/" }
+libcrux-hacl-rs.workspace = true
 libcrux-macros = { version = "=0.0.3", path = "../../utils/macros" }
 libcrux-traits.workspace = true
 libcrux-secrets.workspace = true

--- a/crates/algorithms/curve25519/CHANGELOG.md
+++ b/crates/algorithms/curve25519/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.7-rc.1] (2026-05-12)
+## [0.0.7-rc.2] (2026-05-12)
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
 
 ## [0.0.6] (2026-02-12)

--- a/crates/algorithms/curve25519/Cargo.toml
+++ b/crates/algorithms/curve25519/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-curve25519"
 description = "Formally verified curve25519 ECDH library"
-version = "0.0.7-rc.1"
+version = "0.0.7-rc.2"
 readme = "Readme.md"
 
 authors.workspace = true
@@ -11,7 +11,7 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-libcrux-hacl-rs = { version = "=0.0.4", path = "../../utils/hacl-rs/" }
+libcrux-hacl-rs.workspace = true
 libcrux-macros = { version = "=0.0.3", path = "../../utils/macros" }
 libcrux-traits.workspace = true
 libcrux-secrets.workspace = true

--- a/crates/algorithms/ed25519/CHANGELOG.md
+++ b/crates/algorithms/ed25519/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-sha2`
 - [#1385](https://github.com/cryspen/libcrux/pull/1385): Update trait bounds to use `rand` version 0.10
 

--- a/crates/algorithms/ed25519/Cargo.toml
+++ b/crates/algorithms/ed25519/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-libcrux-hacl-rs = { version = "=0.0.4", path = "../../utils/hacl-rs/" }
+libcrux-hacl-rs.workspace = true
 libcrux-sha2 = { workspace = true, features = [
     "expose-hacl",
 ] }

--- a/crates/algorithms/hkdf/CHANGELOG.md
+++ b/crates/algorithms/hkdf/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-hmac`
 - [#1412](https://github.com/cryspen/libcrux/pull/1412): Update dependencies: `libcrux-hmac`
 

--- a/crates/algorithms/hkdf/Cargo.toml
+++ b/crates/algorithms/hkdf/Cargo.toml
@@ -20,5 +20,5 @@ check-secret-independence = ["libcrux-secrets/check-secret-independence"]
 libcrux-hmac = { workspace = true, features = [
     "expose-hacl",
 ] }
-libcrux-hacl-rs = { version = "=0.0.4", path = "../../utils/hacl-rs/" }
+libcrux-hacl-rs.workspace = true
 libcrux-secrets.workspace = true

--- a/crates/algorithms/hmac/CHANGELOG.md
+++ b/crates/algorithms/hmac/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-sha2`
 
 ## [0.0.6] (2026-02-12)

--- a/crates/algorithms/hmac/Cargo.toml
+++ b/crates/algorithms/hmac/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/hmac.rs"
 expose-hacl = []
 
 [dependencies]
-libcrux-hacl-rs = { version = "=0.0.4", path = "../../utils/hacl-rs/" }
+libcrux-hacl-rs.workspace = true
 libcrux-sha2 = { workspace = true, features = [
     "expose-hacl",
 ] }

--- a/crates/algorithms/p256/CHANGELOG.md
+++ b/crates/algorithms/p256/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.7-rc.1]
+## [0.0.7-rc.1] (2026-05-12)
 
+### Changed
+
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-sha2`
 
 ## [0.0.6] (2026-02-12)

--- a/crates/algorithms/p256/Cargo.toml
+++ b/crates/algorithms/p256/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [dependencies]
 libcrux-macros = { version = "=0.0.3", path = "../../utils/macros" }
 libcrux-traits.workspace = true
-libcrux-hacl-rs = { version = "=0.0.4", path = "../../utils/hacl-rs/" }
+libcrux-hacl-rs.workspace = true
 libcrux-secrets.workspace = true
 libcrux-sha2 = { workspace = true, features = [
     "expose-hacl",

--- a/crates/algorithms/poly1305/CHANGELOG.md
+++ b/crates/algorithms/poly1305/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6-rc.1] (2026-05-12)
+
+### Changed
+
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`
+
 ## [0.0.5] (2026-03-19)
 
 ### Fixed

--- a/crates/algorithms/poly1305/Cargo.toml
+++ b/crates/algorithms/poly1305/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-poly1305"
 description = "Formally verified Poly1305 MAC library"
-version = "0.0.5"
+version = "0.0.6-rc.1"
 readme = "Readme.md"
 
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 expose-hacl = []
 
 [dependencies]
-libcrux-hacl-rs = { version = "=0.0.4", path = "../../utils/hacl-rs/" }
+libcrux-hacl-rs.workspace = true
 libcrux-macros = { version = "=0.0.3", path = "../../utils/macros" }
 
 [dev-dependencies]

--- a/crates/algorithms/rsa/CHANGELOG.md
+++ b/crates/algorithms/rsa/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-sha2`
 
 ## [0.0.6] (2026-02-12)

--- a/crates/algorithms/sha2/CHANGELOG.md
+++ b/crates/algorithms/sha2/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.7-rc.1]
+## [0.0.7-rc.1] (2026-05-12)
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
 
 ## [0.0.6] (2026-02-12)

--- a/crates/algorithms/sha2/Cargo.toml
+++ b/crates/algorithms/sha2/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 expose-hacl = []
 
 [dependencies]
-libcrux-hacl-rs = { version = "=0.0.4", path = "../../utils/hacl-rs/" }
+libcrux-hacl-rs.workspace = true
 libcrux-macros = { version = "=0.0.3", path = "../../utils/macros" }
 libcrux-traits.workspace = true
 

--- a/crates/algorithms/sha3/CHANGELOG.md
+++ b/crates/algorithms/sha3/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-intrinsics`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`
 
 ## [0.0.8] (2026-03-19)

--- a/crates/utils/core-models/CHANGELOG.md
+++ b/crates/utils/core-models/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6-rc.1] (2026-05-12)
+
+- [#1385](https://github.com/cryspen/libcrux/pull/1385): Update dependencies: `rand`
+
 ## [0.0.5] (2026-01-22)
 
 - [#1285](https://github.com/cryspen/libcrux/pull/1285): Update `hax-lib` dependency

--- a/crates/utils/core-models/Cargo.toml
+++ b/crates/utils/core-models/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "core-models"
 description = "Models of the Rust core library"
-version = "0.0.5"
+version = "0.0.6-rc.1"
 readme = "readme.md"
 
 authors.workspace = true

--- a/crates/utils/hacl-rs/CHANGELOG.md
+++ b/crates/utils/hacl-rs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5-rc.1] (2026-05-12)
+
+### Changed
+
+- [#1391](https://github.com/cryspen/libcrux/pull/1391): Remove some unnecessary allocations
+
 ## [0.0.4] (2025-11-05)
 
 ## [0.0.3] (2025-06-30)

--- a/crates/utils/hacl-rs/Cargo.toml
+++ b/crates/utils/hacl-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-hacl-rs"
 description = "Formally verified Rust code extracted from HACL* - helper library"
-version = "0.0.4"
+version = "0.0.5-rc.1"
 
 authors.workspace = true
 license.workspace = true

--- a/crates/utils/intrinsics/CHANGELOG.md
+++ b/crates/utils/intrinsics/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7-rc.1] (2026-05-12)
+
+### Changed
+
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `core-models`
+
 ## [0.0.6] (2026-02-12)
 
 ### Added

--- a/crates/utils/intrinsics/Cargo.toml
+++ b/crates/utils/intrinsics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcrux-intrinsics"
-version = "0.0.6"
+version = "0.0.7-rc.1"
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -14,7 +14,7 @@ exclude = ["/proofs"]
 hax-lib.workspace = true
 
 [target.'cfg(hax)'.dependencies]
-core-models = { path = "../core-models", version = "0.0.5" }
+core-models = { path = "../core-models", version = "0.0.6-rc.1" }
 
 [features]
 simd128 = []

--- a/libcrux-ecdh/CHANGELOG.md
+++ b/libcrux-ecdh/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-curve25519`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-p256`, `libcrux-curve25519`
 - [#1385](https://github.com/cryspen/libcrux/pull/1385): Update RNG trait bounds on key generation functions from rand v0.9 `Rng` trait to rand v0.10 `Rng` trait
 

--- a/libcrux-kem/CHANGELOG.md
+++ b/libcrux-kem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-curve25519`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-ml-kem`, `libcrux-p256`, `libcrux-curve25519`, `libcrux-sha3`, `libcrux-ecdh`
 - [#1412](https://github.com/cryspen/libcrux/pull/1412): Update dependencies: `libcrux-ecdh`
 - [#1385](https://github.com/cryspen/libcrux/pull/1385): Update trait bounds to use `rand` version 0.10

--- a/libcrux-ml-dsa/CHANGELOG.md
+++ b/libcrux-ml-dsa/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `core-models`, `libcrux-intrinsics`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-sha3`
 
 ## [0.0.8] (2026-03-19)

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -49,7 +49,7 @@ libcrux-kats = { workspace = true, features = ["mldsa"] }
 pqcrypto-mldsa = { version = "0.1.0" } #, default-features = false
 
 [target.'cfg(hax)'.dependencies]
-core-models = { path = "../crates/utils/core-models", version = "0.0.5" }
+core-models = { path = "../crates/utils/core-models", version = "0.0.6-rc.1" }
 
 [features]
 default = ["std", "mldsa44", "mldsa65", "mldsa87"]

--- a/libcrux-ml-kem/CHANGELOG.md
+++ b/libcrux-ml-kem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-intrinsics`
 - [#1433](https://github.com/cryspen/libcrux/pull/1433): Update dependencies: `libcrux-traits`, `libcrux-sha3`
 - [#1385](https://github.com/cryspen/libcrux/pull/1385): Update trait bounds to use `rand` version 0.10
 


### PR DESCRIPTION
This PR prepares additional crates for pre-release:
- `core-models` (this one also got a rand update)
- `libcrux-hacl-rs` (because of no-alloc changes that flew under the radar)
- `libcrux-intrinsics`
- `libcrux-poly1305`