### PR TITLE
[fstar-helpers]: Fix LOCALE dependent sort

### DIFF
--- a/fstar-helpers/Makefile.generic
+++ b/fstar-helpers/Makefile.generic
@@ -101,7 +101,7 @@ export FINDLIBS
 
 FSTAR_INCLUDE_DIRS_EXTRA ?=
 FINDLIBS_OUTPUT ?= $(shell bash -c '${FINDLIBS}')
-FSTAR_INCLUDE_DIRS = $(shell echo $(FSTAR_INCLUDE_DIRS_EXTRA) $(FINDLIBS_OUTPUT) | tr ' ' '\n' | sort -u | tr '\n' ' ')
+FSTAR_INCLUDE_DIRS = $(shell echo $(FSTAR_INCLUDE_DIRS_EXTRA) $(FINDLIBS_OUTPUT) | tr ' ' '\n' | LC_ALL=C sort -u | tr '\n' ' ')
 
 # Make sure FSTAR_INCLUDE_DIRS has the `proof-libs`, print hints and
 # an error message otherwise


### PR DESCRIPTION
Sort is LOCALE dependent which can lead to different and incompatible ordering of the FSTAR_INCLUDE_DIRS. This sets the LOCALE to C which should be what is used in CI.

[skip changelog]