### PR TITLE
[hmac-drbg]: fix panic in reseeding wrappers fill_bytes method

### DIFF
--- a/.github/workflows/hmac-drbg.yml
+++ b/.github/workflows/hmac-drbg.yml
@@ -55,11 +55,11 @@ jobs:
 
       - name: 🏃🏻‍♀️ Test
         run: |
-          cargo hack test --each-feature --exclude-features testing --verbose
+          cargo hack test --each-feature --exclude-features _testing-apis --verbose
 
       - name: 🏃🏻‍♀️ Test Release
         run: |
-          cargo hack test --each-feature --exclude-features testing --verbose --release
+          cargo hack test --each-feature --exclude-features _testing-apis --verbose --release
 
   fuzz:
     strategy:

--- a/.github/workflows/hmac-drbg.yml
+++ b/.github/workflows/hmac-drbg.yml
@@ -1,0 +1,103 @@
+name: HMAC-DRBG
+
+permissions: {}
+
+on:
+  merge_group:
+  pull_request:
+    branches: ["main", "dev", "*"]
+    paths:
+      - "crates/algorithms/hmac-drbg/**"
+      - .github/workflows/hmac-drbg.yml
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: crates/algorithms/hmac-drbg
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
+        with:
+          tool: cargo-hack
+
+      - name: 🔨 Build
+        run: |
+          cargo build --all-targets --verbose
+
+      - name: 🔨 Build Release
+        run: cargo build --release --all-targets --verbose
+
+      # Test ...
+
+      - name: 🏃🏻‍♀️ Test
+        run: |
+          cargo hack test --each-feature --exclude-features testing --verbose
+
+      - name: 🏃🏻‍♀️ Test Release
+        run: |
+          cargo hack test --each-feature --exclude-features testing --verbose --release
+
+  fuzz:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest # macos-15
+          - ubuntu-latest
+        target:
+          - new
+          - generate
+          - lifecycle
+          - reseeding
+
+    runs-on: ${{ matrix.os }}
+    env:
+      FUZZ_TIME: 300 # seconds = 5 mins
+    defaults:
+      run:
+        shell: bash
+        working-directory: crates/algorithms/hmac-drbg
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install latest nightly
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: nightly
+          components: rust-src, llvm-tools-preview
+
+      # install-action with cargo-binstall fallback doesn't work for cargo-fuzz
+      - name: Install cargo-fuzz
+        run: |
+          cargo install cargo-fuzz --locked
+
+      # disable lto for fuzzing due to https://github.com/rust-fuzz/cargo-fuzz/issues/384
+      - name: 🏃🏻‍♀️ Fuzz ${{ matrix.target }}
+        run: CARGO_PROFILE_RELEASE_LTO=false cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=${{ env.FUZZ_TIME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+
+### Fixed
+
+- (libcrux-hmac-drbg) [#1558](https://github.com/celabshq/libcrux/pull/1558): fix panic in reseeding wrappers fill_bytes method
 
 ### Changed
 
 - (libcrux-macros) [#1550](https://github.com/celabshq/libcrux/pull/1550): Update syn dependency to 3.0
 - (libcrux-secrets) [#1551](https://github.com/celabshq/libcrux/pull/1551) Update crabgrind to 0.3.1
-
-### Added
-
-## [Unreleased]
+- (libcrux-hmac-drbg) [#1558](https://github.com/celabshq/libcrux/pull/1558): rename `GenerateError::RequestInvalid` to `GenerateError::OutputTooLarge
 
 ### Added
 
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   post-quantum and PQ/T-hybrid algorithms of
   [draft-ietf-hpke-pq](https://datatracker.ietf.org/doc/html/draft-ietf-hpke-pq-04),
   in the **libcrux provider only**, behind the new `draft-ietf-hpke-pq` feature.
+
 
 ## [0.0.5] (2026-07-15)
 

--- a/crates/algorithms/hmac-drbg/CHANGELOG.md
+++ b/crates/algorithms/hmac-drbg/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [#1558](https://github.com/celabshq/libcrux/pull/1558): fix panic in reseeding wrappers fill_bytes method
+
+### Changed
+
+- [#1558](https://github.com/celabshq/libcrux/pull/1558): rename `GenerateError::RequestInvalid` to `GenerateError::OutputTooLarge`
+
+
 ## [0.0.1] (2026-07-15)
 
 - [#1382](https://github.com/celabshq/libcrux/pull/1382): Initial version of this crate

--- a/crates/algorithms/hmac-drbg/Cargo.toml
+++ b/crates/algorithms/hmac-drbg/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 rand = ["dep:rand"]
 
 # Exposes APIs that should only be used for testing this library.
-testing = []
+_testing-apis = []
 
 # Enables continuous health tests per NIST SP 800-90C §9.3.3 and AIS 20/31 T4:
 #   - Intra-call: each V = HMAC(K,V_old) must satisfy V ≠ V_old.

--- a/crates/algorithms/hmac-drbg/fuzz/Cargo.toml
+++ b/crates/algorithms/hmac-drbg/fuzz/Cargo.toml
@@ -9,10 +9,11 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
+rand = { version = "0.10", default-features = false, features = ["std_rng"]}
 
 [dependencies.libcrux-hmac-drbg]
 path = ".."
-features = ["testing"]
+features = ["testing", "rand"]
 
 [[bin]]
 name = "new"
@@ -33,6 +34,14 @@ harness = false
 [[bin]]
 name = "lifecycle"
 path = "fuzz_targets/lifecycle.rs"
+test = false
+doc = false
+bench = false
+harness = false
+
+[[bin]]
+name = "reseeding"
+path = "fuzz_targets/reseeding.rs"
 test = false
 doc = false
 bench = false

--- a/crates/algorithms/hmac-drbg/fuzz/Cargo.toml
+++ b/crates/algorithms/hmac-drbg/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ rand = { version = "0.10", default-features = false, features = ["std_rng"]}
 
 [dependencies.libcrux-hmac-drbg]
 path = ".."
-features = ["testing", "rand"]
+features = ["_testing-apis", "rand"]
 
 [[bin]]
 name = "new"

--- a/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/generate.rs
+++ b/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/generate.rs
@@ -11,7 +11,7 @@
 //!
 //! Checks:
 //!   - No panic or undefined behaviour for any input.
-//!   - `RequestInvalid` iff output_len == 0 or output_len > MAX_GENERATE_BYTES.
+//!   - `OutputTooLarge` iff output_len > MAX_GENERATE_BYTES.
 //!   - On success the output buffer is fully written (no uninitialised bytes leak).
 #![no_main]
 
@@ -39,10 +39,10 @@ fuzz_target!(|data: &[u8]| {
             match drbg.generate(&mut out, additional_input) {
                 Ok(()) => {
                     // Success must only happen for valid lengths.
-                    assert!(output_len > 0 && output_len <= MAX_GENERATE_BYTES);
+                    assert!(output_len <= MAX_GENERATE_BYTES);
                 }
-                Err(GenerateError::RequestInvalid) => {
-                    assert!(output_len == 0 || output_len > MAX_GENERATE_BYTES);
+                Err(GenerateError::OutputTooLarge) => {
+                    assert!(output_len > MAX_GENERATE_BYTES);
                 }
                 Err(GenerateError::ReseedRequired) => {
                     // Cannot happen with a freshly instantiated DRBG (counter = 1).

--- a/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/lifecycle.rs
+++ b/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/lifecycle.rs
@@ -129,8 +129,8 @@ macro_rules! run_lifecycle {
                             // Counter must not have changed.
                             assert_eq!(drbg.reseed_counter(), counter_before);
                         }
-                        Err(GenerateError::RequestInvalid) => {
-                            // output_len == 0 or > MAX_GENERATE_BYTES: counter unchanged.
+                        Err(GenerateError::OutputTooLarge) => {
+                            // output_len > MAX_GENERATE_BYTES: counter unchanged.
                             assert_eq!(drbg.reseed_counter(), counter_before);
                         }
                         Err(e) => panic!("unexpected generate error: {e:?}"),

--- a/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/new.rs
+++ b/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/new.rs
@@ -14,7 +14,9 @@
 //!   - On success, `needs_reseed()` is false and `reseed_counter()` is 1.
 #![no_main]
 
-use libcrux_hmac_drbg::{HmacDrbgSha256, HmacDrbgSha384, HmacDrbgSha512, InstantiateError};
+use libcrux_hmac_drbg::{
+    HmacDrbgSha256, HmacDrbgSha384, HmacDrbgSha512, InstantiateError, MIN_ENTROPY_BYTES,
+};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -54,6 +56,12 @@ fuzz_target!(|data: &[u8]| {
                         total > MAX_SEED,
                         "InputTooLarge returned but total={total} <= {MAX_SEED}"
                     );
+                }
+                Err(InstantiateError::InsufficientEntropy) => {
+                    assert!(
+                        entropy.len() < MIN_ENTROPY_BYTES,
+                        "InsufficientEntropy returned but entropy.len() >= MIN_ENTROPY_BYTES"
+                    )
                 }
                 // there are more variants if the rand feature is set on the drbg crate,
                 // so we need the exception here

--- a/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/reseeding.rs
+++ b/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/reseeding.rs
@@ -1,0 +1,247 @@
+//! Fuzz the auto-reseeding wrappers `HmacSha256DrbgRng`, `HmacSha384DrbgRng`
+//! and `HmacSha512DrbgRng`.
+//!
+//! These wrap `HmacDrbg` in the *infallible* `rand::CryptoRng` interface, so
+//! every error the inner DRBG can return is handled internally: either by
+//! reseeding from the inner RNG, or by an `unreachable!()`. This target is
+//! therefore mainly a hunt for inputs that reach one of those `unreachable!()`s,
+//! plus a check of the reseed counter against the model in `expect_counter`.
+//!
+//! Input layout (every field is zero-padded when the input ends early, so short
+//! inputs are valid):
+//!   [0]       algorithm selector: 0 → SHA-256, 1 → SHA-384, 2 → SHA-512
+//!   [1]       constructor: even → `new_from_seed`, odd → `new`
+//!   [2..10]   seed for the reseed RNG (little-endian u64)
+//!   [10..42]  entropy         (`new_from_seed` only)
+//!   [42..74]  nonce           (`new_from_seed` only)
+//!   [74..106] personalization
+//!   [106..]   operation stream, each record starting with a tag byte:
+//!     tag % 4 == 0  `next_u32`
+//!     tag % 4 == 1  `next_u64`
+//!     tag % 4 == 2  `fill_bytes`; [1] = length class, [2..6] = raw length
+//!     tag % 4 == 3  jump the reseed counter to the `RESEED_INTERVAL` boundary;
+//!                   [1] selects which side of it
+//!
+//! Every operation runs against two identically seeded wrappers, so that output
+//! can be checked by comparison instead of against a probabilistic property.
+//!
+//! Checks:
+//!   - No panic or undefined behaviour for any input.
+//!   - The reseed counter follows `expect_counter`: every generated block
+//!     increments it, and a block requested while the counter is past
+//!     `RESEED_INTERVAL` reseeds first (resetting it to 1) rather than failing.
+//!     This is what distinguishes these wrappers from plain `HmacDrbg`, whose
+//!     `generate` would return `ReseedRequired` instead.
+//!   - The two wrappers agree on every byte of output, for every request size.
+//!     Since their `fill_bytes` buffers start pre-filled with *different*
+//!     sentinels, any byte the wrapper fails to write shows up as a mismatch —
+//!     including in requests too short for an "output is not all sentinel"
+//!     check to be usable (a 1-byte request is legitimately all-sentinel one
+//!     time in 256).
+#![no_main]
+
+use libcrux_hmac_drbg::{
+    HmacSha256DrbgRng, HmacSha384DrbgRng, HmacSha512DrbgRng, MAX_GENERATE_BYTES, RESEED_INTERVAL,
+};
+use libfuzzer_sys::fuzz_target;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+/// A cursor over the fuzz input that zero-pads once the data runs out.
+struct Cursor<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    /// The next byte, or `None` once the input is exhausted. Used for the
+    /// operation tags, where running out ends the stream.
+    fn byte(&mut self) -> Option<u8> {
+        let b = self.data.get(self.pos)?;
+        self.pos += 1;
+        Some(*b)
+    }
+
+    /// The next byte, or 0 once the input is exhausted.
+    fn byte_or_zero(&mut self) -> u8 {
+        self.byte().unwrap_or(0)
+    }
+
+    /// The next `N` bytes, zero-padded once the input is exhausted.
+    fn array<const N: usize>(&mut self) -> [u8; N] {
+        let mut out = [0u8; N];
+        for b in out.iter_mut() {
+            *b = self.byte_or_zero();
+        }
+        out
+    }
+
+    fn u32_le(&mut self) -> u32 {
+        u32::from_le_bytes(self.array::<4>())
+    }
+}
+
+/// Model of the reseed counter after `blocks` calls to
+/// `HmacDrbgRng::safe_generate_small`: each call reseeds first (counter → 1)
+/// when the counter is past the interval, then increments it.
+fn expect_counter(mut counter: u64, blocks: usize) -> u64 {
+    for _ in 0..blocks {
+        if counter > RESEED_INTERVAL {
+            counter = 1;
+        }
+        counter += 1;
+    }
+    counter
+}
+
+/// Pick a `fill_bytes` length. Most requests stay small so that execution stays
+/// cheap, while class 3 covers the `MAX_GENERATE_BYTES` chunking boundary and
+/// the multi-chunk case.
+fn pick_len(class: u8, raw: u32) -> usize {
+    match class % 4 {
+        0 | 1 => (raw % 256) as usize,
+        2 => (raw % 8192) as usize,
+        _ => MAX_GENERATE_BYTES - 2 + (raw % (MAX_GENERATE_BYTES as u32 + 6)) as usize,
+    }
+}
+
+/// Sentinels the two output buffers are pre-filled with. They must differ, so
+/// that a byte left unwritten by `fill_bytes` differs between the buffers.
+const SENTINEL_A: u8 = 0xaa;
+const SENTINEL_B: u8 = 0x55;
+
+/// Runs the operation stream against two identically seeded `$alias` wrappers.
+///
+/// Takes the type alias rather than a constructed wrapper because the two
+/// replicas have to be built the same way, and because `HmacDrbgRng`'s
+/// `HmacAlgorithm` bound is crate-private — a generic function over it can't be
+/// written from outside the crate.
+macro_rules! run_reseeding {
+    ($alias:ident, $cur:expr, $from_seed:expr, $seed:expr, $entropy:expr, $nonce:expr, $pers:expr) => {{
+        let cur = &mut $cur;
+        let make_reseeding_rng = || StdRng::seed_from_u64($seed);
+        let (mut rng_a, mut rng_b) = if $from_seed {
+            (
+                $alias::new_from_seed(make_reseeding_rng(), $entropy, $nonce, $pers),
+                $alias::new_from_seed(make_reseeding_rng(), $entropy, $nonce, $pers),
+            )
+        } else {
+            (
+                $alias::new(make_reseeding_rng(), $pers),
+                $alias::new(make_reseeding_rng(), $pers),
+            )
+        };
+
+        // Bound iterations so the fuzzer doesn't get stuck in long loops.
+        const MAX_OPS: usize = 16;
+
+        for _ in 0..MAX_OPS {
+            let tag = match cur.byte() {
+                Some(b) => b,
+                None => break,
+            };
+
+            match tag % 4 {
+                // next_u32 / next_u64: one generated block each.
+                0 | 1 => {
+                    let before = rng_a.reseed_counter();
+                    if tag % 4 == 0 {
+                        assert_eq!(rng_a.next_u32(), rng_b.next_u32());
+                    } else {
+                        assert_eq!(rng_a.next_u64(), rng_b.next_u64());
+                    }
+                    let expected = expect_counter(before, 1);
+                    assert_eq!(rng_a.reseed_counter(), expected);
+                    assert_eq!(rng_b.reseed_counter(), expected);
+                }
+
+                // fill_bytes
+                2 => {
+                    let class = cur.byte_or_zero();
+                    let len = pick_len(class, cur.u32_le());
+
+                    let before = rng_a.reseed_counter();
+                    let mut out_a = vec![SENTINEL_A; len];
+                    let mut out_b = vec![SENTINEL_B; len];
+                    rng_a.fill_bytes(&mut out_a);
+                    rng_b.fill_bytes(&mut out_b);
+
+                    // Reporting the first differing index keeps the failure
+                    // readable — the buffers can be 64 KiB or more.
+                    if let Some(i) = out_a.iter().zip(&out_b).position(|(a, b)| a != b) {
+                        panic!(
+                            "fill_bytes({len}): byte {i} differs ({:#04x} vs {:#04x}) — \
+                             left unwritten, or output is not deterministic",
+                            out_a[i], out_b[i]
+                        );
+                    }
+
+                    // One block per full chunk, plus one for the remainder.
+                    let blocks = len / MAX_GENERATE_BYTES + 1;
+                    let expected = expect_counter(before, blocks);
+                    assert_eq!(rng_a.reseed_counter(), expected);
+                    assert_eq!(rng_b.reseed_counter(), expected);
+                }
+
+                // Jump the counter to the reseed boundary, which generating
+                // cannot reach (RESEED_INTERVAL is 2^48).
+                _ => {
+                    let counter = match cur.byte_or_zero() % 4 {
+                        0 => RESEED_INTERVAL - 1,
+                        1 => RESEED_INTERVAL,
+                        2 => RESEED_INTERVAL + 1,
+                        _ => u64::MAX,
+                    };
+                    rng_a.set_reseed_counter(counter);
+                    rng_b.set_reseed_counter(counter);
+                    assert_eq!(rng_a.reseed_counter(), counter);
+                    assert_eq!(rng_b.reseed_counter(), counter);
+                }
+            }
+        }
+    }};
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut cur = Cursor::new(data);
+
+    let alg = cur.byte_or_zero() % 3;
+    let from_seed = cur.byte_or_zero() % 2 == 0;
+    let seed = u64::from_le_bytes(cur.array::<8>());
+    let entropy = cur.array::<32>();
+    let nonce = cur.array::<32>();
+    let pers = cur.array::<32>();
+
+    match alg {
+        0 => run_reseeding!(
+            HmacSha256DrbgRng,
+            cur,
+            from_seed,
+            seed,
+            &entropy,
+            &nonce,
+            &pers
+        ),
+        1 => run_reseeding!(
+            HmacSha384DrbgRng,
+            cur,
+            from_seed,
+            seed,
+            &entropy,
+            &nonce,
+            &pers
+        ),
+        _ => run_reseeding!(
+            HmacSha512DrbgRng,
+            cur,
+            from_seed,
+            seed,
+            &entropy,
+            &nonce,
+            &pers
+        ),
+    }
+});

--- a/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/reseeding.rs
+++ b/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/reseeding.rs
@@ -44,7 +44,7 @@ use libcrux_hmac_drbg::{
     HmacSha256DrbgRng, HmacSha384DrbgRng, HmacSha512DrbgRng, MAX_GENERATE_BYTES, RESEED_INTERVAL,
 };
 use libfuzzer_sys::fuzz_target;
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 /// A cursor over the fuzz input that zero-pads once the data runs out.
 struct Cursor<'a> {

--- a/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/reseeding.rs
+++ b/crates/algorithms/hmac-drbg/fuzz/fuzz_targets/reseeding.rs
@@ -180,7 +180,8 @@ macro_rules! run_reseeding {
                     }
 
                     // One block per full chunk, plus one for the remainder.
-                    let blocks = len / MAX_GENERATE_BYTES + 1;
+                    // No block for an empty chunk, so we use div_ceil.
+                    let blocks = len.div_ceil(MAX_GENERATE_BYTES);
                     let expected = expect_counter(before, blocks);
                     assert_eq!(rng_a.reseed_counter(), expected);
                     assert_eq!(rng_b.reseed_counter(), expected);

--- a/crates/algorithms/hmac-drbg/src/errors.rs
+++ b/crates/algorithms/hmac-drbg/src/errors.rs
@@ -96,10 +96,10 @@ pub enum GenerateError {
     /// [`RESEED_INTERVAL`]: crate::RESEED_INTERVAL
     ReseedRequired,
 
-    /// The requested output length is zero or exceeds [`MAX_GENERATE_BYTES`].
+    /// The requested output length exceeds [`MAX_GENERATE_BYTES`].
     ///
     /// [`MAX_GENERATE_BYTES`]: crate::MAX_GENERATE_BYTES
-    RequestInvalid,
+    OutputTooLarge,
 
     /// The combined seed material exceeds the internal limit.
     InputTooLarge,
@@ -118,7 +118,9 @@ impl fmt::Display for GenerateError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             GenerateError::ReseedRequired => f.write_str("reseed required before next generate"),
-            GenerateError::RequestInvalid => f.write_str("generate request size out of range"),
+            GenerateError::OutputTooLarge => {
+                f.write_str("generate request size exceeds maximum allowed size")
+            }
             GenerateError::InputTooLarge => {
                 f.write_str("seed material exceeds maximum allowed size")
             }

--- a/crates/algorithms/hmac-drbg/src/health_tests.rs
+++ b/crates/algorithms/hmac-drbg/src/health_tests.rs
@@ -240,7 +240,7 @@ impl<const OUTLEN: usize, Alg: HmacAlgorithm<OUTLEN>> HmacDrbg<OUTLEN, Alg> {
     }
 
     /// Poison this instance directly (for testing error-path behaviour).
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "_testing-apis"))]
     pub fn poison_for_testing(&mut self) {
         self.health.set_poisoned();
     }

--- a/crates/algorithms/hmac-drbg/src/lib.rs
+++ b/crates/algorithms/hmac-drbg/src/lib.rs
@@ -365,7 +365,7 @@ impl<const OUTLEN: usize, Alg: HmacAlgorithm<OUTLEN>> HmacDrbg<OUTLEN, Alg> {
     }
 
     /// Force-set the reseed counter (for testing error paths).
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "_testing-apis"))]
     pub fn set_reseed_counter(&mut self, v: u64) {
         self.reseed_counter = v;
     }

--- a/crates/algorithms/hmac-drbg/src/lib.rs
+++ b/crates/algorithms/hmac-drbg/src/lib.rs
@@ -69,7 +69,7 @@ pub const RESEED_INTERVAL: u64 = 1 << 48;
 /// Maximum number of bytes that can be requested in a single [`HmacDrbg::generate`] call
 /// (SP 800-90A §10.1 Tables 1 and 2).
 ///
-/// Requesting more returns [`GenerateError::RequestInvalid`].
+/// Requesting more returns [`GenerateError::OutputTooLarge`].
 pub const MAX_GENERATE_BYTES: usize = 65_536;
 
 /// Minimum entropy input length in bytes (SP 800-90A Table 2: security strength).
@@ -284,7 +284,6 @@ impl<const OUTLEN: usize, Alg: HmacAlgorithm<OUTLEN>> HmacDrbg<OUTLEN, Alg> {
     /// On any failure the instance is poisoned and `Error::HealthCheckFailed` is
     /// returned.
     //
-    // #hax: requires output.len() > 0
     // #hax: requires output.len() <= MAX_GENERATE_BYTES
     // #hax: requires true   // additional_input has no length constraint
     // #hax: requires self.reseed_counter <= RESEED_INTERVAL
@@ -302,11 +301,8 @@ impl<const OUTLEN: usize, Alg: HmacAlgorithm<OUTLEN>> HmacDrbg<OUTLEN, Alg> {
         if self.reseed_counter > RESEED_INTERVAL {
             return Err(GenerateError::ReseedRequired);
         }
-        if output.is_empty() {
-            return Err(GenerateError::RequestInvalid);
-        }
         if output.len() > MAX_GENERATE_BYTES {
-            return Err(GenerateError::RequestInvalid);
+            return Err(GenerateError::OutputTooLarge);
         }
 
         // Update state with additional_input (might be empty).

--- a/crates/algorithms/hmac-drbg/src/rand.rs
+++ b/crates/algorithms/hmac-drbg/src/rand.rs
@@ -347,7 +347,7 @@ impl<const OUTLEN: usize, Hmac: HmacAlgorithm<OUTLEN>, ReseedRng: CryptoRng>
             // we just ensured that no reseed is required
             Err(crate::GenerateError::ReseedRequired) => unreachable!(),
             // We know how much data we request and it's fine
-            Err(crate::GenerateError::RequestInvalid) => unreachable!(),
+            Err(crate::GenerateError::OutputTooLarge) => unreachable!(),
             // Again, the input size is safe.
             Err(crate::GenerateError::InputTooLarge) => unreachable!(),
         }
@@ -392,14 +392,12 @@ impl<const OUTLEN: usize, Hmac: HmacAlgorithm<OUTLEN>, ReseedRng: CryptoRng> ran
     }
 
     fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
-        let (chunks, rest): (&mut [[u8; MAX_GENERATE_BYTES]], _) = dst.as_chunks_mut();
-
-        for chunk in chunks {
-            self.safe_generate_small(chunk);
+        let mut written = 0;
+        while written < dst.len() {
+            let chunk = (dst.len() - written).min(MAX_GENERATE_BYTES);
+            self.safe_generate_small(&mut dst[written..written + chunk]);
+            written += chunk;
         }
-
-        self.safe_generate_small(rest);
-
         Ok(())
     }
 }

--- a/crates/algorithms/hmac-drbg/src/rand.rs
+++ b/crates/algorithms/hmac-drbg/src/rand.rs
@@ -352,6 +352,25 @@ impl<const OUTLEN: usize, Hmac: HmacAlgorithm<OUTLEN>, ReseedRng: CryptoRng>
             Err(crate::GenerateError::InputTooLarge) => unreachable!(),
         }
     }
+
+    /// Returns the inner DRBG's reseed counter.
+    ///
+    /// See [`HmacDrbg::reseed_counter`] for further information.
+    pub fn reseed_counter(&self) -> u64 {
+        self.drbg.reseed_counter()
+    }
+
+    /// Force-set the inner DRBG's reseed counter (for testing the auto-reseed
+    /// path).
+    ///
+    /// Reaching [`RESEED_INTERVAL`] by generating is not feasible, so tests and
+    /// fuzz targets that need the reseed branch have to jump the counter there.
+    ///
+    /// [`RESEED_INTERVAL`]: crate::RESEED_INTERVAL
+    #[cfg(any(test, feature = "testing"))]
+    pub fn set_reseed_counter(&mut self, v: u64) {
+        self.drbg.set_reseed_counter(v);
+    }
 }
 
 #[cfg(not(feature = "health-tests"))]

--- a/crates/algorithms/hmac-drbg/src/rand.rs
+++ b/crates/algorithms/hmac-drbg/src/rand.rs
@@ -63,11 +63,8 @@ impl<const OUTLEN: usize, Alg: HmacAlgorithm<OUTLEN>> rand::TryRng for HmacDrbg<
     // #hax: requires self.reseed_counter + (dst.len() / MAX_GENERATE_BYTES) as u64 + 1 <= RESEED_INTERVAL
     // #hax: ensures result.is_ok() ==> dst is fully written
     fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
-        let mut written = 0;
-        while written < dst.len() {
-            let chunk = (dst.len() - written).min(MAX_GENERATE_BYTES);
-            self.generate(&mut dst[written..written + chunk], &[])?;
-            written += chunk;
+        for chunk in dst.chunks_mut(MAX_GENERATE_BYTES) {
+            self.generate(chunk, &[])?;
         }
         Ok(())
     }
@@ -392,11 +389,8 @@ impl<const OUTLEN: usize, Hmac: HmacAlgorithm<OUTLEN>, ReseedRng: CryptoRng> ran
     }
 
     fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
-        let mut written = 0;
-        while written < dst.len() {
-            let chunk = (dst.len() - written).min(MAX_GENERATE_BYTES);
-            self.safe_generate_small(&mut dst[written..written + chunk]);
-            written += chunk;
+        for chunk in dst.chunks_mut(MAX_GENERATE_BYTES) {
+            self.safe_generate_small(chunk);
         }
         Ok(())
     }

--- a/crates/algorithms/hmac-drbg/src/rand.rs
+++ b/crates/algorithms/hmac-drbg/src/rand.rs
@@ -329,7 +329,7 @@ impl<const OUTLEN: usize, Hmac: HmacAlgorithm<OUTLEN>, ReseedRng: CryptoRng>
     /// hax.
     ///
     ///
-    //hax: requires dst.len() < crate::MAX_GENERATE_BYTES
+    // #hax: requires dst.len() <= crate::MAX_GENERATE_BYTES
     fn safe_generate_small(&mut self, dst: &mut [u8]) {
         if self.drbg.needs_reseed() {
             match self.drbg.reseed_from_rng(&mut self.rng, &[]) {

--- a/crates/algorithms/hmac-drbg/src/rand.rs
+++ b/crates/algorithms/hmac-drbg/src/rand.rs
@@ -364,7 +364,7 @@ impl<const OUTLEN: usize, Hmac: HmacAlgorithm<OUTLEN>, ReseedRng: CryptoRng>
     /// fuzz targets that need the reseed branch have to jump the counter there.
     ///
     /// [`RESEED_INTERVAL`]: crate::RESEED_INTERVAL
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "_testing-apis"))]
     pub fn set_reseed_counter(&mut self, v: u64) {
         self.drbg.set_reseed_counter(v);
     }

--- a/crates/algorithms/hmac-drbg/tests/drbg.rs
+++ b/crates/algorithms/hmac-drbg/tests/drbg.rs
@@ -227,10 +227,9 @@ fn generate_different_seeds_sha256() {
 }
 
 #[test]
-fn request_zero_bytes_rejected() {
+fn request_zero_bytes_succeeds() {
     let mut drbg = make_sha256();
-    let err = drbg.generate(&mut [], &[]).unwrap_err();
-    assert_eq!(err, GenerateError::RequestInvalid);
+    drbg.generate(&mut [], &[]).unwrap();
 }
 
 #[test]
@@ -238,7 +237,7 @@ fn request_too_large() {
     let mut drbg = make_sha256();
     let mut big = vec![0u8; MAX_GENERATE_BYTES + 1];
     let err = drbg.generate(&mut big, &[]).unwrap_err();
-    assert_eq!(err, GenerateError::RequestInvalid);
+    assert_eq!(err, GenerateError::OutputTooLarge);
 }
 
 #[test]

--- a/crates/algorithms/hmac-drbg/tests/rng_traits.rs
+++ b/crates/algorithms/hmac-drbg/tests/rng_traits.rs
@@ -82,7 +82,7 @@ fn try_fill_bytes_exact_max_generate() {
 #[test]
 fn try_fill_bytes_larger_than_max_generate() {
     // try_fill_bytes must split the request into chunks of MAX_GENERATE_BYTES
-    // and must NOT return RequestTooLarge.
+    // and must NOT return OutputTooLarge.
     let mut drbg = make_sha256();
     let mut buf = vec![0u8; libcrux_hmac_drbg::MAX_GENERATE_BYTES + 1];
     drbg.try_fill_bytes(&mut buf).unwrap();

--- a/crates/algorithms/hmac-drbg/tests/simple_rng.rs
+++ b/crates/algorithms/hmac-drbg/tests/simple_rng.rs
@@ -153,8 +153,7 @@ fn sha512_satisfies_crypto_rng() {
 
 /// Regression test for <https://github.com/celabshq/libcrux/issues/1556>
 #[test]
-#[should_panic(expected = "internal error: entered unreachable code")]
-fn sha256_fill_bytes_panics() {
+fn sha256_fill_bytes_succeeds_for_multiple_of_max_bytes() {
     let mut rng = make_sha256();
     for len in [0, MAX_GENERATE_BYTES, 2 * MAX_GENERATE_BYTES] {
         let mut output = vec![0xaa; len];
@@ -169,8 +168,7 @@ fn sha256_fill_bytes_panics() {
 
 /// Regression test for <https://github.com/celabshq/libcrux/issues/1556>
 #[test]
-#[should_panic(expected = "internal error: entered unreachable code")]
-fn sha384_fill_bytes_panics() {
+fn sha384_fill_bytes_succeeds_for_multiple_of_max_bytes() {
     let mut rng = make_sha384();
     for len in [0, MAX_GENERATE_BYTES, 2 * MAX_GENERATE_BYTES] {
         let mut output = vec![0xaa; len];
@@ -183,8 +181,7 @@ fn sha384_fill_bytes_panics() {
 
 /// Regression test for <https://github.com/celabshq/libcrux/issues/1556>
 #[test]
-#[should_panic(expected = "internal error: entered unreachable code")]
-fn sha512_fill_bytes_panics() {
+fn sha512_fill_bytes_succeeds_for_multiple_of_max_bytes() {
     let mut rng = make_sha512();
     for len in [0, MAX_GENERATE_BYTES, 2 * MAX_GENERATE_BYTES] {
         let mut output = vec![0xaa; len];

--- a/crates/algorithms/hmac-drbg/tests/simple_rng.rs
+++ b/crates/algorithms/hmac-drbg/tests/simple_rng.rs
@@ -6,7 +6,9 @@
 //! ```
 #![cfg(all(feature = "rand", not(feature = "health-tests")))]
 
-use libcrux_hmac_drbg::{HmacSha256DrbgRng, HmacSha384DrbgRng, HmacSha512DrbgRng};
+use libcrux_hmac_drbg::{
+    HmacSha256DrbgRng, HmacSha384DrbgRng, HmacSha512DrbgRng, MAX_GENERATE_BYTES,
+};
 use rand::{rand_core::UnwrapErr, rngs::SysRng, CryptoRng, Rng};
 
 type OsRng = UnwrapErr<SysRng>;
@@ -147,4 +149,48 @@ fn sha512_satisfies_crypto_rng() {
     }
     let mut rng = make_sha512();
     need_crypto(&mut rng);
+}
+
+/// Regression test for <https://github.com/celabshq/libcrux/issues/1556>
+#[test]
+#[should_panic(expected = "internal error: entered unreachable code")]
+fn sha256_fill_bytes_panics() {
+    let mut rng = make_sha256();
+    for len in [0, MAX_GENERATE_BYTES, 2 * MAX_GENERATE_BYTES] {
+        let mut output = vec![0xaa; len];
+        rng.fill_bytes(&mut output);
+        // assert for an empty vec would be true, but we still want to
+        // execute fill_bytes to check that it doesn't panic
+        if len != 0 {
+            assert!(!output.iter().all(|b| *b == 0xaa))
+        }
+    }
+}
+
+/// Regression test for <https://github.com/celabshq/libcrux/issues/1556>
+#[test]
+#[should_panic(expected = "internal error: entered unreachable code")]
+fn sha384_fill_bytes_panics() {
+    let mut rng = make_sha384();
+    for len in [0, MAX_GENERATE_BYTES, 2 * MAX_GENERATE_BYTES] {
+        let mut output = vec![0xaa; len];
+        rng.fill_bytes(&mut output);
+        if len != 0 {
+            assert!(!output.iter().all(|b| *b == 0xaa))
+        }
+    }
+}
+
+/// Regression test for <https://github.com/celabshq/libcrux/issues/1556>
+#[test]
+#[should_panic(expected = "internal error: entered unreachable code")]
+fn sha512_fill_bytes_panics() {
+    let mut rng = make_sha512();
+    for len in [0, MAX_GENERATE_BYTES, 2 * MAX_GENERATE_BYTES] {
+        let mut output = vec![0xaa; len];
+        rng.fill_bytes(&mut output);
+        if len != 0 {
+            assert!(!output.iter().all(|b| *b == 0xaa))
+        }
+    }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,19 @@
           export RUSTC=${rustNightlyWithMiri}/bin/rustc
           exec ${rustNightlyWithMiri}/bin/cargo-miri "$@"
         '';
+        # `cargo fuzz` needs nightly rustc (`-Zsanitizer=address`), so unlike
+        # miri above it can't be wrapped: `devShells.fuzz` ships this as the
+        # shell's only cargo/rustc. `llvm-tools-preview` is for
+        # `cargo fuzz coverage`, which needs an llvm-profdata matching rustc.
+        rustNightlyForFuzz = pkgs.rust-bin.selectLatestNightlyWith (
+          toolchain:
+          toolchain.default.override {
+            extensions = [
+              "rust-src"
+              "llvm-tools-preview"
+            ];
+          }
+        );
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
         # Cargo.lock is gitignored, so it isn't part of the flake's source
         # tree. Read it from the invocation directory; requires `--impure`
@@ -472,6 +485,37 @@
             '';
           }
         );
+        # `nix develop --impure .#fuzz`, then e.g.
+        #   cd crates/algorithms/hmac-drbg && cargo fuzz run generate
+        # clangStdenv so that libfuzzer-sys builds its bundled libFuzzer C++
+        # sources with clang rather than the default gcc.
+        devShells.fuzz = (pkgs.mkShell.override { stdenv = pkgs.clangStdenv; }) {
+          packages = [
+            rustNightlyForFuzz
+            pkgs.cargo-fuzz
+            pkgs.pkg-config
+            pkgs.git
+          ];
+          RUST_SRC_PATH = "${rustNightlyForFuzz}/lib/rustlib/src/rust/library";
+          ASAN_SYMBOLIZER_PATH = "${pkgs.llvm_18}/bin/llvm-symbolizer";
+          # `cargo fuzz` builds with the release profile, whose workspace
+          # settings are hostile to fuzzing: fat LTO drops the sanitizer
+          # instrumentation, and stripping loses the symbols needed to read a
+          # crash report. (CI works around the former the same way, see
+          # CARGO_PROFILE_RELEASE_LTO in .github/workflows/aes.yml.)
+          # See https://github.com/rust-fuzz/cargo-fuzz/issues/384
+          CARGO_PROFILE_RELEASE_LTO = "false";
+          CARGO_PROFILE_RELEASE_STRIP = "false";
+          CARGO_PROFILE_RELEASE_DEBUG = "1";
+          shellHook = ''
+            root=$(git rev-parse --show-toplevel 2>/dev/null || echo .)
+            if [ ! -f "$root/Cargo.lock" ] && [ -f "$root/Cargo.toml" ]; then
+              echo "[flake] Cargo.lock missing — running 'cargo generate-lockfile'..."
+              (cd "$root" && cargo generate-lockfile)
+            fi
+            echo "[flake] fuzz shell: $(rustc --version), $(cargo fuzz --version)"
+          '';
+        };
       }
     );
 }


### PR DESCRIPTION
fixes #1556
closes #1451

I chose to remove the error variant in the case of 0 byte output generate calls. From my reading of [SP 800-90A][0], this is not disallowed and I see no reason why it should be. This alone would have fixed the bug, but would have caused different behavior between the reseeding wrapper for outputs divisible by the max amount and the non re-seeding `HmacDrbg::try_fill_bytes`. 



I've also added fuzzing for the reseeding wrappers (generated by claude opus 5 and revised by me) which catches the panic and is green after the fix. I also fixed the `new` fuzz target which had a fault.

I noticed that there no CI tests yet for hmac-drbg (#1451 was still open), so I added a basic CI workflow including fuzzing based on the aes workflow.

One question I have: Can the hax annotations that are present be consumed by hax or are they just comments intended for future annotations with `hax_lib`? One of the hax annotations was wrong.

[0]: https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-90ar1.pdf