### PR TITLE
[aes]: use ct compare for tag check

### DIFF
--- a/.github/workflows/aes-riscv-arm.yml
+++ b/.github/workflows/aes-riscv-arm.yml
@@ -48,7 +48,7 @@ jobs:
           cargo build --release --target ${{ matrix.target }}
 
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
         fail-fast: false
         matrix:
@@ -61,18 +61,21 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Update dependencies
-        run: cargo update
-
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install target Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+            toolchain: stable
             targets: ${{ matrix.target }}
-        name: Install target Rust toolchain
+
+      - name: Install cross
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2 
+        with:
+          tool: cross@0.2.5
 
       - name: Test
         run: |
-          nix-shell --run "cargo test --verbose --target ${{ matrix.target }}"
+          cross test --verbose --target ${{ matrix.target }}
 
       - name: Test Release
         run: |
-          nix-shell --run "cargo test --verbose --target ${{ matrix.target }} --release"
+          cross test --verbose --target ${{ matrix.target }} --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (libcrux-secrets) [#1460](https://github.com/cryspen/libcrux/pull/1461): Fix incorrect cmp in aarch64 select/swap implementation
 - (libcrux-sha3) [#1456](https://github.com/cryspen/libcrux/pull/1456): Fix out of bounds indexing in avx2 SHAKE-256 implementation
 - (libcrux-sha3) [#1389](https://github.com/celabshq/libcrux/pull/1389): Fix partial Block output of incremental XOF API
+- (libcrux-aes) [#1474](https://github.com/cryspen/libcrux/pull/1474): Enforce limits on plaintext and AAD lengths for AES-GCM, according to RFC 5116.
 - (libcrux-aes) [#1528](https://github.com/celabshq/libcrux/pull/1528): Use constant time comparison for AES-GCM and AES-CCM tag check
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (libcrux-secrets) [#1460](https://github.com/cryspen/libcrux/pull/1461): Fix incorrect cmp in aarch64 select/swap implementation
 - (libcrux-sha3) [#1456](https://github.com/cryspen/libcrux/pull/1456): Fix out of bounds indexing in avx2 SHAKE-256 implementation
 - (libcrux-sha3) [#1389](https://github.com/celabshq/libcrux/pull/1389): Fix partial Block output of incremental XOF API
+- (libcrux-aes) [#1528](https://github.com/celabshq/libcrux/pull/1528): Use constant time comparison for AES-GCM and AES-CCM tag check
 
 ### Changed
 

--- a/crates/algorithms/aes/CHANGELOG.md
+++ b/crates/algorithms/aes/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#1474](https://github.com/cryspen/libcrux/pull/1474): Enforce limits on plaintext and AAD lengths for AES-GCM, according to RFC 5116.
+- [#1528](https://github.com/celabshq/libcrux/pull/1528): Use constant time comparison for AES-GCM and AES-CCM tag check
 
 ### Changed
 

--- a/crates/algorithms/aes/src/aes_ccm.rs
+++ b/crates/algorithms/aes/src/aes_ccm.rs
@@ -3,6 +3,7 @@ use core::ops::Range;
 
 use crate::{
     aes::{block_cipher, AES_BLOCK_LEN},
+    ct_ops::ct_compare,
     ctr::{AesCtrContext, CcmInit, AES_CCM_CTR_LEN, AES_CCM_NONCE_START},
     platform::AESState,
     DecryptError, CCM_SHORT_TAG_LEN, NONCE_LEN, TAG_LEN,
@@ -90,12 +91,7 @@ where
 
         // Check that recomputed tag in accumulator agrees
         // with provided tag.
-        let mut eq_mask = 0u8;
-        for i in 0..TAG_LEN {
-            eq_mask |= tag_block[i] ^ tag[i];
-        }
-
-        if eq_mask != 0 {
+        if !ct_compare(&tag_block[..TAG_LEN], &tag) {
             return Err(DecryptError::InvalidTag);
         }
 

--- a/crates/algorithms/aes/src/aes_gcm.rs
+++ b/crates/algorithms/aes/src/aes_gcm.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     aes::AES_BLOCK_LEN,
+    ct_ops::ct_compare,
     ctr::{AesCtrContext, GcmInit, AES_GCM_CTR_LEN, AES_GCM_NONCE_START},
     gf128::GF128State,
     platform::{AESState, GF128FieldElement},
@@ -93,12 +94,9 @@ where
             computed_tag[i] ^= self.tag_mix[i];
         }
 
-        let mut eq_mask = 0u8;
-        for i in 0..16 {
-            eq_mask |= computed_tag[i] ^ tag[i];
-        }
+        let correct_tag = ct_compare(&computed_tag, tag);
 
-        if eq_mask == 0 {
+        if correct_tag {
             self.aes_state.aes_ctr_update(2, ciphertext, plaintext);
             Ok(())
         } else {

--- a/crates/algorithms/aes/src/ct_ops.rs
+++ b/crates/algorithms/aes/src/ct_ops.rs
@@ -1,0 +1,72 @@
+//! Constant time compare for byte-slices
+//!
+//! Adapted from <https://github.com/celabshq/libcrux/blob/20d3da2a0b06def4e29a7746c00d65f132c63550/libcrux-ml-kem/src/constant_time_ops.rs>-
+use core::hint::black_box;
+
+// Returns 1 if value is != 0 and 0 otherwise.
+fn is_not_zero(value: u8) -> u8 {
+    let value = black_box(value as u16);
+    let result = ((!value).wrapping_add(1) >> 8) as u8;
+    let res = result & 1;
+    // Steer the compiler away from using the information that res is 0 or 1.
+    // Using black_box can't guarantee this and is only on a best effort basis.
+    black_box(res)
+}
+
+// Use inline(never) to additionally steer the compiler from using the
+// information that the result can only be 0 or 1.
+#[inline(never)]
+fn ct_compare_inner(a: &[u8], b: &[u8]) -> u8 {
+    // Short-circuiting on the lengths is okay, this is not considered secret
+    if a.len() != b.len() {
+        return 1;
+    }
+
+    let mut difference = 0;
+    for i in 0..a.len() {
+        difference |= a[i] ^ b[i];
+    }
+    is_not_zero(difference)
+}
+
+/// Compare two byte slices in constant time.
+///
+/// This function compares the contents of the slices in constant time.
+/// The result is a `bool`, so this function is only suitable if it is okay to branch on
+/// the result of the comparison and leak the result.
+///
+/// # Note
+/// This short-circuits on the length of the slices. The implementation leaks information about the slices lengths.
+pub(crate) fn ct_compare(a: &[u8], b: &[u8]) -> bool {
+    // compare_inner returns 0 if the slices are equal
+    ct_compare_inner(a, b) == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ct_ops::{ct_compare, is_not_zero};
+
+    #[test]
+    fn test_is_not_zero() {
+        assert_eq!(0, is_not_zero(0));
+
+        for i in 1..u8::MAX {
+            assert_eq!(1, is_not_zero(i))
+        }
+    }
+
+    #[test]
+    fn test_ct_compare_length_differs() {
+        assert!(!ct_compare(&[1, 2], &[1, 2, 3]));
+    }
+
+    #[test]
+    fn test_ct_compare_equal() {
+        assert!(ct_compare(&[1, 2], &[1, 2,]));
+    }
+
+    #[test]
+    fn test_ct_compare_not_equal() {
+        assert!(!ct_compare(&[1, 2], &[2, 2,]));
+    }
+}

--- a/crates/algorithms/aes/src/lib.rs
+++ b/crates/algorithms/aes/src/lib.rs
@@ -83,6 +83,7 @@
 extern crate std;
 
 mod aes;
+mod ct_ops;
 mod ctr;
 mod gf128;
 mod platform;


### PR DESCRIPTION
Introduces a `ct_ops` module to libcrux-aes and uses the `ct_compare` function for comparing the tags in the decryption functions of gcm and ccm.

With the previous implementation, there were cases where the compiler would optimize the tag check into a short-circuiting loop.

E.g. running
```
cargo asm --lib --release -p libcrux-aes 'libcrux_aes::decrypt' 0 --rust
```

on the main branch shows that the tag check is compiled into a short-circuiting loop:
<details><summary>Cargo asm output</summary>

```asm
> cargo asm --lib --release -p libcrux-aes 'libcrux_aes::decrypt' 0 --rust
.section .text.libcrux_aes::decrypt,"ax",@progbits
        // Omitted
                // src/aes_gcm.rs:93
                computed_tag[i] ^= self.tag_mix[i];
        xor sil, dl
        xor eax, eax
                // src/aes_gcm.rs:101
                if eq_mask == 0 {
        cmp byte ptr [rdi], sil
        jne .LBB170_17
        mov esi, edx
        shr esi, 8
        xor sil, byte ptr [rsp + 337]
        cmp byte ptr [rdi + 1], sil
        jne .LBB170_17
        mov esi, edx
        shr esi, 16
        xor sil, byte ptr [rsp + 338]
        cmp byte ptr [rdi + 2], sil
        jne .LBB170_17
        mov esi, edx
        shr esi, 24
        xor sil, byte ptr [rsp + 339]
        cmp byte ptr [rdi + 3], sil
        jne .LBB170_17
        mov rsi, rdx
        shr rsi, 32
        xor sil, byte ptr [rsp + 340]
        cmp byte ptr [rdi + 4], sil
        jne .LBB170_17
        mov rsi, rdx
        shr rsi, 40
        xor sil, byte ptr [rsp + 341]
        cmp byte ptr [rdi + 5], sil
        jne .LBB170_17
        mov rsi, rdx
        shr rsi, 48
        xor sil, byte ptr [rsp + 342]
        cmp byte ptr [rdi + 6], sil
        jne .LBB170_17
        shr rdx, 56
        xor dl, byte ptr [rsp + 343]
        cmp byte ptr [rdi + 7], dl
        jne .LBB170_17
        bswap rcx
        movzx edx, byte ptr [rsp + 344]
        xor dl, cl
        cmp byte ptr [rdi + 8], dl
        jne .LBB170_17
        mov edx, ecx
        shr edx, 8
        xor dl, byte ptr [rsp + 345]
        cmp byte ptr [rdi + 9], dl
        jne .LBB170_17
        mov edx, ecx
        shr edx, 16
        xor dl, byte ptr [rsp + 346]
        cmp byte ptr [rdi + 10], dl
        jne .LBB170_17
        mov edx, ecx
        shr edx, 24
        xor dl, byte ptr [rsp + 347]
        cmp byte ptr [rdi + 11], dl
        jne .LBB170_17
        mov rdx, rcx
        shr rdx, 32
        xor dl, byte ptr [rsp + 348]
        cmp byte ptr [rdi + 12], dl
        jne .LBB170_17
        mov rdx, rcx
        shr rdx, 40
        xor dl, byte ptr [rsp + 349]
        cmp byte ptr [rdi + 13], dl
        jne .LBB170_17
        mov rdx, rcx
        shr rdx, 48
        xor dl, byte ptr [rsp + 350]
        cmp byte ptr [rdi + 14], dl
        jne .LBB170_17
        shr rcx, 56
        xor cl, byte ptr [rsp + 351]
        cmp byte ptr [rdi + 15], cl
        jne .LBB170_17
        mov rcx, qword ptr [rsp + 424]
        lea rdi, [rsp + 112]
        mov rsi, qword ptr [rsp + 48]
        mov rdx, qword ptr [rsp + 56]
                // src/aes_gcm.rs:102
                self.aes_state.aes_ctr_update(2, ciphertext, plaintext);
        mov r8, rbx
        call libcrux_aes::ctr::AesCtrContext<T,_,_,_>::aes_ctr_update
        mov al, 5
.LBB170_17:
                // src/lib.rs:1294
                }
        add rsp, 360
        .cfi_def_cfa_offset 56
        pop rbx
        .cfi_def_cfa_offset 48
        pop r12
        .cfi_def_cfa_offset 40
        pop r13
        .cfi_def_cfa_offset 32
        pop r14
        .cfi_def_cfa_offset 24
        pop r15
        .cfi_def_cfa_offset 16
        pop rbp
        .cfi_def_cfa_offset 8
        ret
```

</details>

After the change:

<details><summary>Cargo asm output</summary>

```
> cargo asm --lib --release -p libcrux-aes 'libcrux_aes::decrypt' 0 --rust
.section .text.libcrux_aes::decrypt,"ax",@progbits
        // Omitted
        call libcrux_aes::ct_ops::ct_compare_inner
        test al, al
                // src/aes_gcm.rs:99
                if correct_tag {
        je .LBB172_2
        xor eax, eax
        jmp .LBB172_3
.LBB172_2:
        mov rcx, qword ptr [rsp + 424]
        lea rdi, [rsp + 112]
        mov rsi, qword ptr [rsp + 48]
        mov rdx, qword ptr [rsp + 56]
                // src/aes_gcm.rs:100
                self.aes_state.aes_ctr_update(2, ciphertext, plaintext);
        mov r8, qword ptr [rsp + 432]
        call libcrux_aes::ctr::AesCtrContext<T,_,_,_>::aes_ctr_update
        mov al, 5
.LBB172_3:
                // src/lib.rs:1295
                }
        add rsp, 360
        .cfi_def_cfa_offset 56
        pop rbx
        .cfi_def_cfa_offset 48
        pop r12
        .cfi_def_cfa_offset 40
        pop r13
        .cfi_def_cfa_offset 32
        pop r14
        .cfi_def_cfa_offset 24
        pop r15
        .cfi_def_cfa_offset 16
        pop rbp
        .cfi_def_cfa_offset 8
        ret

> cargo asm --lib --release -p libcrux-aes 'ct_compare_inner' 0 --rust
    Finished `release` profile [optimized] target(s) in 0.10s

.section .text.libcrux_aes::ct_ops::ct_compare_inner,"ax",@progbits
        .p2align        4
.type   libcrux_aes::ct_ops::ct_compare_inner,@function
libcrux_aes::ct_ops::ct_compare_inner:
                // src/ct_ops.rs:19
                fn ct_compare_inner(a: &[u8], b: &[u8]) -> u8 {
        .cfi_startproc
        mov al, 1
                // src/ct_ops.rs:21
                if a.len() != b.len() {
        cmp rsi, rcx
        jne .LBB155_5
                // /nix/store/l8ksz8bzni7pi8bb5ngljcb01nxyddzj-rust-default-1.95.0/lib/rustlib/src/rust/library/core/src/cmp.rs:1916
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        test rsi, rsi
                // /nix/store/l8ksz8bzni7pi8bb5ngljcb01nxyddzj-rust-default-1.95.0/lib/rustlib/src/rust/library/core/src/iter/range.rs:772
                if self.start < self.end {
        je .LBB155_2
        xor eax, eax
        xor ecx, ecx
        .p2align        4
.LBB155_7:
                // src/ct_ops.rs:27
                difference |= a[i] ^ b[i];
        movzx r8d, byte ptr [rdx + rcx]
        xor r8b, byte ptr [rdi + rcx]
                // /nix/store/l8ksz8bzni7pi8bb5ngljcb01nxyddzj-rust-default-1.95.0/lib/rustlib/src/rust/library/core/src/num/uint_macros.rs:844
                intrinsics::unchecked_add(self, rhs)
        inc rcx
                // src/ct_ops.rs:27
                difference |= a[i] ^ b[i];
        or al, r8b
                // /nix/store/l8ksz8bzni7pi8bb5ngljcb01nxyddzj-rust-default-1.95.0/lib/rustlib/src/rust/library/core/src/cmp.rs:1916
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        cmp rsi, rcx
                // /nix/store/l8ksz8bzni7pi8bb5ngljcb01nxyddzj-rust-default-1.95.0/lib/rustlib/src/rust/library/core/src/iter/range.rs:772
                if self.start < self.end {
        jne .LBB155_7
                // src/ct_ops.rs:8
                let value = black_box(value as u16);
        movzx eax, al
        jmp .LBB155_4
.LBB155_2:
        xor eax, eax
.LBB155_4:
                // /nix/store/l8ksz8bzni7pi8bb5ngljcb01nxyddzj-rust-default-1.95.0/lib/rustlib/src/rust/library/core/src/hint.rs:491
                crate::intrinsics::black_box(dummy)
        mov word ptr [rsp - 2], ax
        lea rax, [rsp - 2]
        #APP
        #NO_APP
        xor eax, eax
                // /nix/store/l8ksz8bzni7pi8bb5ngljcb01nxyddzj-rust-default-1.95.0/lib/rustlib/src/rust/library/core/src/num/uint_macros.rs:2457
                intrinsics::wrapping_add(self, rhs)
        sub ax, word ptr [rsp - 2]
                // src/ct_ops.rs:9
                let result = ((!value).wrapping_add(1) >> 8) as u8;
        shr eax, 8
                // src/ct_ops.rs:10
                let res = result & 1;
        and al, 1
                // /nix/store/l8ksz8bzni7pi8bb5ngljcb01nxyddzj-rust-default-1.95.0/lib/rustlib/src/rust/library/core/src/hint.rs:491
                crate::intrinsics::black_box(dummy)
        mov byte ptr [rsp - 3], al
        lea rax, [rsp - 3]
        #APP
        #NO_APP
                // src/ct_ops.rs:30
                }
        movzx eax, byte ptr [rsp - 3]
.LBB155_5:
        ret
```

</details>