### PR TITLE
[ML-DSA] Add valgrind testing for Key Generation

### DIFF
--- a/libcrux-ml-dsa/cg/code_gen.txt
+++ b/libcrux-ml-dsa/cg/code_gen.txt
@@ -3,4 +3,4 @@ Charon: 377317d6b25702c46ffff072fa00a3e32095e46f
 Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
 Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
 F*: unset
-Libcrux: dirty
+Libcrux: 1d9989fe8201ecb97d791f2d5d054c6e9277b382

--- a/libcrux-ml-dsa/cg/header.txt
+++ b/libcrux-ml-dsa/cg/header.txt
@@ -8,5 +8,5 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 1d9989fe8201ecb97d791f2d5d054c6e9277b382
  */

--- a/libcrux-ml-dsa/cg/libcrux_intrinsics_avx2.h
+++ b/libcrux-ml-dsa/cg/libcrux_intrinsics_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 1d9989fe8201ecb97d791f2d5d054c6e9277b382
  */
 
 #ifndef libcrux_intrinsics_avx2_H

--- a/libcrux-ml-dsa/cg/libcrux_mldsa65_avx2.c
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa65_avx2.c
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Cryspen Sarl <info@cryspen.com>
+ *
+ * SPDX-License-Identifier: MIT or Apache-2.0
+ *
+ * This code was generated with the following revisions:
+ * Charon: 377317d6b25702c46ffff072fa00a3e32095e46f
+ * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
+ * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
+ * F*: unset
+ * Libcrux: 1d9989fe8201ecb97d791f2d5d054c6e9277b382
+ */
+
+#include "libcrux_mldsa65_avx2.h"
+
+#include "libcrux_intrinsics_avx2.h"
+#include "libcrux_mldsa65_portable.h"
+#include "libcrux_mldsa_core.h"
+#include "libcrux_sha3_avx2.h"
+#include "libcrux_sha3_portable.h"
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types core_core_arch_x86___m256i
+
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+void libcrux_ml_dsa_ct_test_ct_declassify_17(const __m256i *val) {}

--- a/libcrux-ml-dsa/cg/libcrux_mldsa65_avx2.h
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa65_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 1d9989fe8201ecb97d791f2d5d054c6e9277b382
  */
 
 #ifndef libcrux_mldsa65_avx2_H
@@ -837,6 +837,18 @@ libcrux_ml_dsa_simd_avx2_encoding_error_deserialize_to_unsigned(
   return libcrux_ml_dsa_simd_avx2_encoding_error_deserialize_to_unsigned_when_eta_is_2(
       serialized);
 }
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types core_core_arch_x86___m256i
+
+*/
+void libcrux_ml_dsa_ct_test_ct_declassify_17(const __m256i *val);
 
 /**
 A monomorphic instance of
@@ -4448,6 +4460,21 @@ static inline Eurydice_dst_ref_mut_2a Eurydice_array_to_slice_mut_716(
 }
 
 /**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types Eurydice_arr libcrux_ml_dsa_polynomial_PolynomialRingElement
+libcrux_ml_dsa_simd_avx2_vector_type_Vec256[[$6size_t]]
+
+*/
+KRML_ATTRIBUTE_TARGET("avx2")
+static inline void libcrux_ml_dsa_ct_test_ct_declassify_040(
+    const Eurydice_arr_b50 *val) {}
+
+/**
 A monomorphic instance of libcrux_ml_dsa.arithmetic.power2round_vector
 with types libcrux_ml_dsa_simd_avx2_vector_type_Vec256
 with const generics
@@ -5503,21 +5530,6 @@ libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_64(
   }
   return result;
 }
-
-/**
- Declassify secret memory.
-
- No-op if `valgrind_ct_test` cfg is not enabled.
-*/
-/**
-A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
-with types Eurydice_arr libcrux_ml_dsa_polynomial_PolynomialRingElement
-libcrux_ml_dsa_simd_avx2_vector_type_Vec256[[$6size_t]]
-
-*/
-KRML_ATTRIBUTE_TARGET("avx2")
-static inline void libcrux_ml_dsa_ct_test_ct_declassify_040(
-    const Eurydice_arr_b50 *val) {}
 
 /**
 This function found in impl

--- a/libcrux-ml-dsa/cg/libcrux_mldsa65_portable.c
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa65_portable.c
@@ -8,13 +8,25 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 1d9989fe8201ecb97d791f2d5d054c6e9277b382
  */
 
 #include "libcrux_mldsa65_portable.h"
 
 #include "libcrux_mldsa_core.h"
 #include "libcrux_sha3_portable.h"
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types bool
+
+*/
+void libcrux_ml_dsa_ct_test_ct_declassify_5f(const bool *val) {}
 
 /**
  Mark memory as secret.
@@ -27,6 +39,18 @@ with types Eurydice_arr uint8_t[[$32size_t]]
 
 */
 void libcrux_ml_dsa_ct_test_ct_classify_62(const Eurydice_arr_60 *val) {}
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types Eurydice_derefed_slice uint8_t
+
+*/
+void libcrux_ml_dsa_ct_test_ct_declassify_45(const uint8_t (*val)[]) {}
 
 /**
  Mark memory as secret.
@@ -51,15 +75,3 @@ with types Eurydice_arr uint8_t[[$48size_t]]
 
 */
 void libcrux_ml_dsa_ct_test_ct_declassify_7d(const Eurydice_arr_5f *val) {}
