### PR TITLE
Fix _mm256_bsrli_epi128 shift logic and update mlkem doctest

### DIFF
--- a/crates/testing/kats/src/wycheproof/mlkem.rs
+++ b/crates/testing/kats/src/wycheproof/mlkem.rs
@@ -2,10 +2,10 @@
 //!
 //! ### Example usage
 //! ```rust
-//! use libcrux_kats::wycheproof::mlkem::{ParameterSet, MlKemTests};
+//! use libcrux_kats::wycheproof::mlkem::{ParameterSet, TestGroupType, MlKemTests};
 //!
 //! // load the tests for the ML-KEM-512 parameter set
-//! let tests = MlKemTests::load(ParameterSet::MlKem512);
+//! let tests = MlKemTests::load(ParameterSet::MlKem512, TestGroupType::MlKemTest);
 //!
 //! for test_group in tests.keygen_and_decaps_tests() {
 //!     for test in &test_group.tests {

--- a/crates/utils/core-models/src/core_arch/x86/interpretations.rs
+++ b/crates/utils/core-models/src/core_arch/x86/interpretations.rs
@@ -475,9 +475,12 @@ pub mod int_vec {
 
     pub fn _mm256_bsrli_epi128<const IMM8: i32>(a: i128x2) -> i128x2 {
         i128x2::from_fn(|i| {
-            let tmp = IMM8 % 256;
-            let tmp = tmp % 16;
-            ((a[i] as u128) >> (tmp * 8)) as i128
+            let imm8 = IMM8.rem_euclid(256);
+            if imm8 > 15 {
+                0
+            } else {
+                ((a[i] as u128) >> (imm8 * 8)) as i128
+            }
         })
     }
 


### PR DESCRIPTION
While running the full workspace test suite (`cargo test --all`), I encountered two isolated test failures. This PR addresses both issues to ensure the workspace builds and tests cleanly.

## 1. Fix `_mm256_bsrli_epi128` Shift Logic in `core-models`
**The Issue:** 
The `core-models` interpretation of the `_mm256_bsrli_epi128` (AVX2 Byte Shift Right Logical Immediate) instruction was wrapping the immediate shift value (`imm8`) using modulo 16. 

However, per the [Intel Intrinsics Guide](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_bsrli_epi128), if the byte shift value `imm8` is greater than 15, the entire 128-bit lane must be zeroed out. The previous modulo logic incorrectly caused shifts of e.g., 16 to wrap around to a 0-byte shift, resulting in an assertion failure in the `_mm256_bsrli_epi128` unit test:
```text
assertion `left == right` failed
  left: [-6341777437115142865265983506360485911, -20679178649182049665911232702807607085]
 right: [0, 0]
```

**The Fix:** 
Updated the implementation in `crates/utils/core-models/src/core_arch/x86/interpretations.rs` to explicitly check `if imm8 > 15 { 0 }`. The software model now accurately reflects the underlying x86 hardware behavior.

## 2. Update `libcrux-kats` Doctest for `MlKemTests::load()`
**The Issue:**
A module-level doctest in `crates/testing/kats/src/wycheproof/mlkem.rs` failed to compile (`error[E0061]: this function takes 2 arguments but 1 argument was supplied`). The function signature for `MlKemTests::load()` had been updated to require a second argument (`group_type: TestGroupType`), but the example usage in the documentation comment was left calling the function with only one argument.

**The Fix:**
Updated the doctest to import `TestGroupType` and provide `TestGroupType::MlKemTest` as the required second argument, restoring compilation.

## Verification
Both fixes were verified locally against `rustc 1.90.0`:
- `cargo test -p core-models _mm256_bsrli_epi128` (Passes)
- `cargo test -p libcrux-kats --doc` (Passes)
