### PR TITLE
[secrets] More robust casts instead of transmutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - (libcrux-secrets) [#1446](https://github.com/cryspen/libcrux/pull/1446): Remove const qualifier of secret types constructors
+- (libcrux-secrets) [#1462](https://github.com/cryspen/libcrux/pull/1462): More robust casts instead of transmutes when checking secret independence
 
 ### Added
 

--- a/crates/utils/secrets/CHANGELOG.md
+++ b/crates/utils/secrets/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#1460](https://github.com/cryspen/libcrux/issues/1460): Fix incorrect cmp in aarch64 select/swap implementation 
+- [#1460](https://github.com/cryspen/libcrux/issues/1460): Fix incorrect cmp in aarch64 select/swap implementation
 
 ### Changed
 
 - [#1446](https://github.com/cryspen/libcrux/pull/1446): Remove const qualifier of secret types constructors
+- [#1462](https://github.com/cryspen/libcrux/pull/1462): More robust casts instead of transmutes when checking secret independence
 
 ### Added
 

--- a/crates/utils/secrets/src/int/classify_secret.rs
+++ b/crates/utils/secrets/src/int/classify_secret.rs
@@ -91,7 +91,7 @@ impl<'a, T: Scalar> ClassifyRef for &'a [T] {
         ct_classify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret slices is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { core::slice::from_raw_parts(self.as_ptr().cast::<Secret<T>>(), self.len()) }
     }
 }
 
@@ -102,7 +102,7 @@ impl<'a, T: Scalar> DeclassifyRef for &'a [Secret<T>] {
         ct_declassify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret slices is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { core::slice::from_raw_parts(self.as_ptr().cast::<T>(), self.len()) }
     }
 }
 
@@ -113,7 +113,9 @@ impl<'a, T: Scalar> ClassifyRefMut for &'a mut [T] {
         ct_classify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret slices is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe {
+            core::slice::from_raw_parts_mut(self.as_mut_ptr().cast::<Secret<T>>(), self.len())
+        }
     }
 }
 
@@ -124,7 +126,7 @@ impl<'a, T: Scalar> DeclassifyRefMut for &'a mut [Secret<T>] {
         ct_declassify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret slices is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { core::slice::from_raw_parts_mut(self.as_mut_ptr().cast::<T>(), self.len()) }
     }
 }
 

--- a/crates/utils/secrets/src/int/classify_secret.rs
+++ b/crates/utils/secrets/src/int/classify_secret.rs
@@ -5,6 +5,7 @@ use crate::mem_requests::{ct_classify, ct_declassify};
 /// That is, it should not be used when running the Rust code in production.
 /// Otherwise, the crate defaults to public integers.
 use crate::traits::*;
+use core::ptr;
 
 /// A type for secret values
 #[repr(transparent)]
@@ -69,7 +70,7 @@ impl<'a, T: Scalar> ClassifyRefMut for &'a mut T {
         ct_classify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret values is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { &mut *ptr::from_mut(self).cast::<Secret<T>>() }
     }
 }
 
@@ -80,7 +81,7 @@ impl<'a, T: Scalar> DeclassifyRefMut for &'a mut Secret<T> {
         ct_declassify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret values is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { &mut *ptr::from_mut(self).cast::<T>() }
     }
 }
 
@@ -137,7 +138,7 @@ impl<'a, T: Scalar, const N: usize> ClassifyRef for &'a [T; N] {
         ct_classify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret arrays is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { &*self.as_ptr().cast::<[Secret<T>; N]>() }
     }
 }
 
@@ -148,7 +149,7 @@ impl<'a, T: Scalar, const N: usize> DeclassifyRef for &'a [Secret<T>; N] {
         ct_declassify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret arrays is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { &*self.as_ptr().cast::<[T; N]>() }
     }
 }
 
@@ -159,7 +160,7 @@ impl<'a, T: Scalar, const N: usize> ClassifyRefMut for &'a mut [T; N] {
         ct_classify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret arrays is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { &mut *self.as_mut_ptr().cast::<[Secret<T>; N]>() }
     }
 }
 
@@ -170,6 +171,6 @@ impl<'a, T: Scalar, const N: usize> DeclassifyRefMut for &'a mut [Secret<T>; N] 
         ct_declassify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret arrays is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { &mut *self.as_mut_ptr().cast::<[T; N]>() }
     }
 }

--- a/crates/utils/secrets/src/int/secret_integers.rs
+++ b/crates/utils/secrets/src/int/secret_integers.rs
@@ -4,6 +4,7 @@ use super::classify_secret::*;
 use crate::mem_requests::{ct_classify, ct_declassify};
 use crate::traits::*;
 use core::ops::*;
+use core::ptr;
 
 pub type I8 = Secret<i8>;
 pub type U8 = Secret<u8>;
@@ -46,7 +47,7 @@ impl<'a, T: Scalar> ClassifyRef for &'a T {
         ct_classify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret values is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { &*ptr::from_ref(self).cast::<Secret<T>>() }
     }
 }
 
@@ -57,7 +58,7 @@ impl<'a, T: Scalar> DeclassifyRef for &'a Secret<T> {
         ct_declassify(self);
         // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
         //       the memory representation of the public and secret values is the same
-        unsafe { core::mem::transmute(self) }
+        unsafe { &*ptr::from_ref(self).cast::<T>() }
     }
 }
 

--- a/crates/utils/secrets/src/int/secret_integers.rs
+++ b/crates/utils/secrets/src/int/secret_integers.rs
@@ -66,7 +66,7 @@ pub fn classify_mut_slice<T: Scalar>(x: &mut [T]) -> &mut [Secret<T>] {
     ct_classify(x);
     // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
     //       the memory representation of the public and secret slices is the same
-    unsafe { core::mem::transmute(x) }
+    unsafe { core::slice::from_raw_parts_mut(x.as_mut_ptr().cast::<Secret<T>>(), x.len()) }
 }
 
 /// Declassify a mutable reference to a slice
@@ -74,7 +74,7 @@ pub fn declassify_mut_slice<T: Scalar>(x: &mut [Secret<T>]) -> &mut [T] {
     ct_declassify(x);
     // SAFETY: this is safe since the `Secret` type is `repr(transparent)`, so
     //       the memory representation of the public and secret slices is the same
-    unsafe { core::mem::transmute(x) }
+    unsafe { core::slice::from_raw_parts_mut(x.as_mut_ptr().cast::<T>(), x.len()) }
 }
 
 // We define a series of operations that are safe over secret values


### PR DESCRIPTION
libcrux-secrets contained transmutes of the form `transmute::<&[T], &[Secret<T>]>`. This is *technically* UB, as the layout of slice fat pointers is not defined (in practice it is always `(ptr, len)` and this is unlikely to change and might be guaranteed in the future, but not at the moment)[^refs]. 

The first commit changes the relevant impls to use the `slice::from_raw_parts` functions. This could also be done via ptr casts, but I find the function a bit more clear.

The second commit changes the correct transmutes to more robust ptr casts.

[^refs]: See e.g. [here](https://lore.kernel.org/all/CAH5fLgibt_BQmOtkfEfo1=48zUeoWBJ-=u5gzw_a3X6Q7=aUSA@mail.gmail.com/) or [here](https://users.rust-lang.org/t/is-a-slice-of-transmutable-elements-transmutable-into-a-slice-of-transmuted-elements/79784/3).