### PR TITLE
[ML-DSA]: improve wycheproof test robustness

### DIFF
--- a/libcrux-ml-dsa/tests/wycheproof_sign.rs
+++ b/libcrux-ml-dsa/tests/wycheproof_sign.rs
@@ -44,14 +44,25 @@ macro_rules! wycheproof_sign_test {
                         let message = test.msg;
                         let context = test.ctx;
 
+                        if test.flags.contains(&Flag::InvalidPrivateKey) {
+                            // We do not perform validation of s1/s2 during signing. This is
+                            // not required by FIPS 204 or FIPS 140-3.
+                            // Additional context: https://github.com/pq-code-package/mldsa-native/pull/1003
+                            continue;
+                        }
+
                         let signature = $sign(&signing_key, &message, &context, signing_randomness);
 
                         if let Err(SigningError::ContextTooLongError) = signature {
-                            assert!(test.result == TestResult::Invalid)
+                            assert!(test.result == TestResult::Invalid);
+                            assert!(test.flags.contains(&Flag::InvalidContext));
+                            continue;
                         }
 
                         if test.result == TestResult::Valid {
                             assert_eq!(signature.unwrap().as_slice(), test.sig.as_slice());
+                        } else {
+                            panic!("tc_id: {}, unexpected test failure", test.tc_id)
                         }
                     }
                 }


### PR DESCRIPTION
Previously, the test would ignore unexpected test failures. We now panic should this happen after an update of the test vectors.

I've also documented in the test that we do not perform checking of s1/s2 during signing. There are test vectors for this in wycheproof, but these checks are not mandated or recommended by the specs. I've also linked to this [ml-dsa-native PR](https://github.com/pq-code-package/mldsa-native/pull/1003) which provides a discussion of this topic. They also do not perform these checks.

I noticed this while working on https://github.com/cryspen/libcrux-iot/pull/139.

[skip changelog]