-
-/**
- Declassify secret memory.
-
- No-op if `valgrind_ct_test` cfg is not enabled.
-*/
-/**
-A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
-with types bool
-
-*/
-void libcrux_ml_dsa_ct_test_ct_declassify_5f(const bool *val) {}

--- a/libcrux-ml-dsa/cg/libcrux_mldsa65_portable.h
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa65_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 1d9989fe8201ecb97d791f2d5d054c6e9277b382
  */
 
 #ifndef libcrux_mldsa65_portable_H
@@ -1154,6 +1154,18 @@ libcrux_ml_dsa_simd_portable_rejection_sample_less_than_field_modulus_65(
       randomness, out);
 }
 
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types bool
+
+*/
+void libcrux_ml_dsa_ct_test_ct_declassify_5f(const bool *val);
+
 static KRML_MUSTINLINE size_t
 libcrux_ml_dsa_simd_portable_sample_rejection_sample_less_than_eta_equals_2(
     Eurydice_borrow_slice_u8 randomness, Eurydice_dst_ref_mut_fc out) {
@@ -1163,13 +1175,15 @@ libcrux_ml_dsa_simd_portable_sample_rejection_sample_less_than_eta_equals_2(
     uint8_t byte = randomness.ptr[i0];
     uint8_t try_0 = (uint32_t)byte & 15U;
     uint8_t try_1 = (uint32_t)byte >> 4U;
-    if (try_0 < 15U) {
+    bool try_0_comp = try_0 < 15U;
+    bool try_1_comp = try_1 < 15U;
+    if (try_0_comp) {
       int32_t try_00 = (int32_t)try_0;
       int32_t try_0_mod_5 = try_00 - (try_00 * (int32_t)26 >> 7U) * (int32_t)5;
       out.ptr[sampled] = (int32_t)2 - try_0_mod_5;
       sampled++;
     }
-    if (try_1 < 15U) {
+    if (try_1_comp) {
       int32_t try_10 = (int32_t)try_1;
       int32_t try_1_mod_5 = try_10 - (try_10 * (int32_t)26 >> 7U) * (int32_t)5;
       out.ptr[sampled] = (int32_t)2 - try_1_mod_5;
@@ -1199,11 +1213,13 @@ libcrux_ml_dsa_simd_portable_sample_rejection_sample_less_than_eta_equals_4(
     uint8_t byte = randomness.ptr[i0];
     uint8_t try_0 = (uint32_t)byte & 15U;
     uint8_t try_1 = (uint32_t)byte >> 4U;
-    if (try_0 < 9U) {
+    bool try_0_comp = try_0 < 9U;
+    bool try_1_comp = try_1 < 9U;
+    if (try_0_comp) {
       out.ptr[sampled] = (int32_t)4 - (int32_t)try_0;
       sampled++;
     }
-    if (try_1 < 9U) {
+    if (try_1_comp) {
       out.ptr[sampled] = (int32_t)4 - (int32_t)try_1;
       sampled++;
     }
@@ -3921,6 +3937,30 @@ static inline void libcrux_ml_dsa_simd_portable_barrett_reduce_simd_unit_65(
   libcrux_ml_dsa_simd_portable_arithmetic_barrett_reduce_simd_unit(simd_unit);
 }
 
+/**
+ Mark memory as secret.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_classify
+with types Eurydice_arr uint8_t[[$32size_t]]
+
+*/
+void libcrux_ml_dsa_ct_test_ct_classify_62(const Eurydice_arr_60 *val);
+
+/**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types Eurydice_derefed_slice uint8_t
+
+*/
+void libcrux_ml_dsa_ct_test_ct_declassify_45(const uint8_t (*val)[]);
+
 typedef struct Eurydice_borrow_slice_u8_x2_s {
   Eurydice_borrow_slice_u8 fst;
   Eurydice_borrow_slice_u8 snd;
@@ -4820,6 +4860,20 @@ static inline Eurydice_dst_ref_mut_e7 Eurydice_array_to_slice_mut_712(
 }
 
 /**
+ Declassify secret memory.
+
+ No-op if `valgrind_ct_test` cfg is not enabled.
+*/
+/**
+A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
+with types Eurydice_arr libcrux_ml_dsa_polynomial_PolynomialRingElement
+libcrux_ml_dsa_simd_portable_vector_type_Coefficients[[$6size_t]]
+
+*/
+static inline void libcrux_ml_dsa_ct_test_ct_declassify_04(
+    const Eurydice_arr_a3 *val) {}
+
+/**
 A monomorphic instance of libcrux_ml_dsa.arithmetic.power2round_vector
 with types libcrux_ml_dsa_simd_portable_vector_type_Coefficients
 with const generics
@@ -5193,18 +5247,6 @@ static inline void libcrux_ml_dsa_ml_dsa_65_portable_generate_key_pair_mut(
 */
 /**
 A monomorphic instance of libcrux_ml_dsa.ct_test.ct_classify
-with types Eurydice_arr uint8_t[[$32size_t]]
-
-*/
-void libcrux_ml_dsa_ct_test_ct_classify_62(const Eurydice_arr_60 *val);
-
-/**
- Mark memory as secret.
-
- No-op if `valgrind_ct_test` cfg is not enabled.
-*/
-/**
-A monomorphic instance of libcrux_ml_dsa.ct_test.ct_classify
 with types Eurydice_derefed_slice uint8_t
 
 */
@@ -5221,18 +5263,6 @@ with types Eurydice_arr uint8_t[[$48size_t]]
 
 */
 void libcrux_ml_dsa_ct_test_ct_declassify_7d(const Eurydice_arr_5f *val);
-
-/**
- Declassify secret memory.
-
- No-op if `valgrind_ct_test` cfg is not enabled.
-*/
-/**
-A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
-with types bool
-
-*/
-void libcrux_ml_dsa_ct_test_ct_declassify_5f(const bool *val);
 
 /**
 A monomorphic instance of core.result.Result
@@ -5965,20 +5995,6 @@ libcrux_ml_dsa_arithmetic_vector_infinity_norm_exceeds_37(
   }
   return result;
 }
-
-/**
- Declassify secret memory.
-
- No-op if `valgrind_ct_test` cfg is not enabled.
-*/
-/**
-A monomorphic instance of libcrux_ml_dsa.ct_test.ct_declassify
-with types Eurydice_arr libcrux_ml_dsa_polynomial_PolynomialRingElement
-libcrux_ml_dsa_simd_portable_vector_type_Coefficients[[$6size_t]]
-
-*/
-static inline void libcrux_ml_dsa_ct_test_ct_declassify_04(
-    const Eurydice_arr_a3 *val) {}
 
 /**
 This function found in impl

--- a/libcrux-ml-dsa/cg/libcrux_mldsa_core.h
+++ b/libcrux-ml-dsa/cg/libcrux_mldsa_core.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 1d9989fe8201ecb97d791f2d5d054c6e9277b382
  */
 
 #ifndef libcrux_mldsa_core_H

--- a/libcrux-ml-dsa/cg/libcrux_sha3_avx2.h
+++ b/libcrux-ml-dsa/cg/libcrux_sha3_avx2.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 1d9989fe8201ecb97d791f2d5d054c6e9277b382
  */
 
 #ifndef libcrux_sha3_avx2_H

--- a/libcrux-ml-dsa/cg/libcrux_sha3_portable.h
+++ b/libcrux-ml-dsa/cg/libcrux_sha3_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: b227478b67c6a6e2ff611f978f10d6b7f26472ac
  * Karamel: 4e64d915da3c172d1dfad805b8e1a46beff938bc
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 1d9989fe8201ecb97d791f2d5d054c6e9277b382
  */
 
 #ifndef libcrux_sha3_portable_H

--- a/libcrux-ml-dsa/src/ml_dsa_generic.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_generic.rs
@@ -65,6 +65,8 @@ pub(crate) mod generic {
         signing_key: &mut [u8],
         verification_key: &mut [u8],
     ) {
+        ct_classify(&randomness);
+
         // Check key sizes
         #[cfg(not(eurydice))]
         debug_assert!(signing_key.len() == SIGNING_KEY_SIZE);

--- a/libcrux-ml-dsa/src/ml_dsa_generic.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_generic.rs
@@ -111,6 +111,10 @@ pub(crate) mod generic {
             );
         }
 
+        // Declassification: `t` is part of the public key, but split
+        // into t0 and t1 for public key compression.
+        ct_declassify(&t0);
+
         let mut t1 = [PolynomialRingElement::<SIMDUnit>::zero(); ROWS_IN_A];
         power2round_vector::<SIMDUnit>(&mut t0, &mut t1);
 

--- a/libcrux-ml-dsa/src/ml_dsa_generic.rs
+++ b/libcrux-ml-dsa/src/ml_dsa_generic.rs
@@ -92,6 +92,8 @@ pub(crate) mod generic {
         let mut t0 = [PolynomialRingElement::<SIMDUnit>::zero(); ROWS_IN_A];
         {
             let mut a_as_ntt = [PolynomialRingElement::<SIMDUnit>::zero(); ROW_X_COLUMN];
+            // Declassification: `seed_for_a` is part of the public key.
+            ct_declassify(seed_for_a);
             Sampler::matrix_flat::<SIMDUnit>(COLUMNS_IN_A, seed_for_a, &mut a_as_ntt);
 
             let mut s1_ntt = [PolynomialRingElement::<SIMDUnit>::zero(); COLUMNS_IN_A];

--- a/libcrux-ml-dsa/src/simd/avx2/rejection_sample/less_than_eta.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/rejection_sample/less_than_eta.rs
@@ -61,6 +61,10 @@ pub(crate) fn sample<const ETA: usize>(input: &[u8], output: &mut [i32]) -> usiz
     // - mldsa-native: https://github.com/pq-code-package/mldsa-native/blob/0591fe06832418f8a320d5a1533327df063185cf/dev/x86_64/meta.h#L130
     // - Dilithium reference implementation: https://github.com/pq-crystals/dilithium/blob/6e00625c5b29f516c6de973fe2ee2fbb150973f9/avx2/rejsample.c#L312
     //
+    // It should be noted that the declassification of the comparison
+    // result here does not (and must not) declassify the sampled
+    // coefficients.
+    //
     // While we do not consider protection against power
     // side-channels in scope for libcrux, at this point, a
     // hardened implementation of sampling mod p can be found in

--- a/libcrux-ml-dsa/src/simd/avx2/rejection_sample/less_than_eta.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/rejection_sample/less_than_eta.rs
@@ -1,6 +1,9 @@
-use crate::simd::avx2::{encoding, rejection_sample::shuffle_table::SHUFFLE_TABLE, Eta};
-
 use libcrux_intrinsics::avx2::*;
+
+use crate::{
+    ct_test::ct_declassify,
+    simd::avx2::{encoding, rejection_sample::shuffle_table::SHUFFLE_TABLE, Eta},
+};
 
 // TODO: This code seems to slow the implementation down, but stabilizes
 // benchmarks. Revisit this once the other functions are vectorized.
@@ -37,6 +40,34 @@ pub(crate) fn sample<const ETA: usize>(input: &[u8], output: &mut [i32]) -> usiz
 
     let compare_with_interval_boundary =
         mm256_cmpgt_epi32(mm256_set1_epi32(interval_boundary), potential_coefficients);
+
+    // Declassification: The subsequent operation may leak the
+    // rejection decision for these coefficients. The Dilithium
+    // Specification for Round 3 of the NIST Post-Quantum
+    // Cryptography Standardization Process states that:
+    //
+    // "When performing rejection sampling, our code reveals which of the
+    // conditions was the reason for the rejection, ..."
+    //
+    // and that doing so is safe (Section 5.5,
+    // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf).
+    // However, there is some ambiguity whether this is referring
+    // only to rejection sampling during signature
+    // generation. Other implementations of ML-DSA, including the
+    // reference implementation, do not go out of their way to
+    // avoid this secret-dependent behaviour and are offered as
+    // evidence that this is safe to do:
+    //
+    // - mldsa-native: https://github.com/pq-code-package/mldsa-native/blob/0591fe06832418f8a320d5a1533327df063185cf/dev/x86_64/meta.h#L130
+    // - Dilithium reference implementation: https://github.com/pq-crystals/dilithium/blob/6e00625c5b29f516c6de973fe2ee2fbb150973f9/avx2/rejsample.c#L312
+    //
+    // While we do not consider protection against power
+    // side-channels in scope for libcrux, at this point, a
+    // hardened implementation of sampling mod p can be found in
+    // Azouaoui et al, "Levelling Dilithium Against Leakage",
+    // section 4.4
+    // (https://csrc.nist.gov/csrc/media/Events/2022/fourth-pqc-standardization-conference/documents/papers/leveling-dilithium-against-leakage-pqc2022.pdf).
+    ct_declassify(&compare_with_interval_boundary);
 
     // Since every bit in each lane is either 0 or all 1s, we only need one bit
     // from each lane to tell us what coefficients to keep and what to throw-away.

--- a/libcrux-ml-dsa/src/simd/portable/sample.rs
+++ b/libcrux-ml-dsa/src/simd/portable/sample.rs
@@ -1,7 +1,6 @@
-use crate::constants::FIELD_MODULUS;
-
 #[cfg(hax)]
 use crate::specs::simd::portable::sample::*;
+use crate::{constants::FIELD_MODULUS, ct_test::ct_declassify};
 
 #[inline(always)]
 #[hax_lib::requires(rejection_sample_less_than_field_modulus_pre(randomness, out))]
@@ -90,7 +89,38 @@ pub fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32
                 (Spec.MLDSA.Math.rejection_sample_eta_2_inner $randomness) Seq.empty ($i)"#
         );
 
-        if try_0 < 15 {
+        let try_0_comp = try_0 < 15;
+        let try_1_comp = try_1 < 15;
+
+        // Declassification: The subsequent branch may leak the
+        // rejection decision for this coefficient. The Dilithium
+        // Specification for Round 3 of the NIST Post-Quantum
+        // Cryptography Standardization Process states that:
+        //
+        // "When performing rejection sampling, our code reveals which of the
+        // conditions was the reason for the rejection, ..."
+        //
+        // and that doing so is safe (Section 5.5,
+        // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf).
+        // However, there is some ambiguity whether this is referring
+        // only to rejection sampling during signature
+        // generation. Other implementations of ML-DSA, including the
+        // reference implementation, do not go out of their way to
+        // avoid this secret-dependent branch and are offered as
+        // evidence that this is safe to do:
+        //
+        // - mldsa-native: https://github.com/pq-code-package/mldsa-native/blob/0591fe06832418f8a320d5a1533327df063185cf/mldsa/src/poly_kl.c#L235
+        // - Dilithium reference implementation: https://github.com/pq-crystals/dilithium/blob/6e00625c5b29f516c6de973fe2ee2fbb150973f9/ref/poly.c#L398
+        //
+        // While we do not consider protection against power
+        // side-channels in scope for libcrux, at this point, a
+        // hardened implementation of sampling mod p can be found in
+        // Azouaoui et al, "Levelling Dilithium Against Leakage",
+        // section 4.4
+        // (https://csrc.nist.gov/csrc/media/Events/2022/fourth-pqc-standardization-conference/documents/papers/leveling-dilithium-against-leakage-pqc2022.pdf).
+        ct_declassify(&try_0_comp);
+
+        if try_0_comp {
             let try_0 = try_0 as i32;
             // (try_0 * 26) >> 7 computes ⌊try_0 / 5⌋
             let try_0_mod_5 = try_0 - ((try_0 * 26) >> 7) * 5;
@@ -104,7 +134,35 @@ pub fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32
             sampled += 1;
         }
 
-        if try_1 < 15 {
+        // Declassification: The subsequent branch may leak the
+        // rejection decision for this coefficient. The Dilithium
+        // Specification for Round 3 of the NIST Post-Quantum
+        // Cryptography Standardization Process states that:
+        //
+        // "When performing rejection sampling, our code reveals which of the
+        // conditions was the reason for the rejection, ..."
+        //
+        // and that doing so is safe (Section 5.5,
+        // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf).
+        // However, there is some ambiguity whether this is referring
+        // only to rejection sampling during signature
+        // generation. Other implementations of ML-DSA, including the
+        // reference implementation, do not go out of their way to
+        // avoid this secret-dependent branch and are offered as
+        // evidence that this is safe to do:
+        //
+        // - mldsa-native: https://github.com/pq-code-package/mldsa-native/blob/0591fe06832418f8a320d5a1533327df063185cf/mldsa/src/poly_kl.c#L235
+        // - Dilithium reference implementation: https://github.com/pq-crystals/dilithium/blob/6e00625c5b29f516c6de973fe2ee2fbb150973f9/ref/poly.c#L398
+        //
+        // While we do not consider protection against power
+        // side-channels in scope for libcrux, at this point, a
+        // hardened implementation of sampling mod p can be found in
+        // Azouaoui et al, "Levelling Dilithium Against Leakage",
+        // section 4.4
+        // (https://csrc.nist.gov/csrc/media/Events/2022/fourth-pqc-standardization-conference/documents/papers/leveling-dilithium-against-leakage-pqc2022.pdf).
+        ct_declassify(&try_1_comp);
+
+        if try_1_comp {
             let try_1 = try_1 as i32;
             let try_1_mod_5 = try_1 - ((try_1 * 26) >> 7) * 5;
 
@@ -163,11 +221,71 @@ pub fn rejection_sample_less_than_eta_equals_4(randomness: &[u8], out: &mut [i32
                 (Spec.MLDSA.Math.rejection_sample_eta_4_inner $randomness) Seq.empty ($i)"#
         );
 
-        if try_0 < 9 {
+        let try_0_comp = try_0 < 9;
+        let try_1_comp = try_1 < 9;
+
+        // Declassification: The subsequent branch may leak the
+        // rejection decision for this coefficient. The Dilithium
+        // Specification for Round 3 of the NIST Post-Quantum
+        // Cryptography Standardization Process states that:
+        //
+        // "When performing rejection sampling, our code reveals which of the
+        // conditions was the reason for the rejection, ..."
+        //
+        // and that doing so is safe (Section 5.5,
+        // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf).
+        // However, there is some ambiguity whether this is referring
+        // only to rejection sampling during signature
+        // generation. Other implementations of ML-DSA, including the
+        // reference implementation, do not go out of their way to
+        // avoid this secret-dependent branch and are offered as
+        // evidence that this is safe to do:
+        //
+        // - mldsa-native: https://github.com/pq-code-package/mldsa-native/blob/0591fe06832418f8a320d5a1533327df063185cf/mldsa/src/poly_kl.c#L235
+        // - Dilithium reference implementation: https://github.com/pq-crystals/dilithium/blob/6e00625c5b29f516c6de973fe2ee2fbb150973f9/ref/poly.c#L398
+        //
+        // While we do not consider protection against power
+        // side-channels in scope for libcrux, at this point, a
+        // hardened implementation of sampling mod p can be found in
+        // Azouaoui et al, "Levelling Dilithium Against Leakage",
+        // section 4.4
+        // (https://csrc.nist.gov/csrc/media/Events/2022/fourth-pqc-standardization-conference/documents/papers/leveling-dilithium-against-leakage-pqc2022.pdf).
+        ct_declassify(&try_0_comp);
+
+        if try_0_comp {
             out[sampled] = 4 - (try_0 as i32);
             sampled += 1;
         }
-        if try_1 < 9 {
+
+        // Declassification: The subsequent branch may leak the
+        // rejection decision for this coefficient. The Dilithium
+        // Specification for Round 3 of the NIST Post-Quantum
+        // Cryptography Standardization Process states that:
+        //
+        // "When performing rejection sampling, our code reveals which of the
+        // conditions was the reason for the rejection, ..."
+        //
+        // and that doing so is safe (Section 5.5,
+        // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf).
+        // However, there is some ambiguity whether this is referring
+        // only to rejection sampling during signature
+        // generation. Other implementations of ML-DSA, including the
+        // reference implementation, do not go out of their way to
+        // avoid this secret-dependent branch and are offered as
+        // evidence that this is safe to do:
+        //
+        // - mldsa-native: https://github.com/pq-code-package/mldsa-native/blob/0591fe06832418f8a320d5a1533327df063185cf/mldsa/src/poly_kl.c#L235
+        // - Dilithium reference implementation: https://github.com/pq-crystals/dilithium/blob/6e00625c5b29f516c6de973fe2ee2fbb150973f9/ref/poly.c#L398
+        //
+        // While we do not consider protection against power
+        // side-channels in scope for libcrux, at this point, a
+        // hardened implementation of sampling mod p can be found in
+        // Azouaoui et al, "Levelling Dilithium Against Leakage",
+        // section 4.4
+        // (https://csrc.nist.gov/csrc/media/Events/2022/fourth-pqc-standardization-conference/documents/papers/leveling-dilithium-against-leakage-pqc2022.pdf).
+        ct_declassify(&try_1_comp);
+
+        if try_1_comp {
             out[sampled] = 4 - (try_1 as i32);
             sampled += 1;
         }


### PR DESCRIPTION
While the key generation declassifications are partly in platform-dependent code, this does not yet ensure #1448, so we should take care that all implementations are covered here: I added classifcations for portable and AVX2 and the under-documented NEON implementation uses the portable code for the declassifications in question.  

resolves #1443 

[skip changelog]