### PR TITLE
Replace IntOps and EncodeOps traits with inherent methods (#1491)

### DIFF
--- a/crates/utils/secrets/CHANGELOG.md
+++ b/crates/utils/secrets/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1491](https://github.com/cryspen/libcrux/issues/1491): Replace `IntOps` and `EncodeOps` traits with inherent methods on `Secret`
 - [#1446](https://github.com/cryspen/libcrux/pull/1446): Remove const qualifier of secret types constructors
 - [#1462](https://github.com/cryspen/libcrux/pull/1462): More robust casts instead of transmutes when checking secret independence
 - [#1484](https://github.com/cryspen/libcrux/pull/1484): seal scalar trait and synchronize De-/Classify trait impls for public/secret types

--- a/crates/utils/secrets/src/int.rs
+++ b/crates/utils/secrets/src/int.rs
@@ -157,8 +157,6 @@ pub trait Select {
 mod portable {
     use super::{Select, Swap};
     use crate::Declassify;
-    #[cfg(feature = "check-secret-independence")]
-    use crate::IntOps;
     use crate::{CastOps, U16, U32, U64, U8};
     use core::hint::black_box;
 

--- a/crates/utils/secrets/src/int/secret_integers.rs
+++ b/crates/utils/secrets/src/int/secret_integers.rs
@@ -174,32 +174,32 @@ impl<U, T: ShlAssign<U> + Scalar> ShlAssign<U> for Secret<T> {
     }
 }
 
-// Implement Intops for secret integers
+// Implement inherent methods for secret integers
 macro_rules! impl_int_ops {
     ($t:ty) => {
-        impl IntOps for Secret<$t> {
-            fn wrapping_add<T: Into<Secret<$t>>>(self, rhs: T) -> Self {
+        impl Secret<$t> {
+            pub fn wrapping_add<T: Into<Secret<$t>>>(self, rhs: T) -> Self {
                 self.declassify()
                     .wrapping_add(rhs.into().declassify())
                     .classify()
             }
-            fn wrapping_sub<T: Into<Secret<$t>>>(self, rhs: T) -> Self {
+            pub fn wrapping_sub<T: Into<Secret<$t>>>(self, rhs: T) -> Self {
                 self.declassify()
                     .wrapping_sub(rhs.into().declassify())
                     .classify()
             }
-            fn wrapping_mul<T: Into<Secret<$t>>>(self, rhs: T) -> Self {
+            pub fn wrapping_mul<T: Into<Secret<$t>>>(self, rhs: T) -> Self {
                 self.declassify()
                     .wrapping_mul(rhs.into().declassify())
                     .classify()
             }
-            fn wrapping_neg(self) -> Self {
+            pub fn wrapping_neg(self) -> Self {
                 self.declassify().wrapping_neg().classify()
             }
-            fn rotate_left(self, rhs: u32) -> Self {
+            pub fn rotate_left(self, rhs: u32) -> Self {
                 self.declassify().rotate_left(rhs).classify()
             }
-            fn rotate_right(self, rhs: u32) -> Self {
+            pub fn rotate_right(self, rhs: u32) -> Self {
                 self.declassify().rotate_right(rhs).classify()
             }
         }
@@ -216,20 +216,20 @@ impl_int_ops!(i32);
 impl_int_ops!(i64);
 impl_int_ops!(i128);
 
-// Implement EncodingOps for secret integers
+// Implement encoding inherent methods for secret integers
 macro_rules! impl_encode_ops {
     ($t:ty, $N:literal) => {
-        impl EncodeOps<U8, $N> for Secret<$t> {
-            fn to_le_bytes(&self) -> [U8; $N] {
+        impl Secret<$t> {
+            pub fn to_le_bytes(&self) -> [U8; $N] {
                 self.0.to_le_bytes().classify()
             }
-            fn to_be_bytes(&self) -> [U8; $N] {
+            pub fn to_be_bytes(&self) -> [U8; $N] {
                 self.0.to_be_bytes().classify()
             }
-            fn from_le_bytes(x: [U8; $N]) -> Self {
+            pub fn from_le_bytes(x: [U8; $N]) -> Self {
                 <$t>::from_le_bytes(x.declassify()).classify()
             }
-            fn from_be_bytes(x: [U8; $N]) -> Self {
+            pub fn from_be_bytes(x: [U8; $N]) -> Self {
                 <$t>::from_be_bytes(x.declassify()).classify()
             }
         }

--- a/crates/utils/secrets/src/traits.rs
+++ b/crates/utils/secrets/src/traits.rs
@@ -51,10 +51,6 @@ impl Scalar for i64 {}
 #[cfg(not(eurydice))]
 impl Scalar for i128 {}
 
-
-
-
-
 // XXX These impls for SIMD registers need to be adapted should we want to support hax
 //  extraction with check-secret-independence enabled at some point.
 

--- a/crates/utils/secrets/src/traits.rs
+++ b/crates/utils/secrets/src/traits.rs
@@ -51,27 +51,9 @@ impl Scalar for i64 {}
 #[cfg(not(eurydice))]
 impl Scalar for i128 {}
 
-/// A trait for integer operations provided by Rust for machine integers
-pub trait IntOps
-where
-    Self: Sized,
-{
-    fn wrapping_add<T: Into<Self>>(self, rhs: T) -> Self;
-    fn wrapping_sub<T: Into<Self>>(self, rhs: T) -> Self;
-    fn wrapping_mul<T: Into<Self>>(self, rhs: T) -> Self;
-    fn wrapping_neg(self) -> Self;
-    fn rotate_left(self, rhs: u32) -> Self;
-    fn rotate_right(self, rhs: u32) -> Self;
-}
 
-/// A trait for byte conversion operations provided by Rust for machine integers
-pub trait EncodeOps<T, const N: usize> {
-    fn to_le_bytes(&self) -> [T; N];
-    fn to_be_bytes(&self) -> [T; N];
 
-    fn from_le_bytes(x: [T; N]) -> Self;
-    fn from_be_bytes(x: [T; N]) -> Self;
-}
+
 
 // XXX These impls for SIMD registers need to be adapted should we want to support hax
 //  extraction with check-secret-independence enabled at some point.


### PR DESCRIPTION
This PR resolves issue #1491 by replacing the `IntOps` and `EncodeOps` traits in the `libcrux-secrets` crate with inherent methods directly on the `Secret<T>` type. 

## Rationale
Previously, downstream crates utilizing `check-secret-independence` had to conditionally import `IntOps` (and `EncodeOps`) to perform wrapping arithmetic and byte encodings on `Secret` types. Because these operations are already inherent methods on the standard public integer types (like `u8`, `u32`, `i64`), wrapping them behind a custom trait for the `Secret` type introduced unnecessary friction.

By migrating these methods to be inherent on `Secret<T>`, we achieve better API parity with public integers and eliminate the need for `cfg`-gated trait imports in dependent crates.

## Changes
- Removed the `IntOps` and `EncodeOps` trait definitions from `crates/utils/secrets/src/traits.rs`.
- Updated `crates/utils/secrets/src/int/secret_integers.rs` to implement `Secret<$t>` inherently instead of implementing the traits.
- Modified visibility of the migrated methods (e.g., `wrapping_add`, `to_le_bytes`) to `pub fn`.
- Cleaned up the unused `IntOps` import in `crates/utils/secrets/src/int.rs`.

## Verification
- `cargo test -p libcrux-secrets` passes.
- `cargo test -p libcrux-secrets --features check-secret-independence` passes.
- The full `libcrux` workspace (`cargo test --workspace`) compiles and passes without any downstream trait resolution issues.
