### PR TITLE
[traits/sha3] Digest traits consume hasher on `finish` & provide Instantiable `libcrux-traits` incremental hashing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- (libcrux-traits, libcrux-sha3, libcrux-sha2, libcrux-blake2) [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
+- (libcrux-traits, libcrux-sha3, libcrux-sha2, libcrux-blake2, libcrux-hmac) [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
 - (libcrux-secrets) [#1446](https://github.com/cryspen/libcrux/pull/1446): Remove const qualifier of secret types constructors
 - (libcrux-secrets) [#1462](https://github.com/cryspen/libcrux/pull/1462): More robust casts instead of transmutes when checking secret independence
 - (libcrux-sha3) [1454](https://github.com/cryspen/libcrux/pull/1454): `debug_assert` that generic `LEN` matches algorithm in `hash` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- (libcrux-traits, libcrux-sha3, libcrux-sha2, libcrux-blake2, libcrux-hmac) [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
+- (libcrux-traits, libcrux-sha3, libcrux-sha2, libcrux-blake2) [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
 - (libcrux-secrets) [#1446](https://github.com/cryspen/libcrux/pull/1446): Remove const qualifier of secret types constructors
 - (libcrux-secrets) [#1462](https://github.com/cryspen/libcrux/pull/1462): More robust casts instead of transmutes when checking secret independence
 - (libcrux-sha3) [1454](https://github.com/cryspen/libcrux/pull/1454): `debug_assert` that generic `LEN` matches algorithm in `hash` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- (libcrux-sha3) [#1493](https://github.com/cryspen/libcrux/pull/1493): Provide instantiable `libcrux-traits` incremental hashing API
 - (libcrux-secrets) [#1460](https://github.com/cryspen/libcrux/issues/1460): Fix incorrect cmp in aarch64 select/swap implementation
 - (libcrux-sha3) [#1456](https://github.com/cryspen/libcrux/pull/1456): Fix out of bounds indexing in avx2 SHAKE-256 implementation
 
 ### Changed
 
+- (libcrux-traits, libcrux-sha3, libcrux-sha2, libcrux-blake2) [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
 - (libcrux-secrets) [#1446](https://github.com/cryspen/libcrux/pull/1446): Remove const qualifier of secret types constructors
 - (libcrux-secrets) [#1462](https://github.com/cryspen/libcrux/pull/1462): More robust casts instead of transmutes when checking secret independence
 - (libcrux-sha3) [1454](https://github.com/cryspen/libcrux/pull/1454): `debug_assert` that generic `LEN` matches algorithm in `hash` function

--- a/crates/algorithms/blake2/CHANGELOG.md
+++ b/crates/algorithms/blake2/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
+
+
 ## [0.0.7] (2026-05-13)
 
 - [#1434](https://github.com/cryspen/libcrux/pull/1434): Update dependencies: `libcrux-hacl-rs`

--- a/crates/algorithms/blake2/src/impl_digest_trait.rs
+++ b/crates/algorithms/blake2/src/impl_digest_trait.rs
@@ -1,9 +1,8 @@
-use crate::impl_hacl::*;
 use libcrux_traits::digest::{
     arrayref, slice, DigestIncrementalBase, Hasher, InitializeDigestState, UpdateError,
 };
 
-use crate::impl_hacl::SupportsOutLen;
+use crate::impl_hacl::{SupportsOutLen, *};
 
 macro_rules! impl_digest_traits {
     ($out_size:ident, $type:ty, $blake2:ty, $hasher:ty, $set:ty, $builder:ty) => {
@@ -37,7 +36,7 @@ macro_rules! impl_digest_traits {
                         UpdateError::Unknown => arrayref::HashError::Unknown,
                     },
                 )?;
-                <Self as arrayref::DigestIncremental<$out_size>>::finish(&mut digest_state, digest);
+                <Self as arrayref::DigestIncremental<$out_size>>::finish(digest_state, digest);
 
                 Ok(())
             }
@@ -87,7 +86,7 @@ macro_rules! impl_digest_traits {
             $set: SupportsOutLen<$out_size>,
         {
             fn finish(
-                state: &mut Self::IncrementalState,
+                state: Self::IncrementalState,
                 digest: &mut [u8],
             ) -> Result<usize, slice::FinishError> {
                 let digest: &mut [u8; $out_size] = digest
@@ -105,7 +104,7 @@ macro_rules! impl_digest_traits {
             // implement for supported digest lengths only
             $set: SupportsOutLen<$out_size>,
         {
-            fn finish(state: &mut Self::IncrementalState, dst: &mut [u8; $out_size]) {
+            fn finish(state: Self::IncrementalState, dst: &mut [u8; $out_size]) {
                 state.finalize(dst)
             }
         }

--- a/crates/algorithms/blake2/tests/blake2.rs
+++ b/crates/algorithms/blake2/tests/blake2.rs
@@ -208,17 +208,23 @@ fn test_blake2s() {
 
 #[test]
 fn test_digest_traits_2s() {
+    fn updated_hasher() -> Blake2sHasher<32> {
+        let mut hasher = Blake2sHasher::<32>::new();
+        hasher.update(b"this is a test").unwrap();
+        hasher
+    }
+
     let mut got_hash = [0; 32];
 
     // test unkeyed, with const key and digest len
     let expected_hash = b"\xf2\x01\x46\xc0\x54\xf9\xdd\x6b\x67\x64\xb6\xc0\x93\x57\xf7\xcd\x75\x51\xdf\xbc\xba\x54\x59\x72\xa4\xc8\x16\x6d\xf8\xaf\xde\x60";
-    let mut hasher = Blake2sHasher::<32>::new();
-    hasher.update(b"this is a test").unwrap();
+    let hasher = updated_hasher();
     hasher.finish(&mut got_hash);
 
     assert_eq!(&got_hash, expected_hash);
 
     let mut too_short = vec![0; 31];
+    let hasher = updated_hasher();
     let err = hasher.finish_slice(&mut too_short).unwrap_err();
     assert_eq!(
         err,
@@ -226,6 +232,7 @@ fn test_digest_traits_2s() {
     );
 
     let mut too_long = vec![0; 33];
+    let hasher = updated_hasher();
     let err = hasher.finish_slice(&mut too_long).unwrap_err();
     assert_eq!(
         err,
@@ -234,17 +241,23 @@ fn test_digest_traits_2s() {
 }
 #[test]
 fn test_digest_traits_2b() {
+    fn updated_hasher() -> Blake2bHasher<32> {
+        let mut hasher = Blake2bHasher::<32>::new();
+        hasher.update(b"this is a test").unwrap();
+        hasher
+    }
+
     let mut got_hash = [0; 32];
 
     // test unkeyed, with const key and digest len
     let expected_hash = b"\xe9\xed\x14\x1d\xf1\xce\xbf\xc8\x9e\x46\x6c\xe0\x89\xee\xdd\x4f\x12\x5a\xa7\x57\x15\x01\xa0\xaf\x87\x1f\xab\x60\x59\x71\x17\xb7";
-    let mut hasher = Blake2bHasher::<32>::new();
-    hasher.update(b"this is a test").unwrap();
+    let hasher = updated_hasher();
     hasher.finish(&mut got_hash);
 
     assert_eq!(&got_hash, expected_hash);
 
     let mut too_short = vec![0; 31];
+    let hasher = updated_hasher();
     let err = hasher.finish_slice(&mut too_short).unwrap_err();
     assert_eq!(
         err,
@@ -252,6 +265,7 @@ fn test_digest_traits_2b() {
     );
 
     let mut too_long = vec![0; 33];
+    let hasher = updated_hasher();
     let err = hasher.finish_slice(&mut too_long).unwrap_err();
     assert_eq!(
         err,

--- a/crates/algorithms/hmac/CHANGELOG.md
+++ b/crates/algorithms/hmac/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1382](https://github.com/cryspen/libcrux/pull/1382): Add an incremental API
 
-## Changed
-
-- [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
-
 ## [0.0.7] (2026-05-13)
 
 ### Removed

--- a/crates/algorithms/hmac/CHANGELOG.md
+++ b/crates/algorithms/hmac/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1382](https://github.com/cryspen/libcrux/pull/1382): Add an incremental API
 
+## Changed
+
+- [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
+
 ## [0.0.7] (2026-05-13)
 
 ### Removed

--- a/crates/algorithms/hmac/src/incremental.rs
+++ b/crates/algorithms/hmac/src/incremental.rs
@@ -1,5 +1,6 @@
-use crate::{Error, HmacState};
 use libcrux_traits::digest::{arrayref, InitializeDigestState};
+
+use crate::{Error, HmacState};
 
 /// Generic streaming HMAC state, parametrized by output length, block size,
 /// and an incremental digest implementation `D`.
@@ -40,7 +41,7 @@ where
             Digest::update(&mut tmp, key)
                 .expect("This can't fail because we checked that key.len() <= u32::MAX");
             let mut hashed = [0u8; OUTLEN];
-            Digest::finish(&mut tmp, &mut hashed);
+            Digest::finish(tmp, &mut hashed);
             key_block[..OUTLEN].copy_from_slice(&hashed);
         }
 
@@ -68,16 +69,16 @@ where
         Digest::update(&mut self.inner, data).map_err(|_| Error::InvalidInputLength)
     }
 
-    fn finalize(mut self, dst: &mut [u8; OUTLEN]) {
+    fn finalize(self, dst: &mut [u8; OUTLEN]) {
         // Inner hash: finalize H((K xor ipad) || data).
         let mut inner_hash = [0u8; OUTLEN];
-        Digest::finish(&mut self.inner, &mut inner_hash);
+        Digest::finish(self.inner, &mut inner_hash);
 
         // Outer hash: H((K xor opad) || inner_hash).
         let mut outer = Digest::IncrementalState::new();
         Digest::update(&mut outer, &self.opad).expect("self.opad.len() is always <= u32::MAX");
         Digest::update(&mut outer, &inner_hash).expect("inner_hash.len() is always <= u32::MAX");
-        Digest::finish(&mut outer, dst);
+        Digest::finish(outer, dst);
     }
 }
 

--- a/crates/algorithms/sha2/CHANGELOG.md
+++ b/crates/algorithms/sha2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
+
 ## [0.0.7] (2026-05-13)
 
 ### Changed

--- a/crates/algorithms/sha2/src/impl_digest_trait.rs
+++ b/crates/algorithms/sha2/src/impl_digest_trait.rs
@@ -1,15 +1,14 @@
-use crate::impl_hacl::*;
-
-use libcrux_traits::Digest;
-
-use libcrux_traits::digest::{
-    arrayref, slice, DigestIncrementalBase, InitializeDigestState, UpdateError,
+use libcrux_traits::{
+    digest::{arrayref, slice, DigestIncrementalBase, InitializeDigestState, UpdateError},
+    Digest,
 };
+
+use crate::impl_hacl::*;
 
 // Streaming API - This is the recommended one.
 // For implementations based on hacl_rs (over hacl-c)
 macro_rules! impl_hash {
-    ($hasher_name:ident, $name:ident, $state_name:ty, $digest_size:literal) => {
+    ($hasher_name:ident, $name:ident, $state_name:ty, $digest_size:literal, $test_name:ident) => {
         #[derive(Clone, Default)]
 
         #[doc = concat!("A struct that implements [`libcrux_traits::digest`] traits.")]
@@ -69,7 +68,7 @@ macro_rules! impl_hash {
         impl arrayref::DigestIncremental<$digest_size> for $name {
 
             #[inline(always)]
-            fn finish(state: &mut Self::IncrementalState, digest: &mut [u8; $digest_size]) {
+            fn finish(state: Self::IncrementalState, digest: &mut [u8; $digest_size]) {
                 state.finish (digest);
             }
 
@@ -77,11 +76,16 @@ macro_rules! impl_hash {
         slice::impl_hash_trait!($name => $digest_size);
         slice::impl_digest_incremental_trait!($name => $state_name, $digest_size);
 
+
+        #[test]
+        fn $test_name() {
+            libcrux_traits::digest::tests::simple::<$digest_size, $name>();
+        }
     };
 }
 
-impl_hash!(Sha224Hasher, Sha224Hash, Sha224, 28);
-impl_hash!(Sha256Hasher, Sha256Hash, Sha256, 32);
+impl_hash!(Sha224Hasher, Sha224Hash, Sha224, 28, sha224_traits_test);
+impl_hash!(Sha256Hasher, Sha256Hash, Sha256, 32, sha256_traits_test);
 
-impl_hash!(Sha384Hasher, Sha384Hash, Sha384, 48);
-impl_hash!(Sha512Hasher, Sha512Hash, Sha512, 64);
+impl_hash!(Sha384Hasher, Sha384Hash, Sha384, 48, sha384_traits_test);
+impl_hash!(Sha512Hasher, Sha512Hash, Sha512, 64, sha512_traits_test);

--- a/crates/algorithms/sha3/CHANGELOG.md
+++ b/crates/algorithms/sha3/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#XXX](https://github.com/cryspen/libcrux/pull/XXX): Provide instantiable `libcrux-traits` incremental hashing API
 - [#1456](https://github.com/cryspen/libcrux/pull/1456): Fix out of bounds indexing in avx2 SHAKE-256 implementation
 
 ### Changed

--- a/crates/algorithms/sha3/CHANGELOG.md
+++ b/crates/algorithms/sha3/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#1493](https://github.com/cryspen/libcrux/pull/XXX): Provide instantiable `libcrux-traits` incremental hashing API
+- [#1493](https://github.com/cryspen/libcrux/pull/1493): Provide instantiable `libcrux-traits` incremental hashing API
 - [#1456](https://github.com/cryspen/libcrux/pull/1456): Fix out of bounds indexing in avx2 SHAKE-256 implementation
 
 ### Changed
 
-- [1454](https://github.com/cryspen/libcrux/pull/1454): `debug_assert` that generic `LEN` matches algorithm in `hash` function
+- [#1454](https://github.com/cryspen/libcrux/pull/1454): `debug_assert` that generic `LEN` matches algorithm in `hash` function
+- [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
+
 
 ### Added
 

--- a/crates/algorithms/sha3/CHANGELOG.md
+++ b/crates/algorithms/sha3/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#XXX](https://github.com/cryspen/libcrux/pull/XXX): Provide instantiable `libcrux-traits` incremental hashing API
+- [#1493](https://github.com/cryspen/libcrux/pull/XXX): Provide instantiable `libcrux-traits` incremental hashing API
 - [#1456](https://github.com/cryspen/libcrux/pull/1456): Fix out of bounds indexing in avx2 SHAKE-256 implementation
 
 ### Changed

--- a/crates/algorithms/sha3/src/impl_digest_trait.rs
+++ b/crates/algorithms/sha3/src/impl_digest_trait.rs
@@ -1,19 +1,86 @@
-use crate::*;
+use libcrux_traits::digest::{DigestIncrementalBase, InitializeDigestState, UpdateError};
+
+use crate::{generic_keccak::xof::KeccakXofState, *};
 
 const SHA3_224_LEN: usize = 28;
 const SHA3_256_LEN: usize = 32;
 const SHA3_384_LEN: usize = 48;
 const SHA3_512_LEN: usize = 64;
 
+#[doc(hidden)]
+/// Incremental hasher state
+///
+/// We implement the `libcrux-traits` traits `InitializeDigestState`
+/// and `DigestIncrementalState` generically for any `RATE`, but
+/// `libcrux_traits::digest::arrayref::DigestIncremental`,
+/// i.e. `finish`, is only implemented for the supported digest
+/// lengths.
+pub struct HasherState<const RATE: usize, const OUTLEN: usize> {
+    // We use a portable XOF state here, but AVX2 and NEON variants
+    // would be possible in principle.  However, `PARALLEL_LANES = 1`
+    // is necessary until `squeeze` is implemented for `PARALLEL_LANES
+    // > 1`.
+    inner: KeccakXofState<1, RATE, u64>,
+    absorb_state: AbsorbState<OUTLEN>,
+}
+
+enum AbsorbState<const OUTLEN: usize> {
+    Absorbing,
+    Finished([u8; OUTLEN]),
+}
+
+impl<const RATE: usize, const OUTLEN: usize> InitializeDigestState for HasherState<RATE, OUTLEN> {
+    fn new() -> Self {
+        Self {
+            inner: KeccakXofState::<1, RATE, u64>::new(),
+            absorb_state: AbsorbState::<OUTLEN>::Absorbing,
+        }
+    }
+}
+
+impl<const RATE: usize, const OUTLEN: usize> DigestIncrementalBase for HasherState<RATE, OUTLEN> {
+    type IncrementalState = Self;
+
+    fn reset(state: &mut Self::IncrementalState) {
+        *state = Self::IncrementalState::new();
+    }
+
+    fn update(state: &mut Self::IncrementalState, payload: &[u8]) -> Result<(), UpdateError> {
+        match state.absorb_state {
+            AbsorbState::Absorbing => {
+                state.inner.absorb(&[payload]);
+                Ok(())
+            }
+            AbsorbState::Finished(_) => Err(UpdateError::Unknown),
+        }
+    }
+}
+
 macro_rules! impl_hash_traits {
-    ($type:ident, $hasher:ident, $len:expr, $method:expr) => {
+    ($type:ident, $hasher:ident, $len:expr, $rate:expr, $method:expr) => {
         #[doc = concat!("A struct that implements [`libcrux_traits::digest`] traits.")]
         #[doc = concat!("\n\n")]
         #[doc = concat!("[`",stringify!($hasher), "`] is a convenient hasher for this struct.")]
         pub struct $type;
 
         #[doc = concat!("A hasher for [`",stringify!($type), "`].")]
-        pub type $hasher = libcrux_traits::digest::Hasher<$len, $type>;
+        pub type $hasher = libcrux_traits::digest::Hasher<$len, HasherState<$rate, $len>>;
+
+        // Squeeze is only implemented for the correct digest lengths.
+        impl libcrux_traits::digest::arrayref::DigestIncremental<$len>
+            for HasherState<$rate, $len>
+        {
+            fn finish(state: &mut Self::IncrementalState, digest: &mut [u8; $len]) {
+                match state.absorb_state {
+                    AbsorbState::Absorbing => {
+                        state.inner.absorb_final::<0x06u8>(&[&[]]);
+                        state.inner.squeeze(digest);
+                        state.absorb_state = AbsorbState::Finished(digest.clone());
+                    }
+                    AbsorbState::Finished(existing_digest) => *digest = existing_digest.clone(),
+                }
+            }
+        }
 
         impl libcrux_traits::digest::arrayref::Hash<$len> for $type {
             #[inline(always)]
@@ -33,10 +100,28 @@ macro_rules! impl_hash_traits {
     };
 }
 
-impl_hash_traits!(Sha3_224, Sha3_224Hasher, SHA3_224_LEN, portable::sha224);
-impl_hash_traits!(Sha3_256, Sha3_256Hasher, SHA3_256_LEN, portable::sha256);
-impl_hash_traits!(Sha3_384, Sha3_384Hasher, SHA3_384_LEN, portable::sha384);
-impl_hash_traits!(Sha3_512, Sha3_512Hasher, SHA3_512_LEN, portable::sha512);
+impl_hash_traits!(
+    Sha3_224,
+    Sha3_224Hasher,
+    SHA3_224_LEN,
+    144,
+    portable::sha224
+);
+impl_hash_traits!(
+    Sha3_256,
+    Sha3_256Hasher,
+    SHA3_256_LEN,
+    136,
+    portable::sha256
+);
+impl_hash_traits!(
+    Sha3_384,
+    Sha3_384Hasher,
+    SHA3_384_LEN,
+    104,
+    portable::sha384
+);
+impl_hash_traits!(Sha3_512, Sha3_512Hasher, SHA3_512_LEN, 72, portable::sha512);
 
 // Implement the slice hash trait
 // This is excluded for the hax extraction

--- a/crates/algorithms/sha3/src/impl_digest_trait.rs
+++ b/crates/algorithms/sha3/src/impl_digest_trait.rs
@@ -7,78 +7,44 @@ const SHA3_256_LEN: usize = 32;
 const SHA3_384_LEN: usize = 48;
 const SHA3_512_LEN: usize = 64;
 
-#[doc(hidden)]
-/// Incremental hasher state
-///
-/// We implement the `libcrux-traits` traits `InitializeDigestState`
-/// and `DigestIncrementalState` generically for any `RATE`, but
-/// `libcrux_traits::digest::arrayref::DigestIncremental`,
-/// i.e. `finish`, is only implemented for the supported digest
-/// lengths.
-pub struct HasherState<const RATE: usize, const OUTLEN: usize> {
-    // We use a portable XOF state here, but AVX2 and NEON variants
-    // would be possible in principle.  However, `PARALLEL_LANES = 1`
-    // is necessary until `squeeze` is implemented for `PARALLEL_LANES
-    // > 1`.
-    inner: KeccakXofState<1, RATE, u64>,
-    absorb_state: AbsorbState<OUTLEN>,
-}
-
-enum AbsorbState<const OUTLEN: usize> {
-    Absorbing,
-    Finished([u8; OUTLEN]),
-}
-
-impl<const RATE: usize, const OUTLEN: usize> InitializeDigestState for HasherState<RATE, OUTLEN> {
-    fn new() -> Self {
-        Self {
-            inner: KeccakXofState::<1, RATE, u64>::new(),
-            absorb_state: AbsorbState::<OUTLEN>::Absorbing,
-        }
-    }
-}
-
-impl<const RATE: usize, const OUTLEN: usize> DigestIncrementalBase for HasherState<RATE, OUTLEN> {
-    type IncrementalState = Self;
-
-    fn reset(state: &mut Self::IncrementalState) {
-        *state = Self::IncrementalState::new();
-    }
-
-    fn update(state: &mut Self::IncrementalState, payload: &[u8]) -> Result<(), UpdateError> {
-        match state.absorb_state {
-            AbsorbState::Absorbing => {
-                state.inner.absorb(&[payload]);
-                Ok(())
-            }
-            AbsorbState::Finished(_) => Err(UpdateError::Unknown),
-        }
-    }
-}
-
 macro_rules! impl_hash_traits {
     ($type:ident, $hasher:ident, $len:expr, $rate:expr, $method:expr) => {
-        #[doc = concat!("A struct that implements [`libcrux_traits::digest`] traits.")]
-        #[doc = concat!("\n\n")]
-        #[doc = concat!("[`",stringify!($hasher), "`] is a convenient hasher for this struct.")]
-        pub struct $type;
+        /// A struct that implements [`libcrux_traits::digest`] traits.
+        pub struct $type {
+            state: KeccakXofState<1, $rate, u64>,
+        }
 
+        impl InitializeDigestState for $type {
+            fn new() -> Self {
+                Self {
+                    state: KeccakXofState::<1, $rate, u64>::new(),
+                }
+            }
+        }
+
+        impl DigestIncrementalBase for $type {
+            type IncrementalState = Self;
+
+            fn reset(state: &mut Self::IncrementalState) {
+                *state = Self::IncrementalState::new();
+            }
+
+            fn update(
+                state: &mut Self::IncrementalState,
+                payload: &[u8],
+            ) -> Result<(), UpdateError> {
+                state.state.absorb(&[payload]);
+                Ok(())
+            }
+        }
         #[doc = concat!("A hasher for [`",stringify!($type), "`].")]
-        pub type $hasher = libcrux_traits::digest::Hasher<$len, HasherState<$rate, $len>>;
+        pub type $hasher = libcrux_traits::digest::Hasher<$len, $type>;
 
         // Squeeze is only implemented for the correct digest lengths.
-        impl libcrux_traits::digest::arrayref::DigestIncremental<$len>
-            for HasherState<$rate, $len>
-        {
-            fn finish(state: &mut Self::IncrementalState, digest: &mut [u8; $len]) {
-                match state.absorb_state {
-                    AbsorbState::Absorbing => {
-                        state.inner.absorb_final::<0x06u8>(&[&[]]);
-                        state.inner.squeeze(digest);
-                        state.absorb_state = AbsorbState::Finished(digest.clone());
-                    }
-                    AbsorbState::Finished(existing_digest) => *digest = existing_digest.clone(),
-                }
+        impl libcrux_traits::digest::arrayref::DigestIncremental<$len> for $type {
+            fn finish(mut state: Self::IncrementalState, digest: &mut [u8; $len]) {
+                state.state.absorb_final::<0x06u8>(&[&[]]);
+                state.state.squeeze(digest);
             }
         }
 

--- a/crates/algorithms/sha3/tests/incremental_traits.rs
+++ b/crates/algorithms/sha3/tests/incremental_traits.rs
@@ -1,0 +1,129 @@
+use libcrux_sha3::{
+    sha224, sha256, sha384, sha512, Sha3_224Hasher, Sha3_256Hasher, Sha3_384Hasher, Sha3_512Hasher,
+};
+
+fn input_lens(rate: usize) -> Vec<usize> {
+    vec![
+        0,
+        rate / 2,
+        rate - 1,
+        rate,
+        rate + 1,
+        2 * rate,
+        2 * rate + rate / 2,
+        3 * rate,
+    ]
+}
+
+fn partitionings(rate: usize) -> Vec<Vec<usize>> {
+    vec![
+        vec![],
+        vec![0, rate],
+        vec![rate],
+        vec![0, rate / 3, rate],
+        vec![rate / 2, rate + rate / 2],
+        vec![rate / 2, rate / 2, rate, 2 * rate],
+        vec![rate - 1, rate],
+        vec![rate + 1],
+        vec![rate + 1, rate + rate / 2],
+        vec![2 * rate - 1, 2 * rate],
+        vec![rate, 2 * rate],
+        vec![3 * rate],
+    ]
+}
+
+/// Create a test that tests an incremental sha3 hasher with different input lengths
+/// and different partitions of that input against a non-incremental version.
+macro_rules! sha3_incremental_hash_test {
+    ($test_name:ident, $non_incremental_fn:ident, $incremental_hasher:ty, $rate:literal) => {
+        #[test]
+        fn $test_name() {
+            let input_lens = input_lens($rate);
+            let partitionings = partitionings($rate);
+
+            for len in input_lens {
+                let input = vec![0; len];
+                for partition_points in &partitionings {
+                    let expected = $non_incremental_fn(&input);
+
+                    let mut hasher = <$incremental_hasher>::new();
+
+                    for chunk in partitions(&input, partition_points) {
+                        hasher.update(chunk).unwrap();
+                    }
+                    let digest = hasher.finish_to_owned();
+                    assert_eq!(
+                        expected, digest,
+                        "input len: {len} failed with partitioning: {partition_points:?}"
+                    );
+
+                    // Running `finish` a second time results in the same digest output.
+                    let digest = hasher.finish_to_owned();
+                    assert_eq!(
+                        expected, digest,
+                        "input len: {len} failed with partitioning: {partition_points:?}"
+                    );
+
+                    // Running `update` on a finished Hasher results in an error.
+                    let err = hasher.update(&input);
+                    assert!(err.is_err());
+
+                    // After reset the hasher works like a new one.
+                    hasher.reset();
+                    for chunk in partitions(&input, partition_points) {
+                        hasher.update(chunk).unwrap();
+                    }
+                    let digest = hasher.finish_to_owned();
+                    assert_eq!(
+                        expected, digest,
+                        "input len: {len} failed with partitioning: {partition_points:?}"
+                    );
+
+                    // Running `finish` a second time results in the same digest output.
+                    let digest = hasher.finish_to_owned();
+                    assert_eq!(
+                        expected, digest,
+                        "input len: {len} failed with partitioning: {partition_points:?}"
+                    );
+
+                    // Running `update` on a finished Hasher results in an error.
+                    let err = hasher.update(&input);
+                    assert!(err.is_err());
+                }
+            }
+        }
+    };
+}
+
+sha3_incremental_hash_test!(sha3_224_incremental_traits, sha224, Sha3_224Hasher, 144);
+sha3_incremental_hash_test!(sha3_256_incremental_traits, sha256, Sha3_256Hasher, 136);
+sha3_incremental_hash_test!(sha3_384_incremental_traits, sha384, Sha3_384Hasher, 104);
+sha3_incremental_hash_test!(sha3_512_incremental_traits, sha512, Sha3_512Hasher, 72);
+
+/// Partition data into chunks according to the partition_points.
+///
+/// For `partition_points = &[0, 3, 5]` this will return an iterator over the chunks
+/// `[&data[0..0], &data[0..3], &data[3..5], &[5..]]`.  
+/// If data is smaller than some partition point, the last chunk will be smaller than
+/// requested by the partition point. If the last partition point is smaller than the length
+/// of data, the last chunk will be the rest.
+fn partitions<'p, 'd: 'p>(
+    data: &'d [u8],
+    partition_points: &'p [usize],
+) -> impl Iterator<Item = &'d [u8]> + 'p {
+    let mut partition_points = partition_points.iter();
+    let mut offset = 0;
+    core::iter::from_fn(move || {
+        if let Some(&index) = partition_points.next() {
+            debug_assert!(index >= offset, "partition points must be increasing");
+            let chunk = data.get(offset..index).or_else(|| data.get(offset..));
+            offset = index;
+            chunk
+        } else {
+            let chunk = data.get(offset..);
+            // Next iteration, return None by setting offset past the end of data
+            offset = data.len() + 1;
+            chunk
+        }
+    })
+}

--- a/crates/algorithms/sha3/tests/incremental_traits.rs
+++ b/crates/algorithms/sha3/tests/incremental_traits.rs
@@ -56,39 +56,6 @@ macro_rules! sha3_incremental_hash_test {
                         expected, digest,
                         "input len: {len} failed with partitioning: {partition_points:?}"
                     );
-
-                    // Running `finish` a second time results in the same digest output.
-                    let digest = hasher.finish_to_owned();
-                    assert_eq!(
-                        expected, digest,
-                        "input len: {len} failed with partitioning: {partition_points:?}"
-                    );
-
-                    // Running `update` on a finished Hasher results in an error.
-                    let err = hasher.update(&input);
-                    assert!(err.is_err());
-
-                    // After reset the hasher works like a new one.
-                    hasher.reset();
-                    for chunk in partitions(&input, partition_points) {
-                        hasher.update(chunk).unwrap();
-                    }
-                    let digest = hasher.finish_to_owned();
-                    assert_eq!(
-                        expected, digest,
-                        "input len: {len} failed with partitioning: {partition_points:?}"
-                    );
-
-                    // Running `finish` a second time results in the same digest output.
-                    let digest = hasher.finish_to_owned();
-                    assert_eq!(
-                        expected, digest,
-                        "input len: {len} failed with partitioning: {partition_points:?}"
-                    );
-
-                    // Running `update` on a finished Hasher results in an error.
-                    let err = hasher.update(&input);
-                    assert!(err.is_err());
                 }
             }
         }

--- a/traits/CHANGELOG.md
+++ b/traits/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- [#1493](https://github.com/cryspen/libcrux/pull/1493): `finish` methods on digest traits consume the hasher
+
 ## [0.0.7] (2026-05-13)
 
 ### Changed

--- a/traits/src/digest.rs
+++ b/traits/src/digest.rs
@@ -84,8 +84,8 @@ impl<const N: usize, D: DigestIncrementalBase + slice::Hash> Hasher<N, D> {
 
 impl<const N: usize, D: slice::DigestIncremental> Hasher<N, D> {
     /// Finalize and write into a digest buffer, provided as a `&mut [u8]` slice.
-    pub fn finish_slice(&mut self, digest: &mut [u8]) -> Result<usize, slice::FinishError> {
-        D::finish(&mut self.state, digest)
+    pub fn finish_slice(self, digest: &mut [u8]) -> Result<usize, slice::FinishError> {
+        D::finish(self.state, digest)
     }
 }
 
@@ -109,12 +109,12 @@ impl<const N: usize, D: DigestIncrementalBase> Hasher<N, D> {
 
 impl<const N: usize, D: arrayref::DigestIncremental<N>> Hasher<N, D> {
     /// Finalize and write into a digest buffer, provided as a `&mut [u8; N]` array reference.
-    pub fn finish(&mut self, digest: &mut [u8; N]) {
-        D::finish(&mut self.state, digest)
+    pub fn finish(self, digest: &mut [u8; N]) {
+        D::finish(self.state, digest)
     }
     /// owned version of `finish()`
-    pub fn finish_to_owned(&mut self) -> [u8; N] {
-        <D as owned::DigestIncremental<N>>::finish(&mut self.state)
+    pub fn finish_to_owned(self) -> [u8; N] {
+        <D as owned::DigestIncremental<N>>::finish(self.state)
     }
 }
 

--- a/traits/src/digest/arrayref.rs
+++ b/traits/src/digest/arrayref.rs
@@ -1,6 +1,5 @@
 //! This module contains the traits and related errors for hashers that take array references as
 //! arguments and write the outputs to mutable array references.
-//!
 
 #[derive(Debug, PartialEq)]
 /// Error indicating that hashing failed.
@@ -30,10 +29,8 @@ mod error_in_core {
 
 /// A trait for incremental hashing, where the output is written into a provided buffer.
 pub trait DigestIncremental<const OUTPUT_LEN: usize>: super::DigestIncrementalBase {
-    /// Writes the digest into `digest`.
-    ///
-    /// Note that the digest state can be continued to be used, to extend the digest.
-    fn finish(state: &mut Self::IncrementalState, digest: &mut [u8; OUTPUT_LEN]);
+    /// Writes the digest into `digest`, consuming the hasher.
+    fn finish(state: Self::IncrementalState, digest: &mut [u8; OUTPUT_LEN]);
 }
 
 /// A trait for oneshot hashing, where the output is written into a provided buffer.

--- a/traits/src/digest/owned.rs
+++ b/traits/src/digest/owned.rs
@@ -1,10 +1,9 @@
 //! This module contains the traits and related errors for hashers that take array references as
 //! arguments and return values as arrays.
-//!
-
-use super::arrayref;
 
 pub use arrayref::HashError;
+
+use super::arrayref;
 
 /// A trait for oneshot hashing, where the output is returned as an array.
 pub trait Hash<const OUTPUT_LEN: usize> {
@@ -14,10 +13,8 @@ pub trait Hash<const OUTPUT_LEN: usize> {
 
 /// A trait for incremental hashing, where the output is returned as an array.
 pub trait DigestIncremental<const OUTPUT_LEN: usize>: super::DigestIncrementalBase {
-    /// Returns the digest as an array.
-    ///
-    /// Note that the digest state can be continued to be used, to extend the digest.
-    fn finish(state: &mut Self::IncrementalState) -> [u8; OUTPUT_LEN];
+    /// Returns the digest as an array, consuming the hasher.
+    fn finish(state: Self::IncrementalState) -> [u8; OUTPUT_LEN];
 }
 
 impl<const OUTPUT_LEN: usize, D: arrayref::Hash<OUTPUT_LEN>> Hash<OUTPUT_LEN> for D {
@@ -29,7 +26,7 @@ impl<const OUTPUT_LEN: usize, D: arrayref::Hash<OUTPUT_LEN>> Hash<OUTPUT_LEN> fo
 impl<const OUTPUT_LEN: usize, D: arrayref::DigestIncremental<OUTPUT_LEN>>
     DigestIncremental<OUTPUT_LEN> for D
 {
-    fn finish(state: &mut Self::IncrementalState) -> [u8; OUTPUT_LEN] {
+    fn finish(state: Self::IncrementalState) -> [u8; OUTPUT_LEN] {
         let mut digest = [0; OUTPUT_LEN];
         Self::finish(state, &mut digest);
         digest

--- a/traits/src/digest/slice.rs
+++ b/traits/src/digest/slice.rs
@@ -11,10 +11,8 @@ pub trait Hash {
 
 /// A trait for incremental hashing, where the output is written to a provided slice.
 pub trait DigestIncremental: super::DigestIncrementalBase {
-    /// Writes the digest into `digest`.
-    ///
-    /// Note that the digest state can be continued to be used, to extend the digest.
-    fn finish(state: &mut Self::IncrementalState, digest: &mut [u8]) -> Result<usize, FinishError>;
+    /// Writes the digest into `digest`, consuming the hasher.
+    fn finish(state: Self::IncrementalState, digest: &mut [u8]) -> Result<usize, FinishError>;
 }
 
 /// Error indicating that finalizing failed.
@@ -104,7 +102,7 @@ macro_rules! impl_digest_incremental_trait {
     ($type:ty => $incremental_state:ty, $len:expr) => {
         impl $crate::digest::slice::DigestIncremental for $type {
             fn finish(
-                state: &mut Self::IncrementalState,
+                state: Self::IncrementalState,
                 digest: &mut [u8],
             ) -> Result<usize, $crate::digest::slice::FinishError> {
                 let digest: &mut [u8; $len] = digest


### PR DESCRIPTION
This PR updates the digest traits, so `finish` methods consume the hasher. It also updates implementations of these traits in `libcrux-sha2`, `libcrux-blake2`, `libcrux-hmac` and the initial implementation in `libcrux-sha3` that was the start of this PR.

Resolves #1496 

---
## Original PR description.

This PR provides an instantiable type under the `Sha3_XYXHasher` type aliases, which can be used for incremental hashing via `libcrux-traits`.

I've adapted test-code from the embedded-cal branch of `libcrux-iot` and also attempted to make the incremental hashing API somewhat safer than what is enforced by `libcrux-traits`, in that calling `update` on a hasher that has already finished results in a an error (`UpdateError::Unknown` is unfortunately the best error for this currently provided by `libcrux-traits`) unless the hasher is reset first. Repeatedly calling `finish` on a hasher will always copy out the digest that was computed on the first call to `finish`.

Resolves #1492 