### PR TITLE
sha3: fix footgun in runtime dispatched sha3 function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (libcrux-secrets) [#1446](https://github.com/cryspen/libcrux/pull/1446): Remove const qualifier of secret types constructors
 - (libcrux-secrets) [#1462](https://github.com/cryspen/libcrux/pull/1462): More robust casts instead of transmutes when checking secret independence
+- (libcrux-sha3) [1454](https://github.com/cryspen/libcrux/pull/1454): `debug_assert` that generic `LEN` matches algorithm in `hash` function
 
 ### Added
 

--- a/crates/algorithms/sha3/CHANGELOG.md
+++ b/crates/algorithms/sha3/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- [1454](https://github.com/cryspen/libcrux/pull/1454): `debug_assert` that generic `LEN` matches algorithm in `hash` function
+
 ## [0.0.9] (2026-05-13)
 
 ### Changed

--- a/crates/algorithms/sha3/src/lib.rs
+++ b/crates/algorithms/sha3/src/lib.rs
@@ -87,10 +87,13 @@ pub const fn digest_size(mode: Algorithm) -> usize {
 
 /// SHA3
 #[hax_lib::fstar::options("--split_queries always")]
-#[hax_lib::requires(payload.len().to_int() <= u32::MAX.to_int())]
+#[hax_lib::requires(
+    payload.len().to_int() <= u32::MAX.to_int() &&
+    digest_size(algorithm) == LEN
+)]
 pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[u8]) -> [u8; LEN] {
-    #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
+    debug_assert_eq!(digest_size(algorithm), LEN);
 
     let mut out = [0u8; LEN];
     match algorithm {

--- a/crates/algorithms/sha3/src/lib.rs
+++ b/crates/algorithms/sha3/src/lib.rs
@@ -34,7 +34,8 @@ pub const SHA3_512_DIGEST_SIZE: usize = 64;
 pub(crate) mod proof_utils;
 
 /// The Digest Algorithm.
-#[cfg_attr(not(eurydice), derive(Clone, Copy, Debug, PartialEq))]
+#[cfg_attr(not(eurydice), derive(Debug, PartialEq))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum Algorithm {
     /// SHA3 224

--- a/libcrux-ml-kem/extracts/cpp_header_only/extract.sh
+++ b/libcrux-ml-kem/extracts/cpp_header_only/extract.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Previously, you could call the `hash` (or aliased sha3) function with a constant LEN parameter not corresponding to the passed algorithm. In that case, the digest would be silently truncated.

I've removed the `#[cfg(not(eurydice))]` as the other sha3 functions also don't have it above their debug_asserts. 