### PR TITLE
 bump tls_codec to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ libcrux-macros = { version = "=0.0.3", path = "crates/utils/macros" }
 libcrux-secrets = { version = "=0.0.5", path = "crates/utils/secrets" }
 
 # Encodings
- tls_codec = { version = "0.5.0-pre.1", features = ["derive"], default-features = false }
+ tls_codec = { version = "0.5.0", features = ["derive"], default-features = false }
 
 # 3rd Party
 rand = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ libcrux-macros = { version = "=0.0.3", path = "crates/utils/macros" }
 libcrux-secrets = { version = "=0.0.5", path = "crates/utils/secrets" }
 
 # Encodings
- tls_codec = { version = "0.4.3-pre.1", features = ["derive"], default-features = false }
+ tls_codec = { version = "0.5.0-pre.1", features = ["derive"], default-features = false }
 
 # 3rd Party
 rand = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,9 @@ libcrux-kats = { path = "crates/testing/kats" }
 libcrux-macros = { version = "=0.0.3", path = "crates/utils/macros" }
 libcrux-secrets = { version = "=0.0.5", path = "crates/utils/secrets" }
 
+# Encodings
+ tls_codec = { version = "0.4.3-pre.1", features = ["derive"], default-features = false }
+
 # 3rd Party
 rand = { version = "0.10", default-features = false }
 crabgrind = "0.2.6"

--- a/crates/algorithms/ed25519/Cargo.toml
+++ b/crates/algorithms/ed25519/Cargo.toml
@@ -17,7 +17,7 @@ libcrux-sha2 = { workspace = true, features = [
 ] }
 libcrux-macros = { version = "=0.0.3", path = "../../utils/macros" }
 rand_core = { version = "0.10", optional = true }
-tls_codec = { version = "0.4.2", features = ["derive"], optional = true }
+tls_codec = { workspace = true, optional = true }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/crates/protocols/hpke/Cargo.toml
+++ b/crates/protocols/hpke/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/tests"]
 [dependencies]
 log = "0.4"
 serde = { version = "1.0", features = ["derive"], optional = true }
-tls_codec = { version = "0.4.2", features = ["derive"], optional = true }
+tls_codec = { workspace = true, optional = true }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1.5", features = ["zeroize_derive"] }
 hpke-rs-crypto.workspace = true

--- a/crates/utils/ctgrind-test/src/bin/mldsa.rs
+++ b/crates/utils/ctgrind-test/src/bin/mldsa.rs
@@ -1,5 +1,3 @@
-#![cfg(valgrind_ct_test)]
-
 use libcrux_ml_dsa::{ml_dsa_44, ml_dsa_65, ml_dsa_87};
 use std::hint::black_box;
 

--- a/libcrux-ecdh/Cargo.toml
+++ b/libcrux-ecdh/Cargo.toml
@@ -19,9 +19,7 @@ libcrux-curve25519 = { workspace = true, default-features = true }
 libcrux-p256 = { workspace = true, default-features = true, features = [
     "expose-hacl",
 ] }
-tls_codec = { version = "0.4.2", features = [
-    "derive",
-], optional = true }
+tls_codec = { workspace = true, optional = true }
 
 [features]
 default = ["std"]

--- a/libcrux-ecdh/Cargo.toml
+++ b/libcrux-ecdh/Cargo.toml
@@ -23,8 +23,8 @@ tls_codec = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
-std = ["rand/std"]
-codec = ["dep:tls_codec", "tls_codec/std"]
+std = ["rand/std", "tls_codec?/std"]
+codec = ["dep:tls_codec"]
 
 [dev-dependencies]
 rand = { version = "0.10", features = ["sys_rng"] }

--- a/libcrux-ecdh/Cargo.toml
+++ b/libcrux-ecdh/Cargo.toml
@@ -24,7 +24,7 @@ tls_codec = { workspace = true, optional = true }
 [features]
 default = ["std"]
 std = ["rand/std"]
-codec = ["dep:tls_codec"]
+codec = ["dep:tls_codec", "tls_codec/std"]
 
 [dev-dependencies]
 rand = { version = "0.10", features = ["sys_rng"] }

--- a/libcrux-kem/Cargo.toml
+++ b/libcrux-kem/Cargo.toml
@@ -25,7 +25,7 @@ libcrux-p256.workspace = true
 libcrux-traits.workspace = true
 
 rand = { version = "0.10", default-features = false }
-tls_codec = { version = "0.4.2", features = ["derive"], optional = true }
+tls_codec = { workspace = true, optional = true }
 
 [features]
 default = ["std"]

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -32,9 +32,7 @@ libcrux-platform.workspace = true
 libcrux-macros.workspace = true
 libcrux-secrets.workspace = true
 hax-lib.workspace = true
-tls_codec = { version = "0.4.2", features = [
-    "derive",
-], default-features = false, optional = true }
+tls_codec = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand = { version = "0.10" }

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -63,10 +63,10 @@ mldsa65 = []
 mldsa87 = []
 
 # std support
-std = []
+std = ["tls_codec?/std"]
 
 # Serialization & Deserialization using tls_codec
