### PR TITLE
[CT/ML-DSA] Add valgrind constant time tests and ML-DSA valgrind requests 

### DIFF
--- a/.github/workflows/libcrux-ct-test.yml
+++ b/.github/workflows/libcrux-ct-test.yml
@@ -1,0 +1,47 @@
+name: Libcrux - Constant Time Tests
+
+on:
+  merge_group:
+  push:
+    branches: ["main", "dev"]
+  pull_request:
+    branches: ["main", "dev"]
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  ct-test:
+    name: Constant Time Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      
+      - name: Install valgrind / libclang-dev
+        run: sudo apt-get update && sudo apt-get install -y valgrind libclang-dev
+
+      - name: Compile ctgrind-test crate
+        env:
+          # needed for the ML-DSA CT tests
+          RUSTFLAGS: '--cfg valgrind_ct_test'
+        run: cargo build --package ctgrind-test --profile release-debug --bins
+
+      - name: Run valgrind ML-DSA
+        run: valgrind --tool=memcheck --error-exitcode=1 --track-origins=yes target/release-debug/mldsa
+
+      - name: Run valgrind ML-KEM
+        run: valgrind --tool=memcheck --error-exitcode=1 --track-origins=yes target/release-debug/mlkem
+
+      - name: Run valgrind SHA-3
+        run: valgrind --tool=memcheck --error-exitcode=1 --track-origins=yes target/release-debug/sha3
+

--- a/.github/workflows/libcrux-ct-test.yml
+++ b/.github/workflows/libcrux-ct-test.yml
@@ -3,9 +3,9 @@ name: Libcrux - Constant Time Tests
 on:
   merge_group:
   push:
-    branches: ["main", "dev"]
+    branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
+    branches: ["main"]
   workflow_dispatch:
 
 permissions: {}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "crates/sys/pqclean",
     "crates/testing/kats",
     "crates/utils/core-models",
+    "crates/utils/ctgrind-test",
     "crates/utils/hacl-rs",
     "crates/utils/intrinsics",
     "crates/utils/macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,6 +242,12 @@ codegen-units = 1
 panic = "abort"
 strip = true
 
+[profile.release-debug]
+inherits = "release"
+debug = true
+strip = false
+
+
 # XXX: Not needed anymore, but nice for test speed
 # [profile.dev.package."libcrux-ml-dsa"]
 # opt-level = 1

--- a/crates/utils/ctgrind-test/Cargo.toml
+++ b/crates/utils/ctgrind-test/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ctgrind-test"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+edition.workspace = true
+repository.workspace = true
+readme.workspace = true
+
+[dependencies]
+crabgrind = "0.2"
+libcrux-sha3 = { workspace = true }
+libcrux-ml-kem = { workspace = true, features = ["mlkem512"] }
+libcrux-ml-dsa = { workspace = true }
+
+[[bin]]
+name = "sha3"
+path = "src/bin/sha3.rs"
+
+[[bin]]
+name = "mlkem"
+path = "src/bin/mlkem.rs"
+
+[[bin]]
+name = "mldsa"
+path = "src/bin/mldsa.rs"

--- a/crates/utils/ctgrind-test/Cargo.toml
+++ b/crates/utils/ctgrind-test/Cargo.toml
@@ -25,3 +25,6 @@ path = "src/bin/mlkem.rs"
 [[bin]]
 name = "mldsa"
 path = "src/bin/mldsa.rs"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(valgrind_ct_test)'] }

--- a/crates/utils/ctgrind-test/Cargo.toml
+++ b/crates/utils/ctgrind-test/Cargo.toml
@@ -6,7 +6,8 @@ license.workspace = true
 homepage.workspace = true
 edition.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
+publish = false
 
 [dependencies]
 crabgrind = "0.2"

