### PR TITLE
update MSRV (found with `cargo-msrv`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ authors = ["Cryspen"]
 license = "Apache-2.0"
 homepage = "https://github.com/cryspen/libcrux"
 edition = "2021"
+rust-version = "1.89.0"
 repository = "https://github.com/cryspen/libcrux"
 readme = "Readme.md"
 

--- a/Readme.md
+++ b/Readme.md
@@ -42,8 +42,8 @@ This repository also contains a `libcrux` crate, which is a simple re-exporter o
 
 ## Minimum Supported Rust Version (MSRV)
 
-The default feature set has a MSRV of `1.78.0`. `no_std` environments
-are supported starting from Rust version `1.81.0`.
+The default feature set has a MSRV of `1.89.0`. `no_std` environments
+are supported starting from Rust version `1.89.0`.
 
 ## `no_std` support
 `libcrux` and the individual primitive crates it depends on support


### PR DESCRIPTION
This PR fixes compile errors downstream for projects supporting older MSRV than `libcrux`. What I did:

- found out the current MSRV with [cargo-msrv](https://github.com/foresterre/cargo-msrv)
- updated the `Readme.md`
- added `rust-version` key to `Cargo.toml`

<details>

<summary> Result of `cargo msrv find --features default` </summary>

```text
$ cargo msrv find --features default
  [Meta]   cargo-msrv 0.19.3  

Compatibility Check #1: Rust 1.47.0
  [FAIL]   Is incompatible 
                                                                        
  ╭────────────────────────────────────────────────────────────────────╮
  │ error: failed to parse manifest at `/home/user/libcrux/Cargo.toml` │
  │                                                                    │
  │ Caused by:                                                         │
  │   invalid type: map, expected a sequence for key `package.authors` │
  │                                                                    │
  ╰────────────────────────────────────────────────────────────────────╯
                                                                        

Compatibility Check #2: Rust 1.72.1
  [FAIL]   Is incompatible 
                                                                                                                                          
  ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │ warning: /home/user/libcrux/crates/algorithms/sha3/Cargo.toml: unused manifest key `lints` (may be supported in a future version)    │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/sys/platform/Cargo.toml: unused manifest key `lints` (may be supported in a future version)       │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/utils/secrets/Cargo.toml: unused manifest key `lints` (may be supported in a future version)      │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/utils/ctgrind-test/Cargo.toml: unused manifest key `lints` (may be supported in a future version) │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/Cargo.toml: unused manifest key `lints` (may be supported in a future version)                           │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/libcrux-ml-kem/Cargo.toml: unused manifest key `lints` (may be supported in a future version)            │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/algorithms/aesgcm/Cargo.toml: unused manifest key `lints` (may be supported in a future version)  │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/benchmarks/Cargo.toml: unused manifest key `lints` (may be supported in a future version)                │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/utils/intrinsics/Cargo.toml: unused manifest key `lints` (may be supported in a future version)   │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/utils/core-models/Cargo.toml: unused manifest key `lints` (may be supported in a future version)  │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/libcrux-ml-dsa/Cargo.toml: unused manifest key `lints` (may be supported in a future version)            │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ error: failed to parse lock file at: /home/user/libcrux/Cargo.lock                                                                   │
  │                                                                                                                                      │
  │ Caused by:                                                                                                                           │
  │   lock file version `4` was found, but this version of Cargo does not understand this lock file, perhaps Cargo needs to be updated?  │
  │                                                                                                                                      │
  ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                                          

Compatibility Check #3: Rust 1.84.1
  [FAIL]   Is incompatible 
                                                                                                                                                                 
  ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │  Downloading crates ...                                                                                                                                     │
  │ error: failed to download `getrandom v0.4.2`                                                                                                                │
  │                                                                                                                                                             │
  │ Caused by:                                                                                                                                                  │
  │   unable to get packages from source                                                                                                                        │
  │                                                                                                                                                             │
  │ Caused by:                                                                                                                                                  │
  │   failed to parse manifest at `/home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.4.2/Cargo.toml`                                  │
  │                                                                                                                                                             │
  │ Caused by:                                                                                                                                                  │
  │   feature `edition2024` is required                                                                                                                         │
  │                                                                                                                                                             │
  │   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.1 (66221abde 2024-11-19)). │
  │   Consider trying a newer version of Cargo (this may require the nightly release).                                                                          │
  │   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.                   │
  │                                                                                                                                                             │
  ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                                                                 

Compatibility Check #4: Rust 1.90.0
  [OK]     Is compatible 

Compatibility Check #5: Rust 1.87.0
  [FAIL]   Is incompatible 
                                                                                                                    
  ╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │     Checking libcrux-psq v0.0.9 (/home/user/libcrux/libcrux-psq)                                               │
  │    Compiling libcrux v0.0.4 (/home/user/libcrux)                                                               │
  │ error[E0716]: temporary value dropped while borrowed                                                           │
  │    --> libcrux-psq/src/handshake/initiator/registration.rs:217:30                                              │
  │     |                                                                                                          │
  │ 217 |                         vk: &sig_auth.into(),                                                            │
  │     |                              ^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use │
  │ ...                                                                                                            │
  │ 227 |                 });                                                                                      │
  │     |                   - temporary value is freed at the end of this statement                                │
  │ 228 |                 let (outer_ciphertext, outer_tag) =                                                      │
  │ 229 |                     state.k0.handshake_encrypt(&outer_payload, self.outer_aad)?;                         │
  │     |                                                -------------- borrow later used here                     │
  │     |                                                                                                          │
  │     = note: consider using a `let` binding to create a longer lived value                                      │
  │                                                                                                                │
  │ For more information about this error, try `rustc --explain E0716`.                                            │
  │ error: could not compile `libcrux-psq` (lib) due to 1 previous error                                           │
  │                                                                                                                │
  ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                    

Compatibility Check #6: Rust 1.88.0
  [FAIL]   Is incompatible 
                                                                                                                    
  ╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │     Checking libcrux-psq v0.0.9 (/home/user/libcrux/libcrux-psq)                                               │
  │    Compiling libcrux v0.0.4 (/home/user/libcrux)                                                               │
  │ error[E0716]: temporary value dropped while borrowed                                                           │
  │    --> libcrux-psq/src/handshake/initiator/registration.rs:217:30                                              │
  │     |                                                                                                          │
  │ 217 |                         vk: &sig_auth.into(),                                                            │
  │     |                              ^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use │
  │ ...                                                                                                            │
  │ 227 |                 });                                                                                      │
  │     |                   - temporary value is freed at the end of this statement                                │
  │ 228 |                 let (outer_ciphertext, outer_tag) =                                                      │
  │ 229 |                     state.k0.handshake_encrypt(&outer_payload, self.outer_aad)?;                         │
  │     |                                                -------------- borrow later used here                     │
  │     |                                                                                                          │
  │     = note: consider using a `let` binding to create a longer lived value                                      │
  │                                                                                                                │
  │ For more information about this error, try `rustc --explain E0716`.                                            │
  │ error: could not compile `libcrux-psq` (lib) due to 1 previous error                                           │
  │                                                                                                                │
  ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                    

Compatibility Check #7: Rust 1.89.0
  [OK]     Is compatible 

Result:
   Considered (min … max):   Rust 0.11.0 … Rust 1.96.0 
   Search method:            bisect                    
   MSRV:                     1.89.0                    
   Target:                   x86_64-unknown-linux-gnu  
                                                       

```

</details>

<details>

<summary> Results of `$ cargo msrv find --no-default-features --features all,wasm` </summary>

```text
$ cargo msrv find --no-default-features --features all,wasm
  [Meta]   cargo-msrv 0.19.3  

Compatibility Check #1: Rust 1.47.0
  [FAIL]   Is incompatible 
                                                                        
  ╭────────────────────────────────────────────────────────────────────╮
  │ error: failed to parse manifest at `/home/user/libcrux/Cargo.toml` │
  │                                                                    │
  │ Caused by:                                                         │
  │   invalid type: map, expected a sequence for key `package.authors` │
  │                                                                    │
  ╰────────────────────────────────────────────────────────────────────╯
                                                                        

Compatibility Check #2: Rust 1.72.1
  [FAIL]   Is incompatible 
                                                                                                                                          
  ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │ warning: /home/user/libcrux/crates/algorithms/aesgcm/Cargo.toml: unused manifest key `lints` (may be supported in a future version)  │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/utils/ctgrind-test/Cargo.toml: unused manifest key `lints` (may be supported in a future version) │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/sys/platform/Cargo.toml: unused manifest key `lints` (may be supported in a future version)       │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/utils/intrinsics/Cargo.toml: unused manifest key `lints` (may be supported in a future version)   │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/libcrux-ml-dsa/Cargo.toml: unused manifest key `lints` (may be supported in a future version)            │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/algorithms/sha3/Cargo.toml: unused manifest key `lints` (may be supported in a future version)    │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/benchmarks/Cargo.toml: unused manifest key `lints` (may be supported in a future version)                │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/utils/core-models/Cargo.toml: unused manifest key `lints` (may be supported in a future version)  │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/Cargo.toml: unused manifest key `lints` (may be supported in a future version)                           │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/libcrux-ml-kem/Cargo.toml: unused manifest key `lints` (may be supported in a future version)            │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ warning: /home/user/libcrux/crates/utils/secrets/Cargo.toml: unused manifest key `lints` (may be supported in a future version)      │
  │                                                                                                                                      │
  │ this Cargo does not support nightly features, but if you                                                                             │
  │ switch to nightly channel you can pass                                                                                               │
  │ `-Zlints` to enable this feature.                                                                                                    │
  │ error: failed to parse lock file at: /home/user/libcrux/Cargo.lock                                                                   │
  │                                                                                                                                      │
  │ Caused by:                                                                                                                           │
  │   lock file version `4` was found, but this version of Cargo does not understand this lock file, perhaps Cargo needs to be updated?  │
  │                                                                                                                                      │
  ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                                          

Compatibility Check #3: Rust 1.84.1
  [FAIL]   Is incompatible 
                                                                                                                                                                 
  ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │  Downloading crates ...                                                                                                                                     │
  │ error: failed to download `getrandom v0.4.2`                                                                                                                │
  │                                                                                                                                                             │
  │ Caused by:                                                                                                                                                  │
  │   unable to get packages from source                                                                                                                        │
  │                                                                                                                                                             │
  │ Caused by:                                                                                                                                                  │
  │   failed to parse manifest at `/home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.4.2/Cargo.toml`                                  │
  │                                                                                                                                                             │
  │ Caused by:                                                                                                                                                  │
  │   feature `edition2024` is required                                                                                                                         │
  │                                                                                                                                                             │
  │   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.1 (66221abde 2024-11-19)). │
  │   Consider trying a newer version of Cargo (this may require the nightly release).                                                                          │
  │   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.                   │
  │                                                                                                                                                             │
  ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                                                                 

Compatibility Check #4: Rust 1.90.0
  [OK]     Is compatible 

Compatibility Check #5: Rust 1.87.0
  [FAIL]   Is incompatible 
                                                                                                                    
  ╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │    Compiling libcrux v0.0.4 (/home/user/libcrux)                                                               │
  │     Checking libcrux-psq v0.0.9 (/home/user/libcrux/libcrux-psq)                                               │
  │ error[E0716]: temporary value dropped while borrowed                                                           │
  │    --> libcrux-psq/src/handshake/initiator/registration.rs:217:30                                              │
  │     |                                                                                                          │
  │ 217 |                         vk: &sig_auth.into(),                                                            │
  │     |                              ^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use │
  │ ...                                                                                                            │
  │ 227 |                 });                                                                                      │
  │     |                   - temporary value is freed at the end of this statement                                │
  │ 228 |                 let (outer_ciphertext, outer_tag) =                                                      │
  │ 229 |                     state.k0.handshake_encrypt(&outer_payload, self.outer_aad)?;                         │
  │     |                                                -------------- borrow later used here                     │
  │     |                                                                                                          │
  │     = note: consider using a `let` binding to create a longer lived value                                      │
  │                                                                                                                │
  │ For more information about this error, try `rustc --explain E0716`.                                            │
  │ error: could not compile `libcrux-psq` (lib) due to 1 previous error                                           │
  │                                                                                                                │
  ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                    

Compatibility Check #6: Rust 1.88.0
  [FAIL]   Is incompatible 
                                                                                                                    
  ╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │    Compiling libcrux v0.0.4 (/home/user/libcrux)                                                               │
  │     Checking libcrux-psq v0.0.9 (/home/user/libcrux/libcrux-psq)                                               │
  │ error[E0716]: temporary value dropped while borrowed                                                           │
  │    --> libcrux-psq/src/handshake/initiator/registration.rs:217:30                                              │
  │     |                                                                                                          │
  │ 217 |                         vk: &sig_auth.into(),                                                            │
  │     |                              ^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use │
  │ ...                                                                                                            │
  │ 227 |                 });                                                                                      │
  │     |                   - temporary value is freed at the end of this statement                                │
  │ 228 |                 let (outer_ciphertext, outer_tag) =                                                      │
  │ 229 |                     state.k0.handshake_encrypt(&outer_payload, self.outer_aad)?;                         │
  │     |                                                -------------- borrow later used here                     │
  │     |                                                                                                          │
  │     = note: consider using a `let` binding to create a longer lived value                                      │
  │                                                                                                                │
  │ For more information about this error, try `rustc --explain E0716`.                                            │
  │ error: could not compile `libcrux-psq` (lib) due to 1 previous error                                           │
  │                                                                                                                │
  ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                    

Compatibility Check #7: Rust 1.89.0
  [OK]     Is compatible 

Result:
   Considered (min … max):   Rust 0.11.0 … Rust 1.96.0 
   Search method:            bisect                    
   MSRV:                     1.89.0                    
   Target:                   x86_64-unknown-linux-gnu  
                                                       

```

</details>