-codec = ["dep:tls_codec", "tls_codec/std"]
+codec = ["dep:tls_codec"]
 
 [[bench]]
 name = "manual44"

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -66,7 +66,7 @@ mldsa87 = []
 std = []
 
 # Serialization & Deserialization using tls_codec
-codec = ["dep:tls_codec"]
+codec = ["dep:tls_codec", "tls_codec/std"]
 
 [[bench]]
 name = "manual44"

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -29,9 +29,7 @@ libcrux-intrinsics.workspace = true
 libcrux-secrets.workspace = true
 libcrux-traits.workspace = true
 hax-lib.workspace = true
-tls_codec = { version = "0.4.2", features = [
-    "derive",
-], default-features = false, optional = true }
+tls_codec = { workspace = true, optional = true }
 
 [features]
 # By default all variants and std are enabled.

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -57,7 +57,7 @@ kyber = []
 rand = ["dep:rand"]
 
 # std support
-std = ["alloc", "rand/std", "tls_codec/std"]
+std = ["alloc", "rand/std", "tls_codec?/std"]
 alloc = []
 
 # Incremental encapsulation API

--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -38,7 +38,7 @@ libcrux-ed25519 = { workspace = true, features = [
     "rand",
     "codec",
 ] }
-tls_codec = { version = "0.4.2", features = ["derive"] }
+tls_codec = { workspace = true }
 libcrux-ml-dsa = { workspace = true, features = ["codec"] }
 libcrux-aes.workspace = true
 