--- a/crates/utils/ctgrind-test/Dockerfile
+++ b/crates/utils/ctgrind-test/Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:latest
+
+# Install Valgrind, Clang, and libclang so bindgen can parse C headers
+RUN apt-get update && apt-get install -y \
+    valgrind \
+    clang \
+    libclang-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -1,0 +1,88 @@
+# ctgrind-test
+
+Constant-time (CT) tests using [Valgrind memcheck](https://valgrind.org/docs/manual/mc-manual.html).
+
+Each binary marks secret data as "undefined" with `crabgrind::memcheck::mark_memory`, runs a
+cryptographic operation, then unpoisons the output. Valgrind flags any conditional branch or
+memory access whose value flows from a poisoned (secret) byte — indicating a CT violation.
+
+## Binaries
+
+| Binary         | What is tested                                       | Expected result                   |
+| -------------- | ---------------------------------------------------- | --------------------------------- |
+| `ctgrind-test` | Insecure vs. secure byte comparison (demo)           | Insecure comparison flagged       |
+| `sha3`         | SHA-256, SHA-512, SHAKE-256 over a secret message    | Clean                             |
+| `mlkem`        | ML-KEM-512 `decapsulate` with a poisoned private key | Clean                             |
+| `mldsa`        | ML-DSA-44 `sign` with a poisoned signing key         | Violations (expected — see below) |
+
+## Running with Docker
+
+_Required on MacOS (arm)_
+
+Build the image once from the repo root:
+
+```sh
+docker build -t valgrind crates/utils/ctgrind-test/
+```
+
+Then run each binary from the **repo root**:
+
+```sh
+# SHA-3
+docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
+  "CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p ctgrind-test --release && valgrind --error-exitcode=1 ./target/release/sha3"
+
+# ML-KEM
+docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
+  "CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p ctgrind-test --release && valgrind --error-exitcode=1 ./target/release/mlkem"
+
+# ML-DSA
+docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
+  "CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p ctgrind-test --release && valgrind --error-exitcode=1 ./target/release/mldsa"
+```
+
+Run all three in one go:
+
+```sh
+docker run --rm -v "$PWD":/app -w /app valgrind bash -c "
+  CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p ctgrind-test --release &&
+  echo '--- SHA3 ---'  && valgrind --error-exitcode=1 ./target/release/sha3 &&
+  echo '--- ML-KEM ---' && valgrind --error-exitcode=1 ./target/release/mlkem &&
+  echo '--- ML-DSA ---' && valgrind --error-exitcode=1 ./target/release/mldsa
+"
+```
+
+> **Why Docker?**  
+> Valgrind on macOS/Apple Silicon does not support all Apple-proprietary ARM64 system registers
+> and aborts with `disInstr: unhandled instruction`. The Docker image runs a Linux environment
+> where Valgrind works correctly.
+
+## What is and isn't poisoned
+
+Only the genuinely secret bytes are poisoned. Public data embedded in key structs must stay
+clean or Valgrind produces false positives in public sampling routines.
+
+**ML-KEM private key** (`[cpa_sk | pk | H(pk) | z]`, 1632 bytes for ML-KEM-512):
+- Poisoned: `cpa_sk` (first 768 bytes) and `z` (last 32 bytes)
+- Not poisoned: embedded public key and `H(pk)` — these are used in the FO re-encryption
+  step to reconstruct matrix A from the public seed ρ
+
+**ML-DSA signing key** (`[ρ | K | tr | s₁, s₂, t₀]`, 2560 bytes for ML-DSA-44):
+- Poisoned: `K` (bytes 32–64) and `s₁, s₂, t₀` (bytes 128–end)
+- Not poisoned: `ρ` (public seed for matrix A) and `tr` (hash of verification key)
+
+## ML-DSA findings
+
+The `mldsa` binary intentionally produces Valgrind errors. Two violation classes are found in
+`ml_dsa_44::sign`:
+
+1. **`infinity_norm_exceeds`** (`ml_dsa_generic.rs:284`)  
+   The Fiat-Shamir-with-aborts rejection check `||z||∞ ≥ γ₁ − β` where `z = y + c·s₁`.
+   Since `z` depends on the secret `s₁`, this branch is inherently key-dependent. This is a
+   known and expected property of the Dilithium/ML-DSA algorithm.
+
+2. **`inside_out_shuffle`** (`sample.rs:450`) in `sample_challenge_ring_element`  
+   The Fisher-Yates shuffle that builds the sparse challenge polynomial `c`. The challenge
+   input `c̃ = H(μ ‖ w₁)` is public, but tainted values from `z` (computed in a previous
+   loop iteration) appear to spill into scratch memory reused by the shuffle on subsequent
+   retries.

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -3,17 +3,21 @@
 Constant-time (CT) tests using [Valgrind memcheck](https://valgrind.org/docs/manual/mc-manual.html).
 
 Each binary marks secret data as "undefined" with `crabgrind::memcheck::mark_memory`, runs a
-cryptographic operation, then unpoisons the output. Valgrind flags any conditional branch or
-memory access whose value flows from a poisoned (secret) byte — indicating a CT violation.
+cryptographic operation, then marks the output as defined. Valgrind flags any use of a value
+containing undefined bits which would result in observable differences in program behaviour,
+indicating a potential timing side channel.
+
+For libcrux-ml-dsa, appropriate valgrind requests are already issued in the crate itself, if compiled
+with the `valgrind_ct_test` cfg enabled.
 
 ## Binaries
 
-| Binary         | What is tested                                       | Expected result                   |
-| -------------- | ---------------------------------------------------- | --------------------------------- |
-| `ctgrind-test` | Insecure vs. secure byte comparison (demo)           | Insecure comparison flagged       |
-| `sha3`         | SHA-256, SHA-512, SHAKE-256 over a secret message    | Clean                             |
-| `mlkem`        | ML-KEM-512 `decapsulate` with a poisoned private key | Clean                             |
-| `mldsa`        | ML-DSA-44 `sign` with a poisoned signing key         | Violations (expected — see below) |
+| Binary         | What is tested                                          | Expected result                   |
+| -------------- | ----------------------------------------------------    | --------------------------------- |
+| `ctgrind-test` | Insecure vs. secure byte comparison (demo)              | Insecure comparison flagged       |
+| `sha3`         | SHA-256, SHA-512, SHAKE-256 over a secret message       | Clean                             |
+| `mlkem`        | ML-KEM-512 `decapsulate` with an undefined private key  | Clean                             |
+| `mldsa`        | ML-DSA-{44, 65, 87} `sign` with an undefined signing key| Clean                             |
 
 ## Running with Docker
 
@@ -30,25 +34,25 @@ Then run each binary from the **repo root**:
 ```sh
 # SHA-3
 docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
-  "CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p ctgrind-test --release && valgrind --error-exitcode=1 ./target/release/sha3"
+  "cargo build -p ctgrind-test --profile release-debug --bin sha3 && valgrind --error-exitcode=1 ./target/release-debug/sha3"
 
 # ML-KEM
 docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
-  "CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p ctgrind-test --release && valgrind --error-exitcode=1 ./target/release/mlkem"
+  "cargo build -p ctgrind-test --profile release-debug --bin mlkem && valgrind --error-exitcode=1 ./target/release-debug/mlkem"
 
 # ML-DSA
 docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
-  "CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p ctgrind-test --release && valgrind --error-exitcode=1 ./target/release/mldsa"
+  "RUSTGLAGS='--cfg valgrind_ct_test' cargo build -p ctgrind-test --profile release-debug --bin mldsa && valgrind --error-exitcode=1 ./target/release-debug/mldsa"
 ```
 
 Run all three in one go:
 
 ```sh
 docker run --rm -v "$PWD":/app -w /app valgrind bash -c "
-  CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p ctgrind-test --release &&
-  echo '--- SHA3 ---'  && valgrind --error-exitcode=1 ./target/release/sha3 &&
-  echo '--- ML-KEM ---' && valgrind --error-exitcode=1 ./target/release/mlkem &&
-  echo '--- ML-DSA ---' && valgrind --error-exitcode=1 ./target/release/mldsa
+  RUSTGLAGS='--cfg valgrind_ct_test' cargo build -p ctgrind-test --profile release-debug &&
+  echo '--- SHA3 ---'  && valgrind --error-exitcode=1 ./target/release-debug/sha3 &&
+  echo '--- ML-KEM ---' && valgrind --error-exitcode=1 ./target/release-debug/mlkem &&
+  echo '--- ML-DSA ---' && valgrind --error-exitcode=1 ./target/release-debug/mldsa
 "
 ```
 
@@ -57,32 +61,17 @@ docker run --rm -v "$PWD":/app -w /app valgrind bash -c "
 > and aborts with `disInstr: unhandled instruction`. The Docker image runs a Linux environment
 > where Valgrind works correctly.
 
-## What is and isn't poisoned
+## What is and isn't undefined
 
-Only the genuinely secret bytes are poisoned. Public data embedded in key structs must stay
+Only the genuinely secret bytes are marked as undefined. Public data embedded in key structs must stay
 clean or Valgrind produces false positives in public sampling routines.
 
 **ML-KEM private key** (`[cpa_sk | pk | H(pk) | z]`, 1632 bytes for ML-KEM-512):
-- Poisoned: `cpa_sk` (first 768 bytes) and `z` (last 32 bytes)
-- Not poisoned: embedded public key and `H(pk)` — these are used in the FO re-encryption
+- Undefined: `cpa_sk` (first 768 bytes) and `z` (last 32 bytes)
+- Not Undefined: embedded public key and `H(pk)` — these are used in the FO re-encryption
   step to reconstruct matrix A from the public seed ρ
 
 **ML-DSA signing key** (`[ρ | K | tr | s₁, s₂, t₀]`, 2560 bytes for ML-DSA-44):
-- Poisoned: `K` (bytes 32–64) and `s₁, s₂, t₀` (bytes 128–end)
-- Not poisoned: `ρ` (public seed for matrix A) and `tr` (hash of verification key)
+- Undefined: `K` (bytes 32–64) and `s₁, s₂` (bytes 128–896)
+- Not Undefined: `ρ` (public seed for matrix A), `tr` (hash of verification key) and `t₀` (𝑑 least significant bits of each coefficient of the uncompressed public-key polynomial 𝐭)
 
-## ML-DSA findings
-
-The `mldsa` binary intentionally produces Valgrind errors. Two violation classes are found in
-`ml_dsa_44::sign`:
-
-1. **`infinity_norm_exceeds`** (`ml_dsa_generic.rs:284`)  
-   The Fiat-Shamir-with-aborts rejection check `||z||∞ ≥ γ₁ − β` where `z = y + c·s₁`.
-   Since `z` depends on the secret `s₁`, this branch is inherently key-dependent. This is a
-   known and expected property of the Dilithium/ML-DSA algorithm.
-
-2. **`inside_out_shuffle`** (`sample.rs:450`) in `sample_challenge_ring_element`  
-   The Fisher-Yates shuffle that builds the sparse challenge polynomial `c`. The challenge
-   input `c̃ = H(μ ‖ w₁)` is public, but tainted values from `z` (computed in a previous
-   loop iteration) appear to spill into scratch memory reused by the shuffle on subsequent
-   retries.

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -61,17 +61,17 @@ docker run --rm -v "$PWD":/app -w /app valgrind bash -c "
 > and aborts with `disInstr: unhandled instruction`. The Docker image runs a Linux environment
 > where Valgrind works correctly.
 
-## What is and isn't undefined
+## What is and isn't marked undefined
 
 Only the genuinely secret bytes are marked as undefined. Public data embedded in key structs must stay
 clean or Valgrind produces false positives in public sampling routines.
 
-**ML-KEM private key** (`[cpa_sk | pk | H(pk) | z]`, 1632 bytes for ML-KEM-512):
+**ML-KEM private key** (`[cpa_sk | pk | H(pk) | z]`, e.g. 1632 bytes for ML-KEM-512):
 - Undefined: `cpa_sk` (first 768 bytes) and `z` (last 32 bytes)
 - Not Undefined: embedded public key and `H(pk)` — these are used in the FO re-encryption
   step to reconstruct matrix A from the public seed ρ
 
-**ML-DSA signing key** (`[ρ | K | tr | s₁, s₂, t₀]`, 2560 bytes for ML-DSA-44):
+**ML-DSA signing key** (`[ρ | K | tr | s₁, s₂, t₀]`, e.g. 2560 bytes for ML-DSA-44):
 - Undefined: `K` (bytes 32–64) and `s₁, s₂` (bytes 128–896)
 - Not Undefined: `ρ` (public seed for matrix A), `tr` (hash of verification key) and `t₀` (𝑑 least significant bits of each coefficient of the uncompressed public-key polynomial 𝐭)
 

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -99,3 +99,13 @@ in the random oracle model.
 Standardization.
 (https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)
 
+### Infinity Norm Checks
+[(link)](https://github.com/cryspen/libcrux/blob/jonas%2Fct-mldsa/libcrux-ml-dsa/src/polynomial.rs#L80)
+
+It is safe to leak the index of a violating coefficient during ML-DSA
+signature generation.
+
+See section 5.5 of the Dilithium Specification for Round 3 of the NIST
+Post-Quantum Cryptography Standardization.
+(https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)
+

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -42,14 +42,14 @@ docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
 
 # ML-DSA
 docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
-  "RUSTGLAGS='--cfg valgrind_ct_test' cargo build -p ctgrind-test --profile release-debug --bin mldsa && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/mldsa"
+  "RUSTFLAGS='--cfg valgrind_ct_test' cargo build -p ctgrind-test --profile release-debug --bin mldsa && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/mldsa"
 ```
 
 Run all three in one go:
 
 ```sh
 docker run --rm -v "$PWD":/app -w /app valgrind bash -c "
-  RUSTGLAGS='--cfg valgrind_ct_test' cargo build -p ctgrind-test --profile release-debug &&
+  RUSTFLAGS='--cfg valgrind_ct_test' cargo build -p ctgrind-test --profile release-debug &&
   echo '--- SHA3 ---'  && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/sha3 &&
   echo '--- ML-KEM ---' && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/mlkem &&
   echo '--- ML-DSA ---' && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/mldsa

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -75,3 +75,27 @@ clean or Valgrind produces false positives in public sampling routines.
 - Undefined: `K` (bytes 32–64) and `s₁, s₂` (bytes 128–896)
 - Not Undefined: `ρ` (public seed for matrix A), `tr` (hash of verification key) and `t₀` (𝑑 least significant bits of each coefficient of the uncompressed public-key polynomial 𝐭)
 
+## Declassifications in ML-DSA
+
+The signing operation in ML-DSA includes some operations that
+technically depend on secret data, but are in fact safe under the
+assumptions of the Dilithium security proof. In these cases we
+explicitly mark the memory as `MemState::Defined` for valgrind, in
+order to avoid false positives.
+
+### Verifier Challenge
+[(link)](https://github.com/cryspen/libcrux/blob/jonas%2Fct-mldsa/libcrux-ml-dsa/src/ml_dsa_generic.rs#L285)
+
+Revealing the verifier challenge `commitment_hash_candidate` is safe
+in the random oracle model.
+
+> The challenge reveals information about H(μ||w₁) also
+> in the case of rejected y, but this does not reveal any
+> information about the secret key when H is modelled as
+> a random oracle and w₁ has high min-entropy.
+
+-- Section 5.5 of the Dilithium Specification for Round
+3 of the NIST Post-Quantum Cryptography
+Standardization.
+(https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)
+

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -109,3 +109,18 @@ See section 5.5 of the Dilithium Specification for Round 3 of the NIST
 Post-Quantum Cryptography Standardization.
 (https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)
 
+### `w0` after norm checks have passed
+[(link)](https://github.com/cryspen/libcrux/blob/jonas%2Fct-mldsa/libcrux-ml-dsa/src/ml_dsa_generic.rs#L350)
+
+After the norm checks have passed it is safe to serialize the
+signature, so any value that could be derived from the signature and
+the public key is safe to leak.
+
+At this point `w0` = w - c * s2, and
+
+    A * `mask` - `verifier_challenge` * t = w - c * s2
+
+where `mask` and `verifier_challenge` are hold values that are part of
+the signature to be serialized, and A and t are part of the public
+key.
+

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -34,15 +34,15 @@ Then run each binary from the **repo root**:
 ```sh
 # SHA-3
 docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
-  "cargo build -p ctgrind-test --profile release-debug --bin sha3 && valgrind --error-exitcode=1 ./target/release-debug/sha3"
+  "cargo build -p ctgrind-test --profile release-debug --bin sha3 && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/sha3"
 
 # ML-KEM
 docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
-  "cargo build -p ctgrind-test --profile release-debug --bin mlkem && valgrind --error-exitcode=1 ./target/release-debug/mlkem"
+  "cargo build -p ctgrind-test --profile release-debug --bin mlkem && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/mlkem"
 
 # ML-DSA
 docker run --rm -v "$PWD":/app -w /app valgrind bash -c \
-  "RUSTGLAGS='--cfg valgrind_ct_test' cargo build -p ctgrind-test --profile release-debug --bin mldsa && valgrind --error-exitcode=1 ./target/release-debug/mldsa"
+  "RUSTGLAGS='--cfg valgrind_ct_test' cargo build -p ctgrind-test --profile release-debug --bin mldsa && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/mldsa"
 ```
 
 Run all three in one go:
@@ -50,9 +50,9 @@ Run all three in one go:
 ```sh
 docker run --rm -v "$PWD":/app -w /app valgrind bash -c "
   RUSTGLAGS='--cfg valgrind_ct_test' cargo build -p ctgrind-test --profile release-debug &&
-  echo '--- SHA3 ---'  && valgrind --error-exitcode=1 ./target/release-debug/sha3 &&
-  echo '--- ML-KEM ---' && valgrind --error-exitcode=1 ./target/release-debug/mlkem &&
-  echo '--- ML-DSA ---' && valgrind --error-exitcode=1 ./target/release-debug/mldsa
+  echo '--- SHA3 ---'  && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/sha3 &&
+  echo '--- ML-KEM ---' && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/mlkem &&
+  echo '--- ML-DSA ---' && valgrind --error-exitcode=1 --track-origins=yes ./target/release-debug/mldsa
 "
 ```
 

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -81,55 +81,5 @@ The signing operation in ML-DSA includes some operations that
 technically depend on secret data, but are in fact safe under the
 assumptions of the Dilithium security proof [1][dilithium-round3]. In these cases we
 explicitly mark the memory as `MemState::Defined` for valgrind, in
-order to avoid false positives.
-
-### Verifier Challenge
-
-Revealing the verifier challenge `commitment_hash_candidate` is safe
-in the random oracle model.
-
-> The challenge reveals information about H(μ||w₁) also
-> in the case of rejected y, but this does not reveal any
-> information about the secret key when H is modelled as
-> a random oracle and w₁ has high min-entropy.
-
--- Section 5.5 of the [Dilithium Specification for Round
-3 of the NIST Post-Quantum Cryptography
-Standardization][dilithium-round3].
-
-### Infinity Norm Checks
-
-It is safe to leak the index of a violating coefficient during ML-DSA
-signature generation.
-
-See section 5.5 of the [Dilithium Specification for Round 3 of the NIST
-Post-Quantum Cryptography Standardization][dilithium-round3].
-
-
-### `w0` after norm checks have passed
-
-After the norm checks have passed it is safe to serialize the
-signature, so any value that could be derived from the signature and
-the public key is safe to leak.
-
-At this point `w0` = w - c * s2, and
-
-    A * `mask` - `verifier_challenge` * t = w - c * s2
-
-where `mask` and `verifier_challenge` are hold values that are part of
-the signature to be serialized, and A and t are part of the public
-key.
-
-### `challenge_times_t0` after norm checks have passed
-
-After the norm checks have passed it is safe to serialize the
-signature, so any value that could be derived from the signature and
-the public key is safe to leak.
-
-`t0` is technically part of the signing key, but only for compression
-of the public key. It can be considered public. `verifier_challenge`
-will be part of the signature that is now safe to serialize, cf. [FIPS
-204, section
-6.1](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf)
-
-[dilithium-round3]: https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
+order to avoid false positives. The reasoning for each declassify operation 
+is given in the ML-DSA implementation.

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -124,3 +124,17 @@ where `mask` and `verifier_challenge` are hold values that are part of
 the signature to be serialized, and A and t are part of the public
 key.
 
+### `challenge_times_t0` after norm checks have passed
+[(link)](https://github.com/cryspen/libcrux/blob/jonas%2Fct-mldsa/libcrux-ml-dsa/src/ml_dsa_generic.rs#L357)
+
+After the norm checks have passed it is safe to serialize the
+signature, so any value that could be derived from the signature and
+the public key is safe to leak.
+
+`t0` is technically part of the signing key, but
+only for compression of the public key. It can be considered
+public. `verifier_challenge` will be part of the signature that is now
+safe to serialize.
+
+cf. FIPS 204, section 6.1
+(https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf)

--- a/crates/utils/ctgrind-test/README.md
+++ b/crates/utils/ctgrind-test/README.md
@@ -79,12 +79,11 @@ clean or Valgrind produces false positives in public sampling routines.
 
 The signing operation in ML-DSA includes some operations that
 technically depend on secret data, but are in fact safe under the
-assumptions of the Dilithium security proof. In these cases we
+assumptions of the Dilithium security proof [1][dilithium-round3]. In these cases we
 explicitly mark the memory as `MemState::Defined` for valgrind, in
 order to avoid false positives.
 
 ### Verifier Challenge
-[(link)](https://github.com/cryspen/libcrux/blob/jonas%2Fct-mldsa/libcrux-ml-dsa/src/ml_dsa_generic.rs#L285)
 
 Revealing the verifier challenge `commitment_hash_candidate` is safe
 in the random oracle model.
@@ -94,23 +93,20 @@ in the random oracle model.
 > information about the secret key when H is modelled as
 > a random oracle and w₁ has high min-entropy.
 
--- Section 5.5 of the Dilithium Specification for Round
+-- Section 5.5 of the [Dilithium Specification for Round
 3 of the NIST Post-Quantum Cryptography
-Standardization.
-(https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)
+Standardization][dilithium-round3].
 
 ### Infinity Norm Checks
-[(link)](https://github.com/cryspen/libcrux/blob/jonas%2Fct-mldsa/libcrux-ml-dsa/src/polynomial.rs#L80)
 
 It is safe to leak the index of a violating coefficient during ML-DSA
 signature generation.
 
-See section 5.5 of the Dilithium Specification for Round 3 of the NIST
-Post-Quantum Cryptography Standardization.
-(https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)
+See section 5.5 of the [Dilithium Specification for Round 3 of the NIST
+Post-Quantum Cryptography Standardization][dilithium-round3].
+
 
 ### `w0` after norm checks have passed
-[(link)](https://github.com/cryspen/libcrux/blob/jonas%2Fct-mldsa/libcrux-ml-dsa/src/ml_dsa_generic.rs#L350)
 
 After the norm checks have passed it is safe to serialize the
 signature, so any value that could be derived from the signature and
@@ -125,16 +121,15 @@ the signature to be serialized, and A and t are part of the public
 key.
 
 ### `challenge_times_t0` after norm checks have passed
-[(link)](https://github.com/cryspen/libcrux/blob/jonas%2Fct-mldsa/libcrux-ml-dsa/src/ml_dsa_generic.rs#L357)
 
 After the norm checks have passed it is safe to serialize the
 signature, so any value that could be derived from the signature and
 the public key is safe to leak.
 
-`t0` is technically part of the signing key, but
-only for compression of the public key. It can be considered
-public. `verifier_challenge` will be part of the signature that is now
-safe to serialize.
+`t0` is technically part of the signing key, but only for compression
+of the public key. It can be considered public. `verifier_challenge`
+will be part of the signature that is now safe to serialize, cf. [FIPS
+204, section
+6.1](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf)
 
-cf. FIPS 204, section 6.1
-(https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf)
+[dilithium-round3]: https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf

--- a/crates/utils/ctgrind-test/src/bin/mldsa.rs
+++ b/crates/utils/ctgrind-test/src/bin/mldsa.rs
@@ -1,0 +1,69 @@
+use crabgrind::memcheck::{self, MemState};
+use libcrux_ml_dsa::ml_dsa_44;
+use std::ffi::c_void;
+use std::hint::black_box;
+
+#[inline(never)]
+fn test_sign() {
+    // Generate key pair with known randomness — not secret yet.
+    let key_pair = ml_dsa_44::generate_key_pair(black_box([0u8; 32]));
+
+    // The ML-DSA signing key layout (per spec): [ρ(32) | K(32) | tr(64) | s₁,s₂,t₀(rest)]
+    //   ρ  = public seed for matrix A  → PUBLIC, must not be poisoned
+    //   K  = signing key seed          → SECRET
+    //   tr = hash of verification key  → PUBLIC, must not be poisoned
+    //   s₁, s₂, t₀                    → SECRET
+    //
+    // Poisoning ρ or tr causes false positives in `rejection_sample_less_than_field_modulus`
+    // during matrix A construction, which branches on XOF output from the public ρ.
+    const SEED_FOR_A_SIZE: usize = 32; // ρ
+    const SEED_FOR_SIGNING_SIZE: usize = 32; // K
+    const TR_SIZE: usize = 64; // tr = hash of vk
+
+    let sk = &key_pair.signing_key;
+    let sk_bytes: &[u8] = sk.as_slice();
+
+    // Poison K (bytes 32..64)
+    let _ = memcheck::mark_memory(
+        sk_bytes[SEED_FOR_A_SIZE..].as_ptr() as *const c_void,
+        SEED_FOR_SIGNING_SIZE,
+        MemState::Undefined,
+    );
+    // Poison s₁, s₂, t₀ (bytes 128..end)
+    let secret_tail_offset = SEED_FOR_A_SIZE + SEED_FOR_SIGNING_SIZE + TR_SIZE;
+    let _ = memcheck::mark_memory(
+        sk_bytes[secret_tail_offset..].as_ptr() as *const c_void,
+        sk_bytes.len() - secret_tail_offset,
+        MemState::Undefined,
+    );
+
+    let message = b"test message";
+    let context = b"";
+    // FINDINGS: Valgrind reports two classes of violations in sign():
+    //
+    // 1. `infinity_norm_exceeds` (ml_dsa_generic.rs:284)
+    //    The rejection check `||z||∞ ≥ γ₁ - β` where z = y + c·s₁.
+    //    z depends on s₁ (secret), so this branch is inherently key-dependent.
+    //    This is the Fiat-Shamir-with-aborts abort step — a known, expected
+    //    property of the Dilithium/ML-DSA algorithm.
+    //
+    // 2. `inside_out_shuffle` (sample.rs:450) in `sample_challenge_ring_element`
+    //    The Fisher-Yates shuffle that builds the sparse challenge polynomial c.
+    //    The challenge input c̃ = H(μ ‖ w₁) should be public, but tainted values
+    //    from z (computed in a previous loop iteration) appear to spill into the
+    //    scratch memory used by the shuffle in subsequent retries.
+    let mut sig = ml_dsa_44::sign(sk, message, context, black_box([0u8; 32])).unwrap();
+
+    // Unpoison signature before use.
+    let sig_bytes: &mut [u8] = sig.as_mut_slice();
+    let _ = memcheck::mark_memory(
+        sig_bytes.as_mut_ptr() as *mut c_void,
+        sig_bytes.len(),
+        MemState::Defined,
+    );
+    println!("mldsa44 signature: {:02x?}", &sig.as_slice()[..4]);
+}
+
+pub fn main() {
+    test_sign();
+}

--- a/crates/utils/ctgrind-test/src/bin/mldsa.rs
+++ b/crates/utils/ctgrind-test/src/bin/mldsa.rs
@@ -1,69 +1,52 @@
-use crabgrind::memcheck::{self, MemState};
-use libcrux_ml_dsa::ml_dsa_44;
-use std::ffi::c_void;
+use libcrux_ml_dsa::{ml_dsa_44, ml_dsa_65, ml_dsa_87};
 use std::hint::black_box;
 
 #[inline(never)]
-fn test_sign() {
-    // Generate key pair with known randomness — not secret yet.
+fn test_sign_mldsa_44() {
     let key_pair = ml_dsa_44::generate_key_pair(black_box([0u8; 32]));
-
-    // The ML-DSA signing key layout (per spec): [ρ(32) | K(32) | tr(64) | s₁,s₂,t₀(rest)]
-    //   ρ  = public seed for matrix A  → PUBLIC, must not be poisoned
-    //   K  = signing key seed          → SECRET
-    //   tr = hash of verification key  → PUBLIC, must not be poisoned
-    //   s₁, s₂, t₀                    → SECRET
-    //
-    // Poisoning ρ or tr causes false positives in `rejection_sample_less_than_field_modulus`
-    // during matrix A construction, which branches on XOF output from the public ρ.
-    const SEED_FOR_A_SIZE: usize = 32; // ρ
-    const SEED_FOR_SIGNING_SIZE: usize = 32; // K
-    const TR_SIZE: usize = 64; // tr = hash of vk
-
     let sk = &key_pair.signing_key;
-    let sk_bytes: &[u8] = sk.as_slice();
-
-    // Poison K (bytes 32..64)
-    let _ = memcheck::mark_memory(
-        sk_bytes[SEED_FOR_A_SIZE..].as_ptr() as *const c_void,
-        SEED_FOR_SIGNING_SIZE,
-        MemState::Undefined,
-    );
-    // Poison s₁, s₂, t₀ (bytes 128..end)
-    let secret_tail_offset = SEED_FOR_A_SIZE + SEED_FOR_SIGNING_SIZE + TR_SIZE;
-    let _ = memcheck::mark_memory(
-        sk_bytes[secret_tail_offset..].as_ptr() as *const c_void,
-        sk_bytes.len() - secret_tail_offset,
-        MemState::Undefined,
-    );
 
     let message = b"test message";
     let context = b"";
-    // FINDINGS: Valgrind reports two classes of violations in sign():
-    //
-    // 1. `infinity_norm_exceeds` (ml_dsa_generic.rs:284)
-    //    The rejection check `||z||∞ ≥ γ₁ - β` where z = y + c·s₁.
-    //    z depends on s₁ (secret), so this branch is inherently key-dependent.
-    //    This is the Fiat-Shamir-with-aborts abort step — a known, expected
-    //    property of the Dilithium/ML-DSA algorithm.
-    //
-    // 2. `inside_out_shuffle` (sample.rs:450) in `sample_challenge_ring_element`
-    //    The Fisher-Yates shuffle that builds the sparse challenge polynomial c.
-    //    The challenge input c̃ = H(μ ‖ w₁) should be public, but tainted values
-    //    from z (computed in a previous loop iteration) appear to spill into the
-    //    scratch memory used by the shuffle in subsequent retries.
-    let mut sig = ml_dsa_44::sign(sk, message, context, black_box([0u8; 32])).unwrap();
+    let sig = ml_dsa_44::sign(sk, message, context, black_box([0u8; 32])).unwrap();
 
-    // Unpoison signature before use.
-    let sig_bytes: &mut [u8] = sig.as_mut_slice();
-    let _ = memcheck::mark_memory(
-        sig_bytes.as_mut_ptr() as *mut c_void,
-        sig_bytes.len(),
-        MemState::Defined,
-    );
     println!("mldsa44 signature: {:02x?}", &sig.as_slice()[..4]);
 }
 
+#[inline(never)]
+fn test_sign_mldsa_65() {
+    let key_pair = ml_dsa_65::generate_key_pair(black_box([0u8; 32]));
+    let sk = &key_pair.signing_key;
+
+    let message = b"test message";
+    let context = b"";
+    let sig = ml_dsa_65::sign(sk, message, context, black_box([0u8; 32])).unwrap();
+
+    println!("mldsa65 signature: {:02x?}", &sig.as_slice()[..4]);
+}
+
+#[inline(never)]
+fn test_sign_mldsa_87() {
+    let key_pair = ml_dsa_87::generate_key_pair(black_box([0u8; 32]));
+    let sk = &key_pair.signing_key;
+
+    let message = b"test message";
+    let context = b"";
+    let sig = ml_dsa_87::sign(sk, message, context, black_box([0u8; 32])).unwrap();
+
+    println!("mldsa87 signature: {:02x?}", &sig.as_slice()[..4]);
+}
+
+// XXX test other parameter configurations
+
 pub fn main() {
-    test_sign();
+    #[cfg(not(valgrind_ct_test))]
+    {
+        compile_error!(
+            "ctgrind_test mldsa binary needs to be compiled with '--cfg valgrind_ct_test'"
+        );
+    }
+    test_sign_mldsa_44();
+    test_sign_mldsa_65();
+    test_sign_mldsa_87();
 }

--- a/crates/utils/ctgrind-test/src/bin/mlkem.rs
+++ b/crates/utils/ctgrind-test/src/bin/mlkem.rs
@@ -1,0 +1,50 @@
+use crabgrind::memcheck::{self, MemState};
+use libcrux_ml_kem::mlkem512;
+use std::ffi::c_void;
+use std::hint::black_box;
+
+#[inline(never)]
+fn test_decapsulate() {
+    // Generate key pair and ciphertext with known randomness — not secret yet.
+    // KEY_GENERATION_SEED_SIZE = CPA_PKE_KEY_GENERATION_SEED_SIZE + SHARED_SECRET_SIZE = 64
+    let key_pair = mlkem512::generate_key_pair(black_box([0u8; 64]));
+    let (ct, _) = mlkem512::encapsulate(key_pair.public_key(), black_box([0u8; 32]));
+
+    // The IND-CCA private key packs: [cpa_sk | pk | H(pk) | z]
+    // Only cpa_sk and z are secret; the embedded pk and H(pk) are public.
+    // Derive layout from public type sizes rather than internal constants.
+    // Marking everything as secret will fail us in `rej_sample`.
+    let sk_bytes: &[u8] = key_pair.private_key().as_ref();
+    let pk_len = key_pair.public_key().as_ref().len(); // 800 for mlkem512
+    const H_DIGEST_LEN: usize = 32;
+    const Z_LEN: usize = 32;
+    let cpa_sk_len = sk_bytes.len() - pk_len - H_DIGEST_LEN - Z_LEN; // 768
+    let z_offset = cpa_sk_len + pk_len + H_DIGEST_LEN; // 1600
+
+    // Poison CPA secret key
+    let _ = memcheck::mark_memory(
+        sk_bytes.as_ptr() as *const c_void,
+        cpa_sk_len,
+        MemState::Undefined,
+    );
+    // Poison implicit rejection value z
+    let _ = memcheck::mark_memory(
+        sk_bytes[z_offset..].as_ptr() as *const c_void,
+        Z_LEN,
+        MemState::Undefined,
+    );
+
+    let mut ss = mlkem512::decapsulate(key_pair.private_key(), &ct);
+
+    // Unpoison shared secret before use.
+    let _ = memcheck::mark_memory(
+        ss.as_mut_ptr() as *mut c_void,
+        ss.len(),
+        MemState::Defined,
+    );
+    println!("mlkem512 shared secret: {:02x?}", &ss[..4]);
+}
+
+pub fn main() {
+    test_decapsulate();
+}

--- a/crates/utils/ctgrind-test/src/bin/mlkem.rs
+++ b/crates/utils/ctgrind-test/src/bin/mlkem.rs
@@ -21,13 +21,13 @@ fn test_decapsulate() {
     let cpa_sk_len = sk_bytes.len() - pk_len - H_DIGEST_LEN - Z_LEN; // 768
     let z_offset = cpa_sk_len + pk_len + H_DIGEST_LEN; // 1600
 
-    // Poison CPA secret key
+    // Classify CPA secret key
     let _ = memcheck::mark_memory(
         sk_bytes.as_ptr() as *const c_void,
         cpa_sk_len,
         MemState::Undefined,
     );
-    // Poison implicit rejection value z
+    // Classify implicit rejection value z
     let _ = memcheck::mark_memory(
         sk_bytes[z_offset..].as_ptr() as *const c_void,
         Z_LEN,
@@ -36,12 +36,8 @@ fn test_decapsulate() {
 
     let mut ss = mlkem512::decapsulate(key_pair.private_key(), &ct);
 
-    // Unpoison shared secret before use.
-    let _ = memcheck::mark_memory(
-        ss.as_mut_ptr() as *mut c_void,
-        ss.len(),
-        MemState::Defined,
-    );
+    // Declassify shared secret before use.
+    let _ = memcheck::mark_memory(ss.as_mut_ptr() as *mut c_void, ss.len(), MemState::Defined);
     println!("mlkem512 shared secret: {:02x?}", &ss[..4]);
 }
 

--- a/crates/utils/ctgrind-test/src/bin/sha3.rs
+++ b/crates/utils/ctgrind-test/src/bin/sha3.rs
@@ -1,0 +1,60 @@
+use crabgrind::memcheck::{self, MemState};
+use std::ffi::c_void;
+use std::hint::black_box;
+
+#[inline(never)]
+fn test_sha256() {
+    let message = black_box([0x42u8; 64]);
+    let _ = memcheck::mark_memory(
+        message.as_ptr() as *const c_void,
+        message.len(),
+        MemState::Undefined,
+    );
+    let mut digest = libcrux_sha3::sha256(&message);
+    let _ = memcheck::mark_memory(
+        digest.as_mut_ptr() as *mut c_void,
+        digest.len(),
+        MemState::Defined,
+    );
+    println!("sha256: {:02x?}", &digest[..4]);
+}
+
+#[inline(never)]
+fn test_sha512() {
+    let message = black_box([0x42u8; 64]);
+    let _ = memcheck::mark_memory(
+        message.as_ptr() as *const c_void,
+        message.len(),
+        MemState::Undefined,
+    );
+    let mut digest = libcrux_sha3::sha512(&message);
+    let _ = memcheck::mark_memory(
+        digest.as_mut_ptr() as *mut c_void,
+        digest.len(),
+        MemState::Defined,
+    );
+    println!("sha512: {:02x?}", &digest[..4]);
+}
+
+#[inline(never)]
+fn test_shake256() {
+    let message = black_box([0x42u8; 64]);
+    let _ = memcheck::mark_memory(
+        message.as_ptr() as *const c_void,
+        message.len(),
+        MemState::Undefined,
+    );
+    let mut digest = libcrux_sha3::shake256::<64>(&message);
+    let _ = memcheck::mark_memory(
+        digest.as_mut_ptr() as *mut c_void,
+        digest.len(),
+        MemState::Defined,
+    );
+    println!("shake256: {:02x?}", &digest[..4]);
+}
+
+pub fn main() {
+    test_sha256();
+    test_sha512();
+    test_shake256();
+}

--- a/crates/utils/ctgrind-test/src/main.rs
+++ b/crates/utils/ctgrind-test/src/main.rs
@@ -1,0 +1,62 @@
+use crabgrind::memcheck::{self, MemState};
+use std::ffi::c_void;
+use std::hint::black_box;
+
+/* VULNERABLE: Returns early if a mismatch is found.
+ * Execution time depends on the secret data. */
+#[inline(never)]
+fn compare_insecure(secret: &[u8], public: &[u8]) -> bool {
+    for i in 0..secret.len() {
+        if secret[i] != public[i] {
+            // Valgrind will flag this!
+            return false;
+        }
+    }
+    true
+}
+
+/* SECURE: Always iterates through the entire array.
+ * Execution time is completely independent of the secret data. */
+#[inline(never)]
+fn compare_secure(secret: &[u8], public: &[u8]) -> bool {
+    let mut diff = 0u8;
+    for i in 0..secret.len() {
+        diff |= secret[i] ^ public[i];
+    }
+    diff == 0
+}
+
+pub fn main() {
+    // We use black_box to prevent LLVM from pre-calculating the result at compile time
+    let secret = black_box([0xDE, 0xAD, 0xBE, 0xEF]);
+    let public = black_box([0xDE, 0xAD, 0xBE, 0x00]);
+
+    // 1. POISON THE SECRET: Tell Valgrind to treat this memory as uninitialized
+    // We use `let _ =` because `mark_memory` returns the number of unaddressable bytes (usize)
+    let _ = memcheck::mark_memory(
+        secret.as_ptr() as *const c_void,
+        secret.len(),
+        MemState::Undefined,
+    );
+    // --- TEST SECURE FUNCTION ---
+    let mut res_sec = compare_secure(&secret, &public);
+
+    // Unpoison the result so we can safely branch/print it
+    let _ = memcheck::mark_memory(
+        &mut res_sec as *mut _ as *mut c_void,
+        std::mem::size_of_val(&res_sec),
+        MemState::Defined,
+    );
+    println!("Secure result: {}", res_sec);
+
+    // --- TEST INSECURE FUNCTION ---
+    let mut res_insec = compare_insecure(&secret, &public);
+
+    // Unpoison the result
+    let _ = memcheck::mark_memory(
+        &mut res_insec as *mut _ as *mut c_void,
+        std::mem::size_of_val(&res_insec),
+        MemState::Defined,
+    );
+    println!("Insecure result: {}", res_insec);
+}

--- a/crates/utils/ctgrind-test/src/main.rs
+++ b/crates/utils/ctgrind-test/src/main.rs
@@ -31,7 +31,7 @@ pub fn main() {
     let secret = black_box([0xDE, 0xAD, 0xBE, 0xEF]);
     let public = black_box([0xDE, 0xAD, 0xBE, 0x00]);
 
-    // 1. POISON THE SECRET: Tell Valgrind to treat this memory as uninitialized
+    // 1. CLASSIFY THE SECRET: Tell Valgrind to treat this memory as uninitialized
     // We use `let _ =` because `mark_memory` returns the number of unaddressable bytes (usize)
     let _ = memcheck::mark_memory(
         secret.as_ptr() as *const c_void,
@@ -41,7 +41,7 @@ pub fn main() {
     // --- TEST SECURE FUNCTION ---
     let mut res_sec = compare_secure(&secret, &public);
 
-    // Unpoison the result so we can safely branch/print it
+    // Unclassify the result so we can safely branch/print it
     let _ = memcheck::mark_memory(
         &mut res_sec as *mut _ as *mut c_void,
         std::mem::size_of_val(&res_sec),
@@ -52,7 +52,7 @@ pub fn main() {
     // --- TEST INSECURE FUNCTION ---
     let mut res_insec = compare_insecure(&secret, &public);
 
-    // Unpoison the result
+    // Declassify the result
     let _ = memcheck::mark_memory(
         &mut res_insec as *mut _ as *mut c_void,
         std::mem::size_of_val(&res_insec),

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -51,6 +51,10 @@ pqcrypto-mldsa = { version = "0.1.0" } #, default-features = false
 [target.'cfg(hax)'.dependencies]
 core-models = { path = "../crates/utils/core-models", version = "0.0.6" }
 
+[target.'cfg(valgrind_ct_test)'.dependencies]
+# Used for constant time testing using valgrind
+crabgrind = { version = "0.2.6" }
+
 [features]
 default = ["std", "mldsa44", "mldsa65", "mldsa87"]
 simd128 = ["libcrux-sha3/simd128", "libcrux-intrinsics/simd128"]
@@ -86,4 +90,4 @@ name = "ml-dsa"
 harness = false
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(valgrind_ct_test)'] }

--- a/libcrux-ml-dsa/boring.sh
+++ b/libcrux-ml-dsa/boring.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/libcrux-ml-dsa/cg/code_gen.txt
+++ b/libcrux-ml-dsa/cg/code_gen.txt
@@ -3,4 +3,4 @@ Charon: 377317d6b25702c46ffff072fa00a3e32095e46f
 Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
 Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
 F*: unset
-Libcrux: d3ed1c47cd34e327523d0f5444286676b7f7abe1
+Libcrux: dirty

--- a/libcrux-ml-dsa/cg/header.txt
+++ b/libcrux-ml-dsa/cg/header.txt
@@ -8,5 +8,5 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: d3ed1c47cd34e327523d0f5444286676b7f7abe1
+ * Libcrux: dirty
  */

--- a/libcrux-ml-dsa/cg/libcrux_intrinsics_avx2.h
+++ b/libcrux-ml-dsa/cg/libcrux_intrinsics_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: d3ed1c47cd34e327523d0f5444286676b7f7abe1
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_intrinsics_avx2_H

--- a/libcrux-ml-dsa/cg/libcrux_mldsa65_avx2.h
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa65_avx2.h
@@ -5459,12 +5459,26 @@ libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_64(
   bool result = false;
   for (size_t i = (size_t)0U; i < (size_t)32U; i++) {
     size_t i0 = i;
-    result = result || libcrux_ml_dsa_simd_avx2_infinity_norm_exceeds_a2(
-                           &self->data[i0], bound);
+    bool coeff_exceeds = libcrux_ml_dsa_simd_avx2_infinity_norm_exceeds_a2(
+        &self->data[i0], bound);
+    bool uu____0;
+    if (result) {
+      uu____0 = true;
+    } else {
+      uu____0 = coeff_exceeds;
+    }
+    result = uu____0;
   }
   return result;
 }
 
+/**
+ CAUTION: This function must only be called with inputs for
+ which it is safe to leak the index of a violating coefficient.
+
+ For all norm checks during ML-DSA signature generation it is
+ safe to leak the index of a violating coefficient.
+*/
 /**
 A monomorphic instance of libcrux_ml_dsa.arithmetic.vector_infinity_norm_exceeds
 with types libcrux_ml_dsa_simd_avx2_vector_type_Vec256
@@ -5478,9 +5492,14 @@ libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
   bool result = false;
   for (size_t i = (size_t)0U; i < vector.meta; i++) {
     size_t i0 = i;
-    bool uu____0 = result;
-    result = uu____0 || libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_64(
-                            &vector.ptr[i0], bound);
+    bool uu____0;
+    if (result) {
+      uu____0 = true;
+    } else {
+      uu____0 = libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_64(
+          &vector.ptr[i0], bound);
+    }
+    result = uu____0;
   }
   return result;
 }
@@ -5824,19 +5843,15 @@ libcrux_ml_dsa_ml_dsa_generic_ml_dsa_65_sign_internal_07(
         LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_ROWS_IN_A,
         Eurydice_array_to_slice_mut_716(&w0),
         Eurydice_array_to_slice_shared_715(&challenge_times_s2));
-    bool mask_invalid =
-        libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
+    if (!libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
             Eurydice_array_to_slice_shared_713(&mask),
             ((int32_t)1 << (uint32_t)
                  LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_GAMMA1_EXPONENT) -
-                LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA);
-    if (!mask_invalid) {
-      bool w0_invalid =
-          libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
+                LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA)) {
+      if (!libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
               Eurydice_array_to_slice_shared_715(&w0),
               LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_GAMMA2 -
-                  LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA);
-      if (!w0_invalid) {
+                  LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA)) {
         Eurydice_arr_b50 challenge_times_t0 =
             core_array__core__clone__Clone_for__Array_T__N___clone(
                 (size_t)6U, &t0_as_ntt, Eurydice_arr_cd0, Eurydice_arr_b50);

--- a/libcrux-ml-dsa/cg/libcrux_mldsa65_avx2.h
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa65_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: d3ed1c47cd34e327523d0f5444286676b7f7abe1
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_mldsa65_avx2_H
@@ -5459,14 +5459,8 @@ libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_64(
   bool result = false;
   for (size_t i = (size_t)0U; i < (size_t)32U; i++) {
     size_t i0 = i;
-    bool uu____0;
-    if (result) {
-      uu____0 = true;
-    } else {
-      uu____0 = libcrux_ml_dsa_simd_avx2_infinity_norm_exceeds_a2(
-          &self->data[i0], bound);
-    }
-    result = uu____0;
+    result = result || libcrux_ml_dsa_simd_avx2_infinity_norm_exceeds_a2(
+                           &self->data[i0], bound);
   }
   return result;
 }
@@ -5484,17 +5478,27 @@ libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
   bool result = false;
   for (size_t i = (size_t)0U; i < vector.meta; i++) {
     size_t i0 = i;
-    bool uu____0;
-    if (result) {
-      uu____0 = true;
-    } else {
-      uu____0 = libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_64(
-          &vector.ptr[i0], bound);
-    }
-    result = uu____0;
+    bool uu____0 = result;
+    result = uu____0 || libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_64(
+                            &vector.ptr[i0], bound);
   }
   return result;
 }
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types Eurydice_arr libcrux_ml_dsa_polynomial_PolynomialRingElement
+libcrux_ml_dsa_simd_avx2_vector_type_Vec256[[$6size_t]]
+
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline void libcrux_ml_dsa_ct_test_ct_declassify_040(
+    const Eurydice_arr_b50 *val) {}
 
 /**
 This function found in impl
@@ -5820,15 +5824,19 @@ libcrux_ml_dsa_ml_dsa_generic_ml_dsa_65_sign_internal_07(
         LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_ROWS_IN_A,
         Eurydice_array_to_slice_mut_716(&w0),
         Eurydice_array_to_slice_shared_715(&challenge_times_s2));
-    if (!libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
+    bool mask_invalid =
+        libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
             Eurydice_array_to_slice_shared_713(&mask),
             ((int32_t)1 << (uint32_t)
                  LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_GAMMA1_EXPONENT) -
-                LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA)) {
-      if (!libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
+                LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA);
+    if (!mask_invalid) {
+      bool w0_invalid =
+          libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
               Eurydice_array_to_slice_shared_715(&w0),
               LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_GAMMA2 -
-                  LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA)) {
+                  LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA);
+      if (!w0_invalid) {
         Eurydice_arr_b50 challenge_times_t0 =
             core_array__core__clone__Clone_for__Array_T__N___clone(
                 (size_t)6U, &t0_as_ntt, Eurydice_arr_cd0, Eurydice_arr_b50);

--- a/libcrux-ml-dsa/cg/libcrux_mldsa65_portable.c
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa65_portable.c
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Cryspen Sarl <info@cryspen.com>
+ *
+ * SPDX-License-Identifier: MIT or Apache-2.0
+ *
+ * This code was generated with the following revisions:
+ * Charon: 377317d6b25702c46ffff072fa00a3e32095e46f
+ * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
+ * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
+ * F*: unset
+ * Libcrux: dirty
+ */
+
+#include "libcrux_mldsa65_portable.h"
+
+#include "libcrux_mldsa_core.h"
+#include "libcrux_sha3_portable.h"
+
+/**
+ Mark memory as secret.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_classify
+with types Eurydice_arr uint8_t[[$32size_t]]
+
+*/
+void libcrux_ml_dsa_ct_test_ct_classify_62(const Eurydice_arr_60 *val) {}
+
+/**
+ Mark memory as secret.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_classify
+with types Eurydice_derefed_slice uint8_t
+
+*/
+void libcrux_ml_dsa_ct_test_ct_classify_45(const uint8_t (*val)[]) {}
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types Eurydice_arr uint8_t[[$48size_t]]
+
+*/
+void libcrux_ml_dsa_ct_test_ct_declassify_7d(const Eurydice_arr_5f *val) {}
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types bool
+
+*/
+void libcrux_ml_dsa_ct_test_ct_declassify_5f(const bool *val) {}

--- a/libcrux-ml-dsa/cg/libcrux_mldsa65_portable.h
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa65_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: d3ed1c47cd34e327523d0f5444286676b7f7abe1
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_mldsa65_portable_H
@@ -5187,6 +5187,54 @@ static inline void libcrux_ml_dsa_ml_dsa_65_portable_generate_key_pair_mut(
 }
 
 /**
+ Mark memory as secret.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_classify
+with types Eurydice_arr uint8_t[[$32size_t]]
+
+*/
+void libcrux_ml_dsa_ct_test_ct_classify_62(const Eurydice_arr_60 *val);
+
+/**
+ Mark memory as secret.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_classify
+with types Eurydice_derefed_slice uint8_t
+
+*/
+void libcrux_ml_dsa_ct_test_ct_classify_45(const uint8_t (*val)[]);
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types Eurydice_arr uint8_t[[$48size_t]]
+
+*/
+void libcrux_ml_dsa_ct_test_ct_declassify_7d(const Eurydice_arr_5f *val);
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types bool
+
+*/
+void libcrux_ml_dsa_ct_test_ct_declassify_5f(const bool *val);
+
+/**
 A monomorphic instance of core.result.Result
 with types (), libcrux_ml_dsa_types_SigningError
 
@@ -5874,14 +5922,9 @@ libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_37(
   bool result = false;
   for (size_t i = (size_t)0U; i < (size_t)32U; i++) {
     size_t i0 = i;
-    bool uu____0;
-    if (result) {
-      uu____0 = true;
-    } else {
-      uu____0 = libcrux_ml_dsa_simd_portable_infinity_norm_exceeds_65(
-          &self->data[i0], bound);
-    }
-    result = uu____0;
+    bool uu____0 = result;
+    result = uu____0 || libcrux_ml_dsa_simd_portable_infinity_norm_exceeds_65(
+                            &self->data[i0], bound);
   }
   return result;
 }
@@ -5898,17 +5941,26 @@ libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
   bool result = false;
   for (size_t i = (size_t)0U; i < vector.meta; i++) {
     size_t i0 = i;
-    bool uu____0;
-    if (result) {
-      uu____0 = true;
-    } else {
-      uu____0 = libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_37(
-          &vector.ptr[i0], bound);
-    }
-    result = uu____0;
+    bool uu____0 = result;
+    result = uu____0 || libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_37(
+                            &vector.ptr[i0], bound);
   }
   return result;
 }
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types Eurydice_arr libcrux_ml_dsa_polynomial_PolynomialRingElement
+libcrux_ml_dsa_simd_portable_vector_type_Coefficients[[$6size_t]]
+
+*/
+static inline void libcrux_ml_dsa_ct_test_ct_declassify_04(
+    const Eurydice_arr_a3 *val) {}
 
 /**
 This function found in impl
@@ -6227,15 +6279,19 @@ libcrux_ml_dsa_ml_dsa_generic_ml_dsa_65_sign_internal_5a(
         LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_ROWS_IN_A,
         Eurydice_array_to_slice_mut_712(&w0),
         Eurydice_array_to_slice_shared_711(&challenge_times_s2));
-    if (!libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
+    bool mask_invalid =
+        libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
             Eurydice_array_to_slice_shared_71(&mask),
             ((int32_t)1 << (uint32_t)
                  LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_GAMMA1_EXPONENT) -
-                LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA)) {
-      if (!libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
+                LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA);
+    if (!mask_invalid) {
+      bool w0_invalid =
+          libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
               Eurydice_array_to_slice_shared_711(&w0),
               LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_GAMMA2 -
-                  LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA)) {
+                  LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA);
+      if (!w0_invalid) {
         Eurydice_arr_a3 challenge_times_t0 =
             core_array__core__clone__Clone_for__Array_T__N___clone(
                 (size_t)6U, &t0_as_ntt, Eurydice_arr_a4, Eurydice_arr_a3);

--- a/libcrux-ml-dsa/cg/libcrux_mldsa65_portable.h
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa65_portable.h
@@ -5922,13 +5922,26 @@ libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_37(
   bool result = false;
   for (size_t i = (size_t)0U; i < (size_t)32U; i++) {
     size_t i0 = i;
-    bool uu____0 = result;
-    result = uu____0 || libcrux_ml_dsa_simd_portable_infinity_norm_exceeds_65(
-                            &self->data[i0], bound);
+    bool coeff_exceeds = libcrux_ml_dsa_simd_portable_infinity_norm_exceeds_65(
+        &self->data[i0], bound);
+    bool uu____0;
+    if (result) {
+      uu____0 = true;
+    } else {
+      uu____0 = coeff_exceeds;
+    }
+    result = uu____0;
   }
   return result;
 }
 
+/**
+ CAUTION: This function must only be called with inputs for
+ which it is safe to leak the index of a violating coefficient.
+
+ For all norm checks during ML-DSA signature generation it is
+ safe to leak the index of a violating coefficient.
+*/
 /**
 A monomorphic instance of libcrux_ml_dsa.arithmetic.vector_infinity_norm_exceeds
 with types libcrux_ml_dsa_simd_portable_vector_type_Coefficients
@@ -5941,9 +5954,14 @@ libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
   bool result = false;
   for (size_t i = (size_t)0U; i < vector.meta; i++) {
     size_t i0 = i;
-    bool uu____0 = result;
-    result = uu____0 || libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_37(
-                            &vector.ptr[i0], bound);
+    bool uu____0;
+    if (result) {
+      uu____0 = true;
+    } else {
+      uu____0 = libcrux_ml_dsa_polynomial_infinity_norm_exceeds_ff_37(
+          &vector.ptr[i0], bound);
+    }
+    result = uu____0;
   }
   return result;
 }
@@ -6279,19 +6297,15 @@ libcrux_ml_dsa_ml_dsa_generic_ml_dsa_65_sign_internal_5a(
         LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_ROWS_IN_A,
         Eurydice_array_to_slice_mut_712(&w0),
         Eurydice_array_to_slice_shared_711(&challenge_times_s2));
-    bool mask_invalid =
-        libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
+    if (!libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
             Eurydice_array_to_slice_shared_71(&mask),
             ((int32_t)1 << (uint32_t)
                  LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_GAMMA1_EXPONENT) -
-                LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA);
-    if (!mask_invalid) {
-      bool w0_invalid =
-          libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
+                LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA)) {
+      if (!libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
               Eurydice_array_to_slice_shared_711(&w0),
               LIBCRUX_ML_DSA_CONSTANTS_ML_DSA_65_GAMMA2 -
-                  LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA);
-      if (!w0_invalid) {
+                  LIBCRUX_ML_DSA_ML_DSA_GENERIC_ML_DSA_65_BETA)) {
         Eurydice_arr_a3 challenge_times_t0 =
             core_array__core__clone__Clone_for__Array_T__N___clone(
                 (size_t)6U, &t0_as_ntt, Eurydice_arr_a4, Eurydice_arr_a3);

--- a/libcrux-ml-dsa/cg/libcrux_mldsa_core.h
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa_core.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: d3ed1c47cd34e327523d0f5444286676b7f7abe1
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_mldsa_core_H

--- a/libcrux-ml-dsa/cg/libcrux_sha3_avx2.h
+++ b/libcrux-ml-dsa/cg/libcrux_sha3_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: d3ed1c47cd34e327523d0f5444286676b7f7abe1
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_sha3_avx2_H

--- a/libcrux-ml-dsa/cg/libcrux_sha3_portable.h
+++ b/libcrux-ml-dsa/cg/libcrux_sha3_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: d3ed1c47cd34e327523d0f5444286676b7f7abe1
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_sha3_portable_H

--- a/libcrux-ml-dsa/src/arithmetic.rs
+++ b/libcrux-ml-dsa/src/arithmetic.rs
@@ -16,8 +16,9 @@ pub(crate) fn vector_infinity_norm_exceeds<SIMDUnit: Operations>(
 ) -> bool {
     let mut result = false;
     for i in 0..vector.len() {
-        result = result || vector[i].infinity_norm_exceeds(bound);
+        result = result | vector[i].infinity_norm_exceeds(bound);
     }
+
     result
 }
 

--- a/libcrux-ml-dsa/src/arithmetic.rs
+++ b/libcrux-ml-dsa/src/arithmetic.rs
@@ -10,13 +10,27 @@ use crate::{
         (forall i. forall j. Spec.Utils.is_i32b_array_opaque 
             (v ${crate::simd::traits::specs::FIELD_MAX}) 
             (i0._super_i2.f_repr (Seq.index (Seq.index vector i).f_simd_units j)))"#))]
+/// CAUTION: This function must only be called with inputs for
+/// which it is safe to leak the index of a violating coefficient.
+///
+/// For all norm checks during ML-DSA signature generation it is
+/// safe to leak the index of a violating coefficient.
 pub(crate) fn vector_infinity_norm_exceeds<SIMDUnit: Operations>(
     vector: &[PolynomialRingElement<SIMDUnit>],
     bound: i32,
 ) -> bool {
     let mut result = false;
     for i in 0..vector.len() {
-        result = result | vector[i].infinity_norm_exceeds(bound);
+        // XXX: We can't use the non-short-circuiting core::ops::BitOr
+        // here, because of an issue in hax-lib v0.3.6.
+        // (cf. https://github.com/cryspen/libcrux/issues/1437)
+        //
+        // Using the short-circuiting OR here is safe, even if it
+        // leaks the index of a coefficient that violates the norm
+        // check. See
+        // `PolynomialRingElemen<SIMDUnit>::infinity_norm_exceeds` for
+        // more details.
+        result = result || vector[i].infinity_norm_exceeds(bound);
     }
 
     result

--- a/libcrux-ml-dsa/src/ct_test.rs
+++ b/libcrux-ml-dsa/src/ct_test.rs
@@ -1,0 +1,45 @@
+//! Helper functions for constant time tests using valgrind.
+//!
+//! When libcrux-ml-dsa is compiled with the `valgrind_ct_test` cfg,
+//! these functions will mark the respective memory as undefined (classify)
+//! or defined (declassify). Running the binary compiled with the cfg
+//! under valgrind's memcheck tool will check for any code paths
+//! dependent on the classified memory.
+
+/// Mark memory as secret.
+///
+/// No-op if `valgrind_ct_test` cfg is not enabled.
+#[cfg_attr(not(valgrind_ct_test), allow(unused_variables))]
+pub(crate) fn ct_classify<T: ?Sized>(val: &T) {
+    #[cfg(valgrind_ct_test)]
+    {
+        use std::ffi::c_void;
+        crabgrind::memcheck::mark_memory(
+            val as *const _ as *const c_void,
+            size_of_val(val),
+            crabgrind::memcheck::MemState::Undefined,
+        )
+        .expect("libcrux-ml-dsa compiled with '--cfg valgrind_ct_test' must be run under valgrind");
+    }
+    // Otherwise, no-op
+}
+
+/// Declassify secret memory.
+///
+/// No-op if `valgrind_ct_test` cfg is not enabled.
+#[cfg_attr(not(valgrind_ct_test), allow(unused_variables))]
+pub(crate) fn ct_declassify<T: ?Sized>(val: &T) {
+    #[cfg(valgrind_ct_test)]
+    {
+        use std::ffi::c_void;
+        // If we expect the error, we get false positives in sign_internal.
+        // If a valgrind_ct_test binary is not run under valgrind, the expect
+        // in the classify should fail, so it is okay here to ignore the error
+        let _ = crabgrind::memcheck::mark_memory(
+            val as *const _ as *const c_void,
+            size_of_val(val),
+            crabgrind::memcheck::MemState::Defined,
+        );
+    }
+    // Otherwise, no-op
+}

--- a/libcrux-ml-dsa/src/lib.rs
+++ b/libcrux-ml-dsa/src/lib.rs
@@ -7,6 +7,7 @@ extern crate std;
 
 mod arithmetic;
 mod constants;
+mod ct_test;
 mod encoding;
 mod hash_functions;
 mod helper;

--- a/libcrux-ml-dsa/src/ml_dsa_generic.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_generic.rs
@@ -317,6 +317,19 @@ pub(crate) mod generic {
                         // XXX: https://github.com/hacspec/hax/issues/1171
                         // continue;
                     } else {
+                        // After the norm checks have passed it is
+                        // safe to serialize the signature, so any
+                        // value that could be derived from the
+                        // signature and the public key is safe to
+                        // leak.
+
+                        // Declassification:
+                        // At this point `w0` = w - c * s2, and
+                        //
+                        //     A * `mask` - `verifier_challenge` * t = w - c * s2
+                        //
+                        // where `mask` and `verifier_challenge` are part of the signature to be serialized,
+                        // and A and t are part of the public key.
                         ct_declassify(&w0);
                         ct_declassify(&challenge_times_t0);
                         add_vectors::<SIMDUnit>(ROWS_IN_A, &mut w0, &challenge_times_t0);

--- a/libcrux-ml-dsa/src/ml_dsa_generic.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_generic.rs
@@ -331,6 +331,16 @@ pub(crate) mod generic {
                         // where `mask` and `verifier_challenge` are part of the signature to be serialized,
                         // and A and t are part of the public key.
                         ct_declassify(&w0);
+
+                        // Declassification: `t0` is technically part
+                        // of the signing key, but only for
+                        // compression of the public key. It can be
+                        // considered public. `verifier_challenge`
+                        // will be part of the signature that is now
+                        // safe to serialize.
+                        //
+                        // cf. FIPS 204, section 6.1
+                        // (https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf)
                         ct_declassify(&challenge_times_t0);
                         add_vectors::<SIMDUnit>(ROWS_IN_A, &mut w0, &challenge_times_t0);
                         let mut hint_candidate = [[0; COEFFICIENTS_IN_RING_ELEMENT]; ROWS_IN_A];

--- a/libcrux-ml-dsa/src/ml_dsa_generic.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_generic.rs
@@ -27,9 +27,8 @@ pub(crate) mod multiplexing;
 
 #[libcrux_macros::ml_dsa_parameter_sets(44, 65, 87)]
 pub(crate) mod generic {
-    use crate::ct_test::ct_classify;
-
     use super::*;
+    use crate::ct_test::ct_classify;
 
     // Derived constants
     const ROW_COLUMN: usize = ROWS_IN_A + COLUMNS_IN_A;
@@ -291,18 +290,19 @@ pub(crate) mod generic {
             add_vectors::<SIMDUnit>(COLUMNS_IN_A, &mut mask, &challenge_times_s1);
             subtract_vectors::<SIMDUnit>(ROWS_IN_A, &mut w0, &challenge_times_s2);
 
-            let mask_invalid =
-                vector_infinity_norm_exceeds::<SIMDUnit>(&mask, (1 << GAMMA1_EXPONENT) - BETA);
-
-            ct_declassify(&mask_invalid);
-
-            if mask_invalid {
+            // NOTE: Regarding the norm checks below, it is safe to
+            // leak the index of a violating coefficient during ML-DSA
+            // signature generation.
+            //
+            // See section 5.5 of the Dilithium Specification for
+            // Round 3 of the NIST Post-Quantum Cryptography
+            // Standardization.
+            // (https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)
+            if vector_infinity_norm_exceeds::<SIMDUnit>(&mask, (1 << GAMMA1_EXPONENT) - BETA) {
                 // XXX: https://github.com/hacspec/hax/issues/1171
                 // continue;
             } else {
-                let w0_invalid = vector_infinity_norm_exceeds::<SIMDUnit>(&w0, GAMMA2 - BETA);
-                ct_declassify(&w0_invalid);
-                if w0_invalid {
+                if vector_infinity_norm_exceeds::<SIMDUnit>(&w0, GAMMA2 - BETA) {
                     // XXX: https://github.com/hacspec/hax/issues/1171
                     // continue;
                 } else {

--- a/libcrux-ml-dsa/src/ml_dsa_generic.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_generic.rs
@@ -269,6 +269,19 @@ pub(crate) mod generic {
                 shake.squeeze(&mut commitment_hash_candidate);
             }
 
+            // Declassification: Revealing the verifier challenge
+            // `commitment_hash_candidate` is safe in the random
+            // oracle model.
+            //
+            // "The challenge reveals information about H(μ||w₁) also
+            // in the case of rejected y, but this does not reveal any
+            // information about the secret key when H is modelled as
+            // a random oracle and w₁ has high min-entropy."
+            //
+            // -- Section 5.5 of the Dilithium Specification for Round
+            // 3 of the NIST Post-Quantum Cryptography
+            // Standardization.
+            // (https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)
             ct_declassify(&commitment_hash_candidate);
 
             let mut verifier_challenge = PolynomialRingElement::zero();

--- a/libcrux-ml-dsa/src/ml_dsa_generic.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_generic.rs
@@ -3,6 +3,7 @@ use crate::{
         decompose_vector, make_hint, power2round_vector, use_hint, vector_infinity_norm_exceeds,
     },
     constants::*,
+    ct_test::ct_declassify,
     encoding::{self},
     hash_functions::{shake128, shake256},
     matrix::{
@@ -26,6 +27,8 @@ pub(crate) mod multiplexing;
 
 #[libcrux_macros::ml_dsa_parameter_sets(44, 65, 87)]
 pub(crate) mod generic {
+    use crate::ct_test::ct_classify;
+
     use super::*;
 
     // Derived constants
@@ -153,6 +156,11 @@ pub(crate) mod generic {
         let (s2_serialized, t0_serialized) =
             remaining_serialized.split_at(ERROR_RING_ELEMENT_SIZE * ROWS_IN_A);
 
+        ct_classify(&randomness);
+        ct_classify(seed_for_signing);
+        ct_classify(s1_serialized);
+        ct_classify(s2_serialized);
+
         // Deserialize s1, s2, and t0.
         let mut s1_as_ntt = [PolynomialRingElement::zero(); COLUMNS_IN_A];
         let mut s2_as_ntt = [PolynomialRingElement::zero(); ROWS_IN_A];
@@ -262,6 +270,8 @@ pub(crate) mod generic {
                 shake.squeeze(&mut commitment_hash_candidate);
             }
 
+            ct_declassify(&commitment_hash_candidate);
+
             let mut verifier_challenge = PolynomialRingElement::zero();
             sample_challenge_ring_element::<SIMDUnit, Shake256>(
                 &commitment_hash_candidate,
@@ -281,11 +291,18 @@ pub(crate) mod generic {
             add_vectors::<SIMDUnit>(COLUMNS_IN_A, &mut mask, &challenge_times_s1);
             subtract_vectors::<SIMDUnit>(ROWS_IN_A, &mut w0, &challenge_times_s2);
 
-            if vector_infinity_norm_exceeds::<SIMDUnit>(&mask, (1 << GAMMA1_EXPONENT) - BETA) {
+            let mask_invalid =
+                vector_infinity_norm_exceeds::<SIMDUnit>(&mask, (1 << GAMMA1_EXPONENT) - BETA);
+
+            ct_declassify(&mask_invalid);
+
+            if mask_invalid {
                 // XXX: https://github.com/hacspec/hax/issues/1171
                 // continue;
             } else {
-                if vector_infinity_norm_exceeds::<SIMDUnit>(&w0, GAMMA2 - BETA) {
+                let w0_invalid = vector_infinity_norm_exceeds::<SIMDUnit>(&w0, GAMMA2 - BETA);
+                ct_declassify(&w0_invalid);
+                if w0_invalid {
                     // XXX: https://github.com/hacspec/hax/issues/1171
                     // continue;
                 } else {
@@ -300,6 +317,8 @@ pub(crate) mod generic {
                         // XXX: https://github.com/hacspec/hax/issues/1171
                         // continue;
                     } else {
+                        ct_declassify(&w0);
+                        ct_declassify(&challenge_times_t0);
                         add_vectors::<SIMDUnit>(ROWS_IN_A, &mut w0, &challenge_times_t0);
                         let mut hint_candidate = [[0; COEFFICIENTS_IN_RING_ELEMENT]; ROWS_IN_A];
                         let ones_in_hint =

--- a/libcrux-ml-dsa/src/polynomial.rs
+++ b/libcrux-ml-dsa/src/polynomial.rs
@@ -63,7 +63,7 @@ impl<SIMDUnit: Operations> PolynomialRingElement<SIMDUnit> {
     pub(crate) fn infinity_norm_exceeds(&self, bound: i32) -> bool {
         let mut result = false;
         for i in 0..self.simd_units.len() {
-            result = result || SIMDUnit::infinity_norm_exceeds(&self.simd_units[i], bound);
+            result = result | SIMDUnit::infinity_norm_exceeds(&self.simd_units[i], bound);
         }
 
         result

--- a/libcrux-ml-dsa/src/polynomial.rs
+++ b/libcrux-ml-dsa/src/polynomial.rs
@@ -60,10 +60,32 @@ impl<SIMDUnit: Operations> PolynomialRingElement<SIMDUnit> {
         (forall i. Spec.Utils.is_i32b_array_opaque 
             (v ${FIELD_MAX}) 
             (i0._super_i2.f_repr (Seq.index self.f_simd_units i)))"#))]
+    /// CAUTION: This function must only be called with inputs for
+    /// which it is safe to leak the index of a violating coefficient.
+    ///
+    /// For all norm checks during ML-DSA signature generation it is
+    /// safe to leak the index of a violating coefficient.
     pub(crate) fn infinity_norm_exceeds(&self, bound: i32) -> bool {
         let mut result = false;
         for i in 0..self.simd_units.len() {
-            result = result | SIMDUnit::infinity_norm_exceeds(&self.simd_units[i], bound);
+            let coeff_exceeds = SIMDUnit::infinity_norm_exceeds(&self.simd_units[i], bound);
+            // Declassification: It is safe to leak the index of a
+            // violating coefficient during ML-DSA signature
+            // generation.
+            //
+            // See section 5.5 of the Dilithium Specification for
+            // Round 3 of the NIST Post-Quantum Cryptography
+            // Standardization.
+            // (https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)
+            crate::ct_test::ct_declassify(&coeff_exceeds);
+            // XXX: We can't use the non-short-circuiting
+            // core::ops::BitOr here, because of an issue in hax-lib
+            // v0.3.6.
+            // (cf. https://github.com/cryspen/libcrux/issues/1437)
+            //
+            // Using the short-circuiting OR is safe, see comment on
+            // declassification above.
+            result = result || coeff_exceeds;
         }
 
         result


### PR DESCRIPTION
This PR adds a `ctgrind_test` crate that performs constant time tests of ML-DSA, ML-KEM, and SHA-3 by using the [valgrind memcheck tool](https://valgrind.org/docs/manual/mc-manual.html). 

Each binary marks secret data as "undefined" with [`crabgrind::memcheck::mark_memory`](https://docs.rs/crabgrind/latest/crabgrind/memcheck/fn.mark_memory.html), runs a cryptographic operation, then marks the output as defined. Valgrind flags any use of a value containing undefined bits which would result in observable differences[^1] in program behaviour, indicating a potential timing side channel.

For libcrux-ml-dsa, appropriate valgrind requests are already issued in the crate itself, if compiled with the `valgrind_ct_test` cfg enabled.


These tests are only on a best effort basis. They cannot, e.g., guarantee the absence of cache side channel attacks.

resolves #1111 

[^1]: > Checks on definedness only occur in three places: when a value is used to generate a memory address, when control flow decision needs to be made, and when a system call is detected, Memcheck checks definedness of parameters as required. https://valgrind.org/docs/manual/mc-manual.html#mc-manual.value

----

Reasoning for declassifications in ML-DSA by @jschneider-bensch:

## Declassifications in ML-DSA

The signing operation in ML-DSA includes some operations that
technically depend on secret data, but are in fact safe under the
assumptions of the Dilithium security proof [1][dilithium-round3]. In these cases we
explicitly mark the memory as `MemState::Defined` for valgrind, in
order to avoid false positives.

### Verifier Challenge

Revealing the verifier challenge `commitment_hash_candidate` is safe
in the random oracle model.

> The challenge reveals information about H(μ||w₁) also
> in the case of rejected y, but this does not reveal any
> information about the secret key when H is modelled as
> a random oracle and w₁ has high min-entropy.

-- Section 5.5 of the [Dilithium Specification for Round
3 of the NIST Post-Quantum Cryptography
Standardization][dilithium-round3].

### Infinity Norm Checks

It is safe to leak the index of a violating coefficient during ML-DSA
signature generation.

See section 5.5 of the [Dilithium Specification for Round 3 of the NIST
Post-Quantum Cryptography Standardization][dilithium-round3].


### `w0` after norm checks have passed

After the norm checks have passed it is safe to serialize the
signature, so any value that could be derived from the signature and
the public key is safe to leak.

At this point `w0` = w - c * s2, and

    A * `mask` - `verifier_challenge` * t = w - c * s2

where `mask` and `verifier_challenge` are hold values that are part of
the signature to be serialized, and A and t are part of the public
key.

### `challenge_times_t0` after norm checks have passed

After the norm checks have passed it is safe to serialize the
signature, so any value that could be derived from the signature and
the public key is safe to leak.

`t0` is technically part of the signing key, but only for compression
of the public key. It can be considered public. `verifier_challenge`
will be part of the signature that is now safe to serialize, cf. [FIPS
204, section
6.1](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf)

[dilithium-round3]: https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf

[skip changelog]