--- a/libcrux-psq/src/aead.rs
+++ b/libcrux-psq/src/aead.rs
@@ -104,8 +104,8 @@ impl AEADKeyNonce {
                 libcrux_hkdf::sha2_256::hkdf(
                     &mut key,
                     &[],
-                    &ikm.tls_serialize().map_err(AEADError::Serialize)?,
-                    &info.tls_serialize().map_err(AEADError::Serialize)?,
+                    &ikm.tls_serialize_bytes().map_err(AEADError::Serialize)?,
+                    &info.tls_serialize_bytes().map_err(AEADError::Serialize)?,
                 )
                 .map_err(|_| AEADError::CryptoError)?;
                 Ok(AEADKeyNonce {
@@ -119,8 +119,8 @@ impl AEADKeyNonce {
                 libcrux_hkdf::sha2_256::hkdf(
                     &mut key,
                     &[],
-                    &ikm.tls_serialize().map_err(AEADError::Serialize)?,
-                    &info.tls_serialize().map_err(AEADError::Serialize)?,
+                    &ikm.tls_serialize_bytes().map_err(AEADError::Serialize)?,
+                    &info.tls_serialize_bytes().map_err(AEADError::Serialize)?,
                 )
                 .map_err(|_| AEADError::CryptoError)?;
                 Ok(AEADKeyNonce {

--- a/libcrux-psq/src/classic_mceliece.rs
+++ b/libcrux-psq/src/classic_mceliece.rs
@@ -122,8 +122,8 @@ impl<'a> Size for SharedSecret<'a> {
 }
 
 impl<'a> SerializeBytes for SharedSecret<'a> {
-    fn tls_serialize(&self) -> Result<Vec<u8>, tls_codec::Error> {
-        SerializeBytes::tls_serialize(&self.0.as_ref())
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        self.0.as_ref().tls_serialize_bytes()
     }
 }
 

--- a/libcrux-psq/src/handshake/ciphersuite/initiator.rs
+++ b/libcrux-psq/src/handshake/ciphersuite/initiator.rs
@@ -71,7 +71,9 @@ impl<'a> SigningKeyPair<'a> {
         rng: &mut impl CryptoRng,
         tx: &Transcript,
     ) -> Result<Signature, HandshakeError> {
-        let payload = tx.tls_serialize_bytes().map_err(HandshakeError::Serialize)?;
+        let payload = tx
+            .tls_serialize_bytes()
+            .map_err(HandshakeError::Serialize)?;
         match self {
             SigningKeyPair::Ed25519(signing_key, _) => {
                 let sig = libcrux_ed25519::sign(&payload, signing_key.as_ref())?;

--- a/libcrux-psq/src/handshake/ciphersuite/initiator.rs
+++ b/libcrux-psq/src/handshake/ciphersuite/initiator.rs
@@ -71,7 +71,7 @@ impl<'a> SigningKeyPair<'a> {
         rng: &mut impl CryptoRng,
         tx: &Transcript,
     ) -> Result<Signature, HandshakeError> {
-        let payload = tx.tls_serialize().map_err(HandshakeError::Serialize)?;
+        let payload = tx.tls_serialize_bytes().map_err(HandshakeError::Serialize)?;
         match self {
             SigningKeyPair::Ed25519(signing_key, _) => {
                 let sig = libcrux_ed25519::sign(&payload, signing_key.as_ref())?;

--- a/libcrux-psq/src/handshake/ciphersuite/types.rs
+++ b/libcrux-psq/src/handshake/ciphersuite/types.rs
@@ -87,7 +87,9 @@ impl SignatureVerificationKey {
         signature: &Signature,
     ) -> Result<(), HandshakeError> {
         use tls_codec::SerializeBytes;
-        let payload = tx1.tls_serialize_bytes().map_err(HandshakeError::Serialize)?;
+        let payload = tx1
+            .tls_serialize_bytes()
+            .map_err(HandshakeError::Serialize)?;
         match (self, signature) {
             (SignatureVerificationKey::Ed25519(verification_key), Signature::Ed25519(sig)) => {
                 libcrux_ed25519::verify(&payload, verification_key.as_ref(), sig)

--- a/libcrux-psq/src/handshake/ciphersuite/types.rs
+++ b/libcrux-psq/src/handshake/ciphersuite/types.rs
@@ -87,7 +87,7 @@ impl SignatureVerificationKey {
         signature: &Signature,
     ) -> Result<(), HandshakeError> {
         use tls_codec::SerializeBytes;
-        let payload = tx1.tls_serialize().map_err(HandshakeError::Serialize)?;
+        let payload = tx1.tls_serialize_bytes().map_err(HandshakeError::Serialize)?;
         match (self, signature) {
             (SignatureVerificationKey::Ed25519(verification_key), Signature::Ed25519(sig)) => {
                 libcrux_ed25519::verify(&payload, verification_key.as_ref(), sig)

--- a/libcrux-psq/src/handshake/transcript.rs
+++ b/libcrux-psq/src/handshake/transcript.rs
@@ -31,7 +31,8 @@ impl Transcript {
         let mut hasher = libcrux_sha2::Sha256::new();
         hasher.update(&[DOMAIN_SEPARATOR]);
         hasher.update(
-            <Option<&Transcript> as SerializeBytes>::tls_serialize(&old_transcript)
+            old_transcript
+                .tls_serialize_bytes()
                 .map_err(Error::Serialize)?
                 .as_slice(),
         );

--- a/libcrux-psq/src/protocol/api.rs
+++ b/libcrux-psq/src/protocol/api.rs
@@ -110,7 +110,7 @@ fn derive_pk_binder(
     libcrux_hkdf::sha2_256::hkdf(
         &mut pk_binder,
         &[],
-        &SerializeBytes::tls_serialize(&key.key).map_err(serialize_error)?,
+        &key.key.tls_serialize_bytes().map_err(serialize_error)?,
         &info_buf,
     )
     .map_err(|_| Error::CryptoError)?;

--- a/libcrux-psq/src/session.rs
+++ b/libcrux-psq/src/session.rs
@@ -134,7 +134,9 @@ fn derive_pk_binder(
     libcrux_hkdf::sha2_256::hkdf(
         &mut binder,
         &[],
-        &key.key.tls_serialize_bytes().map_err(SessionError::Serialize)?,
+        &key.key
+            .tls_serialize_bytes()
+            .map_err(SessionError::Serialize)?,
         &info_buf,
     )
     .map_err(|_| SessionError::CryptoError)?;

--- a/libcrux-psq/src/session.rs
+++ b/libcrux-psq/src/session.rs
@@ -134,7 +134,7 @@ fn derive_pk_binder(
     libcrux_hkdf::sha2_256::hkdf(
         &mut binder,
         &[],
-        &SerializeBytes::tls_serialize(&key.key).map_err(SessionError::Serialize)?,
+        &key.key.tls_serialize_bytes().map_err(SessionError::Serialize)?,
         &info_buf,
     )
     .map_err(|_| SessionError::CryptoError)?;
@@ -382,7 +382,7 @@ impl Session {
                 context,
                 separator: *PSQ_EXPORT_CONTEXT,
             }
-            .tls_serialize()
+            .tls_serialize_bytes()
             .map_err(SessionError::Serialize)?,
         )
         .map_err(|_| SessionError::CryptoError)

--- a/libcrux-psq/src/session/session_key.rs
+++ b/libcrux-psq/src/session/session_key.rs
@@ -34,7 +34,7 @@ fn session_key_id(key: &AEADKeyNonce) -> Result<[u8; SESSION_ID_LENGTH], Error> 
     libcrux_hkdf::sha2_256::hkdf(
         &mut session_id,
         SESSION_KEY_SALT,
-        &SerializeBytes::tls_serialize(&key).map_err(Error::Serialize)?,
+        &key.tls_serialize_bytes().map_err(Error::Serialize)?,
         SESSION_KEY_INFO,
     )
     .map_err(|_| Error::CryptoError)?;

--- a/libcrux-psq/src/session/transport.rs
+++ b/libcrux-psq/src/session/transport.rs
@@ -215,7 +215,7 @@ fn derive_channel_key<const IS_INITIATOR: bool>(session: &Session) -> Result<AEA
                 .map(|pk_binder| pk_binder.as_slice()),
             counter: session.channel_counter,
         }
-        .tls_serialize()
+        .tls_serialize_bytes()
         .map_err(Error::Serialize)?,
         session.aead_type,
     )


### PR DESCRIPTION
There are some changes I want to do on the tls codec release before getting this out. But let's get this first one in already.
[skip changelog]